### PR TITLE
Remove dev flag from composer in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ matrix:
     - php: hhvm
 
 before_script:
-  - composer install --dev --prefer-source
+  - composer install --prefer-source
 
 script: bin/phpspec run


### PR DESCRIPTION
This PR removes the `--dev` flag from the `composer` `before_script` in the `.travis.yml` file as it's a no-op option and is only included for BC.
