### PR TITLE
Parse configuration using InputInterface passed to Application

### DIFF
--- a/spec/PhpSpec/Console/ApplicationSpec.php
+++ b/spec/PhpSpec/Console/ApplicationSpec.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace spec\PhpSpec\Console;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ApplicationSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('test');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('PhpSpec\Console\Application');
+    }
+}

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -75,6 +75,7 @@ class Application extends BaseApplication
         $this->container->set('console.helpers', $this->getHelperSet());
 
         $this->setupContainer($this->container);
+        $this->loadConfigurationFile($input, $this->container);
 
         foreach ($this->container->getByPrefix('console.commands') as $command) {
             $this->add($command);
@@ -130,7 +131,6 @@ class Application extends BaseApplication
         $this->setupRunner($container);
         $this->setupCommands($container);
 
-        $this->loadConfigurationFile($container);
     }
 
     protected function setupIO(ServiceContainer $container)
@@ -443,9 +443,9 @@ class Application extends BaseApplication
      *
      * @throws \RuntimeException
      */
-    protected function loadConfigurationFile(ServiceContainer $container)
+    protected function loadConfigurationFile(InputInterface $input, ServiceContainer $container)
     {
-        $config = $this->parseConfigurationFile();
+        $config = $this->parseConfigurationFile($input);
 
         foreach ($config as $key => $val) {
             if ('extensions' === $key && is_array($val)) {
@@ -472,11 +472,10 @@ class Application extends BaseApplication
     /**
      * @return array
      */
-    protected function parseConfigurationFile()
+    protected function parseConfigurationFile(InputInterface $input)
     {
         $paths = array('phpspec.yml','phpspec.yml.dist');
 
-        $input = new ArgvInput();
         if ($customPath = $input->getParameterOption(array('-c','--config'))) {
             if (!file_exists($customPath)) {
                 throw new FileNotFoundException('Custom configuration file not found at '.$customPath);


### PR DESCRIPTION
Currently the `Console\Application` retrieves a configuration file path from a newly create `ArgvInput`. If a customised `InputInterface` is passed to `Application::run`, any configuration file set is ignored. This commit uses the `InputInterface` passed to the application to load configuration.

Please advise on how best to test this! I'm new to PhpSpec and BDD. The existing specs and features run, though I can't see any specific to the `Application` class. The `loadConfigurationFile` and `parseConfigurationFile` methods are protected so I can't test them directly.

M
