### PR TITLE
Remove dead code & fix notice in StringPresenter

### DIFF
--- a/src/PhpSpec/Formatter/Presenter/StringPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/StringPresenter.php
@@ -179,13 +179,11 @@ class StringPresenter implements PresenterInterface
 
             if (isset($call['class'])) {
                 $text .= $this->presentExceptionTraceMethod(
-                    $call['class'], $call['type'], $call['function'], $call['args']
+                    $call['class'], $call['type'], $call['function'], isset($call['args']) ? $call['args'] : array()
                 );
             } elseif (isset($call['function'])) {
-                $args = array_map(array($this, 'presentValue'), $call['args']);
-
                 $text .= $this->presentExceptionTraceFunction(
-                    $call['function'], $call['args']
+                    $call['function'], isset($call['args']) ? $call['args'] : array()
                 );
             }
         }


### PR DESCRIPTION
Couldn't easy find way how to reproduce this in specs as the cover only `presentValue()`.

Found at: https://travis-ci.org/Sylius/Sylius/jobs/15712000#L6453 (warning: really long log)
