### PR TITLE
Refactor the way default Matchers are set to avoid re-sorting

### DIFF
--- a/spec/PhpSpec/Runner/Maintainer/MatchersMaintainerSpec.php
+++ b/spec/PhpSpec/Runner/Maintainer/MatchersMaintainerSpec.php
@@ -20,6 +20,6 @@ class MatchersMaintainerSpec extends ObjectBehavior
         $this->beConstructedWith($presenter, array($matcher));
         $this->prepare($example, $context, $matchers, $collaborators);
 
-        $matchers->setDefault(array($matcher))->shouldHaveBeenCalled();
+        $matchers->replace(array($matcher))->shouldHaveBeenCalled();
     }
 }

--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -70,7 +70,7 @@ class MatchersMaintainer implements MaintainerInterface
                             MatcherManager $matchers, CollaboratorManager $collaborators)
     {
 
-        $matchers->setDefault($this->defaultMatchers);
+        $matchers->replace($this->defaultMatchers);
 
         if (!$context instanceof Matcher\MatchersProviderInterface) {
             return;

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -48,9 +48,11 @@ class MatcherManager
     }
 
     /**
+     * Replaces matchers with an already-sorted list
+     *
      * @param MatcherInterface[] $matchers
      */
-    public function setDefault(array $matchers)
+    public function replace(array $matchers)
     {
         $this->matchers = $matchers;
     }


### PR DESCRIPTION
Currently before _every_ example, MatchersMaintainer adds all of the default matchers one at a time to the MatcherManager. The list of matchers inside MatcherManager is re-sorted every time a new one is added.

This PR adds a method to MatcherManager to uncritically take a pre-sorted list of Default matchers that can then be re-used between executions, and sorting only needs to be triggered when an inline matcher is encountered.

Blackfire.io shows >10% speed increase on the PhpSpec self-test suite:
![comparison](https://cloud.githubusercontent.com/assets/237866/5234902/1c7a1d18-77db-11e4-921b-6462f12402c4.png)
