### PR TITLE
Add public visibility to it_is_initializable in spec template

### DIFF
--- a/features/code_generation/developer_generates_spec.feature
+++ b/features/code_generation/developer_generates_spec.feature
@@ -16,7 +16,7 @@ Feature: Developer generates a spec
 
       class MarkdownSpec extends ObjectBehavior
       {
-          function it_is_initializable()
+          public function it_is_initializable()
           {
               $this->shouldHaveType('CodeGeneration\SpecExample1\Markdown');
           }
@@ -38,7 +38,7 @@ Feature: Developer generates a spec
 
       class Text_MarkdownSpec extends ObjectBehavior
       {
-          function it_is_initializable()
+          public function it_is_initializable()
           {
               $this->shouldHaveType('CodeGeneration\SpecExample1\Text_Markdown');
           }
@@ -60,7 +60,7 @@ Feature: Developer generates a spec
 
       class Text_MarkdownSpec extends ObjectBehavior
       {
-          function it_is_initializable()
+          public function it_is_initializable()
           {
               $this->shouldHaveType('CodeGeneration\Spec_Example2\Text_Markdown');
           }
@@ -88,7 +88,7 @@ Feature: Developer generates a spec
 
       class MarkdownSpec extends ObjectBehavior
       {
-          function it_is_initializable()
+          public function it_is_initializable()
           {
               $this->shouldHaveType('Behat\CodeGeneration\Markdown');
           }

--- a/src/PhpSpec/CodeGenerator/Generator/templates/specification.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/specification.template
@@ -7,7 +7,7 @@ use Prophecy\Argument;
 
 class %name% extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType('%subject%');
     }


### PR DESCRIPTION
The generated code for the spec should use the public visibility keyword in the method `it_is_initializable()` to follow PSR2.
