### PR TITLE
Add ArrayKeyValueMatcher entry in the 'Matchers' chapter of the cookbook...

### DIFF
--- a/docs/cookbook/matchers.rst
+++ b/docs/cookbook/matchers.rst
@@ -289,6 +289,28 @@ identity (``===``).
     }
 
 
+ArrayKeyWithValue Matcher
+--------------------
+
+This matcher lets you assert a specific value for a specific key on a method that returns an array or an implementor of ArrayAccess.
+
+.. code-block:: php
+
+    <?php
+
+    namespace spec;
+
+    use PhpSpec\ObjectBehavior;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function it_should_have_jane_smith_in_the_cast_with_a_lead_role()
+        {
+            $this->getCast()->shouldHaveKeyWithValue('leadRole', 'John Smith');
+        }
+    }
+
+
 ArrayKey Matcher
 ----------------
 


### PR DESCRIPTION
Just add an entry in the "Matchers" chapter of the cookbook documentation to include the new **shouldHaveKeyWithValue** matcher #640 that will be included in the version 2.2.0

I know there is no glory on this PR ;) and that I know that it took time to change the link that points the  official website to the readthedocs documentation, so I think it has more value when the doc is updated. 

Regards,
kiko

