### PR TITLE
Lower prophecy dependency and use feature detection instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ install:
   - export COMPOSER_ROOT_VERSION=dev-master
   - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
-  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
+  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; TAGS="~@prophecy-1.4"; fi;
 
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - if [ "$SMOKE" != "true" ]; then ./vendor/bin/behat --format=pretty; fi;
-   - if [ "$SMOKE" == "true" ]; then ./vendor/bin/behat --format=pretty --profile=smoke; fi;
+   - if [ "$SMOKE" != "true" ]; then ./vendor/bin/behat --format=pretty `if [ $TAGS ]; then echo "--tags=$TAGS"; fi;`; fi;
+   - if [ "$SMOKE" == "true" ]; then ./vendor/bin/behat --format=pretty --profile=smoke `if [ $TAGS ]; then echo "--tags=$TAGS"; fi;`; fi;
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 
     "require": {
         "php":                      ">=5.3.3",
-        "phpspec/prophecy":         "~1.4",
+        "phpspec/prophecy":         "~1.1",
         "phpspec/php-diff":         "~1.0.0",
         "sebastian/exporter":       "~1.0",
         "symfony/console":          "~2.3",

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -58,6 +58,16 @@ class ApplicationContext implements Context, MatchersProviderInterface
         $this->setupPrompter();
     }
 
+    /**
+     * @beforeScenario @prophecy-1.4
+     */
+    public function checkProphecy()
+    {
+        if (!method_exists('Prophecy\Exception\Doubler\MethodNotFoundException', 'getArguments')) {
+            throw new \Exception('Cannot run scenario tagged @prophecy-1.4 that depends on Prophecy 1.4 or greater');
+        }
+    }
+
     private function setupPrompter()
     {
         $this->prompter = new Prompter();

--- a/features/code_generation/developer_generates_collaborator_method.feature
+++ b/features/code_generation/developer_generates_collaborator_method.feature
@@ -163,6 +163,7 @@ Feature: Developer generates a collaborator's method
 
       """
 
+  @prophecy-1.4
   Scenario: Asking for the method signature to be generated with multiple parameters
     Given the spec file "spec/CodeGeneration/CollaboratorMethodExample4/MarkdownSpec.php" contains:
       """

--- a/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
@@ -30,7 +30,10 @@ class CollaboratorMethodNotFoundListenerSpec extends ObjectBehavior
         $io->askConfirmation(Argument::any())->willReturn(false);
 
         $resources->createResource(Argument::any())->willReturn($resource);
-        $exception->getArguments()->willReturn(array());
+
+        if (method_exists('Prophecy\Exception\Doubler\MethodNotFoundException', 'getArguments')) {
+            $exception->getArguments()->willReturn(array());
+        }
     }
 
     function it_is_an_event_subscriber()

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -87,7 +87,7 @@ class CollaboratorMethodNotFoundListener implements EventSubscriberInterface
             $this->interfaces[$interface] = array();
         }
 
-        $this->interfaces[$interface][$exception->getMethodName()] = $exception->getArguments();
+        $this->interfaces[$interface][$exception->getMethodName()] = method_exists($exception, 'getArguments') ? $exception->getArguments() : array();
     }
 
     /**


### PR DESCRIPTION
This allows prophecy versions `<1.4.0` and just turns off the relevant argument generation.

The reason for this change is that PHPUnit depends on `~1.3.1` so currently PHPUnit's latest version cannot coexist with PhpSpec `2.2.0-BETA`