### PR TITLE
Add option to generate final classes.

### DIFF
--- a/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
@@ -51,6 +51,7 @@ class ClassGeneratorSpec extends ObjectBehavior
             '%name%'            => 'App',
             '%namespace%'       => 'Acme',
             '%namespace_block%' => "\n\nnamespace Acme;",
+            '%final_mark%'      => '',
         );
 
         $tpl->render('class', $values)->willReturn(null);
@@ -77,6 +78,7 @@ class ClassGeneratorSpec extends ObjectBehavior
             '%name%'            => 'App',
             '%namespace%'       => 'Acme',
             '%namespace_block%' => "\n\nnamespace Acme;",
+            '%final_mark%'      => ''
         );
 
         $tpl->render('class', $values)->willReturn('template code');

--- a/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
@@ -56,6 +56,7 @@ class ClassGenerator extends PromptingGenerator implements GeneratorInterface
             '%namespace_block%' => '' !== $resource->getSrcNamespace()
                                 ?  sprintf("\n\nnamespace %s;", $resource->getSrcNamespace())
                                 : '',
+            '%final_mark%'      => $this->getOption('generator.final_classes') ? 'final ' : ''
         );
 
         if (!$content = $this->getTemplateRenderer()->render('class', $values)) {
@@ -101,6 +102,6 @@ class ClassGenerator extends PromptingGenerator implements GeneratorInterface
 }
 __halt_compiler();<?php%namespace_block%
 
-class %name%
+%final_mark%class %name%
 {
 }

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -34,15 +34,22 @@ abstract class PromptingGenerator
     private $filesystem;
 
     /**
+     * @var array
+     */
+    private $options;
+
+    /**
      * @param IO               $io
      * @param TemplateRenderer $templates
      * @param Filesystem       $filesystem
+     * @param array            $options
      */
-    public function __construct(IO $io, TemplateRenderer $templates, Filesystem $filesystem = null)
+    public function __construct(IO $io, TemplateRenderer $templates, Filesystem $filesystem = null, array $options = array())
     {
         $this->io         = $io;
         $this->templates  = $templates;
         $this->filesystem = $filesystem ?: new Filesystem;
+        $this->options    = $options;
     }
 
     /**
@@ -139,5 +146,15 @@ abstract class PromptingGenerator
 
         $this->filesystem->putFileContents($filepath, $content);
         $this->io->writeln($this->getGeneratedMessage($resource, $filepath));
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     */
+    protected function getOption($key)
+    {
+        return isset($this->options[$key]) ? $this->options[$key] : null;
     }
 }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -79,7 +79,7 @@ class Application extends BaseApplication
         foreach ($this->container->getByPrefix('console.commands') as $command) {
             $this->add($command);
         }
-        
+
         return parent::doRun($input, $output);
     }
 
@@ -218,9 +218,13 @@ class Application extends BaseApplication
             );
         });
         $container->set('code_generator.generators.class', function ($c) {
+            $generateFinalClasses = (bool) $c->getParam('generator.final_classes', false);
+
             return new CodeGenerator\Generator\ClassGenerator(
                 $c->get('console.io'),
-                $c->get('code_generator.templates')
+                $c->get('code_generator.templates'),
+                null,
+                array('generator.final_classes' => $generateFinalClasses)
             );
         });
         $container->set('code_generator.generators.method', function ($c) {


### PR DESCRIPTION
This PR expands on the one by @everzet (#313) by adding `final` class generation as an option.

By default, nothing changes and class generation will happen as it always has done. By adding the following to `phpspec.yml`, however, `final` classes will be generated:

``` yaml
generator.final_classes: true
```
