### PR TITLE
Trigger an error when expected spec class is not found in file

### DIFF
--- a/features/bootstrap/PhpSpecContext.php
+++ b/features/bootstrap/PhpSpecContext.php
@@ -112,18 +112,21 @@ class PhpSpecContext implements Context
     }
 
     /**
-     * @Given /^(?:|the )(?:spec |class )file "(?P<file>[^"]+)" contains:$/
+     * @Given /^(?:|the )class file "(?P<file>[^"]+)" contains:$/
      */
     public function theFileContains($file, PyStringNode $string)
     {
-        $dirname = dirname($file);
-        if (!file_exists($dirname)) {
-            mkdir($dirname, 0777, true);
-        }
-
-        file_put_contents($file, $string->getRaw());
+        $this->writeTestFile($file, $string->getRaw());
 
         require_once($file);
+    }
+
+    /**
+     * @Given /^(?:|the )spec file "(?P<file>[^"]+)" contains:$/
+     */
+    public function theSpecFileContains($file, PyStringNode $string)
+    {
+        $this->writeTestFile($file, $string->getRaw());
     }
 
     /**
@@ -275,6 +278,20 @@ class PhpSpecContext implements Context
         $application->setAutoExit(false);
 
         return new ApplicationTester($application);
+    }
+
+    /**
+     * @param string $file
+     * @param string $content
+     */
+    private function writeTestFile($file, $content)
+    {
+        $dirname = dirname($file);
+        if (!file_exists($dirname)) {
+            mkdir($dirname, 0777, true);
+        }
+
+        file_put_contents($file, $content);
     }
 
     /**

--- a/features/construction/developer_specifies_object_construction.feature
+++ b/features/construction/developer_specifies_object_construction.feature
@@ -97,7 +97,7 @@ Feature: Developer specifies object construction
     Then the suite should pass
 
   Scenario: Default static constructor parameter is overridden in example
-    Given the spec file "spec/Runner/ConstructorExample3/ClassWith.php" contains:
+    Given the spec file "spec/Runner/ConstructorExample3/ClassWithConstructorSpec.php" contains:
       """
       <?php
 
@@ -334,7 +334,7 @@ Feature: Developer specifies object construction
     Then the suite should pass
 
     Scenario: Developer cannot redefine constructor parameters if object is already instantiated
-    Given the spec file "spec/Runner/ConstructorExample9/ClassWithConstructorSpec.php" contains:
+    Given the spec file "spec/Runner/ConstructorExample9/ClassConstructorSpec.php" contains:
     """
     <?php
 

--- a/features/loader/developer_loads_suite.feature
+++ b/features/loader/developer_loads_suite.feature
@@ -31,4 +31,4 @@ Feature: Developer loads suite
     """
 
     When I run phpspec
-    Then I should see "spec\Loader\SpecExample1\BadNameSpec was not defined."
+    Then I should see "spec\Loader\SpecExample1\IncorrectlyNamedSpec is a badly named spec"

--- a/spec/PhpSpec/Listener/WarningListenerSpec.php
+++ b/spec/PhpSpec/Listener/WarningListenerSpec.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace spec\PhpSpec\Listener;
+
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Console\IO;
+use PhpSpec\Event\SpecificationEvent;
+use PhpSpec\Loader\Node\SpecificationNode;
+use PhpSpec\Event\SuiteEvent;
+
+class WarningListenerSpec extends ObjectBehavior
+{
+    function let(IO $io)
+    {
+        $this->beConstructedWith($io);
+    }
+
+    function it_subscribes_to_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn(
+            array(
+                'afterSpecification'  => array('afterSpecification', -10),
+                'afterSuite'          => array('afterSuite', -10),
+            )
+        );
+    }
+
+    function it_outputs_warnings_after_suite_has_run(
+        $io,
+        SpecificationEvent $specEvent,
+        SpecificationNode $node,
+        SuiteEvent $suiteEvent
+    ) {
+        $node->getWarnings()->willReturn(array('warning 1', 'warning 2'));
+        $specEvent->getSpecification()->willReturn($node);
+        $this->afterSpecification($specEvent);
+
+        $this->afterSuite($suiteEvent);
+
+        $io->writeln('Warning: warning 1')->shouldHaveBeenCalled();
+        $io->writeln('Warning: warning 2')->shouldHaveBeenCalled();
+    }
+}

--- a/spec/PhpSpec/Loader/Node/SpecificationNodeSpec.php
+++ b/spec/PhpSpec/Loader/Node/SpecificationNodeSpec.php
@@ -62,4 +62,12 @@ class SpecificationNodeSpec extends ObjectBehavior
 
         $this->count()->shouldReturn(3);
     }
+
+    function it_stores_warning_messages()
+    {
+        $this->addWarning('warning 1');
+        $this->addWarning('warning 2');
+
+        $this->getWarnings()->shouldReturn(array('warning 1', 'warning 2'));
+    }
 }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -142,6 +142,11 @@ class ContainerAssembler
                 $c->get('util.method_analyser')
             );
         });
+        $container->setShared('event_dispatcher.listeners.warning', function (ServiceContainer $c) {
+            return new Listener\WarningListener(
+                $c->get('console.io')
+            );
+        });
         $container->setShared('util.method_analyser', function(){
             return new MethodAnalyser();
         });

--- a/src/PhpSpec/Listener/WarningListener.php
+++ b/src/PhpSpec/Listener/WarningListener.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Listener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use PhpSpec\Console\IO;
+use PhpSpec\Locator\ResourceManager;
+use PhpSpec\CodeGenerator\GeneratorManager;
+
+use PhpSpec\Event\SpecificationEvent;
+use PhpSpec\Event\SuiteEvent;
+
+class WarningListener implements EventSubscriberInterface
+{
+    /**
+     * @var \PhpSpec\Console\IO
+     */
+    private $io;
+
+    /**
+     * @var string
+     */
+    private $warnings = array();
+
+    public function __construct(IO $io)
+    {
+        $this->io = $io;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'afterSpecification'  => array('afterSpecification', -10),
+            'afterSuite'          => array('afterSuite', -10),
+        );
+    }
+
+    public function afterSpecification(SpecificationEvent $event)
+    {
+        $this->warnings = array_merge(
+            $this->warnings,
+            $event->getSpecification()->getWarnings()
+        );
+    }
+
+    public function afterSuite(SuiteEvent $event)
+    {
+        foreach ($this->warnings as $warning) {
+            $this->io->writeln('Warning: ' . $warning);
+        }
+    }
+}

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -39,6 +39,10 @@ class SpecificationNode implements \Countable
      * @var ExampleNode[]
      */
     private $examples = array();
