### PR TITLE
Fix typos, syntax and replace is_decimal with is_float.

### DIFF
--- a/docs/cookbook/console.rst
+++ b/docs/cookbook/console.rst
@@ -5,7 +5,7 @@ The phpspec console command uses Symfony's console component. This means
 that it inherits the `default Symfony console command and options <http://symfony.com/doc/current/components/console/usage.html>`_.
 
 **phpspec** has an additional global option to let you specify a config file
-other then `phpspec.yml` or `phpspec.yml.dist`:
+other than `phpspec.yml` or `phpspec.yml.dist`:
 
 .. code-block:: bash
 
@@ -58,14 +58,14 @@ The run command runs the specs:
 
     $ php bin/phpspec run
 
- Will run all the specs in the `spec` directory.
+Will run all the specs in the `spec` directory.
 
 .. code-block:: bash
 
     $ php bin/phpspec run spec/ClassNameSpec.php
 
- Will run only the ClassNameSpec. You can run just the specs in a directory
- with:
+Will run only the ClassNameSpec. You can run just the specs in a directory
+with:
 
 .. code-block:: bash
 

--- a/docs/cookbook/matchers.rst
+++ b/docs/cookbook/matchers.rst
@@ -241,7 +241,7 @@ Scalar Matcher
 
 To specify that the value returned by a method should be a specific primitive
 type you can use the Scalar matcher. It's like using one of the ``is_*`` functions,
-e.g, ``is_bool``, ``is_integer``, ``is_decimal``, etc.
+e.g, ``is_bool``, ``is_integer``, ``is_float``, etc.
 
 .. code-block:: php
 

--- a/docs/cookbook/templates.rst
+++ b/docs/cookbook/templates.rst
@@ -39,7 +39,7 @@ You can copy the contents of the default template found in **phpspec** at
     }
 
 So now, for example, you want to describe a class ``Acme\Model\Foo`` which does not exist. You can run
-the spec``spec/Acme/Model/FooSpec.php``` and let **phpspec** generate the missing class.
+the spec ``spec/Acme/Model/FooSpec.php`` and let **phpspec** generate the missing class.
 **phpspec** will use your overridden template and the generated file will look like:
 
 .. code-block:: php

--- a/docs/manual/prophet-objects.rst
+++ b/docs/manual/prophet-objects.rst
@@ -22,8 +22,8 @@ you can have different implementations for different types of source.
 
 You want to describe a method which has an instance of a `Reader` as an
 argument. It will call ``Markdown\Reader::getMarkdown()`` to get the markdown
-to format. You have not you written any implementations of Reader to pass
-into the method though. You do want to get distracted by creating an implementation
+to format. You have not yet written any implementations of Reader to pass
+into the method though. You do not want to get distracted by creating an implementation
 before you can carry on writing the parser. Instead we can create a fake
 version of Reader called a stub and tell **phpspec** what ``Markdown\Reader::getMarkdown()``
 should return.
@@ -136,13 +136,13 @@ of just returning the formatted text. Again you create an interface:
         public function writeText($text);
     }
 
-You again pass it to to the method but this time the ``Markdown\Writer::writeText($text)``
+You again pass it to the method but this time the ``Markdown\Writer::writeText($text)``
 method does not return something to your parser class. The new method you
 are going to create on the parser will not return anything either. Instead
 it is going to give the formatted text to the `Markdown\Writer` so you want
 to be able to give an example of what that formatted text should be. You
 can do this using a mock, the mock gets created in the same way as the stub.
-This this time you tell it to expect ``Markdown\Writer::writeText($text)``
+This time you tell it to expect ``Markdown\Writer::writeText($text)``
 to get called with a particular value:
 
 .. code-block:: php


### PR DESCRIPTION
Corrected some minor typos and altered some reStructuredText syntax.
Under the matchers section, `is_decimal` is not a valid function so have replaced it with `is_float`.
