### PR TITLE
Added a failing spec for the ArrayContainMatcher with non string values

### DIFF
--- a/spec/PhpSpec/Matcher/ArrayContainMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ArrayContainMatcherSpec.php
@@ -36,6 +36,7 @@ class ArrayContainMatcherSpec extends ObjectBehavior
     function it_does_not_match_array_without_specified_value()
     {
         $this->shouldThrow()->duringPositiveMatch('contain', array(1,2,3), array('abc'));
+        $this->shouldThrow('PhpSpec\Exception\Example\FailureException')->duringPositiveMatch('contain', array(1,2,3), array(new \stdClass()));
     }
 
     function it_matches_array_without_specified_value()


### PR DESCRIPTION
While reviewing the code of PhpSpec today, I figured that the ArrayContainMatcher does not work properly for non-scalar values (when there is a failure): it will try to cast the value as string as it uses `$presenter->presentString()`:

```
$ ./bin/phpspec run spec/PhpSpec/Matcher/ArrayContainMatcherSpec.php --no-ansi

      PhpSpec\Matcher\ArrayContainMatcher

  21  Ô£ö is a matcher
  26  Ô£ö responds to contain
  31  Ô£ö matches array with specified value
  36  Ô£ÿ does not match array without specified value
        expected exception of class "PhpSpec\Exception\Example"..., but got
        [exc:PhpSpec\Exception\Example\ErrorException("notice: Object of class stdClass could not be converted to int in
        C:\wamp\www\phpspec\src\PhpSpec\Matcher\ArrayContainMatcher.php line 28")].
  42  Ô£ö matches array without specified value

----  failed examples

        PhpSpec\Matcher\ArrayContainMatcher
  36  Ô£ÿ does not match array without specified value
        expected exception of class "PhpSpec\Exception\Example"..., but got
        [exc:PhpSpec\Exception\Example\ErrorException("notice: Object of class stdClass could not be converted to int in
        C:\wamp\www\phpspec\src\PhpSpec\Matcher\ArrayContainMatcher.php line 28")].


5 examples (4 passed, 1 failed)
73ms

```

As I wanted to play a bit with PhpSpec, I implemented the failing spec instead of just reporting the issue.

there is 2 ways to fix it:
- quick bug fix, keeping the logic as is but restricting `supports` to scalar arguments
- changing the way the exception message is build to support any value in the array.

I obviously think the second solution is better for functionalities but I don't know the code enough yet to figure the best way to do it. Would it simply be switching to `presentValue` ?
