### PR TITLE
Only convert test suite result code into valid exit code

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -70,9 +70,7 @@ class Application extends BaseApplication
             $this->add($command);
         }
 
-        return $this->container->get('console.result_converter')->convert(
-            parent::doRun($input, $output)
-        );
+        return parent::doRun($input, $output);
     }
 
     /**

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -97,6 +97,8 @@ EOF
         $suite       = $container->get('loader.resource_loader')->load($locator, $linenum);
         $suiteRunner = $container->get('runner.suite');
 
-        return $suiteRunner->run($suite);
+        return $container->get('console.result_converter')->convert(
+            $suiteRunner->run($suite)
+        );
     }
 }


### PR DESCRIPTION
As stated in
https://github.com/phpspec/phpspec/pull/317/files#r16391975,
only the RunCommand requires to convert result code.
