### PR TITLE
notice fix if suite namespace isnt set

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -225,7 +225,7 @@ class Application extends BaseApplication
 
             foreach ($suites as $name => $suite) {
                 $suite      = is_array($suite) ? $suite : array('namespace' => $suite);
-                $srcNS      = $suite['namespace'];
+                $srcNS      = isset($suite['namespace']) ? $suite['namespace'] : '';
                 $specPrefix = isset($suite['spec_prefix']) ? $suite['spec_prefix'] : 'spec';
                 $srcPath    = isset($suite['src_path']) ? $suite['src_path'] : 'src';
                 $specPath   = isset($suite['spec_path']) ? $suite['spec_path'] : '.';


### PR DESCRIPTION
Fix for notice error if namepsace isn't set for suite in phpspec.yml.
