### PR TITLE
Print number of specs in console output

### DIFF
--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -76,6 +76,8 @@ class DotFormatter extends BasicFormatter
             }
         }
 
+        $io->writeln(sprintf("%d specs", $stats->getTotalSpecs()));
+
         $counts = array();
         foreach ($stats->getCountsHash() as $type => $count) {
             if ($count) {

--- a/src/PhpSpec/Formatter/PrettyFormatter.php
+++ b/src/PhpSpec/Formatter/PrettyFormatter.php
@@ -93,6 +93,8 @@ class PrettyFormatter implements FormatterInterface
             }
         }
 
+        $this->io->writeln(sprintf("\n%d specs", $this->stats->getTotalSpecs()));
+
         $counts = array();
         foreach ($this->stats->getCountsHash() as $type => $count) {
             if ($count) {
@@ -100,7 +102,7 @@ class PrettyFormatter implements FormatterInterface
             }
         }
 
-        $this->io->write(sprintf("\n%d examples ", $this->stats->getEventsCount()));
+        $this->io->write(sprintf("%d examples ", $this->stats->getEventsCount()));
         if (count($counts)) {
             $this->io->write(sprintf("(%s)", implode(', ', $counts)));
         }

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -68,6 +68,8 @@ class ProgressFormatter extends BasicFormatter
         $io->freezeTemp();
         $io->writeln();
 
+        $io->writeln(sprintf("%d specs", $stats->getTotalSpecs()));
+
         $counts = array();
         foreach ($stats->getCountsHash() as $type => $count) {
             if ($count) {
@@ -76,7 +78,7 @@ class ProgressFormatter extends BasicFormatter
         }
         $count = $stats->getEventsCount();
         $plural = $count !== 1 ? 's' : '';
-        $io->write(sprintf("\n%d example%s ", $count, $plural));
+        $io->write(sprintf("%d example%s ", $count, $plural));
         if (count($counts)) {
             $io->write(sprintf("(%s)", implode(', ', $counts)));
         }

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -5,10 +5,13 @@ namespace PhpSpec\Listener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\SpecificationEvent;
 
 class StatisticsCollector implements EventSubscriberInterface
 {
     private $globalResult  = 0;
+    private $totalSpecs    = 0;
+
     private $passedEvents  = array();
     private $pendingEvents = array();
     private $failedEvents  = array();
@@ -16,7 +19,15 @@ class StatisticsCollector implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return array('afterExample' => array('afterExample', 10));
+        return array(
+            'afterSpecification' => array('afterSpecification', 10),
+            'afterExample'       => array('afterExample', 10)
+        );
+    }
+
+    public function afterSpecification(SpecificationEvent $event)
+    {
+        $this->totalSpecs++;
     }
 
     public function afterExample(ExampleEvent $event)
@@ -82,6 +93,11 @@ class StatisticsCollector implements EventSubscriberInterface
             'failed'  => count($this->getFailedEvents()),
             'broken'  => count($this->getBrokenEvents()),
         );
+    }
+
+    public function getTotalSpecs()
+    {
+        return $this->totalSpecs;
     }
 
     public function getEventsCount()


### PR DESCRIPTION
Can be useful - especially that the specs with typo in classname/namespace are ignored. (I've discovered this during migration from "old" phpspec2)
