### PR TITLE
WIP - catch fatal errors during execution

### DIFF
--- a/spec/PhpSpec/Listener/ErrorHandlerListenerSpec.php
+++ b/spec/PhpSpec/Listener/ErrorHandlerListenerSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\PhpSpec\Listener;
+
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Loader\Node\ExampleNode;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\ErrorHandler;
+use Prophecy\Argument;
+use ReflectionClass;
+use ReflectionMethod;
+
+class ErrorHandlerListenerSpec extends ObjectBehavior
+{
+    function let(
+        ErrorHandler $handler, ExampleEvent $exampleEvent, ExampleNode $exampleNode,
+        ReflectionMethod $reflectedFunction, ReflectionClass $reflectedClass
+    )
+    {
+        $this->beConstructedWith($handler);
+
+        $exampleEvent->getExample()->willReturn($exampleNode);
+        $exampleNode->getFunctionReflection()->willReturn($reflectedFunction);
+        $reflectedFunction->getDeclaringClass()->willReturn($reflectedClass);
+        $reflectedFunction->getName()->willReturn('it_is_an_example');
+        $reflectedClass->getName()->willReturn('MySpec');
+    }
+
+    function it_tells_errorhandler_which_example_is_about_to_be_run(ExampleEvent $exampleEvent, ErrorHandler $handler)
+    {
+        $this->beforeExample($exampleEvent);
+
+        $handler->setCurrentExample('MySpec', 'it_is_an_example')->shouldhaveBeenCalled();
+    }
+
+    function it_clears_the_example_after_execution(ExampleEvent $exampleEvent, ErrorHandler $handler)
+    {
+        $this->afterExample($exampleEvent);
+
+        $handler->clearCurrentExample()->shouldHaveBeenCalled();
+    }
+}

--- a/spec/PhpSpec/Listener/FatalSkippingListenerSpec.php
+++ b/spec/PhpSpec/Listener/FatalSkippingListenerSpec.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace spec\PhpSpec\Listener;
+
+use PhpSpec\Console\IO;
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\SuiteEvent;
+use PhpSpec\Loader\Node\ExampleNode;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\RerunContext;
+use Prophecy\Argument;
+use ReflectionClass;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FatalSkippingListenerSpec extends ObjectBehavior
+{
+    function let(OutputInterface $output, RerunContext $context, ExampleEvent $exampleEvent,
+        ExampleNode $exampleNode, \ReflectionMethod $reflectedFunction, ReflectionClass $reflectedClass)
+    {
+        $this->beConstructedWith($output, $context);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->setVerbosity(Argument::any())->willReturn();
+
+        $exampleEvent->getExample()->willReturn($exampleNode);
+        $exampleNode->getFunctionReflection()->willReturn($reflectedFunction);
+        $reflectedFunction->getDeclaringClass()->willReturn($reflectedClass);
+
+        $reflectedClass->getName()->willReturn('Foo');
+        $reflectedFunction->getName()->willReturn('Bar');
+    }
+
+    function it_does_not_change_the_verbosity_when_there_are_no_fatals(
+        OutputInterface $output, SuiteEvent $event, RerunContext $context
+    )
+    {
+        $context->listFatalSpecs()->willReturn(array());
+
+        $this->beforeSuite($event);
+
+        $output->setVerbosity(Argument::any())->shouldNotHaveBeenCalled();
+    }
+
+    function it_changes_the_verbosity_to_silent_when_there_is_a_fatal(
+        OutputInterface $output, SuiteEvent $event, RerunContext $context
+    )
+    {
+        $context->listFatalSpecs()->willReturn(array(array('Foo', 'Bar')));
+
+        $this->beforeSuite($event);
+
+        $output->setVerbosity(OutputInterface::VERBOSITY_QUIET)->shouldHaveBeenCalled();
+    }
+
+    function it_does_not_turn_the_verbosity_back_on_when_there_are_still_more_fatals(
+        OutputInterface $output, SuiteEvent $event, RerunContext $context, ExampleEvent $exampleEvent
+    )
+    {
+        $context->listFatalSpecs()->willReturn(array(array('Foo', 'Bar'), array('Baz', 'Boz')));
+
+        $this->beforeSuite($event);
+        $this->beforeExample($exampleEvent);
+
+        $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL)->shouldNotHaveBeenCalled();
+    }
+
+    function it_does_turns_the_verbosity_back_on_when_there_are_no_more_fatals(
+        OutputInterface $output, SuiteEvent $event, RerunContext $context, ExampleEvent $exampleEvent
+    )
+    {
+        $context->listFatalSpecs()->willReturn(array(array('Foo', 'Bar')));
+
+        $this->beforeSuite($event);
+        $this->beforeExample($exampleEvent);
+
+        $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL)->shouldHaveBeenCalled();
+    }
+
+}

