### PR TITLE
Add Caller extension point

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
-Upcoming
-========
+2.2.1 / 2015-05-30
+==================
 
 * Fix false positives in `shouldHaveKeyWithValue` matcher
+* Fix fatal error in edge case when method call parameters don't match expectations
 
 2.2.0 / 2015-04-18
 ==================

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-define('PHPSPEC_VERSION', '2.2.0');
+define('PHPSPEC_VERSION', '2.2.1');
 
 if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
     require $autoload;

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-define('PHPSPEC_VERSION', '2.2.1');
+define('PHPSPEC_VERSION', '2.2.x-dev');
 
 if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
     require $autoload;

--- a/spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace spec\PhpSpec\CodeAnalysis;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class MagicAwareAccessInspectorSpec extends ObjectBehavior
+{
+    function it_should_be_an_access_inspector()
+    {
+        $this->shouldImplement('PhpSpec\CodeAnalysis\AccessInspectorInterface');
+    }
+
+    function it_should_fail_to_check_for_a_property_of_a_non_object()
+    {
+        $this->isPropertyAccessible('foo', 'property')->shouldReturn(false);
+    }
+
+    function it_should_detect_a_magic_getter_if_no_value_is_given()
+    {
+        $this->isPropertyAccessible(new ObjectWithMagicGet, 'property')->shouldReturn(true);
+    }
+
+    function it_should_detect_a_magic_setter_if_a_value_is_given()
+    {
+        $this->isPropertyAccessible(new ObjectWithMagicSet, 'property', true)->shouldReturn(true);
+    }
+
+    function it_should_reject_an_object_if_the_property_does_not_exist()
+    {
+        $this->isPropertyAccessible(new ObjectWithNoProperty, 'property')->shouldReturn(false);
+    }
+
+    function it_should_reject_a_private_property()
+    {
+        $this->isPropertyAccessible(new ObjectWithPrivateProperty, 'property')->shouldReturn(false);
+    }
+
+    function it_should_detect_a_public_property()
+    {
+        $this->isPropertyAccessible(new ObjectWithPublicProperty, 'property')->shouldReturn(true);
+    }
+
+    function it_should_fail_to_check_for_a_method_of_a_non_object()
+    {
+        $this->isMethodAccessible('foo', 'method')->shouldReturn(false);
+    }
+
+    function it_should_detect_a_magic_call_method()
+    {
+        $this->isMethodAccessible(new ObjectWithMagicCall, 'method')->shouldreturn(true);
+    }
+
+    function it_should_reject_an_object_if_a_method_does_not_exist()
+    {
+        $this->isMethodAccessible(new ObjectWithNoMethod, 'method')->shouldReturn(false);
+    }
+
+    function it_should_reject_a_private_method()
+    {
+        $this->isMethodAccessible(new ObjectWithPrivateMethod, 'method')->shouldReturn(false);
+    }
+
+    function it_should_detect_a_public_method()
+    {
+        $this->isMethodAccessible(new ObjectWithPublicMethod, 'method')->shouldReturn(true);
+    }
+}
+
+class ObjectWithMagicGet
+{
+    public function __get($name)
+    {
+    }
+}
+
+class ObjectWithMagicSet
+{
+    public function __set($name, $value)
+    {
+    }
+}
+
+class ObjectWithNoProperty
+{
+}
+
+class ObjectWithPrivateProperty
+{
+    private $property;
+}
+
+class ObjectWithPublicProperty
+{
+    public $property;
+}
+
+class ObjectWithMagicCall
+{
+    public function __call($name, $args)
+    {
+    }
+}
+
+class ObjectWithNoMethod
+{
+}
+
+class ObjectWithPrivateMethod
+{
+    private function method()
+    {
+    }
+}
+
+class ObjectWithPublicMethod
+{
+    public function method()
+    {
+    }
+}

--- a/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Wrapper\Subject;
 
+use Phpspec\CodeAnalysis\AccessInspectorInterface;
 use PhpSpec\Exception\ExceptionFactory;
 use PhpSpec\Wrapper\Subject\WrappedObject;
 use PhpSpec\Wrapper\Wrapper;
