### PR TITLE
fix supportsQuery for not default configurations

### DIFF
--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -163,6 +163,13 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->supportsQuery($this->srcPath)->shouldReturn(true);
     }
 
+    function it_supports_srcPath_queries_when_specsPath_is_not_default()
+    {
+        $this->beConstructedWith('PhpSpec', 'spec', $this->srcPath, realpath($this->specPath . '/vendor'));
+
+        $this->supportsQuery($this->srcPath)->shouldReturn(true);
+    }
+
     function it_supports_file_queries_in_srcPath()
     {
         $this->beConstructedWith('PhpSpec', 'spec', $this->srcPath, $this->specPath);

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -142,7 +142,7 @@ class PSR0Locator implements ResourceLocatorInterface
     public function supportsQuery($query)
     {
         $sepr = DIRECTORY_SEPARATOR;
-        $path = rtrim(realpath(str_replace(array('\\', '/'), $sepr, $query)), $sepr);
+        $path = realpath(str_replace(array('\\', '/'), $sepr, $query)) . $sepr;
 
         if (null === $path) {
             return false;


### PR DESCRIPTION
In not default configurations (phpspec.yml.dist) in some situations (like running specs from vendor dir) it is not possible to run only one spec (by filepath or by spec path).

This fixes the issue.