### PR TITLE
Made autoload path check a single if statement.

### DIFF
--- a/bin/phpspec
+++ b/bin/phpspec
@@ -7,9 +7,7 @@ if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
     require $autoload;
 } elseif (is_file($autoload = getcwd() . '/../../autoload.php')) {
     require $autoload;
-}
-
-if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
+} elseif (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
     require($autoload);
 } elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
     require($autoload);


### PR DESCRIPTION
I'm not sure why there were two if statements here?

In my case the first if statement found the autoload file and the second one didn't, which lead to it throwing the standard error and not running phpspec.

This change to the file fixed the issue for me so wanted to put it forward as a pull request unless theres an non-obvious reason why it's setup like this?