### PR TITLE
add object engine differ

### DIFF
--- a/spec/PhpSpec/Formatter/Presenter/Differ/ObjectEngineSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Differ/ObjectEngineSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Differ;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use PhpSpec\Formatter\Presenter\Differ\EngineInterface;
+
+class ObjectEngineSpec extends ObjectBehavior
+{
+    function let(EngineInterface $engine)
+    {
+        $this->beConstructedWith($engine);
+    }
+
+    function it_is_a_diff_engine()
+    {
+        $this->shouldBeAnInstanceOf('PhpSpec\Formatter\Presenter\Differ\EngineInterface');
+    }
+
+    function it_supports_objects()
+    {
+        $this->supports(new \stdClass, new \stdClass)->shouldReturn(true);
+    }
+
+    function it_does_not_support_anything_else()
+    {
+        $this->supports(new \stdClass, 'not an object')->shouldReturn(false);
+    }
+
+    function it_compares_print_r_string_results_by_default($engine, \stdClass $object)
+    {
+        $arg = Argument::that(function($value) {
+            return false !== strpos($value, '*RECURSION*'); // print_r proof
+        });
+        $engine->compare($arg, $arg)->willReturn('<diff>');
+
+        $this->compare($object, $object)->shouldReturn('<diff>');
+    }
+
+    function it_compares_results_with_custom_callable($engine, \stdClass $object)
+    {
+        $this->beConstructedWith($engine, function($object) { return 'object_diff'; });
+        $engine->compare('object_diff', 'object_diff')->willReturn('<diff>');
+
+        $this->compare($object, $object)->shouldReturn('<diff>');
+    }
+
+    function it_should_not_allow_non_callable_diffSource($engine, \stdClass $object)
+    {
+        $this->shouldThrow(new \InvalidArgumentException('Argument 2 passed to ObjectEngine::__construct must be a callable, string given.'))->during('__construct', array($engine, 'not callable'));
+    }
+}

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -30,7 +30,7 @@ class Application extends BaseApplication
     public function __construct($version)
     {
         $this->setupContainer($this->container = new ServiceContainer);
-        
+
         parent::__construct('phpspec', $version);
     }
 
@@ -49,11 +49,11 @@ class Application extends BaseApplication
 
         return parent::doRun($input, $output);
     }
-    
+
     protected function fixDefinitions()
     {
         $description = 'Do not ask any interactive question (disables code generation).';
-        
+
         $definition = $this->getDefaultInputDefinition();
         $options = $definition->getOptions();
 
@@ -66,23 +66,23 @@ class Application extends BaseApplication
                 $description
             );
         }
-         
+
         $definition->setOptions($options);
         $this->setDefinition($definition);
     }
-    
+
     protected function getCommandName(InputInterface $input)
     {
         $name = parent::getCommandName($input);
-        
+
         if (!$name) {
             $name = 'run';
             parent::getDefinition()->setArguments();
         }
-        
+
         return $name;
     }
-    
+
     public function getDefaultCommands()
     {
         $commands = $this->container->getByPrefix('console.commands');
@@ -235,6 +235,11 @@ class Application extends BaseApplication
         $container->set('formatter.presenter.differ.engines.array', function($c) {
             return new Formatter\Presenter\Differ\ArrayEngine;
         });
+        $container->set('formatter.presenter.differ.engines.object', function($c) {
+            return new Formatter\Presenter\Differ\ObjectEngine(
+                $c->get('formatter.presenter.differ.engines.string')
+            );
+        });
     }
 
     protected function setupLocator(ServiceContainer $container)
@@ -339,7 +344,7 @@ class Application extends BaseApplication
                 $c->get('runner.specification')
             );
         });
-        
+
         $container->setShared('runner.specification', function($c) {
             return new Runner\SpecificationRunner(
                 $c->get('event_dispatcher'),

--- a/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PhpSpec\Formatter\Presenter\Differ;
+
+use PhpSpec\Formatter\Presenter\Differ\EngineInterface;
+
+class ObjectEngine implements EngineInterface
+{
+    private $engine;
+    private $diffSource;
+
+    public function __construct(EngineInterface $engine, $diffSource = null)
+    {
+        $this->engine = $engine;
+        $this->diffSource = $diffSource;
+
+        if (null === $diffSource) {
+            $this->diffSource = function ($value) {
+                return print_r($value, true);
+            };
+        }
+
+        if (!is_callable($this->diffSource)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Argument 2 passed to ObjectEngine::__construct must be a callable, %s given.',
+                gettype($diffSource)
+            ));
+        }
+    }
+
+    public function supports($expected, $actual)
+    {
+        return is_object($expected) && is_object($actual);
+    }
+
+    public function compare($expected, $actual)
+    {
+        $expectedString = call_user_func($this->diffSource, $expected);
+        $actualString   = call_user_func($this->diffSource, $actual);
+
+        return $this->engine->compare($expectedString, $actualString);
+    }
+}


### PR DESCRIPTION
using print_r by default (subject to discussion).

Can be very slow sometimes, so, I don't know if we should add a way to deactivate it.
There is already a way to change the way the string to diff is generated.

PS: as other engines, it's only executed in --verbose mode.
