### PR TITLE
Generate final classes by default. Fixes #632.

### DIFF
--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -13,7 +13,7 @@ Feature: Developer generates a class
 
       namespace CodeGeneration\ClassExample1;
 
-      class Markdown
+      final class Markdown
       {
       }
 
@@ -36,7 +36,7 @@ Feature: Developer generates a class
 
     namespace Behat\Tests\MyNamespace;
 
-    class Markdown
+    final class Markdown
     {
     }
 
@@ -52,7 +52,7 @@ Feature: Developer generates a class
 
       namespace CodeGeneration\ClassExample1;
 
-      class Text_Markdown
+      final class Text_Markdown
       {
       }
 
@@ -68,7 +68,7 @@ Feature: Developer generates a class
 
       namespace CodeGeneration\Class_Example2;
 
-      class Text_Markdown
+      final class Text_Markdown
       {
       }
 
@@ -126,7 +126,7 @@ Feature: Developer generates a class
 
     namespace CodeGeneration\MethodExample2;
 
-    class ForgotPassword
+    final class ForgotPassword
     {
     }
 

--- a/src/PhpSpec/CodeGenerator/Generator/templates/class.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/class.template
@@ -1,5 +1,5 @@
 <?php%namespace_block%
 
-class %name%
+final class %name%
 {
 }


### PR DESCRIPTION
This adds final class generation by default.

This addresses #632.