### PR TITLE
Extracted template loading to provide extension points

### DIFF
--- a/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
@@ -42,20 +42,7 @@ class ClassGenerator implements GeneratorInterface
             $this->filesystem->makeDirectory($path);
         }
 
-        $values = array(
-            '%filepath%'        => $filepath,
-            '%name%'            => $resource->getName(),
-            '%namespace%'       => $resource->getSrcNamespace(),
-            '%namespace_block%' => '' !== $resource->getSrcNamespace()
-                                ?  sprintf("\n\nnamespace %s;", $resource->getSrcNamespace())
-                                : '',
-        );
-
-        if (!$content = $this->templates->render('class', $values)) {
-            $content = $this->templates->renderString(
-                file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__), $values
-            );
-        }
+        $content = $this->renderTemplate($resource, $filepath);
 
         $this->filesystem->putFileContents($filepath, $content);
         $this->io->writeln(sprintf(
@@ -67,6 +54,31 @@ class ClassGenerator implements GeneratorInterface
     public function getPriority()
     {
         return 0;
+    }
+
+    protected function renderTemplate(ResourceInterface $resource, $filepath)
+    {
+        $values = array(
+            '%filepath%'        => $filepath,
+            '%name%'            => $resource->getName(),
+            '%namespace%'       => $resource->getSrcNamespace(),
+            '%namespace_block%' => '' !== $resource->getSrcNamespace()
+                                ?  sprintf("\n\nnamespace %s;", $resource->getSrcNamespace())
+                                : '',
+        );
+
+        if (!$content = $this->templates->render('class', $values)) {
+            $content = $this->templates->renderString(
+                $this->getTemplate(), $values
+            );
+        }
+
+        return $content;
+    }
+
+    protected function getTemplate()
+    {
+        return file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__);
     }
 }
 __halt_compiler();<?php%namespace_block%

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -39,7 +39,7 @@ class MethodGenerator implements GeneratorInterface
         $values = array('%name%' => $name, '%arguments%' => $argString);
         if (!$content = $this->templates->render('method', $values)) {
             $content = $this->templates->renderString(
-                file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__), $values
+                $this->getTemplate(), $values
             );
         }
 
@@ -56,6 +56,11 @@ class MethodGenerator implements GeneratorInterface
     public function getPriority()
     {
         return 0;
+    }
+
+    protected function getTemplate()
+    {
+        return file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__);
     }
 }
 __halt_compiler();

--- a/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
@@ -42,18 +42,7 @@ class SpecificationGenerator implements GeneratorInterface
             $this->filesystem->makeDirectory($path);
         }
 
-        $values = array(
-            '%filepath%'  => $filepath,
-            '%name%'      => $resource->getSpecName(),
-            '%namespace%' => $resource->getSpecNamespace(),
-            '%subject%'   => $resource->getSrcClassname()
-        );
-
-        if (!$content = $this->templates->render('specification', $values)) {
-            $content = $this->templates->renderString(
-                file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__), $values
-            );
-        }
+        $content = $this->renderTemplate($resource, $filepath);
 
         $this->filesystem->putFileContents($filepath, $content);
         $this->io->writeln(sprintf(
@@ -65,6 +54,27 @@ class SpecificationGenerator implements GeneratorInterface
     public function getPriority()
     {
         return 0;
+    }
+
+    protected function renderTemplate(ResourceInterface $resource, $filepath)
+    {
+        $values = array(
+            '%filepath%'  => $filepath,
+            '%name%'      => $resource->getSpecName(),
+            '%namespace%' => $resource->getSpecNamespace(),
+            '%subject%'   => $resource->getSrcClassname()
+        );
+
+        if (!$content = $this->templates->render('specification', $values)) {
+            $content = $this->templates->renderString($this->getTemplate(), $values);
+        }
+
+        return $content;
+    }
+
+    protected function getTemplate()
+    {
+        return file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__);
     }
 }
 __halt_compiler();<?php


### PR DESCRIPTION
I'm working on a phpspec extension and I'd find it useful if it was possible to overload a default template provided by generators. This extracts template handling to separate methods to allow just that. 
