### PR TITLE
Update prophecy requirement back to 1.4 and remove conditionals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,10 @@ install:
   - export COMPOSER_ROOT_VERSION=dev-master
   - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
-  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; TAGS="~@prophecy-1.4"; fi;
+  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - if [ "$SMOKE" != "true" ]; then ./vendor/bin/behat --format=pretty `if [ $TAGS ]; then echo "--tags=$TAGS"; fi;`; fi;
-   - if [ "$SMOKE" == "true" ]; then ./vendor/bin/behat --format=pretty --profile=smoke `if [ $TAGS ]; then echo "--tags=$TAGS"; fi;`; fi;
+   - ./vendor/bin/behat --format=pretty `if [ "$SMOKE" == "true" ]; then echo '--profile=smoke'; fi;`
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 
     "require": {
         "php":                      ">=5.3.3",
-        "phpspec/prophecy":         "~1.1",
+        "phpspec/prophecy":         "~1.4",
         "phpspec/php-diff":         "~1.0.0",
         "sebastian/exporter":       "~1.0",
         "symfony/console":          "~2.3",
@@ -31,7 +31,7 @@
     },
 
     "require-dev": {
-        "behat/behat": "^3.0.11",
+        "behat/behat":           "^3.0.11",
         "bossa/phpspec2-expect": "~1.0",
         "symfony/filesystem":    "~2.1",
         "symfony/process":       "~2.1",

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -58,16 +58,6 @@ class ApplicationContext implements Context, MatchersProviderInterface
         $this->setupPrompter();
     }
 
-    /**
-     * @beforeScenario @prophecy-1.4
-     */
-    public function checkProphecy()
-    {
-        if (!method_exists('Prophecy\Exception\Doubler\MethodNotFoundException', 'getArguments')) {
-            throw new \Exception('Cannot run scenario tagged @prophecy-1.4 that depends on Prophecy 1.4 or greater');
-        }
-    }
-
     private function setupPrompter()
     {
         $this->prompter = new Prompter();

--- a/features/code_generation/developer_generates_collaborator_method.feature
+++ b/features/code_generation/developer_generates_collaborator_method.feature
@@ -163,7 +163,6 @@ Feature: Developer generates a collaborator's method
 
       """
 
-  @prophecy-1.4
   Scenario: Asking for the method signature to be generated with multiple parameters
     Given the spec file "spec/CodeGeneration/CollaboratorMethodExample4/MarkdownSpec.php" contains:
       """

--- a/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
@@ -31,9 +31,7 @@ class CollaboratorMethodNotFoundListenerSpec extends ObjectBehavior
 
         $resources->createResource(Argument::any())->willReturn($resource);
 
-        if (method_exists('Prophecy\Exception\Doubler\MethodNotFoundException', 'getArguments')) {
-            $exception->getArguments()->willReturn(array());
-        }
+        $exception->getArguments()->willReturn(array());
     }
 
     function it_is_an_event_subscriber()

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -87,7 +87,7 @@ class CollaboratorMethodNotFoundListener implements EventSubscriberInterface
             $this->interfaces[$interface] = array();
         }
 
-        $this->interfaces[$interface][$exception->getMethodName()] = method_exists($exception, 'getArguments') ? $exception->getArguments() : array();
+        $this->interfaces[$interface][$exception->getMethodName()] = $exception->getArguments();
     }
 
     /**


### PR DESCRIPTION
I added some conditionals to cope with the lower prophecy versions, this PR removes them now that PHPUnit 4.5.1 allows Prophecy 1.4.0 to be installed