### PR TITLE
Adding smoke test running command at CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: php
 
-php: [5.3, 5.4, 5.5, hhvm-nightly]
-
 matrix:
   include:
+    - php: 5.3
     - php: 5.3.3
       env: DEPENDENCIES='low'
-    - php: 5.6
-      env: SMOKE='true'
+           SMOKE='true'
+    - php: 5.4
+    - php: 5.5
     - php: 5.6
       env: DEPENDENCIES='dev'
+    - php: 5.6
+      env: SMOKE='true'
     - php: hhvm
       env: SMOKE='true'
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: php
 
-php: [5.3, 5.4, 5.5, 5.6, hhvm, hhvm-nightly]
+php: [5.3, 5.4, 5.5, hhvm-nightly]
 
 matrix:
   include:
     - php: 5.3.3
       env: DEPENDENCIES='low'
     - php: 5.6
+      env: SMOKE='true'
+    - php: 5.6
       env: DEPENDENCIES='dev'
+    - php: hhvm
+      env: SMOKE='true'
   allow_failures:
     - php: hhvm-nightly
     - env: DEPENDENCIES='dev'
@@ -18,7 +22,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - sudo apt-get install expect
+  - if [ "$SMOKE" == "true" ]; then sudo apt-get install expect; fi;
   - composer selfupdate
 
 install:
@@ -30,5 +34,6 @@ install:
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty
+   - if [ "$SMOKE" != "true" ]; then ./vendor/bin/behat --format=pretty; fi;
+   - if [ "$SMOKE" == "true" ]; then ./vendor/bin/behat --format=pretty --profile=smoke; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ matrix:
     - env: DEPENDENCIES='dev'
   fast_finish: true
 
-cache:
-  directories:
-    - $HOME/.composer/cache
-
 before_install:
   - if [ "$SMOKE" == "true" ]; then sudo apt-get install expect; fi;
   - composer selfupdate

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,12 @@ matrix:
     - env: DEPENDENCIES='dev'
   fast_finish: true
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
+  - sudo apt-get install expect
   - composer selfupdate
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: SMOKE='true'
     - php: hhvm
       env: SMOKE='true'
+    - php: hhvm-nightly
   allow_failures:
     - php: hhvm-nightly
     - env: DEPENDENCIES='dev'

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,8 +2,12 @@ default:
   suites:
     application:
       contexts: [ ApplicationContext, FilesystemContext ]
+  formatters:
+    progress: ~
+
+smoke:
+  suites:
     smoke:
       contexts: [ IsolatedProcessContext, FilesystemContext ]
       filters: { tags: @smoke }
-  formatters:
-    progress: ~
+

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,5 +2,8 @@ default:
   suites:
     application:
       contexts: [ ApplicationContext, FilesystemContext ]
+    smoke:
+      contexts: [ IsolatedProcessContext, FilesystemContext ]
+      filters: { tags: @smoke }
   formatters:
     progress: ~

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "behat/behat": "^3.0.11",
         "bossa/phpspec2-expect": "~1.0",
         "symfony/filesystem":    "~2.1",
-        "phpunit/phpunit": "~4.4"
+        "symfony/process":       "~2.1",
+        "phpunit/phpunit":       "~4.4"
     },
 
     "suggest": {

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -5,7 +5,6 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
-use PhpSpec\Exception\Example\SkippingException;
 use Symfony\Component\Process\Process;
 
 /**
@@ -31,10 +30,6 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
      */
     public function iRunPhpspecAndAnswerWhenAskedIfIWantToGenerateTheCode($answer)
     {
-        if (!`which expect`) {
-            throw new SkippingException('Cannot test interactive scripts on this platform');
-        }
-
         $process = new Process(
             "exec expect -c '\n" .
             "set timeout 10\n" .
@@ -42,13 +37,12 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             "expect \"Y/n\"\n" .
             "sleep 0.1\n" .
             "send \"$answer\n\"\n" .
-            "sleep 0.5\n" .
+            "sleep 1\n" .
             "interact\n" .
             "'"
         );
 
         $process->run();
-
         $this->lastOutput = $process->getOutput();
 
         expect($process->getErrorOutput())->toBe(null);

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -37,7 +37,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             "expect \"Y/n\"\n" .
             "sleep 0.1\n" .
             "send \"$answer\n\"\n" .
-            "sleep 1\n" .
+            "sleep 5\n" .
             "interact\n" .
             "'"
         );
@@ -45,7 +45,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
         $process->run();
         $this->lastOutput = $process->getOutput();
 
-        expect($process->getErrorOutput())->toBe(null);
+        expect((bool)$process->getErrorOutput())->toBe(false);
     }
 
     /**

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -46,9 +46,8 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             "set timeout 10\n" .
             "spawn {$this->buildPhpSpecCmd()} run\n" .
             "expect \"Y/n\"\n" .
-            "sleep 0.1\n" .
             "send \"$answer\n\"\n" .
-            "sleep 2\n" .
+            "expect \"Y/n\"\n" .
             "interact\n" .
             "'"
         );

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -15,6 +15,17 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     private $lastOutput;
 
     /**
+     * @beforeSuite
+     */
+    public static function checkDependencies()
+    {
+        chdir(sys_get_temp_dir());
+        if (!@`which expect`) {
+            throw new \Exception('Smoke tests require the `expect` command line application');
+        }
+    }
+
+    /**
      * @Given I have started describing the :class class
      */
     public function iHaveStartedDescribingTheClass($class)

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -48,7 +48,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             "expect \"Y/n\"\n" .
             "sleep 0.1\n" .
             "send \"$answer\n\"\n" .
