### PR TITLE
Fixing "Undefined offset" error in ReflectionMethod::isEmpty()

### DIFF
--- a/src/PHPSpec/Util/ReflectionMethod.php
+++ b/src/PHPSpec/Util/ReflectionMethod.php
@@ -68,8 +68,8 @@ class ReflectionMethod
             $this->_objectOrClassName,
             $this->_methodName
         );
-        list(,$path,) = explode("\n", (string)$method);
-        preg_match('/(@@ )(.*\.php)( )(\d+)(\D*)(\d+)/', $path, $matches);
+        $methodString = explode("\n", (string)$method);
+        preg_match('/(@@ )(.*\.php)( )(\d+)(\D*)(\d+)/', $methodString[ count($methodString) - 3 ], $matches);
         list ($path, $start, $end) = array(
             $matches[2], $matches[4], $matches[6]
         );


### PR DESCRIPTION
Since the path element is not always the second element of the array, an error **Undefined offset: 2** will be raised in the ReflectionMethod::isEmpty() method.
