### PR TITLE
Add option to generate final classes

### DIFF
--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -19,6 +19,26 @@ Feature: Developer generates a class
 
       """
 
+  @issue632
+  Scenario: Generating a final class
+    Given the config file contains:
+    """
+    generator.final_classes: true
+    """
+    And I have started describing the "CodeGeneration/FinalClasses/Markdown" class
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then a new class should be generated in the "src/CodeGeneration/FinalClasses/Markdown.php":
+      """
+      <?php
+
+      namespace CodeGeneration\FinalClasses;
+
+      final class Markdown
+      {
+      }
+
+      """
+
   @issue269
   Scenario: Generating a class with psr4 prefix
     Given the config file contains:
@@ -131,3 +151,4 @@ Feature: Developer generates a class
     }
 
     """
+

--- a/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
@@ -50,6 +50,7 @@ class ClassGeneratorSpec extends ObjectBehavior
             '%name%'            => 'App',
             '%namespace%'       => 'Acme',
             '%namespace_block%' => "\n\nnamespace Acme;",
+            '%final_mark%'      => '',
         );
 
         $tpl->render('class', $values)->willReturn(null);
@@ -75,6 +76,7 @@ class ClassGeneratorSpec extends ObjectBehavior
             '%name%'            => 'App',
             '%namespace%'       => 'Acme',
             '%namespace_block%' => "\n\nnamespace Acme;",
+            '%final_mark%'      => '',
         );
 
         $tpl->render('class', $values)->willReturn('template code');

--- a/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
@@ -56,6 +56,7 @@ class ClassGenerator extends PromptingGenerator
             '%namespace_block%' => '' !== $resource->getSrcNamespace()
                                 ?  sprintf("\n\nnamespace %s;", $resource->getSrcNamespace())
                                 : '',
+            '%final_mark%'      => $this->getOption('generator.final_classes') ? 'final ' : '',
         );
 
         if (!$content = $this->getTemplateRenderer()->render('class', $values)) {

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -39,15 +39,21 @@ abstract class PromptingGenerator implements GeneratorInterface
     private $filesystem;
 
     /**
+     * @var array
+     */
+    private $options;
+
+    /**
      * @param IO               $io
      * @param TemplateRenderer $templates
      * @param Filesystem       $filesystem
      */
-    public function __construct(IO $io, TemplateRenderer $templates, Filesystem $filesystem = null)
+    public function __construct(IO $io, TemplateRenderer $templates, Filesystem $filesystem = null, array $options = array())
     {
         $this->io         = $io;
         $this->templates  = $templates;
         $this->filesystem = $filesystem ?: new Filesystem();
+        $this->options    = $options;
     }
 
     /**
@@ -144,5 +150,15 @@ abstract class PromptingGenerator implements GeneratorInterface
 
         $this->filesystem->putFileContents($filepath, $content);
         $this->io->writeln($this->getGeneratedMessage($resource, $filepath));
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     */
+    protected function getOption($key)
+    {
+        return isset($this->options[$key]) ? $this->options[$key] : null;
     }
 }

--- a/src/PhpSpec/CodeGenerator/Generator/templates/class.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/class.template
@@ -1,5 +1,5 @@
 <?php%namespace_block%
 
-class %name%
+%final_mark%class %name%
 {
 }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -201,9 +201,15 @@ class ContainerAssembler
             );
         });
         $container->set('code_generator.generators.class', function (ServiceContainer $c) {
+            $generateFinalClasses = (bool) $c->getParam('generator.final_classes', false);
+
             return new CodeGenerator\Generator\ClassGenerator(
                 $c->get('console.io'),
-                $c->get('code_generator.templates')
+                $c->get('code_generator.templates'),
+                null,
+                array(
+                    'generator.final_classes' => $generateFinalClasses
+                )
             );
         });
         $container->set('code_generator.generators.method', function (ServiceContainer $c) {


### PR DESCRIPTION
This adds the option to generate final classes by specifying:

```yaml
generator.final_classes: true
```

In the `phpspec.yml` file. By default the option is switched off.

This addresses #632.