### PR TITLE
Check arguments for custom config

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -477,7 +477,7 @@ class Application extends BaseApplication
     {
         $paths = array('phpspec.yml','phpspec.yml.dist');
 
-        $input = new ArgvInput();
+        $input = $this->container->get('console.input');
         if ($customPath = $input->getParameterOption(array('-c','--config'))) {
             if (!file_exists($customPath)) {
                 throw new FileNotFoundException('Custom configuration file not found at '.$customPath);


### PR DESCRIPTION
It seems like at the moment specifying a custom config path is ignored because when the check for a custom config file is made it checks against a new, empty argument object instead of the one the application was instantiated with.
