### PR TITLE
Patch MethodAnalyser to find code of the method in traits from different files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,10 @@ install:
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
+before_script:
+  - echo "<?php if (PHP_VERSION_ID >= 50400) echo ',@php5.4';" > php_version_tags.php
+
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty `if [ "$SMOKE" == "true" ]; then echo '--profile=smoke'; fi;`
-
+   - ./vendor/bin/behat --format=pretty `if [ "$SMOKE" == "true" ]; then echo '--profile=smoke'; fi;` --tags '~@php-version'`php php_version_tags.php`

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,12 @@
         }
     },
 
+    "autoload-dev": {
+        "psr-0": {
+            "spec\\PhpSpec": "."
+        }
+    },
+
     "bin": ["bin/phpspec"],
 
     "extra": {

--- a/features/bootstrap/FilesystemContext.php
+++ b/features/bootstrap/FilesystemContext.php
@@ -59,8 +59,9 @@ class FilesystemContext implements Context, MatchersProviderInterface
     /**
      * @Given the class file :file contains:
      * @Given the spec file :file contains:
+     * @Given the trait file :file contains:
      */
-    public function theClassOrSpecFileContains($file, PyStringNode $contents)
+    public function theClassOrTraitOrSpecFileContains($file, PyStringNode $contents)
     {
         $this->theFileContains($file, $contents);
         require_once($file);

--- a/features/code_generation/developer_generates_return_constant.feature
+++ b/features/code_generation/developer_generates_return_constant.feature
@@ -259,3 +259,66 @@ Feature: Developer generates a method returning a constant
       """
     When I run phpspec interactively
     Then I should be prompted for code generation
+
+  @php-version @php5.4
+  Scenario: Generating a scalar return type when method is in trait
+    Given the spec file "spec/CodeGeneration/ConstantExample7/MarkdownSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\CodeGeneration\ConstantExample7;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class MarkdownSpec extends ObjectBehavior
+      {
+          function it_converts_plain_text_to_html_paragraphs()
+          {
+              $this->toHtml('Hi, there')->shouldReturn('<p>Hi, there</p>');
+          }
+      }
+
+      """
+    And the trait file "src/CodeGeneration/ConstantExample7/MarkdownTrait.php" contains:
+      """
+      <?php
+
+      namespace CodeGeneration\ConstantExample7;
+
+      trait MarkdownTrait
+      {
+          public function toHtml($argument1)
+          {
+          }
+      }
+
+      """
+    And the class file "src/CodeGeneration/ConstantExample7/Markdown.php" contains:
+      """
+      <?php
+
+      namespace CodeGeneration\ConstantExample7;
+
+      class Markdown
+      {
+          use MarkdownTrait;
+      }
+
+      """
+    When I run phpspec with the option "fake" and answer "y" when asked if I want to generate the code
+    Then the class in "src/CodeGeneration/ConstantExample7/MarkdownTrait.php" should contain:
+      """
+      <?php
+
+      namespace CodeGeneration\ConstantExample7;
+
+      trait MarkdownTrait
+      {
+          public function toHtml($argument1)
+          {
+              return '<p>Hi, there</p>';
+          }
+      }
+
+      """

--- a/features/runner/developer_is_told_about_pending_specs.feature
+++ b/features/runner/developer_is_told_about_pending_specs.feature
@@ -88,3 +88,38 @@ Feature: Developer is told about pending specs
       """
       1 examples (1 passed)
       """
+
+  @php-version @php5.4
+  Scenario: Spec defined in trait does not cause pending
+    Given the trait file "spec/Runner/PendingExample4/PartialSpecTrait.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\PendingExample4;
+
+      trait PartialSpecTrait
+      {
+          function it_converts_plain_text_to_html_paragraphs()
+          {
+              pow(2,2);
+          }
+      }
+      """
+    And the spec file "spec/Runner/PendingExample4/MarkdownSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\PendingExample4;
+
+      use PhpSpec\ObjectBehavior;
+
+      class MarkdownSpec extends ObjectBehavior
+      {
+          use PartialSpecTrait;
+      }
+      """
+    When I run phpspec using the "pretty" format
+    Then I should see:
+      """
+      1 examples (1 passed)
+      """

--- a/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
@@ -33,6 +33,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         $io->isFakingEnabled()->willReturn(true);
 
         $methodAnalyser->methodIsEmpty(Argument::cetera())->willReturn(true);
+        $methodAnalyser->getMethodOwnerName(Argument::cetera())->willReturn('Foo');;
     }
 
     function it_is_an_event_listener()

--- a/spec/PhpSpec/Util/ExampleObjectUsingTrait.php
+++ b/spec/PhpSpec/Util/ExampleObjectUsingTrait.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace spec\PhpSpec\Util;
+
+class ExampleObjectUsingTrait
+{
+    use ExampleTrait, AnotherExampleTrait;
+}

--- a/spec/PhpSpec/Util/ExampleTrait.php
+++ b/spec/PhpSpec/Util/ExampleTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace spec\PhpSpec\Util;
+
+trait ExampleTrait
+{
+    public function emptyMethodInTrait()
+    {
+    }
+}
+
+trait AnotherExampleTrait
+{
+    public function nonEmptyMethodInTrait()
+    {
+        return 'foo';
+    }
+}

--- a/spec/PhpSpec/Util/MethodAnalyserSpec.php
+++ b/spec/PhpSpec/Util/MethodAnalyserSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Util;
 
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -34,6 +35,26 @@ class MethodAnalyserSpec extends ObjectBehavior
     function it_identifies_internal_classes_as_non_empty()
     {
         $this->methodIsEmpty('DateTimeZone', 'getOffset')->shouldReturn(false);
+    }
+
+    function it_identifies_methods_from_traits()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $this->methodIsEmpty('spec\PhpSpec\Util\ExampleObjectUsingTrait', 'emptyMethodInTrait')->shouldReturn(true);
+        $this->methodIsEmpty('spec\PhpSpec\Util\ExampleObjectUsingTrait', 'nonEmptyMethodInTrait')->shouldReturn(false);
+    }
+    
+    function it_finds_the_real_declaring_class_of_a_method()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $this->getMethodOwnerName('spec\PhpSpec\Util\ExampleObjectUsingTrait', 'emptyMethodInTrait')
+            ->shouldReturn('spec\PhpSpec\Util\ExampleTrait');
     }
 }
 

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -120,7 +120,7 @@ class MethodReturnedNullListener implements EventSubscriberInterface
 
         if (!array_key_exists($key, $this->nullMethods)) {
             $this->nullMethods[$key] = array(
-                'class' => $class,
+                'class' => $this->methodAnalyser->getMethodOwnerName($class, $method),
                 'method' => $method,
                 'expected' => array()
             );

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -44,19 +44,81 @@ class MethodAnalyser
     }
 
     /**
+     * @param string $class
+     * @param string $method
+     *
+     * @return string
+     */
+    public function getMethodOwnerName($class, $method)
+    {
+        $reflectionMethod = new \ReflectionMethod($class, $method);
+        $startLine = $reflectionMethod->getStartLine();
+        $endLine = $reflectionMethod->getEndLine();
+        $reflectionClass  = $this->getMethodOwner($reflectionMethod, $startLine, $endLine);
+
+        return $reflectionClass->getName();
+    }
+
+    /**
      * @param \ReflectionMethod $reflectionMethod
      *
      * @return string
      */
     private function getCodeBody(\ReflectionMethod $reflectionMethod)
     {
-        $reflectionClass = $reflectionMethod->getDeclaringClass();
+        $endLine = $reflectionMethod->getEndLine();
+        $startLine = $reflectionMethod->getStartLine();
+        $reflectionClass = $this->getMethodOwner($reflectionMethod, $startLine, $endLine);
 
-        $length = $reflectionMethod->getEndLine() - $reflectionMethod->getStartLine();
+        $length = $endLine - $startLine;
         $lines = file($reflectionClass->getFileName());
-        $code = join(PHP_EOL, array_slice($lines, $reflectionMethod->getStartLine()-1, $length+1));
+        $code = join(PHP_EOL, array_slice($lines, $startLine - 1, $length + 1));
 
         return preg_replace('/.*function[^{]+{/s', '', $code);
+    }
+
+    /**
+     * @param  \ReflectionMethod $reflectionMethod
+     * @param  int $methodStartLine
+     * @param  int $methodEndLine
+     *
+     * @return \ReflectionClass
+     */
+    private function getMethodOwner(\ReflectionMethod $reflectionMethod, $methodStartLine, $methodEndLine)
+    {
+        $reflectionClass = $reflectionMethod->getDeclaringClass();
+
+        // PHP <=5.3 does not handle traits
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            return $reflectionClass;
+        }
+
+        $fileName = $reflectionMethod->getFileName();
+        $trait = $this->getDeclaringTrait($reflectionClass->getTraits(), $fileName, $methodStartLine, $methodEndLine);
+
+        return $trait === null ? $reflectionClass : $trait;
+    }
+
+    /**
+     * @param  \ReflectionClass[] $traits
+     * @param  string  $file
+     * @param  int $start
+     * @param  int $end
+     *
+     * @return null|\ReflectionClass
+     */
+    private function getDeclaringTrait(array $traits, $file, $start, $end)
+    {
+        foreach ($traits as $trait) {
+            if ($trait->getFileName() == $file && $trait->getStartLine() <= $start && $trait->getEndLine() >= $end) {
+                return $trait;
+            }
+            if (null !== ( $trait = $this->getDeclaringTrait($trait->getTraits(), $file, $start, $end) )) {
+                return $trait;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -65,7 +127,7 @@ class MethodAnalyser
      */
     private function stripComments($code)
     {
-        $tokens = token_get_all('<?php '.$code);
+        $tokens = token_get_all('<?php ' . $code);
 
         $comments = array_map(
             function ($token) {
@@ -74,10 +136,8 @@ class MethodAnalyser
             array_filter(
                 $tokens,
                 function ($token) {
-                    return is_array($token)
-                    && in_array($token[0], array(T_COMMENT, T_DOC_COMMENT));
-                }
-            )
+                    return is_array($token) && in_array($token[0], array(T_COMMENT, T_DOC_COMMENT));
+                })
         );
 
         $commentless = str_replace($comments, '', $code);


### PR DESCRIPTION
When using traits from different file, the analyzer fails to find the right code.
This commit fixes it by looking for traits recursively based on [this post](http://mouf-php.com/blog/php_reflection_api_traits).

I am not sure about the flat require in the spec, maybe it would be better to [define autoload-dev in composer.json](https://getcomposer.org/doc/04-schema.md#autoload-dev).