### PR TITLE
Check for successful autoloading after class is generated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,12 @@
 
  * Support for TAP format output
  * Remove deprecated usage of Symfony DialogHelper
+ * Show an error when generating a class in a non-autoloadable location
  * Clearer error message when specs have incorrect namespace prefix
  * Fix suite rerunning for HHVM
 
-Backward Compatibility
-----------------------
+BC notes
+--------
 
  * The unused `ask` and `askAndValidate` methods on `Console\IO` have been removed
 

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -282,17 +282,8 @@ class ApplicationContext implements Context, MatchersProviderInterface
         }
 
         $this->autoloader = function () use ($workingDirectory) {
-            $fs = new CallbackFilterIterator(
-                new RecursiveiteratorIterator(
-                    new RecursiveDirectoryIterator($workingDirectory)
-                ),
-                function (SplFileInfo $fileInfo) {
-                    return $fileInfo->getExtension() == 'php';
-                }
-            );
-
-            foreach ($fs as $f) {
-                require_once $f->getPathName();
+            foreach (new RecursiveiteratorIterator( new RecursiveDirectoryIterator($workingDirectory)) as $fs) {
+                if ($fs->getExtension() == 'php') { require_once $fs->getPathName();}
             }
         };
 

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -45,6 +45,16 @@ class ApplicationContext implements Context, MatchersProviderInterface
     private $reRunner;
 
     /**
+     * @var bool
+     */
+    private $shouldAutoload = true;
+
+    /**
+     * @var callable
+     */
+    private $autoloader;
+
+    /**
      * @beforeScenario
      */
     public function setupApplication()
@@ -56,6 +66,16 @@ class ApplicationContext implements Context, MatchersProviderInterface
 
         $this->setupReRunner();
         $this->setupPrompter();
+    }
+
+    /**
+     * @afterScenario
+     */
+    public function cleanAutoloaders()
+    {
+        if ($this->autoloader) {
+            spl_autoload_unregister($this->autoloader);
+        }
     }
 
     private function setupPrompter()
@@ -114,6 +134,8 @@ class ApplicationContext implements Context, MatchersProviderInterface
      */
     public function iRunPhpspecAndAnswerWhenAskedIfIWantToGenerateTheCode($answer, $option=null)
     {
+        $this->makeAutoloadable(getcwd());
+
         $arguments = array (
             'command' => 'run'
         );
@@ -232,5 +254,48 @@ class ApplicationContext implements Context, MatchersProviderInterface
             new ApplicationOutputMatcher(),
             new ValidJUnitXmlMatcher()
         );
+    }
+
+    /**
+     * @Then I should be told autoloading failed
+     */
+    public function iShouldBeToldAutoloadingFailed()
+    {
+        expect($this->tester->getDisplay())->toMatch('/do you have an autoloader/i');
+    }
+
+    /**
+     * @Given I have not configured an autoloader
+     */
+    public function iHaveNotConfiguredAnAutoloader()
+    {
+        $this->shouldAutoload = false;
+    }
+
+    /**
+     * @param $workingDirectory
+     */
+    private function makeAutoloadable($workingDirectory)
+    {
+        if (!$this->shouldAutoload) {
+            return;
+        }
+
+        $this->autoloader = function () use ($workingDirectory) {
+            $fs = new CallbackFilterIterator(
+                new RecursiveiteratorIterator(
+                    new RecursiveDirectoryIterator($workingDirectory)
+                ),
+                function (SplFileInfo $fileInfo) {
+                    return $fileInfo->getExtension() == 'php';
+                }
+            );
+
+            foreach ($fs as $f) {
+                require_once $f->getPathName();
+            }
+        };
+
+        spl_autoload_register($this->autoloader);
     }
 }

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -283,7 +283,7 @@ class ApplicationContext implements Context, MatchersProviderInterface
 
         $this->autoloader = function () use ($workingDirectory) {
             foreach (new RecursiveiteratorIterator( new RecursiveDirectoryIterator($workingDirectory)) as $fs) {
-                if ($fs->getExtension() == 'php') { require_once $fs->getPathName();}
+                if (preg_match('/\\.php$/', $fs->getFilename())) { require_once $fs->getPathName();}
             }
         };
 

--- a/features/bootstrap/FilesystemContext.php
+++ b/features/bootstrap/FilesystemContext.php
@@ -37,6 +37,7 @@ class FilesystemContext implements Context, MatchersProviderInterface
         $this->workingDirectory = tempnam(sys_get_temp_dir(), 'phpspec-behat');
         $this->filesystem->remove($this->workingDirectory);
         $this->filesystem->mkdir($this->workingDirectory);
+        $this->filesystem->mkdir($this->workingDirectory . '/vendor');
         chdir($this->workingDirectory);
     }
 

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -2,7 +2,6 @@
 
 use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Symfony\Component\Process\Process;
@@ -10,7 +9,7 @@ use Symfony\Component\Process\Process;
 /**
  * Defines application features from the specific context.
  */
