### PR TITLE
Removed hhvm-nightly from allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: php
 
 php: [5.3.3, 5.3, 5.4, 5.5, 5.6, hhvm, hhvm-nightly]
 
-matrix:
-  allow_failures:
-    - php: hhvm-nightly
-
 before_script:
   - composer selfupdate
   - export COMPOSER_ROOT_VERSION=2.0.0-RC3


### PR DESCRIPTION
We don't need this anymore, do we?
