### PR TITLE
reformat empty method examples

### DIFF
--- a/spec/PhpSpec/Util/MethodAnalyserSpec.php
+++ b/spec/PhpSpec/Util/MethodAnalyserSpec.php
@@ -37,9 +37,7 @@ class MethodAnalyserSpec extends ObjectBehavior
 
 class ExampleObject
 {
-    public function emptyMethod()
-    {
-    }
+    public function emptyMethod() {}
 
     public function commentedMethod()
     {
@@ -61,16 +59,12 @@ class ExampleObject
         // another comment
     }
 
-    public function nonEmptyOneLineMethod()
-    {
-        return 'foo';
-    }
+    public function nonEmptyOneLineMethod() { return 'foo'; }
+
     public function nonEmptyOneLineMethod2()
-    {
-        return 'foo';
-    }
-    public function nonEmptyOneLineMethod3()
-    {
+    { return 'foo'; }
+
+    public function nonEmptyOneLineMethod3() {
         return 'foo';
     }
 }


### PR DESCRIPTION
- those methods were formatted to comply to coding standards
- in commit 4530033cc640a71166352b3cb1dbcd0dc43ecb47 which misses
- the point for them
