### PR TITLE
Return exit code 0 instead of 2 when examples are skipped

### DIFF
--- a/features/bootstrap/Console/ApplicationTester.php
+++ b/features/bootstrap/Console/ApplicationTester.php
@@ -30,6 +30,11 @@ class ApplicationTester
     private $inputStream;
 
     /**
+     * @var int $statusCode
+     */
+    private $statusCode;
+
+    /**
      * @param Application $application
      */
     public function __construct(Application $application)
@@ -66,7 +71,9 @@ class ApplicationTester
             ->get('dialog')
             ->setInputStream($inputStream);
 
-        return $this->application->run($this->input, $this->output);
+        $this->statusCode = $this->application->run($this->input, $this->output);
+
+        return $this->statusCode;
     }
 
     /**
@@ -121,5 +128,13 @@ class ApplicationTester
         }
 
         return $this->inputStream;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
     }
 }

--- a/features/bootstrap/PhpSpecContext.php
+++ b/features/bootstrap/PhpSpecContext.php
@@ -136,6 +136,7 @@ class PhpSpecContext extends BehatContext
 
         expect($stats['examples'] > 0)->toBe(true);
         expect($stats['examples'])->toBe($stats['passed'] + $stats['skipped']);
+        expect($this->applicationTester->getStatusCode())->toBe(0);
     }
 
     /**

--- a/spec/PhpSpec/Console/ResultConverterSpec.php
+++ b/spec/PhpSpec/Console/ResultConverterSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace spec\PhpSpec\Console;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use PhpSpec\Event\ExampleEvent;
+
+class ResultConverterSpec extends ObjectBehavior
+{
+    function it_converts_passed_result_code_into_0()
+    {
+        $this->convert(ExampleEvent::PASSED)->shouldReturn(0);
+    }
+
+    function it_converts_skipped_result_code_into_0()
+    {
+        $this->convert(ExampleEvent::SKIPPED)->shouldReturn(0);
+    }
+
+    function it_converts_pending_result_code_into_1()
+    {
+        $this->convert(ExampleEvent::PENDING)->shouldReturn(1);
+    }
+
+    function it_converts_failed_result_code_into_1()
+    {
+        $this->convert(ExampleEvent::FAILED)->shouldReturn(1);
+    }
+
+    function it_converts_broken_result_code_into_1()
+    {
+        $this->convert(ExampleEvent::BROKEN)->shouldReturn(1);
+    }
+}

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -79,8 +79,10 @@ class Application extends BaseApplication
         foreach ($this->container->getByPrefix('console.commands') as $command) {
             $this->add($command);
         }
-        
-        return parent::doRun($input, $output);
+
+        return $this->container->get('console.result_converter')->convert(
+            parent::doRun($input, $output)
+        );
     }
 
     /**
@@ -129,6 +131,7 @@ class Application extends BaseApplication
         $this->setupFormatter($container);
         $this->setupRunner($container);
         $this->setupCommands($container);
+        $this->setupResultConverter($container);
 
         $this->loadConfigurationFile($container);
     }
@@ -141,6 +144,13 @@ class Application extends BaseApplication
                 $c->get('console.output'),
                 $c->get('console.helpers')
             );
+        });
+    }
+
+    protected function setupResultConverter(ServiceContainer $container)
+    {
+        $container->setShared('console.result_converter', function ($c) {
+            return new ResultConverter;
         });
     }
 

--- a/src/PhpSpec/Console/ResultConverter.php
+++ b/src/PhpSpec/Console/ResultConverter.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console;
+
+use PhpSpec\Event\ExampleEvent;
+
+/**
+ * Class ResultConverter converts Example result into exit code
+ */
+class ResultConverter
+{
+    /**
+     * Convert Example result into exit code
+     *
+     * @param mixed $result
+     *
+     * @return 0|1
+     */
+    public function convert($result)
+    {
+        switch ($result) {
+            case ExampleEvent::PASSED:
+            case ExampleEvent::SKIPPED:
+                return 0;
+        }
+
+        return 1;
+    }
+}


### PR DESCRIPTION
Skipping examples should not make the spec suite fail (which is the case today).

I've updated the behat step to actually check the application exit code. (Related issue: https://github.com/phpspec/phpspec/issues/315)
