### PR TITLE
The ability to pass file names to Yaml::parse() was deprecated

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -158,7 +158,7 @@ class Application extends BaseApplication
 
         $config = array();
         foreach ($paths as $path) {
-            if ($path && file_exists($path) && $parsedConfig = Yaml::parse($path)) {
+            if ($path && file_exists($path) && $parsedConfig = Yaml::parse(file_get_contents($path))) {
                 $config = $parsedConfig;
                 break;
             }
@@ -166,7 +166,7 @@ class Application extends BaseApplication
 
         if ($homeFolder = getenv('HOME')) {
             $localPath = $homeFolder.'/.phpspec.yml';
-            if (file_exists($localPath) && $parsedConfig = Yaml::parse($localPath)) {
+            if (file_exists($localPath) && $parsedConfig = Yaml::parse(file_get_contents($localPath))) {
                 $config = array_replace_recursive($parsedConfig, $config);
             }
         }


### PR DESCRIPTION
First of all, sorry for re-adding pull request, but now its is more cleaned up :)

2.7 Yaml package throws error (The ability to pass file names to Yaml::parse() was deprecated in 2.7 and will be removed in 3.0.)  due to this. In my case it broke some build processes so I  needed to downgrade. 
