### PR TITLE
Show which spec class is not the correct base spec namespace

### DIFF
--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -349,7 +349,7 @@ class PSR0LocatorSpec extends ObjectBehavior
         $fs->getFileContents($filePath)->willReturn('<?php namespace InvalidSpecNamespace\\PhpSpec; class ServiceContainer {} ?>');
         $file->getRealPath()->willReturn($filePath);
 
-        $exception = new \RuntimeException('Spec class must be in the base spec namespace `spec\\PhpSpec\\`.');
+        $exception = new \RuntimeException('Spec class `InvalidSpecNamespace\\PhpSpec\\ServiceContainer` must be in the base spec namespace `spec\\PhpSpec\\`.');
 
         $this->shouldThrow($exception)->duringFindResources($this->srcPath);
     }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -312,8 +312,8 @@ class PSR0Locator implements ResourceLocatorInterface
 
         if (0 !== strpos($classname, $specNamespace)) {
             throw new \RuntimeException(sprintf(
-                'Spec class must be in the base spec namespace `%s`.',
-                $this->getSpecNamespace()
+                'Spec class `%s` must be in the base spec namespace `%s`.',
+                $classname, $this->getSpecNamespace()
             ));
         }
 


### PR DESCRIPTION
I received this exception during execution

```
  [RuntimeException]                                                                    
  Spec class must be in the base spec namespace `spec\Acme\DemoBundle`. 
```

However, I had absolutely no idea which spec caused the exception, even with verbose output, until passed in the classname to the exception.

Now, exception message should read for example:

```
  [RuntimeException]                                                                    
  Spec class `spec\Acme\Demo\Controller\ControllerSpec` must be in the base spec namespace `spec\Acme\DemoBundle`. 
```