### PR TITLE
Fixed case where config file might be empty

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -356,12 +356,13 @@ class Application extends BaseApplication
 
     protected function loadConfigurationFile(ServiceContainer $container)
     {
-        $config = array();
         if (file_exists($path = 'phpspec.yml')) {
             $config = Yaml::parse(file_get_contents($path));
         } elseif (file_exists($path = 'phpspec.yml.dist')) {
             $config = Yaml::parse(file_get_contents($path));
         }
+
+        $config = $config ?: array();
 
         foreach ($config as $key => $val) {
             if ('extensions' === $key) {


### PR DESCRIPTION
Fix for #136 

Minor bug fix, but when `phpspec.yml` is empty, trying to run PhpSpec results in a PHP Warning

> PHP Warning:  Invalid argument supplied for foreach() in [...]/phpspec/phpspec/src/PhpSpec/Console/Application.php on line 347

In `PhpSpec\Console\Application#loadConfigurationFile` the variable `$config` is initialized as an array.

After which `Yaml::parse` can return `null`, which it will if `phpspec.yml` is empty - and you can't iterate over null.
