### PR TITLE
The fails fast feature in the normal workflow.

### DIFF
--- a/src/PHPSpec/Runner/Cli/Reporter.php
+++ b/src/PHPSpec/Runner/Cli/Reporter.php
@@ -54,13 +54,6 @@ class Reporter extends BaseReporter
     protected $_message = '';
     
     /**
-     * Whether to fail fast
-     *
-     * @var boolean
-     */
-    protected $_failFast = false;
-    
-    /**
      * Adds a failure to the formatters
      * 
      * @param \PHPSpec\Specification\Example        $example
@@ -76,8 +69,6 @@ class Reporter extends BaseReporter
                 Backtrace::pretty($failure->getTrace()), $failure
             )
         );
-        
-        $this->checkFailFast();
     }
     
     /**
@@ -112,7 +103,6 @@ class Reporter extends BaseReporter
                 Backtrace::pretty($failure->getTrace()), $failure
             )
         );
-        $this->checkFailFast();
     }
     
     /**
@@ -131,7 +121,6 @@ class Reporter extends BaseReporter
                 Backtrace::pretty($error->getTrace()), $error
             )
         );
-        $this->checkFailFast();
     }
     
     /**
@@ -149,7 +138,6 @@ class Reporter extends BaseReporter
                 $e->getMessage(), Backtrace::pretty($e->getTrace()), $e
             )
         );
-        $this->checkFailFast();
     }
     
     /**
@@ -222,37 +210,6 @@ class Reporter extends BaseReporter
         throw new DeprecatedNotice(
             "setFormatter is deprecate, please use addFormatter"
         );
-    }
-    
-    /**
-     * Gets the fail fast flag value
-     * 
-     * @return boolean
-     */
-    public function getFailFast()
-    {
-        return $this->_failFast;
-    }
-    
-    /**
-     * Set fail fast flag
-     * 
-     * @param boolean $failFast
-     */
-    public function setFailFast($failFast)
-    {
-        $this->_failFast = $failFast;
-    }
-    
-    /**
-     * Checks whether fails fast is set, and sends a message to the formatter
-     * to exit the output
-     */
-    private function checkFailFast()
-    {
-        if ($this->getFailFast() === true) {
-            $this->notify(new ReporterEvent('exit', '', ''));
-        }
     }
     
     /**

--- a/src/PHPSpec/Runner/Cli/Runner.php
+++ b/src/PHPSpec/Runner/Cli/Runner.php
@@ -143,6 +143,10 @@ class Runner implements \PHPSpec\Runner\Runner
                 $exampleGroup, $world->getReporter()
             );
             $exampleGroup->afterAll();
+
+            if ($world->getReporter()->checkFailFast()) {
+                break;
+            }
         }
     }
     

--- a/src/PHPSpec/Runner/Reporter.php
+++ b/src/PHPSpec/Runner/Reporter.php
@@ -89,6 +89,13 @@ abstract class Reporter implements \SPLSubject
      * @var array
      */
     protected $_passing = array();
+
+    /**
+     * Whether to fail fast
+     *
+     * @var boolean
+     */
+    protected $_failFast = false;
     
     /**
      * Sets the message to be printed by the formatter
@@ -432,5 +439,25 @@ abstract class Reporter implements \SPLSubject
     public function getPassing()
     {
         return $this->_passing;
+    }
+
+    /**
+     * Set fail fast flag
+     *
+     * @param boolean $failFast
+     */
+    public function setFailFast($failFast)
+    {
+        $this->_failFast = $failFast;
+    }
+
+    /**
+     * Checks whether fails fast is set, and sends a message to the formatter
+     * to exit the output
+     */
+    public function checkFailFast()
+    {
+        return $this->_failFast
+            && ($this->getFailures()->count() + $this->getErrors()->count() + $this->getExceptions()->count() > 0);
     }
 }

--- a/src/PHPSpec/Specification/ExampleRunner.php
+++ b/src/PHPSpec/Specification/ExampleRunner.php
@@ -156,6 +156,10 @@ class ExampleRunner
                 $this->createExample($exampleGroup, $methodName)
                      ->run($reporter);
             }
+
+            if ($reporter->checkFailFast()) {
+                break;
+            }
         }
     }
     


### PR DESCRIPTION
In these days I've developed our test runner product http://goo.gl/jfbNV to integrate PHPSpec with Eclipse PDT using our Eclipse plugin http://goo.gl/dfIWC

I think that there are a few problems to integrate naturally, I will send pull requests.

First, this pull request that changes the _fails fast_ feature to be embedded into the normal workflow of a run. I think that the normal workflow is important for such as calling the ExampleGroup::afterAll() method, closing opened tags for realtime JUnit XML writing because to stop by the _fails fast_ feature is just expected behavior, not unexpected.
