### PR TITLE
New matcher asserting $array[$key] === $expectedValue

### DIFF
--- a/features/matchers/developer_users_array_key_value_matcher.feature
+++ b/features/matchers/developer_users_array_key_value_matcher.feature
@@ -1,0 +1,41 @@
+Feature: Developer uses array-key-value matcher
+  As a Developer
+  I want an array-key-value matcher
+  In order to confirm an array the expected value for a key
+
+  Scenario: "HaveKeyWithValue" alias matches using the array-key-value matcher
+    Given the spec file "spec/Matchers/ArrayKeyValueExample1/MovieSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Matchers\ArrayKeyValueExample1;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function it_should_contain_jane_smith_in_the_cast()
+        {
+            $this->getCast()->shouldHaveKeyWithValue('leadRole', 'John Smith');
+        }
+    }
+    """
+
+    And the class file "src/Matchers/ArrayKeyValueExample1/Movie.php" contains:
+    """
+    <?php
+
+    namespace Matchers\ArrayKeyValueExample1;
+
+    class Movie
+    {
+        public function getCast()
+        {
+            return array('leadRole' => 'John Smith', 'supportingRole' => 'Jane Smith');
+        }
+    }
+    """
+
+    When I run phpspec
+    Then the suite should pass

--- a/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace spec\PhpSpec\Matcher;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+use PhpSpec\Formatter\Presenter\PresenterInterface;
+
+use ArrayObject;
+
+class ArrayKeyValueMatcherSpec extends ObjectBehavior
+{
+    function let(PresenterInterface $presenter)
+    {
+        $presenter->presentValue(Argument::any())->willReturn('countable');
+        $presenter->presentString(Argument::any())->willReturnArgument();
+
+        $this->beConstructedWith($presenter);
+    }
+
+    function it_is_a_matcher()
+    {
+        $this->shouldBeAnInstanceOf('PhpSpec\Matcher\MatcherInterface');
+    }
+
+    function it_responds_to_haveKeyWithValue()
+    {
+        $this->supports('haveKeyWithValue', array(), array('', ''))->shouldReturn(true);
+    }
+
+    function it_matches_array_with_correct_value_for_specified_key()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('haveKeyWithValue', array('abc' => 123), array('abc', 123));
+    }
+
+    function it_matches_ArrayObject_with_correct_value_for_specified_offset(ArrayObject $array)
+    {
+        $array->offsetExists('abc')->willReturn(true);
+        $array->offsetGet('abc')->willReturn(123);
+
+        $this->shouldNotThrow()->duringPositiveMatch('haveKeyWithValue', $array, array('abc', 123));
+    }
+
+    function it_does_not_match_array_without_specified_key()
+    {
+        $this->shouldThrow()->duringPositiveMatch('haveKeyWithValue', array(1,2,3), array('abc', 123));
+    }
+
+    function it_does_not_match_ArrayObject_without_specified_offset(ArrayObject $array)
+    {
+        $array->offsetExists('abc')->willReturn(false);
+
+        $this->shouldThrow()->duringPositiveMatch('haveKeyWithValue', $array, array('abc', 123));
+    }
+
+    function it_matches_array_without_specified_key()
+    {
+        $this->shouldNotThrow()->duringNegativeMatch('haveKeyWithValue', array(1,2,3), array('abc', 123));
+    }
+
+    function it_matches_ArrayObject_without_specified_offset(ArrayObject $array)
+    {
+        $array->offsetExists('abc')->willReturn(false);
+
+        $this->shouldNotThrow()->duringNegativeMatch('haveKeyWithValue', $array, array('abc', 123));
+    }
+}

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -488,6 +488,9 @@ class ContainerAssembler
         $container->set('matchers.array_key', function (ServiceContainer $c) {
             return new Matcher\ArrayKeyMatcher($c->get('formatter.presenter'));
         });
+        $container->set('matchers.array_key_with_value', function (ServiceContainer $c) {
+            return new Matcher\ArrayKeyValueMatcher($c->get('formatter.presenter'));
+        });
         $container->set('matchers.array_contain', function (ServiceContainer $c) {
             return new Matcher\ArrayContainMatcher($c->get('formatter.presenter'));
         });

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Matcher;
+
+use ArrayAccess;
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\PresenterInterface;
+
+class ArrayKeyValueMatcher extends BasicMatcher
+{
+    /**
+     * @var \PhpSpec\Formatter\Presenter\PresenterInterface
+     */
+    private $presenter;
+
+    /**
+     * @param PresenterInterface $presenter
+     */
+    public function __construct(PresenterInterface $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return bool
+     */
+    public function supports($name, $subject, array $arguments)
+    {
+        return 'haveKeyWithValue' === $name
+        && 2 == count($arguments)
+        && (is_array($subject) || $subject instanceof ArrayAccess)
+            ;
+    }
+
+    /**
+     * @param ArrayAccess|array $subject
+     * @param array $arguments
+     *
+     * @return bool
+     */
+    protected function matches($subject, array $arguments)
+    {
+        $key = $arguments[0];
+        $value  = $arguments[1];
+
+        if ($subject instanceof ArrayAccess) {
+            return $subject->offsetExists($key) && $subject->offsetGet($key) === $value;
+        }
+
+        return (isset($subject[$key]) || array_key_exists($arguments[0], $subject) && $subject[$key] === $value);
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
+     */
+    protected function getFailureException($name, $subject, array $arguments)
+    {
+        $key = $arguments[0];
+        $expectedValue = $arguments[1];
+        $actualValue = $subject[$key];
+
+        if (!$this->offsetExists($key, $subject)) {
+            return new FailureException(sprintf('Expected %s to have value %s for %s key, but no key was set.',
+                $this->presenter->presentValue($subject),
+                $this->presenter->presentValue($expectedValue),
+                $this->presenter->presentString($key)
+            ));
+        }
+
+        return new FailureException(sprintf(
+            'Expected %s to have value %s for %s key, but found %s.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($expectedValue),
+            $this->presenter->presentString($key),
+            $this->presenter->presentValue($actualValue)
+        ));
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
+     */
+    protected function getNegativeFailureException($name, $subject, array $arguments)
+    {
+        return new FailureException(sprintf(
+            'Expected %s not to have %s key, but it does.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentString($arguments[0])
+        ));
+    }
+
+    private function offsetExists($key, $subject)
+    {
+        return ($subject instanceof ArrayAccess && $subject->offsetExists($key)) || array_key_exists($key, $subject);
+    }
+}


### PR DESCRIPTION
New matcher that allows for asserting a specific value for a specific key of methods that return an array and or an implementor of ArrayAccess.

Example Spec:

```php
<?php

SomeClassSpec extends ObjectBehavior
{

    function it_returns_an_array_with_myValue_for_myKey()
    {
        $this->someMethodThatReturnsAnArray()->shouldHaveKeyWithValue('myKey', 'myValue');
    }
}
```

Example method under test
```php
<?php

SomeClass
{

    public function someMethodThatReturnsAnArray()
    {
        return ['myKey' => 'myValue'];
    }
}

```