### PR TITLE
Added back the use statement that was removed in efb5686.

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -32,6 +32,8 @@ use PhpSpec\Runner;
 use PhpSpec\CodeGenerator;
 use PhpSpec\Wrapper;
 
+use RuntimeException;
+
 /**
  * The command line application entry point
  */
@@ -339,6 +341,8 @@ class Application extends BaseApplication
 
     /**
      * @param ServiceContainer $container
+     *
+     * @throws \RuntimeException
      */
     protected function setupFormatter(ServiceContainer $container)
     {
@@ -479,6 +483,8 @@ class Application extends BaseApplication
 
     /**
      * @return array
+     *
+     * @throws \RuntimeException
      */
     protected function parseConfigurationFile(InputInterface $input)
     {
@@ -486,7 +492,7 @@ class Application extends BaseApplication
 
         if ($customPath = $input->getParameterOption(array('-c','--config'))) {
             if (!file_exists($customPath)) {
-                throw new \RuntimeException('Custom configuration file not found at '.$customPath);
+                throw new RuntimeException('Custom configuration file not found at '.$customPath);
             }
             $paths = array($customPath);
         }


### PR DESCRIPTION
This was removed, but is actually needed for other exceptions in `PhpSpec\Console\Application`.

Also added some missing `@throws` annotations.
