### PR TITLE
[BasicFormatter] Prevented adding an empty line on each skipped example

### DIFF
--- a/src/PhpSpec/Formatter/BasicFormatter.php
+++ b/src/PhpSpec/Formatter/BasicFormatter.php
@@ -111,6 +111,7 @@ abstract class BasicFormatter implements EventSubscriberInterface
                 $event->getExample()->getTitle()
             ));
             $this->io->writeln(sprintf('<pending>%s</pending>', lcfirst($message)), 6);
+            $this->io->writeln();
         } elseif ($exception instanceof SkippingException) {
             if ($this->io->isVerbose()) {
                 $this->io->writeln(sprintf('<skipped-bg>%s</skipped-bg>', $title));
@@ -120,6 +121,7 @@ abstract class BasicFormatter implements EventSubscriberInterface
                     $event->getExample()->getTitle()
                 ));
                 $this->io->writeln(sprintf('<skipped>%s</skipped>', lcfirst($message)), 6);
+                $this->io->writeln();
             }
         } elseif (ExampleEvent::FAILED === $event->getResult()) {
             $this->io->writeln(sprintf('<failed-bg>%s</failed-bg>', $title));
@@ -129,6 +131,7 @@ abstract class BasicFormatter implements EventSubscriberInterface
                 $event->getExample()->getTitle()
             ));
             $this->io->writeln(sprintf('<failed>%s</failed>', lcfirst($message)), 6);
+            $this->io->writeln();
         } else {
             $this->io->writeln(sprintf('<broken-bg>%s</broken-bg>', $title));
             $this->io->writeln(sprintf(
@@ -137,9 +140,8 @@ abstract class BasicFormatter implements EventSubscriberInterface
                 $event->getExample()->getTitle()
             ));
             $this->io->writeln(sprintf('<broken>%s</broken>', lcfirst($message)), 6);
+            $this->io->writeln();
         }
-
-        $this->io->writeln();
     }
 
     /**


### PR DESCRIPTION
Otherwise, here's what happen to formatters depending on `BasicFormatter::printException()`:
![capture du 2014-03-10 22 36 33](https://f.cloud.github.com/assets/668604/2379532/15259f24-a89c-11e3-9ae3-44bc6d427550.png)
