### PR TITLE
docs: bootstrapping: fixed the config key

### DIFF
--- a/docs/cookbook/configuration.rst
+++ b/docs/cookbook/configuration.rst
@@ -193,4 +193,4 @@ To load a custom bootstrap when running phpspec, use the ``console.io.bootstrap`
 
 .. code-block:: yaml
 
-    console.io.bootstrap: path/to/different-bootstrap.php
+    bootstrap: path/to/different-bootstrap.php


### PR DESCRIPTION
`console.io.bootstrap: path/to/different-bootstrap.php` does not work (does not load the bootstrap file).

`bootstrap: path/to/different-bootstrap.php` does work.

phpspec version 2.2.0