### PR TITLE
Throw an exception on redefined object instantiation

### DIFF
--- a/features/construction/developer_specifies_object_construction.feature
+++ b/features/construction/developer_specifies_object_construction.feature
@@ -332,3 +332,105 @@ Feature: Developer specifies object construction
     """
     When I run phpspec
     Then the suite should pass
+
+    Scenario: Developer cannot redefine constructor parameters if object is already instantiated
+    Given the spec file "spec/Runner/ConstructorExample9/ClassWithConstructorSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Runner\ConstructorExample9;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class ClassConstructorSpec extends ObjectBehavior
+    {
+        function it_behaves_differently_depending_on_type()
+        {
+            $this->beConstructedWith('foo');
+            $this->getType()->shouldReturn('foo');
+
+            $this->beConstructedWith('bar');
+            $this->getType()->shouldReturn('bar');
+        }
+    }
+
+    """
+    And the class file "src/Runner/ConstructorExample9/ClassConstructor.php" contains:
+    """
+    <?php
+
+    namespace Runner\ConstructorExample9;
+
+    class ClassConstructor
+    {
+        public function __construct($type)
+        {
+            $this->type = $type;
+        }
+
+        public function getType()
+        {
+            return $this->type;
+        }
+    }
+
+    """
+    When I run phpspec
+    Then I should see "you can not change object construction method when it is already instantiated"
+
+  Scenario: Developer cannot redefine factory method if object is already instantiated
+    Given the spec file "spec/Runner/ConstructorExample10/ClassWithFactoryMethodSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Runner\ConstructorExample10;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class ClassWithFactoryMethodSpec extends ObjectBehavior
+    {
+        function it_behaves_differently_depending_on_type()
+        {
+            $this->beConstructedThrough('createFoo');
+            $this->getType()->shouldReturn('foo');
+
+            $this->beConstructedWith('createBar');
+            $this->getType()->shouldReturn('bar');
+        }
+    }
+
+    """
+    And the class file "src/Runner/ConstructorExample10/ClassWithFactoryMethod.php" contains:
+    """
+    <?php
+
+    namespace Runner\ConstructorExample10;
+
+    class ClassWithFactoryMethod
+    {
+        private function __construct($type)
+        {
+            $this->type = $type;
+        }
+
+        public function getType()
+        {
+            return $this->type;
+        }
+
+        public static function createFoo()
+        {
+            return new self('foo');
+        }
+
+        public static function createBar()
+        {
+            return new self('bar');
+        }
+    }
+
+    """
+    When I run phpspec
+    Then I should see "you can not change object construction method when it is already instantiated"

--- a/spec/PhpSpec/Wrapper/Subject/WrappedObjectSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/WrappedObjectSpec.php
@@ -59,4 +59,43 @@ class WrappedObjectSpec extends ObjectBehavior
         $message = 'The method \DateTimeZone::listAbbreviations did not return an object, returned array instead';
         $this->shouldThrow(new FactoryDoesNotReturnObjectException($message))->duringInstantiate();
     }
+
+    function it_throws_an_exception_when_trying_to_change_constructor_params_after_instantiation()
+    {
+        $this->callOnWrappedObject('beAnInstanceOf', array('\DateTime'));
+
+        $this->callOnWrappedObject('beConstructedWith', array(array('now')));
+        $this->callOnWrappedObject('instantiate', array());
+        $this->shouldThrow('PhpSpec\Exception\Wrapper\SubjectException')->duringBeConstructedWith('tomorrow');
+    }
+
+    function it_throws_an_exception_when_trying_to_change_factory_method_after_instantiation()
+    {
+        $this->callOnWrappedObject('beAnInstanceOf', array('\DateTime'));
+
+        $this->callOnWrappedObject('beConstructedThrough', array('createFromFormat',array('d-m-Y', '01-01-1980')));
+        $this->callOnWrappedObject('instantiate', array());
+        $this->shouldThrow('PhpSpec\Exception\Wrapper\SubjectException')
+            ->duringBeConstructedThrough(array('createFromFormat',array('d-m-Y', '01-01-1970')));
+    }
+
+    function it_throws_an_exception_when_trying_to_change_from_constructor_to_factory_method_after_instantiation()
+    {
+        $this->callOnWrappedObject('beAnInstanceOf', array('\DateTime'));
+
+        $this->callOnWrappedObject('beConstructedWith', array(array('now')));
+        $this->callOnWrappedObject('instantiate', array());
+        $this->shouldThrow('PhpSpec\Exception\Wrapper\SubjectException')
+            ->duringBeConstructedThrough(array('createFromFormat',array('d-m-Y', '01-01-1970')));
+    }
+
+    function it_throws_an_exception_when_trying_to_change_from_factory_method_to_constructor_after_instantiation()
+    {
+        $this->callOnWrappedObject('beAnInstanceOf', array('\DateTime'));
+
+        $this->callOnWrappedObject('beConstructedThrough', array('createFromFormat',array('d-m-Y', '01-01-1980')));
+        $this->callOnWrappedObject('instantiate', array());
+        $this->shouldThrow('PhpSpec\Exception\Wrapper\SubjectException')->duringBeConstructedWith('tomorrow');
+    }
+
 }

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -99,6 +99,10 @@ class WrappedObject
             ));
         }
 
+        if ($this->isInstantiated()) {
+            throw new SubjectException('You can not change object construction method when it is already instantiated');
+        }
+
         $this->beAnInstanceOf($this->classname, $args);
     }
 
@@ -114,6 +118,10 @@ class WrappedObject
             method_exists($this->classname, $factoryMethod)
         ) {
             $factoryMethod = array($this->classname, $factoryMethod);
+        }
+
+        if ($this->isInstantiated()) {
+            throw new SubjectException('You can not change object construction method when it is already instantiated');
         }
 
         $this->factoryMethod = $factoryMethod;


### PR DESCRIPTION
If an object has already been instantiated, there should be an exception when a developer tries to redefine the instantiation method.

Before this PR, redefinitions of this type are silently ignored leading to unexpected behaviour.

This conflicts with #340 - here I am throwing an exception, in the other PR we are un-instantiating the object. Discussion of why I think this is a better approach can be found on that PR.

This closes #340 and #288 
