### PR TITLE
Cater for different server variables on Windows

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -202,9 +202,15 @@ class Application extends BaseApplication
             return $renderer;
         });
 
+        if(!empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
+            $home = $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'];
+        } else {
+            $home = $_SERVER['HOME'];
+        }
+
         $container->setParam('code_generator.templates.paths', array(
             rtrim(getcwd(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'.phpspec',
-            rtrim($_SERVER['HOME'], DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'.phpspec',
+            rtrim($home, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'.phpspec',
         ));
     }
 


### PR DESCRIPTION
`$_SERVER['HOME']` doesn't exist on Windows, instead you have to join `$_SERVER['HOMEDRIVE']` and `$_SERVER['HOMEPATH']`. 

This PR changes the `Application` class to handle this, preventing a notice being issued when running any command on Windows.

(I'm not aware of any other OSes that don't provide `$_SERVER['HOME']`, though in theory there might be some...)
