### PR TITLE
Filter resources for duplicate specs

### DIFF
--- a/spec/PhpSpec/Locator/ResourceManagerSpec.php
+++ b/spec/PhpSpec/Locator/ResourceManagerSpec.php
@@ -27,6 +27,10 @@ class ResourceManagerSpec extends ObjectBehavior
         $locator2->supportsQuery('s:query')->willReturn(true);
         $locator2->findResources('s:query')->willReturn(array($resource1));
 
+        $resource1->getSpecClassname()->willReturn('Some\Spec1');
+        $resource2->getSpecClassname()->willReturn('Some\Spec2');
+        $resource3->getSpecClassname()->willReturn('Some\Spec3');
+
         $this->locateResources('s:query')->shouldReturn(array($resource1, $resource3, $resource2));
     }
 
@@ -39,6 +43,10 @@ class ResourceManagerSpec extends ObjectBehavior
 
         $locator1->getAllResources()->willReturn(array($resource3, $resource2));
         $locator2->getAllResources()->willReturn(array($resource1));
+
+        $resource1->getSpecClassname()->willReturn('Some\Spec1');
+        $resource2->getSpecClassname()->willReturn('Some\Spec2');
+        $resource3->getSpecClassname()->willReturn('Some\Spec3');
 
         $this->locateResources('')->shouldReturn(array($resource1, $resource3, $resource2));
     }
@@ -75,5 +83,40 @@ class ResourceManagerSpec extends ObjectBehavior
         $locator1->supportsClass('Some\Class')->willReturn(false);
 
         $this->shouldThrow('RuntimeException')->duringCreateResource('Some\Class');
+    }
+
+    function it_does_not_allow_two_resources_for_the_same_spec(
+        $locator1, $locator2, ResourceInterface $resource1, ResourceInterface $resource2
+    )
+    {
+        $this->registerLocator($locator1);
+        $this->registerLocator($locator2);
+
+        $resource1->getSpecClassname()->willReturn('Some\Spec');
+        $resource2->getSpecClassname()->willReturn('Some\Spec');
+
+        $locator1->getAllResources()->willReturn(array($resource1));
+        $locator2->getAllResources()->willReturn(array($resource2));
+
+        $this->locateResources('')->shouldReturn(array($resource2));
+    }
+
+    function it_uses_the_resource_from_the_highest_priority_locator_when_duplicates_occur(
+        $locator1, $locator2, ResourceInterface $resource1, ResourceInterface $resource2
+    )
+    {
+        $locator1->getPriority()->willReturn(2);
+        $locator2->getPriority()->willReturn(1);
+
+        $this->registerLocator($locator1);
+        $this->registerLocator($locator2);
+
+        $resource1->getSpecClassname()->willReturn('Some\Spec');
+        $resource2->getSpecClassname()->willReturn('Some\Spec');
+
+        $locator1->getAllResources()->willReturn(array($resource1));
+        $locator2->getAllResources()->willReturn(array($resource2));
+
+        $this->locateResources('')->shouldReturn(array($resource1));
     }
 }

--- a/src/PhpSpec/Locator/ResourceManager.php
+++ b/src/PhpSpec/Locator/ResourceManager.php
@@ -59,7 +59,7 @@ class ResourceManager implements ResourceManagerInterface
             $resources = array_merge($resources, $locator->findResources($query));
         }
 
-        return array_values($resources);
+        return $this->removeDuplicateResources($resources);
     }
 
     /**
@@ -80,5 +80,23 @@ class ResourceManager implements ResourceManagerInterface
         throw new RuntimeException(sprintf(
             'Can not find appropriate suite scope for class `%s`.', $classname
         ));
+    }
+
+    /**
+     * @param array $resources
+     *
+     * @return ResourceInterface[]
+     */
+    private function removeDuplicateResources(array $resources)
+    {
+        $filteredResources = array();
+
+        foreach ($resources as $resource) {
+            if (!array_key_exists($resource->getSpecClassname(), $filteredResources)) {
+                $filteredResources[$resource->getSpecClassname()] = $resource;
+            }
+        }
+
+        return array_values($filteredResources);
     }
 }


### PR DESCRIPTION
As suggested by @ciaranmcnulty, this PR filters the array of Resources returned by the ResourceManager to remove Resources that are targeting the same spec. When a duplicate is found the decision of which one to keep is made based on the priority of the Resource's Locator.

The requirement for this has arisen from https://github.com/MageTest/MageSpec/issues/70, when we started to see that the PSR0Locator has started matching Zend namespaced specs that were previously only handled by the Magento specific Locators.
