### PR TITLE
Travis hhvm fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php: [5.3.3, 5.3, 5.4, 5.5, 5.6, hhvm, hhvm-nightly]
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php: hhvm-nightly
 
 before_script:
   - composer selfupdate

--- a/src/PhpSpec/Matcher/ArrayKeyMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyMatcher.php
@@ -61,7 +61,13 @@ class ArrayKeyMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments)
     {
-        return isset($subject[$arguments[0]]) || array_key_exists($arguments[0], $subject);
+        $key = $arguments[0];
+
+        if ($subject instanceof ArrayAccess) {
+            return $subject->offsetExists($key);
+        }
+
+        return isset($subject[$key]) || array_key_exists($arguments[0], $subject);
     }
 
     /**


### PR DESCRIPTION
- Removed hhvm-nightly as a build target, as it's too unstable
- Resolved issue with ArrayObject test (@stof pointed out it was probably incorrect for ArrayAccess objects anyhow) so that hhvm build passes
- Moved  hhvm out of allowed_failure now that it's passing