--- a/spec/PhpSpec/Process/ReRunner/PcntlReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/PcntlReRunnerSpec.php
@@ -3,14 +3,15 @@
 namespace spec\PhpSpec\Process\ReRunner;
 
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\RerunContext;
 use Prophecy\Argument;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class PcntlReRunnerSpec extends ObjectBehavior
 {
-    function let(PhpExecutableFinder $executableFinder)
+    function let(PhpExecutableFinder $executableFinder, RerunContext $rerunContext)
     {
-        $this->beConstructedWith($executableFinder);
+        $this->beConstructedWith($executableFinder, $rerunContext);
     }
 
     function it_is_a_rerunner()

--- a/spec/PhpSpec/Process/RerunContextSpec.php
+++ b/spec/PhpSpec/Process/RerunContextSpec.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace spec\PhpSpec\Process;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RerunContextSpec extends ObjectBehavior
+{
+    function it_remembers_fatal_specs()
+    {
+        $this->setFatalSpec('MySpec', 'func', array('This went wrong'));
+        $this->wasFatalSpec('MySpec', 'func')->shouldReturn(true);
+    }
+
+    function it_remembers_errors_of_fatal_specs()
+    {
+        $this->setFatalSpec('MySpec', 'func', array('This went wrong'));
+        $this->getFatalSpecError('MySpec', 'func')->shouldReturn(array('This went wrong'));
+    }
+
+    function it_serialises_itself_to_string()
+    {
+        $this->setFatalSpec('MySpec', 'func', array('This went wrong'));
+        $this->asString()->shouldReturn('{"fatals":{"MySpec":{"func":["This went wrong"]}}}');
+    }
+
+    function it_deserialises_itself_from_string()
+    {
+        $this->beConstructedThrough('fromString', array('{"fatals":{"MySpec":{"func":["This went wrong"]}}}'));
+        $this->wasFatalSpec('MySpec', 'func')->shouldReturn(true);
+    }
+
+    function it_exposes_list_of_fatals()
+    {
+        $this->setFatalSpec('MySpec', 'func', array('This went wrong'));
+
+        $this->listFatalSpecs()->shouldReturn(
+            array(
+                array('MySpec', 'func')
+            )
+        );
+    }
+}

--- a/src/PhpSpec/Listener/ErrorHandlerListener.php
+++ b/src/PhpSpec/Listener/ErrorHandlerListener.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PhpSpec\Listener;
+
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Process\ErrorHandler;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ErrorHandlerListener implements EventSubscriberInterface
+{
+    /**
+     * @var ErrorHandler
+     */
+    private $handler;
+
+    /**
+     * @param ErrorHandler $handler
+     */
+    public function __construct(ErrorHandler $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    /**
+     * @param ExampleEvent $event
+     */
+    public function beforeExample(ExampleEvent $event)
+    {
+        $function = $event->getExample()->getFunctionReflection();
+        $class = $function->getDeclaringClass();
+
+        $this->handler->setCurrentExample($class->getName(), $function->getName());
+    }
+
+    public function afterExample()
+    {
+        $this->handler->clearCurrentExample();
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'beforeExample' => 'beforeExample',
+            'afterExample' => 'afterExample'
+        );
+    }
+}

--- a/src/PhpSpec/Listener/FatalSkippingListener.php
+++ b/src/PhpSpec/Listener/FatalSkippingListener.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PhpSpec\Listener;
+
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\SuiteEvent;
+use PhpSpec\Process\RerunContext;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class FatalSkippingListener implements EventSubscriberInterface
+{
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+    /**
+     * @var RerunContext
+     */
+    private $context;
+
+    /**
+     * @var array
+     */
+    private $fatalSpecs = array();
+
+    /**
+     * @var int
+     */
+    private $verbosity;
+
+    public function __construct(OutputInterface $output, RerunContext $context)
+    {
+        $this->output = $output;
+        $this->context = $context;
+    }
+
+    public function beforeSuite(SuiteEvent $event)
+    {
+        if ($this->fatalSpecs = $this->context->listFatalSpecs()) {
+            $this->verbosity = $this->output->getVerbosity();
+            $this->output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+        }
+    }
+
+    public function beforeExample(ExampleEvent $event)
+    {
+        $spec = $event->getExample()->getFunctionReflection()->getDeclaringClass()->getName();
+        $example = $event->getExample()->getFunctionReflection()->getName();
+
+        $specDef = array($spec, $example);
+
+        if (($key = array_search($specDef, $this->fatalSpecs)) !== false) {
+            unset($this->fatalSpecs[$key]);
+
+            if (!$this->fatalSpecs) {
+                $this->output->setVerbosity($this->verbosity);
+            }
+        }
+    }
+
+    /*
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+          'beforeSuite' => 'beforeSuite',
+          'beforeExample' => 'beforeExample'
+        );
+    }
+}

--- a/src/PhpSpec/Process/ErrorHandler.php
+++ b/src/PhpSpec/Process/ErrorHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace PhpSpec\Process;
+
+class ErrorHandler
+{
+    private $currentExample;
+
+    /**
+     * @var
+     */
+    private $context;
+
+    /**
+     * @var Rerunner
+     */
+    private $rerunner;
+
+    public function __construct(RerunContext $context, Rerunner $rerunner)
+    {
+        $this->context = $context;
+        $this->rerunner = $rerunner;
+    }
+
+    public function init()
+    {
+        error_reporting(E_ALL & ~E_ERROR & ~E_PARSE& ~E_COMPILE_ERROR);
+        register_shutdown_function(array($this, 'shutdown'));
+    }
+
+    public function shutdown()
+    {
+        if ($this->currentExample && $error = error_get_last()) {
+            if (in_array($error['type'], array(E_ERROR, E_PARSE, E_COMPILE_ERROR))) {
+                $this->handleError($error);
+            }
+        }
+    }
+
+    public function setCurrentExample($class, $function)
+    {
+        $this->currentExample = array($class, $function);
+    }
+
+    public function clearCurrentExample()
+    {
+        $this->currentExample = null;
+    }
+
+    /**
+     * @param $error
+     */
+    private function handleError($error)
+    {
+        $this->context->setFatalSpec($this->currentExample[0], $this->currentExample[1], $error);
+        $this->rerunner->reRunSuite();
+    }
+
+} 

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -13,8 +13,22 @@
 
 namespace PhpSpec\Process\ReRunner;
 
+use PhpSpec\Process\RerunContext;
+use Symfony\Component\Process\PhpExecutableFinder;
+
 class PcntlReRunner extends PhpExecutableReRunner
 {
+    /**
+     * @var RerunContext
+     */
+    private $context;
+
+    public function __construct(PhpExecutableFinder $executableFinder, RerunContext $context)
+    {
+        parent::__construct($executableFinder);
+        $this->context = $context;
+    }
+
     /**
      * @return bool
      */
@@ -31,6 +45,7 @@ class PcntlReRunner extends PhpExecutableReRunner
     public function reRunSuite()
     {
         $args = $_SERVER['argv'];
-        pcntl_exec($this->getExecutablePath(), $args);
+        $envs = array_merge($_ENV, $_SERVER, array(RerunContext::ENV_NAME=>$this->context->asString()));
+        pcntl_exec($this->getExecutablePath(), $args, $envs);
     }
 }

--- a/src/PhpSpec/Process/RerunContext.php
+++ b/src/PhpSpec/Process/RerunContext.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace PhpSpec\Process;
+
+class RerunContext
+{
+    const ENV_NAME = 'RERUN_CONTEXT';
+
+    private $fatals = array();
+
+    public static function fromString($string)
+    {
+        $data = json_decode($string, true);
+
+        $rerunContext = new RerunContext();
+        $rerunContext->fatals = $data['fatals'];
+
+        return $rerunContext;
+    }
+
+    public function setFatalSpec($spec, $example, $error)
+    {
+        $this->fatals[$spec][$example] = $error;
+    }
+
+    public function wasFatalSpec($spec, $example)
+    {
+        return array_key_exists($spec, $this->fatals)
+            && array_key_exists($example, $this->fatals[$spec]);
+    }
+
+    public function getFatalSpecError($spec, $example)
+    {
+        return $this->fatals[$spec][$example];
+    }
+
+    public function asString()
+    {
+        return json_encode(array('fatals' => $this->fatals));
+    }
+
+    public function listFatalSpecs()
+    {
+        $fatalSpecs = array();
+
+        foreach ($this->fatals as $spec => $examples) {
+            foreach ($examples as $example => $error) {
+                $fatalSpecs[] = array($spec, $example);
+            }
+        }
+
+        return $fatalSpecs;
+    }
+}

--- a/src/PhpSpec/Process/Runner/FatalSkippingExampleRunner.php
+++ b/src/PhpSpec/Process/Runner/FatalSkippingExampleRunner.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PhpSpec\Process\Runner;
+
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\PresenterInterface;
+use PhpSpec\Loader\Node\ExampleNode;
+use PhpSpec\Process\RerunContext;
+use PhpSpec\Runner\ExampleRunner;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class FatalSkippingExampleRunner extends ExampleRunner
+{
+    /**
+     * @var RerunContext
+     */
+    private $context;
+
+    /**
+     * @var ExampleRunner
+     */
+    private $runner;
+
+    private $dispatcher;
+
+    public function __construct(
+        EventDispatcherInterface $dispatcher, PresenterInterface $presenter,
+        RerunContext $context, ExampleRunner $runner
+    )
+    {
+        parent::__construct($dispatcher, $presenter);
+        $this->context = $context;
+        $this->runner = $runner;
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function run(ExampleNode $example)
+    {
+        $spec = $example->getFunctionReflection()->getDeclaringClass()->getName();
+        $function = $example->getFunctionReflection()->getName();
+
+        if ($this->context->wasFatalSpec($spec, $function)) {
+
+            $event = new ExampleEvent($example);
+            $this->dispatcher->dispatch('beforeExample', $event);
+
+            $error = $this->context->getFatalSpecError($spec, $function);
+            $failure = new FailureException(
+                sprintf(
+                    'Fatal error "%s" in "%s" on line %d',
+                    $error['message'],
+                    $error['file'],
+                    $error['line']
+                )
+            );
+
+            $event = new ExampleEvent($example, null, ExampleEvent::BROKEN, $failure);
+            $this->dispatcher->dispatch('afterExample', $event);
+
+            return ExampleEvent::BROKEN;
+        }
+
+        return $this->runner->run($example);
+    }
+
+}


### PR DESCRIPTION
![fatal-catching](https://cloud.githubusercontent.com/assets/237866/5268102/a70677a4-7a4e-11e4-82b6-a65ef30ae715.gif)

This is submitted mostly as a talking point.

It 'works' but feels dirty. Is it too dirty? It's a feature I'm not sure can be done in a non-dirty way.

Note: only fatals that occur during an Example are caught properly right now, other fatals (phpspec runtime issues or spec parse errors) may cause unexpected results
