### PR TITLE
add Windows support

### DIFF
--- a/bin/phpspec.bat
+++ b/bin/phpspec.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET BIN_TARGET=%~dp0/../phpspec/phpspec/bin/phpspec
+php "%BIN_TARGET%" %*


### PR DESCRIPTION
With that file you're able to call phpspec with `vendor/bin/phpspec` like you are on a unix based os.

This is relevant if you use something like laravel elixir.