### PR TITLE
Make indentation in .travis.yml 4 spaces to be consistent with other ind...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: php
 php: [5.3.3, 5.3, 5.4, 5.5, hhvm]
 
 matrix:
-  allow_failures:
-    - php: hhvm
+    allow_failures:
+        - php: hhvm
 
 before_script:
-  - composer install --prefer-source
+    - composer install --prefer-source
 
 script: bin/phpspec run


### PR DESCRIPTION
...entation.

This PR changes the `.travis.yml` file to use 4 spaces for indentation, as discussed here: https://github.com/phpspec/phpspec/pull/248#discussion-diff-8626941R12
