### PR TITLE
Fix state matcher throwing method not found under hhvm for closures

### DIFF
--- a/spec/PhpSpec/Matcher/ObjectStateMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ObjectStateMatcherSpec.php
@@ -83,4 +83,11 @@ class ObjectStateMatcherSpec extends ObjectBehavior
         $this->shouldThrow('PhpSpec\Exception\Example\FailureException')
             ->duringPositiveMatch('haveProperty', $subject, array('other'));
     }
+
+    function it_does_not_match_if_subject_is_callable()
+    {
+        $subject = function() {};
+
+        $this->supports('beCallable', $subject, array())->shouldReturn(false);
+    }
 }

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -50,7 +50,7 @@ class ObjectStateMatcher implements MatcherInterface
      */
     public function supports($name, $subject, array $arguments)
     {
-        return is_object($subject)
+        return is_object($subject) && !is_callable($subject)
             && (0 === strpos($name, 'be') || 0 === strpos($name, 'have'))
         ;
     }


### PR DESCRIPTION
This patch fixes state matcher by checking if the subject is
a callable. Under hhvm, callables will pass the first condition
of support for state matcher, which causes the matcher to
attempt to call an isCallable method on the callable itself.

This is not the wanted behaviour, the beCallable should be picked
up for support by the scalar matcher, and this is not
happening because is_object returns true in the state matcher
under hhvm. With this patch this is no longer the case
and phpspec will work as expected under hhvm.
