### PR TITLE
close #687 empty prefix is allowed

### DIFF
--- a/features/code_generation/developer_generates_spec.feature
+++ b/features/code_generation/developer_generates_spec.feature
@@ -24,6 +24,70 @@ Feature: Developer generates a spec
 
       """
 
+
+  @issue687
+  Scenario: Generating a spec with the same namespace as the source
+    Given the config file contains:
+    """
+    suites:
+      code_generator_suite:
+        namespace: CodeGeneration\SpecExample2
+        spec_path: spec/
+        spec_prefix: ''
+
+    """
+    When I start describing the "CodeGeneration/SpecExample2/Markdown" class
+    Then a new spec should be generated in the "spec/CodeGeneration/SpecExample2/MarkdownSpec.php":
+    """
+    <?php
+
+    namespace CodeGeneration\SpecExample2;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class MarkdownSpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('CodeGeneration\SpecExample2\Markdown');
+        }
+    }
+
+    """
+
+  @issue687
+  Scenario: Generating a spec with the same namespace as the source even with psr4 prefix on src
+    Given the config file contains:
+    """
+    suites:
+      code_generator_suite:
+        namespace: CodeGeneration\SpecExample2
+        psr4_prefix: CodeGeneration
+        spec_path: spec/
+        spec_prefix: ''
+
+    """
+    When I start describing the "CodeGeneration/SpecExample2/Markdown" class
+    Then a new spec should be generated in the "spec/SpecExample2/MarkdownSpec.php":
+    """
+    <?php
+
+    namespace CodeGeneration\SpecExample2;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class MarkdownSpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('CodeGeneration\SpecExample2\Markdown');
+        }
+    }
+
+    """
+
   @issue127
   Scenario: Generating a spec with PSR0 must convert classname underscores to directory separator
     When I start describing the "CodeGeneration/SpecExample1/Text_Markdown" class

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -58,7 +58,6 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->beConstructedWith('Cust\Ns', '', dirname(__DIR__), __DIR__);
 
         $this->getSpecNamespace()->shouldReturn('Cust\Ns\\');
-        $this->getSpecNamespace()->shouldNotReturn('\Cust\Ns\\');
 
         $this->getFullSpecPath()->shouldReturn(__DIR__.DIRECTORY_SEPARATOR.'Cust'.DIRECTORY_SEPARATOR.'Ns'.DIRECTORY_SEPARATOR);
     }

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -53,6 +53,16 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->getFullSrcPath()->shouldReturn(dirname(__DIR__).DIRECTORY_SEPARATOR);
     }
 
+    function it_should_not_have_backslash_on_missing_prefix()
+    {
+        $this->beConstructedWith('Cust\Ns', '', dirname(__DIR__), __DIR__);
+
+        $this->getSpecNamespace()->shouldReturn('Cust\Ns\\');
+        $this->getSpecNamespace()->shouldNotReturn('\Cust\Ns\\');
+
+        $this->getFullSpecPath()->shouldReturn(__DIR__.DIRECTORY_SEPARATOR.'Cust'.DIRECTORY_SEPARATOR.'Ns'.DIRECTORY_SEPARATOR);
+    }
+
     function it_generates_fullSpecPath_from_specPath_plus_namespace()
     {
         $this->beConstructedWith('C\N', 'spec', dirname(__DIR__), __DIR__);

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -82,8 +82,12 @@ class PSR0Locator implements ResourceLocatorInterface
         $srcNamespacePath = null === $this->psr4Prefix ?
             $this->srcNamespace :
             substr($this->srcNamespace, strlen($this->psr4Prefix));
-        $this->specNamespace = trim($specNamespacePrefix, ' \\').'\\'.$this->srcNamespace;
-        $specNamespacePath = trim($specNamespacePrefix, ' \\').'\\'.$srcNamespacePath;
+        $this->specNamespace = $specNamespacePrefix ?
+            trim($specNamespacePrefix, ' \\').'\\'.$this->srcNamespace :
+            $this->srcNamespace;
+        $specNamespacePath = $specNamespacePrefix ?
+            trim($specNamespacePrefix, ' \\').'\\'.$srcNamespacePath :
+            $srcNamespacePath;
 
         $this->fullSrcPath   = $this->srcPath.str_replace('\\', $sepr, $srcNamespacePath);
         $this->fullSpecPath  = $this->specPath.str_replace('\\', $sepr, $specNamespacePath);


### PR DESCRIPTION
With this PR the spec prefix can be empty, this way the namespace does not start with a backslash, which is a not valid class name.