### PR TITLE
On Windows the directory separator is "\", not "/". The DIRECTORY_SEPARAT

### DIFF
--- a/src/PHPSpec/Loader/ClassLoader.php
+++ b/src/PHPSpec/Loader/ClassLoader.php
@@ -55,7 +55,7 @@ class ClassLoader
     {
         $realPath   = realpath($fullPath);
         $specFile   = basename($realPath);
-        $pathToFile = str_replace("/$specFile", '', $realPath);
+        $pathToFile = str_replace(DIRECTORY_SEPARATOR."$specFile", '', $realPath);
         $convention = $this->getConventionFactory()->create($specFile);
         
         if ($realPath && !$convention->apply()) {
@@ -65,7 +65,7 @@ class ClassLoader
         }
         
         return array($this->loadExample(
-            $pathToFile . "/" . $convention->getClassFile(),
+            $pathToFile . DIRECTORY_SEPARATOR . $convention->getClassFile(),
             $convention->getClass()
         ));
     }


### PR DESCRIPTION
On Windows the directory separator is "\", not "/". The DIRECTORY_SEPARATOR constant in PHP takes care of those differences.
