### PR TITLE
Correct phpspec.yml.dist filename

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -479,7 +479,7 @@ class Application extends BaseApplication
      */
     protected function parseConfigurationFile()
     {
-        $paths = array('phpspec.yml','phpspec.dist.yml');
+        $paths = array('phpspec.yml','phpspec.yml.dist');
 
         $input = new ArgvInput();
         if ($customPath = $input->getParameterOption(array('-c','--config'))) {


### PR DESCRIPTION
#232 renamed `phpspec.yml.dist` to `phpspec.dist.yml`, so anything currently using it runs an empty suite (unless the `--config` option is now set). This reverts it back.
