### PR TITLE
be very verbose

### DIFF
--- a/src/PhpSpec/Formatter/Presenter/StringPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/StringPresenter.php
@@ -77,18 +77,18 @@ class StringPresenter implements PresenterInterface
 
         if ($exception instanceof NotEqualException) {
             if ($diff = $this->presentExceptionDifference($exception)) {
-                return $presentation."\n".$diff;
+                $presentation .= "\n".$diff;
             }
         }
 
         if ($exception instanceof PhpSpecException && !$exception instanceof ErrorException) {
             list($file, $line) = $this->getExceptionExamplePosition($exception);
 
-            return $presentation."\n".$this->presentFileCode($file, $line);
+            $presentation .= "\n".$this->presentFileCode($file, $line);
         }
 
         if (trim($trace = $this->presentExceptionStackTrace($exception))) {
-            return $presentation."\n".$trace;
+            $presentation .= "\n".$trace;
         }
 
         return $presentation;


### PR DESCRIPTION
It concatenates all the output that phpspec can render in --verbose mode.

For example, the stack trace was only shown if it can't present file code,
which itself was only shown if it can't generate a diff.

With this patch, it will display all these informaions using --verbose.
