### PR TITLE
Prevented array to string conversion in the junit formatter

### DIFF
--- a/src/PhpSpec/Formatter/JunitFormatter.php
+++ b/src/PhpSpec/Formatter/JunitFormatter.php
@@ -105,7 +105,7 @@ class JunitFormatter extends BasicFormatter
             . ' ('.$failureString.')' . PHP_EOL;
         $failureMsg .= $event->getMessage() . PHP_EOL;
         if ($backtrace) {
-            $failureMsg .= $event->getBacktrace() . PHP_EOL;
+            $failureMsg .= $event->getException()->getTraceAsString() . PHP_EOL;
         }
 
         $error = $case->addChild($failureType, $failureMsg);


### PR DESCRIPTION
`ExampleEvent::getBacktrace()` returns an array, thus raising an `array to string conversion` notice
