### PR TITLE
[WIP] Adding new step definitions for scenarios that don't require classnames

### DIFF
--- a/features/bootstrap/PhpSpecContext.php
+++ b/features/bootstrap/PhpSpecContext.php
@@ -19,6 +19,11 @@ class PhpSpecContext extends BehatContext
     private $applicationTester = null;
 
     /**
+     * @var integer
+     */
+    private $uniqueTokenCounter = 0;
+
+    /**
      * @BeforeScenario
      */
     public function createWorkDir()
@@ -71,11 +76,68 @@ class PhpSpecContext extends BehatContext
      */
     public function theFileContains($file, PyStringNode $string)
     {
+        $this->writeNewClassFile($file, (string)$string);
+    }
+
+    /**
+     * @param string $file
+     * @param string $string
+     */
+    private function writeNewClassFile($file, $string)
+    {
         mkdir(dirname($file), 0777, true);
 
-        file_put_contents($file, $string->getRaw());
+        file_put_contents($file, $string);
 
         require_once($file);
+    }
+
+    /**
+     * @Given /^I have an example that contains:$/
+     */
+    public function iHaveAnExampleThatContains(PyStringNode $string)
+    {
+        $uniqueToken = ++$this->uniqueTokenCounter;
+        $className = 'Class' . $uniqueToken . 'Spec';
+        $file = 'spec' . DIRECTORY_SEPARATOR . $className . '.php';
+
+        $template = <<<EOF
+<?php
+
+namespace spec;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class $className extends ObjectBehavior
+{
+$string
+}
+
+EOF;
+
+        $this->writeNewClassFile($file, $template);
+    }
+
+    /**
+     * @Given /^the object being specified contains:$/
+     */
+    public function theObjectBeingSpecifiedContains(PyStringNode $string)
+    {
+        $uniqueToken = $this->uniqueTokenCounter;
+        $className = 'Class' . $uniqueToken;
+        $file = 'src' . DIRECTORY_SEPARATOR . $className . '.php';
+
+        $template = <<<EOF
+<?php
+class $className
+{
+$string
+}
+
+EOF;
+
+        $this->writeNewClassFile($file, $template);
     }
 
     /**
@@ -102,6 +164,7 @@ class PhpSpecContext extends BehatContext
 
     /**
      * @Then /^(?:|the )suite should pass$/
+     * @Then /^(?:|the )example should pass$/
      */
     public function theSuiteShouldPass()
     {

--- a/features/runner/developer_runs_specs.feature
+++ b/features/runner/developer_runs_specs.feature
@@ -3,44 +3,25 @@ Feature: Developer runs the specs
   I want to run the specs
   In order to get feedback on a state of my application
 
-  Scenario: Running a spec with a class that doesn't exist
+  Scenario: Running a spec with a class that doesn't exist causes failure
     Given I have started describing the "Runner/SpecExample1/Markdown" class
     When I run phpspec
     Then I should see "class Runner\SpecExample1\Markdown does not exist"
 
-  Scenario: Reporting success when running a spec with correctly implemented class
-    Given the spec file "spec/Runner/SpecExample2/MarkdownSpec.php" contains:
+  Scenario: Running a spec with a correctly implemented class causes successs
+    Given I have an example that contains:
       """
-      <?php
-
-      namespace spec\Runner\SpecExample2;
-
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
-
-      class MarkdownSpec extends ObjectBehavior
-      {
           function it_converts_plain_text_to_html_paragraphs()
           {
               $this->toHtml('Hi, there')->shouldReturn('<p>Hi, there</p>');
           }
-      }
-
       """
-    And the class file "src/Runner/SpecExample2/Markdown.php" contains:
+    And the object being specified contains:
       """
-      <?php
-
-      namespace Runner\SpecExample2;
-
-      class Markdown
-      {
           public function toHtml($text)
           {
               return sprintf('<p>%s</p>', $text);
           }
-      }
-
       """
     When I run phpspec
-    Then the suite should pass
+    Then the example should pass


### PR DESCRIPTION
For discussion, as previously mentioned in comments on #248.

Plenty of features don't need to care about the exact names or paths to the spec or SUS, they just want to talk about specific examples the spec contains.

This is a simple implementation of that sort of syntax.

I can see us having a few different levels:
1. Example scenarios that talk about single examples and don't specify the rest of the spec's contents (as I have in this PR)
2. Spec scenarios that talk about multiple examples (e.g. testing let() behaviour between examples) but which don't care what the spec/SUS are actually named. This can be achieved with something similar to the definitions I've added here
3. Spec scenarios that care about paths/names, e.g. the existing Code Generation scenarios that we have already.

Pros:
- Less boilerplate in features, more focussed and readable
- Removes requirement to think of unique spec/class names

Cons:
- More magic going on
- Less obvious from the scenario what the whole spec looks like
- Potential future issues with namespaces / use statements

Any comments before I go further?
