### PR TITLE
Fix wrong methodNotFoundException call

### DIFF
--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -214,13 +214,12 @@ class Caller
         ), $this->wrappedObject->getClassName());
     }
 
-    private function methodNotfound($method, array $arguments = array())
+    private function methodNotFound($method, array $arguments = array())
     {
-        $className = $this->wrappedObject->getClassName();
         return new MethodNotFoundException(sprintf(
             'Method %s not found.',
-            $this->presenter->presentString($this->wrappedObject->getClassName().'::' . $method)
-        ), new $className , $method, $arguments);
+            $this->presenter->presentString($this->wrappedObject->getClassName().'::'.$method)
+        ), $this->getWrappedObject(), $method, $arguments);
     }
 
     private function propertyNotFound($property)


### PR DESCRIPTION
Fix throw fatal error when use constructor with parameters for wrapped object.

```
class EverChangingWorldSpec extends ObjectBehavior
{
    function let($die)
    {
        $die->beADoubleOf('DieClassName');
        $this->beConstructedWith($die);
    }

    function it_live_and_let_die($die)
    {
        $this->liveAndLet()->shouldReturn($die);
    }
}
```

```
error: Argument 1 passed to testClass::__construct() must be an instance of DieClassName, none given, called in
     phpspec/phpspec/src/PhpSpec/Wrapper/Subject/Caller.php on line 223
```
