### PR TITLE
Throw an exception when during() is used with unknown method

### DIFF
--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -10,6 +10,7 @@ use PhpSpec\Factory\ReflectionFactory;
 use PhpSpec\Exception\Example\MatcherException;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Example\NotEqualException;
+use PhpSpec\Exception\Fracture\MethodNotFoundException;
 
 class ThrowMatcher implements MatcherInterface
 {
@@ -161,6 +162,14 @@ class ThrowMatcher implements MatcherInterface
                 }
 
                 $callable = is_string($callable) ? array($subject, $callable) : $callable;
+                
+                list($class, $methodName) = $callable;
+                if (!method_exists($class, $methodName) && !method_exists($class, '__call')) {
+                    throw new MethodNotFoundException(
+                        sprintf('Method %s::%s not found.', get_class($class), $methodName), 
+                        $class, $methodName, $arguments
+                    );
+                }
 
                 return call_user_func($check, $callable, $arguments, $exception);
             }


### PR DESCRIPTION
As described in #170

The following now fails + prompts method generation when method foo does not exist

```
function it_should_throw_some_sort_of_exception()
{
    $this->shouldThrow(\Exception::class)->during('foo',[]);
}
```
