### PR TITLE
Avoid rounding up to 100% when not all specs passed

### DIFF
--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -27,10 +27,13 @@ class ProgressFormatter extends BasicFormatter
         $counts = $stats->getCountsHash();
 
         $percents = array_map(function ($count) use ($total) {
-            return round($count / ($total / 100), 0);
+            $percent = $count / ($total / 100);
+            return $percent == 0 || $percent > 1 ? floor($percent) : 1;
         }, $counts);
         $lengths  = array_map(function ($percent) {
-            return round($percent / 2, 0);
+            $length = $percent / 2;
+            $res = $length == 0 || $length > 1 ? floor($length) : 1;
+            return $res;
         }, $percents);
 
         $size = 50;


### PR DESCRIPTION
The progress formatter can be a bit misleading. It shows 100% and fully green when something is broken/failed but there are enough specs that this is lost when rounding up.

![screen shot 2014-07-04 at 17 26 04](https://cloud.githubusercontent.com/assets/783827/3484030/f176ce16-039c-11e4-947a-47f899dda5c1.png)

This stops this happening by using floor instead of round and dealing with results between 0 and 1.
