### PR TITLE
Allow StringPresenter::presentCallback() to work with static classes

### DIFF
--- a/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
@@ -67,6 +67,14 @@ class StringPresenterSpec extends ObjectBehavior
             ->shouldReturn('[date()]');
     }
 
+
+    function it_presents_invokable_object_as_string(WithMagicInvoke $object)
+    {
+        $className = get_class($object->getWrappedObject());
+        $this->presentValue($object)
+            ->shouldReturn(sprintf('[obj:%s]', $className));
+    }
+
     function it_presents_string_as_string()
     {
         $this->presentString('some string')->shouldReturn('some string');
@@ -77,5 +85,12 @@ class StringPresenterSpec extends ObjectBehavior
         $invokable = new ObjectBehavior();
         $invokable->setSpecificationSubject($this);
         $this->presentValue($invokable)->shouldReturn('[obj:PhpSpec\Formatter\Presenter\StringPresenter]');
+    }
+}
+
+class WithMagicInvoke
+{
+    function __invoke()
+    {
     }
 }

--- a/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
@@ -67,6 +67,33 @@ class StringPresenterSpec extends ObjectBehavior
             ->shouldReturn('[date()]');
     }
 
+    function it_presents_method_as_string(WithMethod $object)
+    {
+        $className = get_class($object->getWrappedObject());
+        $this->presentValue(array($object, 'specMethod'))
+            ->shouldReturn(sprintf('[obj:%s]::specMethod()', $className));
+    }
+
+    function it_presents_magic_method_as_string(WithMagicCall $object)
+    {
+        $className = get_class($object->getWrappedObject());
+        $this->presentValue(array($object, 'undefinedMethod'))
+            ->shouldReturn(sprintf('[obj:%s]::undefinedMethod()', $className));
+    }
+
+    function it_presents_static_method_as_string(WithMethod $object)
+    {
+        $className = get_class($object->getWrappedObject());
+        $this->presentValue(array($className, 'specMethod'))
+            ->shouldReturn(sprintf('%s::specMethod()', $className));
+    }
+
+    function it_presents_static_magic_method_as_string(WithStaticMagicCall $object)
+    {
+        $className = get_class($object->getWrappedObject());
+        $this->presentValue(array($className, 'undefinedMethod'))
+            ->shouldReturn(sprintf('%s::undefinedMethod()', $className));
+    }
 
     function it_presents_invokable_object_as_string(WithMagicInvoke $object)
     {
@@ -88,9 +115,37 @@ class StringPresenterSpec extends ObjectBehavior
     }
 }
 
+class WithMethod
+{
+    function specMethod()
+    {
+    }
+}
+
+class WithStaticMethod
+{
+    function specMethod()
+    {
+    }
+}
+
 class WithMagicInvoke
 {
     function __invoke()
+    {
+    }
+}
+
+class WithStaticMagicCall
+{
+    static function __callStatic($method, $name)
+    {
+    }
+}
+
+class WithMagicCall
+{
+    function __call($method, $name)
     {
     }
 }

--- a/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
@@ -88,9 +88,9 @@ class StringPresenterSpec extends ObjectBehavior
             ->shouldReturn(sprintf('%s::specMethod()', $className));
     }
 
-    function it_presents_static_magic_method_as_string(WithStaticMagicCall $object)
+    function it_presents_static_magic_method_as_string()
     {
-        $className = get_class($object->getWrappedObject());
+        $className = __NAMESPACE__ . '\\WithStaticMagicCall';
         $this->presentValue(array($className, 'undefinedMethod'))
             ->shouldReturn(sprintf('%s::undefinedMethod()', $className));
     }

--- a/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
@@ -61,6 +61,12 @@ class StringPresenterSpec extends ObjectBehavior
             ->shouldReturn('[exc:RuntimeException("message")]');
     }
 
+    function it_presents_function_callable_as_string()
+    {
+        $this->presentValue('date')
+            ->shouldReturn('[date()]');
+    }
+
     function it_presents_string_as_string()
     {
         $this->presentString('some string')->shouldReturn('some string');

--- a/src/PhpSpec/Formatter/Presenter/StringPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/StringPresenter.php
@@ -345,7 +345,8 @@ class StringPresenter implements PresenterInterface
     private function presentCallable($value)
     {
         if (is_array($value)) {
-            return sprintf('[%s::%s()]', get_class($value[0]), $value[1]);
+            $type = is_object($value[0]) ? $this->presentValue($value[0]) : $value[0];
+            return sprintf('%s::%s()', $type, $value[1]);
         }
 
         if ($value instanceof \Closure) {


### PR DESCRIPTION
When given a callable array, StringFormatter assumes that the first part of the array is an object, even though it may also be a string. 

The StringFormatter is updated to check to see if the first parameter is an object. To allow distinguishing between static and non-static callables, the presentValue() method uses the existing presentValue() method to present the object.
