### PR TITLE
Added use_config_path suite config option (Feature)

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -86,6 +86,21 @@ class ApplicationContext implements Context, MatchersProviderInterface
     }
 
     /**
+     * @Given I have started describing the :class class with the :config (custom) config
+     * @Given I start describing the :class class with the :config (custom) config
+     */
+    public function iDescribeTheClassWithTheConfig($class, $config)
+    {
+        $arguments = array(
+            'command' => 'describe',
+            'class' => $class,
+            '--config' => $config
+        );
+
+        expect($this->tester->run($arguments, array('interactive' => false)))->toBe(0);
+    }
+
+    /**
      * @When I run phpspec (non interactively)
      * @When I run phpspec using the :formatter format
      * @When I run phpspec with the :option option
@@ -119,6 +134,21 @@ class ApplicationContext implements Context, MatchersProviderInterface
         );
 
         $this->addOptionToArguments($option, $arguments);
+
+        $this->prompter->setAnswer($answer=='y');
+
+        $this->lastExitCode = $this->tester->run($arguments, array('interactive' => true));
+    }
+
+    /**
+     * @When I run phpspec with the :config (custom) config and answer :answer when asked if I want to generate the code
+     */
+    public function iRunPhpspecWithConfigAndAnswerIfIWantToGenerateTheCode($config, $answer)
+    {
+        $arguments = array (
+            'command' => 'run',
+            '--config' => $config
+        );
 
         $this->prompter->setAnswer($answer=='y');
 

--- a/features/bootstrap/FilesystemContext.php
+++ b/features/bootstrap/FilesystemContext.php
@@ -76,6 +76,14 @@ class FilesystemContext implements Context, MatchersProviderInterface
     }
 
     /**
+     * @Given the config file located in :folder contains:
+     */
+    public function theConfigFileInFolderContains($folder, PyStringNode $contents)
+    {
+        $this->theFileContains($folder.DIRECTORY_SEPARATOR.'phpspec.yml', $contents);
+    }
+
+    /**
      * @Given there is no file :file
      */
     public function thereIsNoFile($file)

--- a/features/config/paths_can_be_relative_to_config.feature
+++ b/features/config/paths_can_be_relative_to_config.feature
@@ -1,0 +1,76 @@
+Feature: Paths can be relative to config or current working directory
+    As a Developer
+    I want to be able to specify if paths are relative to the directory of the config or current working directory
+    So I may specify a custom location for the config file
+
+    Scenario: Generating a class using a custom config with path being relative to the config directory
+        Given the config file located in "Awesome" contains:
+            """
+            suites:
+              behat_suite:
+                namespace: MilkyWay\OrionCygnusArm
+                use_config_path: true
+            """
+        And I have started describing the "MilkyWay/OrionCygnusArm/Pleiades/Alcyone" class with the "Awesome/phpspec.yml" custom config
+        When I run phpspec with the "Awesome/phpspec.yml" custom config and answer "y" when asked if I want to generate the code
+        Then a new class should be generated in the "Awesome/src/MilkyWay/OrionCygnusArm/Pleiades/Alcyone.php":
+            """
+            <?php
+
+            namespace MilkyWay\OrionCygnusArm\Pleiades;
+
+            class Alcyone
+            {
+            }
+
+            """
+
+    Scenario: Generating a class using a custom config with path being relative to the current working directory
+        Given the config file located in "Awesome" contains:
+            """
+            suites:
+              behat_suite:
+                namespace: MilkyWay\OrionCygnusArm
+                use_config_path: false
+            """
+        And I have started describing the "MilkyWay/OrionCygnusArm/BehiveCluster" class with the "Awesome/phpspec.yml" custom config
+        When I run phpspec with the "Awesome/phpspec.yml" custom config and answer "y" when asked if I want to generate the code
+        Then a new class should be generated in the "src/MilkyWay/OrionCygnusArm/BehiveCluster.php":
+            """
+            <?php
+
+            namespace MilkyWay\OrionCygnusArm;
+
+            class BehiveCluster
+            {
+            }
+
+            """
+
+    Scenario: Generating a spec using a custom config with path being relative to the config directory
+        Given the config file located in "Awesome" contains:
+            """
+            suites:
+              behat_suite:
+                namespace: MilkyWay\OrionCygnusArm
+                use_config_path: true
+            """
+        When I start describing the "MilkyWay/OrionCygnusArm/LocalBubble" class with the "Awesome/phpspec.yml" custom config
+        Then a new spec should be generated in the "Awesome/spec/MilkyWay/OrionCygnusArm/LocalBubbleSpec.php":
+            """
+            <?php
+
+            namespace spec\MilkyWay\OrionCygnusArm;
+
+            use PhpSpec\ObjectBehavior;
+            use Prophecy\Argument;
+
+            class LocalBubbleSpec extends ObjectBehavior
+            {
+                function it_is_initializable()
+                {
+                    $this->shouldHaveType('MilkyWay\OrionCygnusArm\LocalBubble');
+                }
+            }
+
+            """

