### PR TITLE
Added backslash to ArrayAccess to repair broken checkIfSubjectImplements...

### DIFF
--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -72,9 +72,9 @@ class SubjectWithArrayAccess
 
     private function checkIfSubjectImplementsArrayAccess($subject)
     {
-        if (is_object($subject) && !($subject instanceof ArrayAccess)) {
+        if (is_object($subject) && !($subject instanceof \ArrayAccess)) {
             throw $this->interfaceNotImplemented();
-        } elseif (!($subject instanceof ArrayAccess) && !is_array($subject)) {
+        } elseif (!($subject instanceof \ArrayAccess) && !is_array($subject)) {
             throw $this->cantUseAsArray($subject);
         }
     }


### PR DESCRIPTION
checkIfSubjectImplementsArrayAccess was broken because ArrayAccess was neither used nor written with a backslash to use the global interface. There where no specs for this so I just added the backslash.
