### PR TITLE
Fixed asking about generating code

### DIFF
--- a/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
@@ -22,6 +22,12 @@ class ConstructorDecoratorSpec extends ObjectBehavior
         $this->shouldThrow('PhpSpec\Exception\Example\ErrorException')->duringMatch('be', $subject, array(), $wrapped);
     }
 
+    function it_rethrows_fracture_errors_as_phpspec_error_exceptions(Subject $subject, WrappedObject $wrapped)
+    {
+        $subject->__call('getWrappedObject', array())->willThrow('PhpSpec\Exception\Fracture\FractureException');
+        $this->shouldThrow('PhpSpec\Exception\Fracture\FractureException')->duringMatch('be', $subject, array(), $wrapped);
+    }
+
     function it_ignores_any_other_exception(Subject $subject, WrappedObject $wrapped)
     {
         $subject->callOnWrappedObject('getWrappedObject', array())->willThrow('\Exception');

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -4,6 +4,7 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 use Exception;
 use PhpSpec\Exception\Example\ErrorException;
+use PhpSpec\Exception\Fracture\FractureException;
 use PhpSpec\Util\Instantiator;
 use PhpSpec\Wrapper\Subject\WrappedObject;
 
@@ -19,6 +20,8 @@ class ConstructorDecorator extends Decorator implements ExpectationInterface
         try {
             $wrapped = $subject->getWrappedObject();
         } catch (ErrorException $e) {
+            throw $e;
+        } catch (FractureException $e) {
             throw $e;
         } catch (Exception $e) {
             if (null !== $wrappedObject && $wrappedObject->getClassName()) {


### PR DESCRIPTION
It looks that after https://github.com/phpspec/phpspec/commit/d1bc979400a761e76536af041f9875dd33f7d63f phpspec no longer asks about generating code when class or method not exist. I believe that rethrowing FractureException in ConstructorDecorator fixes the problem. 
I just dont know why when I change `$subject->__call('getWrappedObject', array())` into `$subject->callOnWrappedObject('getWrappedObject', array())` like in other specs tests fail with following message: 

```
rethrows fracture errors as phpspec error exceptions
        expected exception of class "PhpSpec\Exception\Fractur"..., but got
        [exc:PhpSpec\Exception\Example\ErrorException("notice: Undefined variable: wrapped in
        /home/norbert/Workspace/PHP/phpspec/phpspec/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php line
        33")].
```
