### PR TITLE
Remove overriding the default command.

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -30,7 +30,7 @@ class Application extends BaseApplication
     public function __construct($version)
     {
         $this->setupContainer($this->container = new ServiceContainer);
-        
+
         parent::__construct('phpspec', $version);
     }
 
@@ -49,11 +49,11 @@ class Application extends BaseApplication
 
         return parent::doRun($input, $output);
     }
-    
+
     protected function fixDefinitions()
     {
         $description = 'Do not ask any interactive question (disables code generation).';
-        
+
         $definition = $this->getDefaultInputDefinition();
         $options = $definition->getOptions();
 
@@ -66,23 +66,11 @@ class Application extends BaseApplication
                 $description
             );
         }
-         
+
         $definition->setOptions($options);
         $this->setDefinition($definition);
     }
-    
-    protected function getCommandName(InputInterface $input)
-    {
-        $name = parent::getCommandName($input);
-        
-        if (!$name) {
-            $name = 'run';
-            parent::getDefinition()->setArguments();
-        }
-        
-        return $name;
-    }
-    
+
     public function getDefaultCommands()
     {
         $commands = $this->container->getByPrefix('console.commands');
@@ -339,7 +327,7 @@ class Application extends BaseApplication
                 $c->get('runner.specification')
             );
         });
-        
+
         $container->setShared('runner.specification', function($c) {
             return new Runner\SpecificationRunner(
                 $c->get('event_dispatcher'),


### PR DESCRIPTION
Having run as the default command makes it difficult to find out the commands for a new user who does not know that you can run list (requires knowing it uses Symfony console component). This is a b/c break an will require people to specify the run command (just r will do) so I can see the disadvantages but it would make it easier to find out what the commands are.
