### PR TITLE
Fixed the replacement of Windows line endings in the docComment

### DIFF
--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -56,8 +56,8 @@ class CollaboratorsMaintainer implements MaintainerInterface
     private function generateCollaborators(CollaboratorManager $collaborators, $function)
     {
         if ($comment = $function->getDocComment()) {
-            $comment = str_replace("\r\n", PHP_EOL, $comment);
-            foreach (explode(PHP_EOL, trim($comment)) as $line) {
+            $comment = str_replace("\r\n", "\n", $comment);
+            foreach (explode("\n", trim($comment)) as $line) {
                 if (preg_match(self::$docex, $line, $match)) {
                     $collaborator = $this->getOrCreateCollaborator($collaborators, $match[2]);
                     $collaborator->beADoubleOf($match[1]);


### PR DESCRIPTION
This allows using the phpdoc to define the type of collaborators for a codebase using LF line-endings and a Windows runtime.
The previous conversion was only handling the case of a CRLF codebase used on a Unix runtime (which is far less common as almost everybody uses LF line endings in the codebase, expect when all devs are using Windows)

The phpspec suite is running fine on Windows without this fix because it uses typehints for collaborators. However, I got lots of failures when running phpspec on the Prophecy codebase which uses doc comments: as they were not parsed properly, all doubles are extending stdClass instead of extending the appropriate class (which of course fails because of undefined methods)
