### PR TITLE
Change rerun strategy for HHVM (pcntl does not work)

### DIFF
--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -22,7 +22,8 @@ class PcntlReRunner extends PhpExecutableReRunner
     {
         return (php_sapi_name() == 'cli')
             && $this->getExecutablePath()
-            && function_exists('pcntl_exec');
+            && function_exists('pcntl_exec')
+            && !defined('HHVM_VERSION');
     }
 
     /**


### PR DESCRIPTION
Fixes problem uncovered in #615 

Rerunning the suite using pcntl_exec does not appear to be working on HHVM, this changes the strategy back to using passthru (as we do when pcntl is not present)