### PR TITLE
Fixed the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-develop": "2.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
there is no develop branch in phpspec. the only branch is master
