### PR TITLE
fix bug in specPath same as srcPath

### DIFF
--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -143,6 +143,13 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->supportsQuery($this->srcPath)->shouldReturn(true);
     }
 
+    function it_supports_specPath_same_as_srcPath()
+    {
+        $this->beConstructedWith('PhpSpec', 'PhpSpec\\Spec', $this->srcPath, $this->srcPath);
+
+        $this->supportsQuery($this->srcPath)->shouldReturn(true);
+    }
+
     function it_supports_file_queries_in_srcPath()
     {
         $this->beConstructedWith('PhpSpec', 'spec', $this->srcPath, $this->specPath);

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -143,6 +143,10 @@ class PSR0Locator implements ResourceLocatorInterface
             return false;
         }
 
+        if ('.php' !== substr($path, -4)) {
+            $path .= $sepr;
+        }
+
         return 0 === strpos($path, $this->srcPath)
             || 0 === strpos($path, $this->specPath)
         ;


### PR DESCRIPTION
There is a bug in specPath same as srcPath that "supportsQuery" method
return "false".

Cause is the presence or absence of the "/" at the end of the path.

Modify like as "findResources".
