### PR TITLE
Moving code generation templates into separate files

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -15,4 +15,3 @@ filter:
   excluded_paths:
     - docs/*
     - vendor/*
-    - src/PhpSpec/CodeGenerator/Generator/*Generator.php # fatal bug in analyzer

--- a/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
@@ -72,7 +72,7 @@ class ClassGenerator extends PromptingGenerator implements GeneratorInterface
      */
     protected function getTemplate()
     {
-        return file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__);
+        return file_get_contents(__DIR__ . '/templates/class.template');
     }
 
     /**
@@ -98,9 +98,4 @@ class ClassGenerator extends PromptingGenerator implements GeneratorInterface
             $resource->getSrcClassname(), $filepath
         );
     }
-}
-__halt_compiler();<?php%namespace_block%
-
-class %name%
-{
 }

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -107,11 +107,6 @@ class MethodGenerator implements GeneratorInterface
      */
     protected function getTemplate()
     {
-        return file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__);
+        return file_get_contents(__DIR__ . '/templates/method.template');
     }
 }
-__halt_compiler();
-    public function %name%(%arguments%)
-    {
-        // TODO: write logic here
-    }

--- a/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
@@ -68,7 +68,7 @@ class SpecificationGenerator extends PromptingGenerator implements GeneratorInte
      */
     protected function getTemplate()
     {
-        return file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__);
+        return file_get_contents(__DIR__ . '/templates/specification.template');
     }
 
     /**
@@ -92,19 +92,5 @@ class SpecificationGenerator extends PromptingGenerator implements GeneratorInte
             "<info>Specification for <value>%s</value> created in <value>%s</value>.</info>\n",
             $resource->getSrcClassname(), $filepath
         );
-    }
-}
-__halt_compiler();<?php
-
-namespace %namespace%;
-
-use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-
-class %name% extends ObjectBehavior
-{
-    function it_is_initializable()
-    {
-        $this->shouldHaveType('%subject%');
     }
 }

--- a/src/PhpSpec/CodeGenerator/Generator/templates/class.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/class.template
@@ -1,0 +1,5 @@
+<?php%namespace_block%
+
+class %name%
+{
+}

--- a/src/PhpSpec/CodeGenerator/Generator/templates/method.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/method.template
@@ -1,0 +1,5 @@
+
+    public function %name%(%arguments%)
+    {
+        // TODO: write logic here
+    }

--- a/src/PhpSpec/CodeGenerator/Generator/templates/specification.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/specification.template
@@ -1,0 +1,14 @@
+<?php
+
+namespace %namespace%;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class %name% extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('%subject%');
+    }
+}


### PR DESCRIPTION
This is a neat trick, but it confuses IDEs and code inspection tools alike. There doesn't seem to be any drawback to having separate template files that I can think of.
