### PR TITLE
Global install + running in a vendor subdir

### DIFF
--- a/bin/phpspec
+++ b/bin/phpspec
@@ -5,6 +5,8 @@ define('PHPSPEC_VERSION', '2.1-dev');
 
 if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
     require $autoload;
+} elseif (is_file($autoload = getcwd() . '/../../autoload.php')) {
+    require $autoload;
 }
 
 if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {


### PR DESCRIPTION
My situation:
- I installed PhpSpec globally (`composer global require phpspec/phpspec`).
- I have a project that I want to write specs for. This contains all the domain-specific classes, but not the HTTP layer. Therefore I have my classes under test in the vendor/A/B/ directory (which is where I want to run phpspec), with all the dependencies available through vendor/autoload.php.

This means when running phpspec globally, it should check for an autoload.php file two levels up, too. Just as it does for local installs. Which is what I did here. =)
