### PR TITLE
Fix haveKeyWithValue matcher for arrays with correct key, but wrong values

### DIFF
--- a/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
@@ -34,12 +34,33 @@ class ArrayKeyValueMatcherSpec extends ObjectBehavior
         $this->shouldNotThrow()->duringPositiveMatch('haveKeyWithValue', array('abc' => 123), array('abc', 123));
     }
 
+    function it_does_not_match_array_with_wrong_value_for_specified_key()
+    {
+        $this->shouldThrow()->duringPositiveMatch(
+            'haveKeyWithValue',
+            array('abc' => 123),
+            array('abc', 456)
+        );
+    }
+
     function it_matches_ArrayObject_with_correct_value_for_specified_offset(ArrayObject $array)
     {
         $array->offsetExists('abc')->willReturn(true);
         $array->offsetGet('abc')->willReturn(123);
 
         $this->shouldNotThrow()->duringPositiveMatch('haveKeyWithValue', $array, array('abc', 123));
+    }
+
+    function it_does_not_match_ArrayObject_with_wrong_value_for_specified_offset(ArrayObject $array)
+    {
+        $array->offsetExists('abc')->willReturn(true);
+        $array->offsetGet('abc')->willReturn(123);
+
+        $this->shouldThrow()->duringPositiveMatch(
+            'haveKeyWithValue',
+            $array,
+            array('abc', 456)
+        );
     }
 
     function it_does_not_match_array_without_specified_key()

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -62,7 +62,7 @@ class ArrayKeyValueMatcher extends BasicMatcher
             return $subject->offsetExists($key) && $subject->offsetGet($key) === $value;
         }
 
-        return (isset($subject[$key]) || array_key_exists($arguments[0], $subject) && $subject[$key] === $value);
+        return (isset($subject[$key]) || array_key_exists($arguments[0], $subject)) && $subject[$key] === $value;
     }
 
     /**


### PR DESCRIPTION
There was a bug, that made tests using the haveKeyWithValue matcher with arrays
pass, if the array had the specified key, but the wrong value.

e.g. before this patch:
```php
// implementation
public function getAttributes()
{
    return ['name' => 'Some Name'];
}

// should be a failing test, but is actually passing
function it_returns_the_right_name()
{
    $this->getAttributes()->shouldHaveKeyWithValue('name', 'Foo Bar');
}
```

Feature originally introduced in #640 

Let me know if you want a Behat feature as well. I don't know what the policy on this project is about what code paths get acceptance tests (the happy path is already covered by an acceptance test).