--- a/spec/PhpSpec/Console/ApplicationSpec.php
+++ b/spec/PhpSpec/Console/ApplicationSpec.php
@@ -16,4 +16,14 @@ class ApplicationSpec extends ObjectBehavior
     {
         $this->shouldHaveType('PhpSpec\Console\Application');
     }
+
+    function it_appends_config_dir_to_suite()
+    {
+        $config = array('suites' => array());
+        $config['suites']['andromeda_suite'] = array('namespace' => 'Andromeda');
+        $configDir = 'folder/to/Config';
+
+        $configResult = $this->appendConfigDirToSuite($configDir, $config);
+        $configResult['suites']['andromeda_suite']['config_dir']->shouldBe($configDir);
+    }
 }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -169,7 +169,7 @@ class Application extends BaseApplication
         $config = array();
         foreach ($paths as $path) {
             if ($path && file_exists($path) && $parsedConfig = Yaml::parse(file_get_contents($path))) {
-                $config = $parsedConfig;
+                $config = $this->appendConfigDirToSuite(dirname($path), $parsedConfig);
                 break;
             }
         }
@@ -178,6 +178,24 @@ class Application extends BaseApplication
             $localPath = $homeFolder.'/.phpspec.yml';
             if (file_exists($localPath) && $parsedConfig = Yaml::parse(file_get_contents($localPath))) {
                 $config = array_replace_recursive($parsedConfig, $config);
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param array $configDir
+     *
+     * @param array $config
+     *
+     * @return array
+     */
+    public function appendConfigDirToSuite($configDir, $config)
+    {
+        if (isset($config['suites']) && is_array($config['suites'])) {
+            foreach ($config['suites'] as &$suiteConfig) {
+                $suiteConfig['config_dir'] = $configDir;
             }
         }
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -327,14 +327,20 @@ class ContainerAssembler
             foreach ($suites as $name => $suite) {
                 $suite      = is_array($suite) ? $suite : array('namespace' => $suite);
                 $defaults = array(
-                    'namespace'     => '',
-                    'spec_prefix'   => 'spec',
-                    'src_path'      => 'src',
-                    'spec_path'     => '.',
-                    'psr4_prefix'   => null
+                    'namespace'       => '',
+                    'spec_prefix'     => 'spec',
+                    'src_path'        => 'src',
+                    'spec_path'       => '.',
+                    'psr4_prefix'     => null,
+                    'use_config_path' => false
                 );
 
                 $config = array_merge($defaults, $suite);
+
+                if ($config['use_config_path'] === true && isset($config['config_dir'])) {
+                    $config['src_path'] = $config['config_dir'].DIRECTORY_SEPARATOR.$config['src_path'];
+                    $config['spec_path'] = $config['config_dir'].DIRECTORY_SEPARATOR.$config['spec_path'];
+                }
 
                 if (!is_dir($config['src_path'])) {
                     mkdir($config['src_path'], 0777, true);


### PR DESCRIPTION
The use_config_path allows a dev to specify if src or spec paths are relative to the phpspec.yml or the current directory where phpspec was invoked. 

This effectively resolves issue #681 

By default it is set to false - phpspec will behave like it was before (i.e., paths re relative to directory where phpspec was invoked)

When set to true, paths will be relative to the config file used. Very useful when used in conjunction with "--config" option.

See "features/config/paths_can_be_relative_to_config.feature" for further details