### PR TITLE
Turn off duplication checks in specs

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,6 +11,10 @@ tools:
     filter:
       excluded-paths: [ spec/* ]
 
+  php_sim:
+    filter:
+      excluded-paths: [ spec/* ]
+
 filter:
   excluded_paths:
     - docs/*


### PR DESCRIPTION
Some specs are deliberately repetitive, so this makes no sense to have turned on. It also makes it harder to see real duplication issues inside the src.