-class IsolatedProcessContext implements Context, SnippetAcceptingContext
+class IsolatedProcessContext implements Context
 {
     private $lastOutput;
 
@@ -41,15 +40,16 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
      */
     public function iRunPhpspecAndAnswerWhenAskedIfIWantToGenerateTheCode($answer)
     {
+        $this->writeAutoloader(getcwd());
+
         $process = new Process(
             "exec expect -c '\n" .
             "set timeout 10\n" .
             "spawn {$this->buildPhpSpecCmd()} run\n" .
             "expect \"Y/n\"\n" .
-            "send \"$answer\n\"\n" .
-            "expect \"Y/n\"\n" .
-            "interact\n" .
-            "'"
+            "send \"$answer\\n\"\n" .
+            "expect \"ms\"\n" .
+            "interact'"
         );
 
         $process->run();
@@ -71,6 +71,14 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
      */
     public function theTestsShouldBeRerun()
     {
-        expect(substr_count($this->lastOutput, 'for you?'))->toBe(2);
+        expect(substr_count($this->lastOutput, 'specs'))->toBe(2);
+    }
+
+    /**
+     * @param $dir
+     */
+    private function writeAutoloader($dir)
+    {
+        copy(__DIR__ . '/autoloader/autoload.php', $dir . '/vendor/autoload.php');
     }
 }

--- a/features/bootstrap/autoloader/autoload.php
+++ b/features/bootstrap/autoloader/autoload.php
@@ -2,17 +2,8 @@
 
 spl_autoload_register(
     function () {
-        $fs = new CallbackFilterIterator(
-            new RecursiveiteratorIterator(
-                new RecursiveDirectoryIterator(__DIR__ . '/..')
-            ),
-            function (SplFileInfo $fileInfo) {
-                return $fileInfo->getExtension() == 'php';
-            }
-        );
-
-        foreach ($fs as $f) {
-            require_once $f->getPathName();
+        foreach (new RecursiveiteratorIterator( new RecursiveDirectoryIterator(__DIR__ . '/..' )) as $fs) {
+            if ($fs->getExtension() == 'php') { require_once $fs->getPathName();}
         }
     }
 );

--- a/features/bootstrap/autoloader/autoload.php
+++ b/features/bootstrap/autoloader/autoload.php
@@ -3,7 +3,7 @@
 spl_autoload_register(
     function () {
         foreach (new RecursiveiteratorIterator( new RecursiveDirectoryIterator(__DIR__ . '/..' )) as $fs) {
-            if ($fs->getExtension() == 'php') { require_once $fs->getPathName();}
+            if (preg_match('/\\.php$/', $fs->getFilename())) { require_once $fs->getPathName();}
         }
     }
 );

--- a/features/bootstrap/autoloader/autoload.php
+++ b/features/bootstrap/autoloader/autoload.php
@@ -1,0 +1,18 @@
+<?php
+
+spl_autoload_register(
+    function () {
+        $fs = new CallbackFilterIterator(
+            new RecursiveiteratorIterator(
+                new RecursiveDirectoryIterator(__DIR__ . '/..')
+            ),
+            function (SplFileInfo $fileInfo) {
+                return $fileInfo->getExtension() == 'php';
+            }
+        );
+
+        foreach ($fs as $f) {
+            require_once $f->getPathName();
+        }
+    }
+);

--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -131,3 +131,21 @@ Feature: Developer generates a class
     }
 
     """
+
+  Scenario: Generating a class when no autoloader is configured
+    Given I have started describing the "CodeGeneration/ClassExample3/Markdown" class
+    But I have not configured an autoloader
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then a new class should be generated in the "src/CodeGeneration/ClassExample3/Markdown.php":
+      """
+      <?php
+
+      namespace CodeGeneration\ClassExample3;
+
+      class Markdown
+      {
+      }
+
+      """
+    But I should be told autoloading failed
+    And the tests should not be rerun

--- a/src/PhpSpec/Exception/CodeGeneration/ClassGenerationFailedException.php
+++ b/src/PhpSpec/Exception/CodeGeneration/ClassGenerationFailedException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpSpec\Exception\CodeGeneration;
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class ClassGenerationFailedException extends \Exception
+{
+}

--- a/src/PhpSpec/Listener/ClassNotFoundListener.php
+++ b/src/PhpSpec/Listener/ClassNotFoundListener.php
@@ -76,13 +76,11 @@ class ClassNotFoundListener implements EventSubscriberInterface
 
             if ($this->io->askConfirmation($message)) {
                 $this->generator->generate($resource, 'class');
-                if (class_exists($classname)) {
-                    $event->markAsWorthRerunning();
-                }
-                else {
+                if (!class_exists($classname)) {
                     $message = 'File was written but the class %s was not autoloadable - do you have an autoloader configured?';
                     throw new ClassGenerationFailedException(sprintf($message, $classname));
                 }
+                $event->markAsWorthRerunning();
             }
         }
     }

--- a/src/PhpSpec/Listener/ClassNotFoundListener.php
+++ b/src/PhpSpec/Listener/ClassNotFoundListener.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Listener;
 
+use PhpSpec\Exception\CodeGeneration\ClassGenerationFailedException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use PhpSpec\Console\IO;
 use PhpSpec\Locator\ResourceManagerInterface;
@@ -75,7 +76,13 @@ class ClassNotFoundListener implements EventSubscriberInterface
 
             if ($this->io->askConfirmation($message)) {
                 $this->generator->generate($resource, 'class');
-                $event->markAsWorthRerunning();
+                if (class_exists($classname)) {
+                    $event->markAsWorthRerunning();
+                }
+                else {
+                    $message = 'File was written but the class %s was not autoloadable - do you have an autoloader configured?';
+                    throw new ClassGenerationFailedException(sprintf($message, $classname));
+                }
             }
         }
     }


### PR DESCRIPTION
This is an FAQ when users have not correctly configured their autoloader and can get stuck in a 'Do you want to generate the class?' loop (see #585)

Now after a class is generated a quick `class_exists` checks whether the class has been written out to an autoloadable path and tells the user / cancels suite re-run if it is not the case.

![autoloader](https://cloud.githubusercontent.com/assets/237866/6545723/6988938c-c58d-11e4-8cc5-d0e836421535.gif)
