### PR TITLE
Adding CLI option to specify custom YML file location

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -100,8 +100,8 @@ class Application extends BaseApplication
             );
         }
 
-        $options['config-file'] = new InputOption(
-            'config-file',
+        $options['config'] = new InputOption(
+            'config',
             'c',
             InputOption::VALUE_REQUIRED,
             'Specify a custom location for the configuration file'
@@ -491,7 +491,7 @@ class Application extends BaseApplication
         $paths = array('phpspec.yml','phpspec.dist.yml');
 
         $input = new ArgvInput();
-        if ($customPath = $input->getParameterOption(array('-c','--config-file'))) {
+        if ($customPath = $input->getParameterOption(array('-c','--config'))) {
             if (!file_exists($customPath)) {
                 throw new FileNotFoundException('Custom configuration file not found at '.$customPath);
             }


### PR DESCRIPTION
Adds a `--config` flag to specify a config file location other than `phpspec.yml`

This change has required some resequencing of how/when the ServiceContainer is set up. There is more that could be done in that area.
