### PR TITLE
Late registration of commands to allow overriding them

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -50,7 +50,7 @@ class Application extends BaseApplication
      */
     public function __construct($version)
     {
-        $this->setupCommands($this->container = new ServiceContainer);
+        $this->container = new ServiceContainer;
         parent::__construct('phpspec', $version);
     }
 
@@ -76,6 +76,10 @@ class Application extends BaseApplication
 
         $this->setupContainer($this->container);
 
+        foreach ($this->container->getByPrefix('console.commands') as $command) {
+            $this->add($command);
+        }
+        
         return parent::doRun($input, $output);
     }
 
@@ -124,12 +128,9 @@ class Application extends BaseApplication
         $this->setupLoader($container);
         $this->setupFormatter($container);
         $this->setupRunner($container);
+        $this->setupCommands($container);
 
         $this->loadConfigurationFile($container);
-
-        foreach ($this->container->getByPrefix('console.commands') as $command) {
-            $this->add($command);
-        }
     }
 
     protected function setupIO(ServiceContainer $container)


### PR DESCRIPTION
This PR allows to override phpspec commands by adding them into the application as late as possible.
The current implementation adds them at the instanciation of the Application (because it relies on the `getDefaultCommand` which is used in the `BaseApplication` constructor) which prevents to override them through extension with this code:

``` php
class MyExtension implements ExtensionInterface
{
    public function load(ServiceContainer $container)
    {
        $container->setShared('console.commands.run', function ($c) {
        });
    }
}
```
