### PR TITLE
Make phpspec compatible with renamed vendor folders

### DIFF
--- a/bin/phpspec
+++ b/bin/phpspec
@@ -9,7 +9,7 @@ if (is_dir($vendor = getcwd() . '/vendor')) {
 
 if (is_dir($vendor = __DIR__ . '/../vendor')) {
     require($vendor . '/autoload.php');
-} elseif (is_dir($vendor = __DIR__ . '/../../../../vendor')) {
+} elseif (is_dir($vendor = __DIR__ . '/../../..')) {
     require($vendor . '/autoload.php');
 } else {
     die(


### PR DESCRIPTION
When being installed in the vendor folders, you don't need to
know its name to access the autoloader, if you don't go outside
it and enter it again.

This fixes the same issue than reported in https://github.com/Behat/Behat/issues/228 but before it gets reported for phpspec
