### PR TITLE
Avoid autoloader false positives.

### DIFF
--- a/bin/phpspec
+++ b/bin/phpspec
@@ -7,10 +7,10 @@ if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
     require $autoload;
 }
 
-if (is_dir($vendor = __DIR__ . '/../vendor')) {
-    require($vendor . '/autoload.php');
-} elseif (is_dir($vendor = __DIR__ . '/../../..')) {
-    require($vendor . '/autoload.php');
+if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
+    require($autoload);
+} elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
+    require($autoload);
 } else {
     die(
         'You must set up the project dependencies, run the following commands:' . PHP_EOL .


### PR DESCRIPTION
Since it's not unlikely that `../../..` is a directory, we should also test
that the `autoload.php` file exists before we try to include it.