@@ -16,17 +17,20 @@ use Prophecy\Argument;
 
 class CallerSpec extends ObjectBehavior
 {
-    function let(WrappedObject $wrappedObject, ExampleNode $example,
-                 Dispatcher $dispatcher, ExceptionFactory $exceptions, Wrapper $wrapper)
+    function let(WrappedObject $wrappedObject, ExampleNode $example, Dispatcher $dispatcher,
+                 ExceptionFactory $exceptions, Wrapper $wrapper, AccessInspectorInterface $accessInspector)
     {
         $this->beConstructedWith($wrappedObject, $example, $dispatcher,
-            $exceptions, $wrapper);
+            $exceptions, $wrapper, $accessInspector);
     }
 
-    function it_dispatches_method_call_events(Dispatcher $dispatcher, WrappedObject $wrappedObject)
+    function it_dispatches_method_call_events(Dispatcher $dispatcher, WrappedObject $wrappedObject,
+                                              AccessInspectorInterface $accessInspector)
     {
         $wrappedObject->isInstantiated()->willReturn(true);
         $wrappedObject->getInstance()->willReturn(new \ArrayObject());
+
+        $accessInspector->isMethodAccessible(Argument::type('ArrayObject'), 'count')->willReturn(true);
 
         $dispatcher->dispatch(
             'beforeMethodCall',
@@ -41,10 +45,15 @@ class CallerSpec extends ObjectBehavior
         $this->call('count');
     }
 
-    function it_sets_a_property_on_the_wrapped_object(WrappedObject $wrappedObject)
+    function it_sets_a_property_on_the_wrapped_object(WrappedObject $wrappedObject,
+                                                      AccessInspectorInterface $accessInspector)
     {
         $obj = new \stdClass();
         $obj->id = 1;
+
+        $accessInspector->isPropertyAccessible(
+            Argument::type('stdClass'), 'id', true
+        )->willReturn('true');
 
         $wrappedObject->isInstantiated()->willReturn(true);
         $wrappedObject->getInstance()->willReturn($obj);
@@ -52,11 +61,16 @@ class CallerSpec extends ObjectBehavior
         $this->set('id', 2)->shouldReturn(2);
     }
 
-    function it_proxies_method_calls_to_wrapped_object(\ArrayObject $obj, WrappedObject $wrappedObject)
+    function it_proxies_method_calls_to_wrapped_object(\ArrayObject $obj, WrappedObject $wrappedObject,
+                                                       AccessInspectorInterface $accessInspector)
     {
         $obj->asort()->shouldBeCalled();
+
         $wrappedObject->isInstantiated()->willReturn(true);
         $wrappedObject->getInstance()->willReturn($obj);
+
+        $accessInspector->isMethodAccessible(Argument::type('ArrayObject'), 'asort')->willReturn(true);
+
         $this->call('asort');
     }
 

--- a/spec/PhpSpec/Wrapper/SubjectSpec.php
+++ b/spec/PhpSpec/Wrapper/SubjectSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Wrapper;
 
+use Phpspec\CodeAnalysis\AccessInspectorInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -14,10 +15,18 @@ use PhpSpec\Wrapper\Subject\Expectation\ExpectationInterface;
 
 class SubjectSpec extends ObjectBehavior
 {
-    function let(Wrapper $wrapper, WrappedObject $wrappedObject, Caller $caller,
-                 SubjectWithArrayAccess $arrayAccess, ExpectationFactory $expectationFactory)
+    function let(Wrapper $wrapper, WrappedObject $wrappedObject, Caller $caller, SubjectWithArrayAccess $arrayAccess,
+                 ExpectationFactory $expectationFactory, AccessInspectorInterface $accessInspector)
     {
-        $this->beConstructedWith(null, $wrapper, $wrappedObject, $caller, $arrayAccess, $expectationFactory);
+        $this->beConstructedWith(
+            null,
+            $wrapper,
+            $wrappedObject,
+            $caller,
+            $arrayAccess,
+            $expectationFactory,
+            $accessInspector
+        );
     }
 
     function it_passes_the_created_subject_to_expectation(WrappedObject $wrappedObject,

--- a/src/PhpSpec/CodeAnalysis/AccessInspectorInterface.php
+++ b/src/PhpSpec/CodeAnalysis/AccessInspectorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Phpspec\CodeAnalysis;
+
+interface AccessInspectorInterface
+{
+    /**
+     * @param object $object
+     * @param string $property
+     * @param bool $withValue
+     * @return bool
+     */
+    public function isPropertyAccessible($object, $property, $withValue);
+
+    /**
+     * @param object $object
+     * @param string $method
+     * @return bool
+     */
+    public function isMethodAccessible($object, $method);
+}

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PhpSpec\CodeAnalysis;
+
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class MagicAwareAccessInspector implements AccessInspectorInterface
+{
+    /**
+     * @param object $object
+     * @param string $property
+     * @param bool $withValue
+     * @return bool
+     */
+    public function isPropertyAccessible($object, $property, $withValue = false)
+    {
+        if (!is_object($object)) {
+            return false;
+        }
+
+        if (method_exists($object, $withValue ? '__set' : '__get')) {
+            return true;
+        }
+
+        if (!property_exists($object, $property)) {
+            return false;
+        }
+
+        $propertyReflection = new ReflectionProperty($object, $property);
+        return $propertyReflection->isPublic();
+    }
+
+    /**
+     * @param object $object
+     * @param string $method
+     * @return bool
+     */
+    public function isMethodAccessible($object, $method)
+    {
+        if (!is_object($object)) {
+            return false;
+        }
+
+        if (method_exists($object, '__call')) {
+            return true;
+        }
+
+        if (!method_exists($object, $method)) {
+            return false;
+        }
+
+        $methodReflection = new ReflectionMethod($object, $method);
+        return $methodReflection->isPublic();
+    }
+}

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Console;
 
+use PhpSpec\CodeAnalysis\MagicAwareAccessInspector;
 use SebastianBergmann\Exporter\Exporter;
 use PhpSpec\Process\ReRunner;
 use PhpSpec\Util\MethodAnalyser;
@@ -523,12 +524,17 @@ class ContainerAssembler
             return new Runner\Maintainer\SubjectMaintainer(
                 $c->get('formatter.presenter'),
                 $c->get('unwrapper'),
-                $c->get('event_dispatcher')
+                $c->get('event_dispatcher'),
+                $c->get('access_inspector')
             );
         });
 
         $container->setShared('unwrapper', function () {
             return new Wrapper\Unwrapper();
+        });
+
+        $container->setShared('access_inspector', function() {
+            return new MagicAwareAccessInspector();
         });
     }
 

