### PR TITLE
[composer] Lock symfony/console version to 2.2.* min

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php":                      ">=5.3.3",
         "phpspec/prophecy":         "~1.0.2",
         "phpspec/php-diff":         "~1.0.0",
-        "symfony/console":          "~2.1",
+        "symfony/console":          "~2.2",
         "symfony/event-dispatcher": "~2.1",
         "symfony/finder":           "~2.1",
         "symfony/yaml":             "~2.1"


### PR DESCRIPTION
On a project using symfony 2.1, I tried to add some specs, and get the following error

```
$ bin/phpspec 
PHP Fatal error:  Call to undefined method PhpSpec\Console\Application::setDefinition()
```

After some investigation, this method only exist since symfony/console v2.2.0 (https://github.com/symfony/Console/commit/226b9e27833a83b0993dbcd5dba806f0ef98cb08)

That's why I suggest locking symfony/console to ~2.2
