### PR TITLE
Fix tests for PHP 5.6

### DIFF
--- a/spec/PhpSpec/Loader/SuiteSpec.php
+++ b/spec/PhpSpec/Loader/SuiteSpec.php
@@ -29,7 +29,8 @@ class SuiteSpec extends ObjectBehavior
         $this->addSpecification($spec);
         $this->addSpecification($spec);
 
-        $spec->count()->willReturn(5);
+        $spec->count(Argument::any())->willReturn(5);
+
         $this->count()->shouldReturn(15);
     }
 }


### PR DESCRIPTION
\Countable::count() is called with the optional $mode parameter starting from PHP 5.6.

See: http://www.php.net/manual/en/countable.count.php

Also, I just fixed a bug in the new feature implementation that was causing random segmentation faults:

https://bugs.php.net/bug.php?id=67433

The fix will be part of the next beta/rc release.
