### PR TITLE
Fix singular count printing s in the dot formatter

### DIFF
--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -76,7 +76,8 @@ class DotFormatter extends BasicFormatter
             }
         }
 
-        $io->writeln(sprintf("%d specs", $stats->getTotalSpecs()));
+        $plural = $stats->getTotalSpecs() !== 1 ? 's' : '';
+        $io->writeln(sprintf("%d spec%s", $stats->getTotalSpecs(), $plural));
 
         $counts = array();
         foreach ($stats->getCountsHash() as $type => $count) {


### PR DESCRIPTION
After merging @pjedrzejewski's PR I noticed that "specs" was being printed even if it was 1 spec.
