### PR TITLE
Fixing warning when extensions key is empty

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -453,7 +453,7 @@ class Application extends BaseApplication
         $config = $this->parseConfigurationFile();
 
         foreach ($config as $key => $val) {
-            if ('extensions' === $key) {
+            if ('extensions' === $key && is_array($val)) {
                 foreach ($val as $class) {
                     $extension = new $class;
 


### PR DESCRIPTION
Small extra check that does not contain an empty extensions key before trying to iterate it:

``` yaml
extensions:
```

Fixes #136
