### PR TITLE
added optional psr4 prefix to configuration

### DIFF
--- a/features/bootstrap/PhpSpecContext.php
+++ b/features/bootstrap/PhpSpecContext.php
@@ -96,6 +96,14 @@ class PhpSpecContext extends BehatContext
     }
 
     /**
+     * @Given /^the config file contains:$/
+     */
+    public function theConfigFileContains(PyStringNode $string)
+    {
+        file_put_contents('phpspec.yml', $string->getRaw());
+    }
+
+    /**
      * @Then /^(?:|a )new spec should be generated in (?:|the )"(?P<file>[^"]*Spec.php)":$/
      * @Then /^(?:|a )new class should be generated in (?:|the )"(?P<file>[^"]+)":$/
      * @Then /^(?:|the )class in (?:|the )"(?P<file>[^"]+)" should contain:$/

--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -19,6 +19,28 @@ Feature: Developer generates a class
       """
 
     @issue269
+  Scenario: Generating a class with psr4 prefix
+    Given the config file contains:
+    """
+    suites:
+      behat_suite:
+        namespace: Behat\Tests\MyNamespace
+        psr4_prefix: Behat\Tests
+    """
+    And I have started describing the "Behat/Tests/MyNamespace/Markdown" class
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then a new class should be generated in the "src/MyNamespace/Markdown.php":
+    """
+    <?php
+
+    namespace Behat\Tests\MyNamespace;
+
+    class Markdown
+    {
+    }
+
+    """
+
   Scenario: Generating a class when expectations on collaborator are defined
     Given the spec file "spec/CodeGeneration/MethodExample2/ForgotPasswordSpec.php" contains:
     """

--- a/features/code_generation/developer_generates_method.feature
+++ b/features/code_generation/developer_generates_method.feature
@@ -50,3 +50,58 @@ Feature: Developer generates a method
       }
 
       """
+  Scenario: Generating a method in a class with psr4 prefix
+    Given the spec file "spec/Behat/Tests/MyNamespace/PrefixSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Behat\Tests\MyNamespace;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class PrefixSpec extends ObjectBehavior
+    {
+        function it_converts_plain_text_to_html_paragraphs()
+        {
+            $this->toHtml('Hi, there')->shouldReturn('<p>Hi, there</p>');
+        }
+    }
+
+    """
+    And the config file contains:
+    """
+    suites:
+      behat_suite:
+        namespace: Behat\Tests\MyNamespace
+        psr4_prefix: Behat\Tests
+    """
+
+    And the class file "src/MyNamespace/Prefix.php" contains:
+    """
+    <?php
+
+    namespace Behat\Tests\MyNamespace;
+
+    class Prefix
+    {
+    }
+
+    """
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then the class in "src/MyNamespace/Prefix.php" should contain:
+    """
+    <?php
+
+    namespace Behat\Tests\MyNamespace;
+
+    class Prefix
+    {
+
+        public function toHtml($argument1)
+        {
+            // TODO: write logic here
+        }
+    }
+
+    """

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -37,6 +37,15 @@ class PSR0LocatorSpec extends ObjectBehavior
         );
     }
 
+    function it_generates_fullSrcPath_from_srcPath_plus_namespace_cutting_psr4_prefix()
+    {
+        $this->beConstructedWith('psr4\prefix\Cust\Ns', 'spec', dirname(__DIR__), __DIR__, null, 'psr4\prefix');
+
+        $this->getFullSrcPath()->shouldReturn(
+            dirname(__DIR__).DIRECTORY_SEPARATOR.'Cust'.DIRECTORY_SEPARATOR.'Ns'.DIRECTORY_SEPARATOR
+        );
+    }
+
     function it_generates_proper_fullSrcPath_even_from_empty_namespace()
     {
         $this->beConstructedWith('', 'spec', dirname(__DIR__), __DIR__);
@@ -50,6 +59,15 @@ class PSR0LocatorSpec extends ObjectBehavior
 
         $this->getFullSpecPath()->shouldReturn(
             __DIR__.DIRECTORY_SEPARATOR.'spec'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'N'.DIRECTORY_SEPARATOR
+        );
+    }
+
+    function it_generates_fullSpecPath_from_specPath_plus_namespace_not_cutting_psr4_prefix()
+    {
+        $this->beConstructedWith('p\pf\C\N', 'spec', dirname(__DIR__), __DIR__, null, 'p\pf');
+
+        $this->getFullSpecPath()->shouldReturn(
+            __DIR__.DIRECTORY_SEPARATOR.'spec'.DIRECTORY_SEPARATOR.'p'.DIRECTORY_SEPARATOR.'pf'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'N'.DIRECTORY_SEPARATOR
         );
     }
 
@@ -381,6 +399,15 @@ class PSR0LocatorSpec extends ObjectBehavior
         );
 
         $this->shouldThrow($exception)->duringCreateResource('Namespace/');
+    }
+
+    function it_throws_an_exception_on_PSR4_prefix_not_matching_namespace()
+    {
+        $exception = new \InvalidArgumentException(
+            'PSR4 prefix doesn\'t match given class namespace.' . PHP_EOL
+        );
+
+        $this->shouldThrow($exception)->during('__construct', array('p\pf\N\S', 'spec', $this->srcPath, $this->specPath, null, 'wrong\prefix'));
     }
 
     private function convert_to_path($path)

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -302,6 +302,7 @@ class Application extends BaseApplication
                 $specPrefix = isset($suite['spec_prefix']) ? $suite['spec_prefix'] : 'spec';
                 $srcPath    = isset($suite['src_path']) ? $suite['src_path'] : 'src';
                 $specPath   = isset($suite['spec_path']) ? $suite['spec_path'] : '.';
+                $psr4prefix   = isset($suite['psr4_prefix']) ? $suite['psr4_prefix'] : null;
 
                 if (!is_dir($srcPath)) {
                     mkdir($srcPath, 0777, true);
@@ -311,8 +312,8 @@ class Application extends BaseApplication
                 }
 
                 $c->set(sprintf('locator.locators.%s_suite', $name),
-                    function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath) {
-                        return new Locator\PSR0\PSR0Locator($srcNS, $specPrefix, $srcPath, $specPath);
+                    function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath, $psr4prefix) {
+                        return new Locator\PSR0\PSR0Locator($srcNS, $specPrefix, $srcPath, $specPath, null, $psr4prefix);
                     }
                 );
             }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -62,7 +62,7 @@ class PSR0Locator implements ResourceLocatorInterface
      * @param Filesystem $filesystem
      */
     public function __construct($srcNamespace = '', $specNamespacePrefix = 'spec',
-                                $srcPath = 'src', $specPath = '.', Filesystem $filesystem = null)
+                                $srcPath = 'src', $specPath = '.', Filesystem $filesystem = null, $psr4Prefix = null)
     {
         $this->filesystem = $filesystem ?: new Filesystem;
         $sepr = DIRECTORY_SEPARATOR;
@@ -70,8 +70,13 @@ class PSR0Locator implements ResourceLocatorInterface
         $this->srcPath       = rtrim(realpath($srcPath), '/\\').$sepr;
         $this->specPath      = rtrim(realpath($specPath), '/\\').$sepr;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\').'\\', '\\');
+        $this->psr4Prefix    = (null === $psr4Prefix) ? null : ltrim(trim($psr4Prefix, ' \\').'\\', '\\');
+        if(null !== $this->psr4Prefix  && substr($this->srcNamespace, 0, strlen($psr4Prefix)) !== $psr4Prefix){
+            throw new InvalidArgumentException('PSR4 prefix doesn\'t match given class namespace.' . PHP_EOL);
+        }
+        $srcNamespacePath = null === $this->psr4Prefix ? $this->srcNamespace : substr($this->srcNamespace, strlen($this->psr4Prefix));
         $this->specNamespace = trim($specNamespacePrefix, ' \\').'\\'.$this->srcNamespace;
-        $this->fullSrcPath   = $this->srcPath.str_replace('\\', $sepr, $this->srcNamespace);
+        $this->fullSrcPath   = $this->srcPath.str_replace('\\', $sepr, $srcNamespacePath);
         $this->fullSpecPath  = $this->specPath.str_replace('\\', $sepr, $this->specNamespace);
 
         if ($sepr === $this->srcPath) {


### PR DESCRIPTION
Added optional ps4-prefix to the PSR0 Locator.

It is now possible to specify the prefix in your config like so:

```
suites:
  behat_suite:
    namespace: Behat\Tests\MyNamespace
    psr4_prefix: Behat\Tests
```

When creating and/or manipulating source files, phpspec will cut the prefix. It will be retained in the spec folder structure.

This is for example needed, if you want to develop for a composer library, that uses the new PSR4 autoloading mechanism and therefore hasn't all the namespace parts represented in its folder structure.
