### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/finder":           "~2.1",
         "symfony/process":          "~2.1",
         "symfony/yaml":             "~2.1",
-        "doctrine/instantiator":    "^1.0.1"
+        "doctrine/instantiator":    "~1.0.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
Currently composer return following error:

Could not load package phpspec/phpspec in http://packagist.org: [UnexpectedValueException] Could not parse version constraint ^1.0.1: Invalid version string "^1.0.1"

This change fix this problem