### PR TITLE
- Fixed broken link & Added clarification that by default phpspec creates mock classes

### DIFF
--- a/docs/cookbook/construction.rst
+++ b/docs/cookbook/construction.rst
@@ -73,6 +73,29 @@ You can tell **phpspec** to pass values to the constructor when it constructs th
             }
         }
 
+Keep in mind that by default, **phpspec** creates a mock object. If you want
+to inject an actual object you could do it like this:
+
+.. code-block:: php
+
+    <?php
+
+        namespace spec;
+
+        use PhpSpec\ObjectBehavior;
+        use Markdown\Writer;
+
+        class MarkdownSpec extends ObjectBehavior
+        {
+            function it_outputs_converted_text()
+            {
+                $this->beConstructedWith(new Writer());
+                $writer->writeText("<p>Hi, there</p>")->shouldBeCalled();
+
+                $this->outputHtml("Hi, there");
+            }
+        }
+
 Using a Factory Method
 ----------------------
 

--- a/docs/manual/installation.rst
+++ b/docs/manual/installation.rst
@@ -31,7 +31,7 @@ Then install phpspec with the composer install command:
 
     $ composer install
 
-Follow instructions on `the composer website <https://getcomposer.org/download/`_
+Follow instructions on `the composer website <https://getcomposer.org/download/>`_
 if you don't have it installed yet.
 
 Phpspec with its dependencies will be installed inside the ``vendor`` folder

--- a/docs/manual/let-and-letgo.rst
+++ b/docs/manual/let-and-letgo.rst
@@ -24,6 +24,29 @@ then you can do it like this:
             }
         }
 
+Keep in mind that by default, **phpspec** creates a mock object. If you want
+to inject an actual object you could do it like this:
+
+.. code-block:: php
+
+    <?php
+
+        namespace spec;
+
+        use PhpSpec\ObjectBehavior;
+        use Markdown\Writer;
+
+        class MarkdownSpec extends ObjectBehavior
+        {
+            function it_outputs_converted_text()
+            {
+                $this->beConstructedWith(new Writer());
+                $writer->writeText("<p>Hi, there</p>")->shouldBeCalled();
+
+                $this->outputHtml("Hi, there");
+            }
+        }
+
 If you have many examples then writing this in each example will get
 tiresome. You can instead move this to a `let` method. The `let` method
 gets run before each example so each time the parser gets constructed with


### PR DESCRIPTION
- Fixed broken link
- Added clarification that by default phpspec creates mock classes

Pretty salty that I spend 30 min figuring out why my tests kept failing only to find out I was working with a mock the entire time instead of the actual object. This is mentioned nowhere in the docs, so I added this for future beginners.