### PR TITLE
Add new duringInstantiation() method for named constructs closes #610 

### DIFF
--- a/docs/cookbook/matchers.rst
+++ b/docs/cookbook/matchers.rst
@@ -130,6 +130,46 @@ passing an exception object to shouldThrow:
         }
     }
 
+If you want to use the Throw matcher to check for exceptions thrown
+during object instantiation you can use the ``duringInstantiation``
+method.
+
+.. code-block:: php
+
+    <?php
+
+    namespace spec;
+
+    use PhpSpec\ObjectBehavior;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function it_should_not_allow_negative_ratings()
+        {
+            $this->beConstructedWith(-3);
+            $this->shouldThrow('\InvalidArgumentException')->duringInstantiation();
+        }
+    }
+
+You can also use the Throw matcher with named constructors.
+
+.. code-block:: php
+
+    <?php
+
+    namespace spec;
+
+    use PhpSpec\ObjectBehavior;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function it_should_not_allow_negative_ratings()
+        {
+            $this->beConstructedThrough('rated', array(-3));
+            $this->shouldThrow('\InvalidArgumentException')->duringInstantiation();
+        }
+    }
+
 
 Type Matcher
 ------------

--- a/features/matchers/developer_uses_throw_matcher.feature
+++ b/features/matchers/developer_uses_throw_matcher.feature
@@ -163,3 +163,53 @@ Feature: Developer uses throw matcher
     """
     When I run phpspec
     Then the suite should pass
+
+  @issue610
+  Scenario: Throwing an exception during object construction
+    Given the spec file "spec/Runner/ThrowExample5/MarkdownSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\ThrowExample5;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class MarkdownSpec extends ObjectBehavior
+      {
+          function it_throws_an_exception_using_during_instantiation_syntax()
+          {
+              $this->beConstructedWith(1, 2);
+              $this->shouldThrow('\InvalidArgumentException')->duringInstantiation();
+          }
+
+          function it_throws_an_exception_using_during_named_instantiation_syntax()
+          {
+              $this->beConstructedThrough('defaultNumber2', array(1));
+              $this->shouldThrow('\InvalidArgumentException')->duringInstantiation();
+          }
+      }
+
+      """
+    And the class file "src/Runner/ThrowExample5/Markdown.php" contains:
+      """
+      <?php
+
+      namespace Runner\ThrowExample5;
+
+      class Markdown
+      {
+          public function __construct($num1, $num2)
+          {
+              throw new \InvalidArgumentException();
+          }
+
+          public static function defaultNumber2($num1, $num2 = 2)
+          {
+              return new self($num1, $num2);
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -73,13 +73,29 @@ abstract class DuringCall
     {
         if ($method === '__construct') {
             $this->subject->beAnInstanceOf($this->wrappedObject->getClassname(), $arguments);
-            $instantiator = new Instantiator();
-            $object = $instantiator->instantiate($this->wrappedObject->getClassname());
-        } else {
-            $object = $this->wrappedObject->instantiate();
+
+            return $this->duringInstantiation();
         }
 
+        $object = $this->wrappedObject->instantiate();
+
         return $this->runDuring($object, $method, $arguments);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function duringInstantiation()
+    {
+        if ($factoryMethod = $this->wrappedObject->getFactoryMethod()) {
+            $method = is_array($factoryMethod) ? $factoryMethod[1] : $factoryMethod;
+        } else {
+            $method = '__construct';
+        }
+        $instantiator = new Instantiator();
+        $object = $instantiator->instantiate($this->wrappedObject->getClassname());
+
+        return $this->runDuring($object, $method, $this->wrappedObject->getArguments());
     }
 
     /**


### PR DESCRIPTION
As said in #610 this implements the a new `duringInstantiation()` method to allow checking for exceptions thrown during the construction of an object.