### PR TITLE
Fix undefined property notice

### DIFF
--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -52,7 +52,7 @@ class SubjectWithArrayAccess
         $unwrapper = new Unwrapper;
         $subject = $this->caller->getWrappedObject();
         $key     = $unwrapper->unwrapOne($key);
-        $value   = $this->unwrapper->unwrapOne($value);
+        $value   = $unwrapper->unwrapOne($value);
 
         $this->checkIfSubjectImplementsArrayAccess($subject);
 


### PR DESCRIPTION
Fixes the error:

```
      notice: Undefined property: PhpSpec\Wrapper\Subject\SubjectWithArrayAccess::$unwrapper in
      /home/workspace/frontend/vendor/phpspec/phpspec/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php line 55
```
