### PR TITLE
Fixed duplicate function parameters

### DIFF
--- a/spec/PhpSpec/Runner/ExampleRunnerSpec.php
+++ b/spec/PhpSpec/Runner/ExampleRunnerSpec.php
@@ -115,7 +115,7 @@ class ExampleRunnerSpec extends ObjectBehavior
 
     function it_runs_let_and_letgo_maintainer_before_and_after_each_example_if_the_example_throws_an_exception(
         ExampleNode $example, SpecificationNode $specification, ReflectionClass $specReflection,
-        $context, ReflectionMethod $exampReflection, LetAndLetgoMaintainer $maintainer,
+        ReflectionMethod $exampReflection, LetAndLetgoMaintainer $maintainer,
         SpecificationInterface $context
     )
     {


### PR DESCRIPTION
The $context parameter appears twice (and is used only once). PHP7 doesn't allow that anymore, but in any case, this looks like a bug to me.