-            "sleep 5\n" .
+            "sleep 2\n" .
             "interact\n" .
             "'"
         );

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -1,0 +1,72 @@
+<?php
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use PhpSpec\Exception\Example\SkippingException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Defines application features from the specific context.
+ */
+class IsolatedProcessContext implements Context, SnippetAcceptingContext
+{
+    private $lastOutput;
+
+    /**
+     * @Given I have started describing the :class class
+     */
+    public function iHaveStartedDescribingTheClass($class)
+    {
+        $process = new Process($this->buildPhpSpecCmd() . ' describe '. escapeshellarg($class));
+        $process->run();
+
+        expect($process->getExitCode())->toBe(0);
+    }
+
+    /**
+     * @When I run phpspec and answer :answer when asked if I want to generate the code
+     */
+    public function iRunPhpspecAndAnswerWhenAskedIfIWantToGenerateTheCode($answer)
+    {
+        if (!`which expect`) {
+            throw new SkippingException('Cannot test interactive scripts on this platform');
+        }
+
+        $process = new Process(
+            "exec expect -c '\n" .
+            "set timeout 10\n" .
+            "spawn {$this->buildPhpSpecCmd()} run\n" .
+            "expect \"Y/n\"\n" .
+            "sleep 0.1\n" .
+            "send \"$answer\n\"\n" .
+            "sleep 0.5\n" .
+            "interact\n" .
+            "'"
+        );
+
+        $process->run();
+
+        $this->lastOutput = $process->getOutput();
+
+        expect($process->getErrorOutput())->toBe(null);
+    }
+
+    /**
+     * @return string
+     */
+    protected function buildPhpSpecCmd()
+    {
+        return escapeshellcmd(__DIR__ . '/../../bin/phpspec');
+    }
+
+    /**
+     * @Then the tests should be rerun
+     */
+    public function theTestsShouldBeRerun()
+    {
+        expect(substr_count($this->lastOutput, 'Y/n'))->toBe(2);
+    }
+}

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -61,6 +61,6 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
      */
     public function theTestsShouldBeRerun()
     {
-        expect(substr_count($this->lastOutput, 'Y/n'))->toBe(2);
+        expect(substr_count($this->lastOutput, 'for you?'))->toBe(2);
     }
 }

--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -3,6 +3,7 @@ Feature: Developer generates a class
   I want to automate creating classes
   In order to avoid repetitive tasks and interruptions in development flow
 
+  @smoke
   Scenario: Generating a class
     Given I have started describing the "CodeGeneration/ClassExample1/Markdown" class
     When I run phpspec and answer "y" when asked if I want to generate the code

--- a/features/code_generation/developer_reruns_features.feature
+++ b/features/code_generation/developer_reruns_features.feature
@@ -3,6 +3,7 @@ Feature: Developer generates a class
   I want the tests to automatically rerun after code generation events
   In order to avoid repetitive tasks and interruptions in development flow
 
+  @smoke
   Scenario: Rerun after class generation
     Given I have started describing the "CodeGeneration/RerunExample1/Markdown" class
     When I run phpspec and answer "y" when asked if I want to generate the code


### PR DESCRIPTION
Covers two critical scenarios by running them through `sh` and interacting as a `tty`.