--- a/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Runner\Maintainer;
 
+use Phpspec\CodeAnalysis\AccessInspectorInterface;
 use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\SpecificationInterface;
 use PhpSpec\Runner\MatcherManager;
@@ -36,6 +37,10 @@ class SubjectMaintainer implements MaintainerInterface
      * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
      */
     private $dispatcher;
+    /**
+     * @var \PhpSpec\CodeAnalysis\AccessInspectorInterface
+     */
+    private $accessInspector;
 
     /**
      * @param PresenterInterface       $presenter
@@ -45,11 +50,13 @@ class SubjectMaintainer implements MaintainerInterface
     public function __construct(
         PresenterInterface $presenter,
         Unwrapper $unwrapper,
-        EventDispatcherInterface $dispatcher
+        EventDispatcherInterface $dispatcher,
+        AccessInspectorInterface $accessInspector
     ) {
         $this->presenter = $presenter;
         $this->unwrapper = $unwrapper;
         $this->dispatcher = $dispatcher;
+        $this->accessInspector = $accessInspector;
     }
 
     /**
@@ -76,7 +83,7 @@ class SubjectMaintainer implements MaintainerInterface
         MatcherManager $matchers,
         CollaboratorManager $collaborators
     ) {
-        $subjectFactory = new Wrapper($matchers, $this->presenter, $this->dispatcher, $example);
+        $subjectFactory = new Wrapper($matchers, $this->presenter, $this->dispatcher, $example, $this->accessInspector);
         $subject = $subjectFactory->wrap(null);
         $subject->beAnInstanceOf(
             $example->getSpecification()->getResource()->getSrcClassname()


### PR DESCRIPTION
The reason behind this change is that some frameworks make use of the magic accessor methods, and so define them in a way that might be undesirable for use by phpspec. Magento is an example of this, where the base object class will attempt to bootstrap the entire application when a call to a magic accessor is made.

Currently Magespec works around this problem by implementing it's own version of Caller: https://github.com/MageTest/MageSpec/blob/master/src/MageTest/PhpSpec/MagentoExtension/Wrapper/Subject/VarienCaller.php. All of this exists so that the two methods named above can be overridden, and it could be made much simpler with much less duplication if the responsibility of these methods is delegated to another object that can be replaced..