### PR TITLE
Replace PHP_EOL with "\n" in ReflectionMethod::isEmpty()

### DIFF
--- a/src/PHPSpec/Util/ReflectionMethod.php
+++ b/src/PHPSpec/Util/ReflectionMethod.php
@@ -68,7 +68,7 @@ class ReflectionMethod
             $this->_objectOrClassName,
             $this->_methodName
         );
-        list(,$path,) = explode(PHP_EOL, (string)$method);
+        list(,$path,) = explode("\n", (string)$method);
         preg_match('/(@@ )(.*\.php)( )(\d+)(\D*)(\d+)/', $path, $matches);
         list ($path, $start, $end) = array(
             $matches[2], $matches[4], $matches[6]


### PR DESCRIPTION
Exploding on PHP_EOL doesn't work as expected on WIndows here, so the method name can't be parsed properly.

PHPSpec\Specification\Result\Error: list(,$path,) = explode(PHP_EOL, (string)$method);
PHP Notice: Undefined offset: 1
