### PR TITLE
Generate final classes by default

### DIFF
--- a/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
@@ -101,6 +101,6 @@ class ClassGenerator extends PromptingGenerator implements GeneratorInterface
 }
 __halt_compiler();<?php%namespace_block%
 
-class %name%
+final class %name%
 {
 }


### PR DESCRIPTION
In order to enforce people thinking more about composition, we need to make it a bit harder to use inheritance.

PhpSpec never was a tool built on top of popular moves. It was created as a tool to enforce **good design**. `final` keyword is the most effective way I know to force people think about composition (over inheritance).

(implementation for #312)
