### PR TITLE
Prevent circular dependency with disaptcher

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -70,6 +70,7 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
+        var_dump('do run');
         $this->container->set('console.input', $input);
         $this->container->set('console.output', $output);
         $this->container->set('console.helpers', $this->getHelperSet());
@@ -79,8 +80,6 @@ class Application extends BaseApplication
         foreach ($this->container->getByPrefix('console.commands') as $command) {
             $this->add($command);
         }
-
-        $this->addEventsToDispatcher();
         
         return parent::doRun($input, $output);
     }
@@ -133,8 +132,6 @@ class Application extends BaseApplication
         $this->setupCommands($container);
 
         $this->loadConfigurationFile($container);
-
-        $container->configure();
     }
 
     protected function setupIO(ServiceContainer $container)
@@ -368,7 +365,7 @@ class Application extends BaseApplication
             } catch (\InvalidArgumentException $e) {
                 throw new RuntimeException(sprintf('Formatter not recognised: "%s"', $formatterName));
             }
-
+var_dump('add formatter listener');
             $c->set('event_dispatcher.listeners.formatter', $formatter);
         });
     }
@@ -491,8 +488,10 @@ class Application extends BaseApplication
         return array();
     }
 
-    protected function addEventsToDispatcher()
+    public function configure()
     {
+        $this->container->configure();
+
         $dispatcher = $this->container->get('event_dispatcher');
         array_map(
             array($dispatcher, 'addSubscriber'),

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -60,7 +60,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $container = $this->getApplication()->getContainer();
-        $container->configure();
+        $this->getApplication()->configure();
 
         $classname = $input->getArgument('class');
         $resource  = $container->get('locator.resource_manager')->createResource($classname);

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -86,7 +86,7 @@ EOF
         $container->setParam('formatter.name',
             $input->getOption('format') ?: $container->getParam('formatter.name')
         );
-        $container->configure();
+        $this->getApplication()->configure();
 
         $locator = $input->getArgument('spec');
         $linenum = null;


### PR DESCRIPTION
Adding listeners to the dispatcher as it is instantiated creates a circular dependency whenever a listener (or one of its dependencies) also depends on the dispatcher. The issue is fixed by waiting until the container is fully populated to add listeners to the dispatcher.
