### PR TITLE
$this->beConstructedWith() now returns $this

### DIFF
--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -39,6 +39,7 @@ class Subject implements ArrayAccess, WrapperInterface
     public function beConstructedWith()
     {
         $this->wrappedObject->beConstructedWith(func_get_args());
+        return $this;
     }
 
     public function getWrappedObject()


### PR DESCRIPTION
Minor tweak to beConstructedWith() to allow chaining. Using the classic default test:

```
    function it_is_initializable()
    {
        $this->beConstructedWith(array())->shouldHaveType('Foo\Bar');
    }
```
