### PR TITLE
Fixed Windows Compatibility issue stemming from improper directory separator.

### DIFF
--- a/src/PHPSpec/Loader/ClassLoader.php
+++ b/src/PHPSpec/Loader/ClassLoader.php
@@ -55,7 +55,7 @@ class ClassLoader
     {
         $realPath   = realpath($fullPath);
         $specFile   = basename($realPath);
-        $pathToFile = str_replace("/$specFile", '', $realPath);
+        $pathToFile = str_replace(DIRECTORY_SEPARATOR . "$specFile", '', $realPath);
         $convention = $this->getConventionFactory()->create($specFile);
         
         if ($realPath && !$convention->apply()) {


### PR DESCRIPTION
Before this fix I was getting the following:

phpspec: Could not include file "C:\path\to\specs\DescribeThing.php/DescribeThing.php"
