### PR TITLE
Fixes #389, `beConstructedThrough()` should unwrap arguments

### DIFF
--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -115,7 +115,8 @@ class WrappedObject
         }
 
         $this->factoryMethod = $factoryMethod;
-        $this->arguments = $arguments;
+        $unwrapper           = new Unwrapper;
+        $this->arguments     = $unwrapper->unwrapAll($arguments);
     }
 
     /**


### PR DESCRIPTION
I need a little more time to write a spec for this fix...
