### PR TITLE
Fix unexpected method call exception presenting

### DIFF
--- a/features/formatter/developer_is_shown_diffs.feature
+++ b/features/formatter/developer_is_shown_diffs.feature
@@ -152,7 +152,7 @@ Feature: Developer is shown diffs
       """
 
 
-  Scenario: Unexpected call arguments string diffing
+  Scenario: Unexpected method arguments call arguments string diffing
     Given the spec file "spec/Diffs/DiffExample4/ClassUnderSpecificationSpec.php" contains:
       """
       <?php
@@ -208,7 +208,7 @@ Feature: Developer is shown diffs
       """
 
 
-  Scenario: Unexpected call arguments array diffing
+  Scenario: Unexpected method arguments call arguments array diffing
     Given the spec file "spec/Diffs/DiffExample5/ClassUnderSpecificationSpec.php" contains:
       """
       <?php
@@ -272,7 +272,7 @@ Feature: Developer is shown diffs
                ]
       """
 
-  Scenario: Unexpected call with multiple arguments icluding null diffing
+  Scenario: Unexpected method arguments call with multiple arguments icluding null diffing
     Given the spec file "spec/Diffs/DiffExample6/ClassUnderSpecificationSpec.php" contains:
       """
       <?php
@@ -337,4 +337,65 @@ Feature: Developer is shown diffs
             @@ -1,1 +1,1 @@
             -null
             +bar
+      """
+
+  Scenario: Unexpected method call
+    Given the spec file "spec/Diffs/DiffExample7/ClassUnderSpecificationSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Diffs\DiffExample7;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+      use Diffs\DiffExample7\ClassBeingMocked;
+
+      class ClassUnderSpecificationSpec extends ObjectBehavior
+      {
+          function it_can_do_work(ClassBeingMocked $objectBeingMocked)
+          {
+              $objectBeingMocked->methodOne('value')->shouldBeCalled();
+              $this->doWork($objectBeingMocked);
+          }
+      }
+      """
+    And the class file "src/Diffs/DiffExample7/ClassUnderSpecification.php" contains:
+      """
+      <?php
+
+      namespace Diffs\DiffExample7;
+
+      class ClassUnderSpecification
+      {
+          public function doWork(ClassBeingMocked $objectBeingMocked)
+          {
+              $objectBeingMocked->methodTwo('value');
+          }
+      }
+      """
+    And the class file "src/Diffs/DiffExample7/ClassBeingMocked.php" contains:
+      """
+      <?php
+
+      namespace Diffs\DiffExample7;
+
+      class ClassBeingMocked
+      {
+          public function methodOne($value)
+          {
+          }
+
+          public function methodTwo($value)
+          {
+          }
+
+      }
+      """
+    When I run phpspec with the "verbose" option
+    Then I should see:
+      """
+            method call:
+              - methodTwo("value")
+            on Double\Diffs\DiffExample7\ClassBeingMocked\P13 was not expected, expected calls were:
+              - methodOne(exact("value"))
       """

--- a/src/PhpSpec/Formatter/Presenter/StringPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/StringPresenter.php
@@ -384,7 +384,12 @@ class StringPresenter implements PresenterInterface
     {
         $actualArguments = $exception->getArguments();
         $methodProphecies = $exception->getObjectProphecy()->getMethodProphecies($exception->getMethodName());
-        $presentedMethodProphecy = $this->findMethodProphecyOfFirstNotExpectedCall($methodProphecies, $exception);
+        if ($this->noMethodPropheciesForUnexpectedCall($methodProphecies)) {
+
+            return '';
+        }
+
+        $presentedMethodProphecy = $this->findMethodProphecyOfFirstNotExpectedArgumentsCall($methodProphecies, $exception);
         $expectedTokens = $presentedMethodProphecy->getArgumentsWildcard()->getTokens();
 
         if ($this->parametersCountMismatch($expectedTokens, $actualArguments)) {
@@ -398,13 +403,18 @@ class StringPresenter implements PresenterInterface
         return $text;
     }
 
+    private function noMethodPropheciesForUnexpectedCall(array $methodProphecies)
+    {
+        return count($methodProphecies) === 0;
+    }
+
     /**
      * @param MethodProphecy[] $methodProphecies
      * @param UnexpectedCallException $exception
      *
      * @return MethodProphecy
      */
-    private function findMethodProphecyOfFirstNotExpectedCall(array $methodProphecies, UnexpectedCallException $exception)
+    private function findMethodProphecyOfFirstNotExpectedArgumentsCall(array $methodProphecies, UnexpectedCallException $exception)
     {
         $objectProphecy = $exception->getObjectProphecy();
         foreach ($methodProphecies as $methodProphecy) {


### PR DESCRIPTION
There is a serious problem with PR #664.
When there is no method prophecy for called method, fatal error is generated (Call to a member function on a non-object).

This PR fixes problem and adds feature coverage.