### PR TITLE
newInstanceArgs requires a array argument

### DIFF
--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -44,7 +44,7 @@ class ExampleRunner
 
         try {
             $this->executeExample(
-                $example->getSpecification()->getClassReflection()->newInstanceArgs(),
+                $example->getSpecification()->getClassReflection()->newInstanceArgs(array()),
                 $example
             );
 


### PR DESCRIPTION
This fixes the last standing issue with running phpspec under hhvm.
