### PR TITLE
Fixed the check of the IO verbosity

### DIFF
--- a/src/PhpSpec/Console/IO.php
+++ b/src/PhpSpec/Console/IO.php
@@ -112,7 +112,7 @@ class IO implements IOInterface
      */
     public function isVerbose()
     {
-        return OutputInterface::VERBOSITY_VERBOSE === $this->output->getVerbosity();
+        return OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity();
     }
 
     /**


### PR DESCRIPTION
Symfony Console 2.3+ supports setting higher verbosity levels than VERBOSE so the isVerbose implementation needs to use an inequality rather than an equality for the condition.

Note that running `phpspec run -v` or `phpspec run -vv` or `phpspec run -vvv` will always give you the same output (after this change), because PhpSpec does not take advantage of the extra verbosity levels to add more output.

Before this change, `phpspec run -vv` or `phpspec run -vvv` would display the non-verbose output (too much verbosity kills the verbosity)