+    /**
+     * @var string[]
+     */
+    private $warnings = array();
 
     /**
      * @param string            $title
@@ -115,5 +119,21 @@ class SpecificationNode implements \Countable
     public function count()
     {
         return count($this->examples);
+    }
+
+    /**
+     * @param string $warning
+     */
+    public function addWarning($warning)
+    {
+        $this->warnings[] = $warning;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWarnings()
+    {
+        return $this->warnings;
     }
 }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -321,7 +321,7 @@ class PSR0Locator implements ResourceLocatorInterface
         $classname = preg_replace('/Spec$/', '', $classname);
 
         // Create the resource
-        return new PSR0Resource(explode('\\', $classname), $this);
+        return new PSR0Resource(explode('\\', $classname), $this, $path);
     }
 
     private function validatePsr0Classname($classname)

--- a/src/PhpSpec/Locator/PSR0/PSR0Resource.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Resource.php
@@ -21,19 +21,27 @@ class PSR0Resource implements ResourceInterface
      * @var array
      */
     private $parts;
+
     /**
      * @var PSR0Locator
      */
     private $locator;
 
     /**
+     * @var string
+     */
+    private $specFile;
+
+    /**
      * @param array       $parts
      * @param PSR0Locator $locator
+     * @param string      $specFile
      */
-    public function __construct(array $parts, PSR0Locator $locator)
+    public function __construct(array $parts, PSR0Locator $locator, $specFile = null)
     {
-        $this->parts   = $parts;
-        $this->locator = $locator;
+        $this->parts    = $parts;
+        $this->locator  = $locator;
+        $this->specFile = $specFile;
     }
 
     /**
@@ -88,6 +96,10 @@ class PSR0Resource implements ResourceInterface
      */
     public function getSpecFilename()
     {
+        if ($this->specFile) {
+            return $this->specFile;
+        }
+
         $nsParts   = $this->parts;
         $classname = array_pop($nsParts);
         $parts     = array_merge($nsParts, explode('_', $classname));


### PR DESCRIPTION
fixes #354

First phpspec PR, please be gentle!

I have often come across this issue when renaming/moving a spec file and forgetting to update the classname/namespace inside.

I'm not sure throwing an exception is the correct thing to do here, if there is a more appropriate way to handle this a nudge in the right direction would be muchly appreciated.
