### PR TITLE
Fixed exception thrown by ArrayKeyValueMatcher

### DIFF
--- a/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
@@ -39,29 +39,9 @@ class ArrayKeyValueMatcherSpec extends ObjectBehavior
         $this->supports('haveKeyWithValue', array(), array('', ''))->shouldReturn(true);
     }
 
-    function it_does_not_matches_null_value()
+    function it_does_not_respond_to_haveKeyWithValue_with_non_array_subject()
     {
-        $this->shouldThrow(new FailureException('Expected array or instance of \ArrayAccess, got NULL'))->duringPositiveMatch('haveKeyWithValue', null, array('abc', 123));
-    }
-
-    function it_does_not_matches_string_value()
-    {
-        $this->shouldThrow(new FailureException('Expected array or instance of \ArrayAccess, got string'))->duringPositiveMatch('haveKeyWithValue', 'foo', array('abc', 123));
-    }
-
-    function it_does_not_matches_integer_value()
-    {
-        $this->shouldThrow(new FailureException('Expected array or instance of \ArrayAccess, got integer'))->duringPositiveMatch('haveKeyWithValue', 42, array('abc', 123));
-    }
-
-    function it_does_not_matches_double_value()
-    {
-        $this->shouldThrow(new FailureException('Expected array or instance of \ArrayAccess, got double'))->duringPositiveMatch('haveKeyWithValue', 1.2, array('abc', 123));
-    }
-
-    function it_does_not_matches_instance_of_something_else_than_ArrayObject()
-    {
-        $this->shouldThrow(new FailureException('Expected array or instance of \ArrayAccess, got stdClass'))->duringPositiveMatch('haveKeyWithValue', new \StdClass(), array('abc', 123));
+        $this->supports('haveKeyWithValue', null, array('', ''))->shouldReturn(false);
     }
 
     function it_matches_array_with_correct_value_for_specified_key()

--- a/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
@@ -34,9 +34,14 @@ class ArrayKeyValueMatcherSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('PhpSpec\Matcher\MatcherInterface');
     }
 
-    function it_responds_to_haveKeyWithValue()
+    function it_responds_to_haveKeyWithValue_with_array_subject()
     {
         $this->supports('haveKeyWithValue', array(), array('', ''))->shouldReturn(true);
+    }
+
+    function it_responds_to_haveKeyWithValue_with_array_access_subject()
+    {
+        $this->supports('haveKeyWithValue', new \ArrayIterator(), array('', ''))->shouldReturn(true);
     }
 
     function it_does_not_respond_to_haveKeyWithValue_with_non_array_subject()

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -41,7 +41,11 @@ class ArrayKeyValueMatcher extends BasicMatcher
      */
     public function supports($name, $subject, array $arguments)
     {
-        return 'haveKeyWithValue' === $name && 2 == count($arguments);
+        return
+            (is_array($subject) || $subject instanceof \ArrayAccess) &&
+            'haveKeyWithValue' === $name &&
+            2 == count($arguments)
+        ;
     }
 
     /**
@@ -52,10 +56,6 @@ class ArrayKeyValueMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments)
     {
-        if (!is_array($subject) && !$subject instanceof \ArrayAccess) {
-            return false;
-        }
-
         $key = $arguments[0];
         $value  = $arguments[1];
 
@@ -75,13 +75,6 @@ class ArrayKeyValueMatcher extends BasicMatcher
      */
     protected function getFailureException($name, $subject, array $arguments)
     {
-        if (!is_array($subject) && !$subject instanceof \ArrayAccess) {
-            return new FailureException(sprintf(
-                'Expected array or instance of \ArrayAccess, got %s',
-                $this->presenter->presentValue(is_object($subject) ? get_class($subject) : gettype($subject))
-            ));
-        }
-
         $key = $arguments[0];
 
         if (!$this->offsetExists($key, $subject)) {

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -41,10 +41,7 @@ class ArrayKeyValueMatcher extends BasicMatcher
      */
     public function supports($name, $subject, array $arguments)
     {
-        return 'haveKeyWithValue' === $name
-        && 2 == count($arguments)
-        && (is_array($subject) || $subject instanceof ArrayAccess)
-            ;
+        return 'haveKeyWithValue' === $name && 2 == count($arguments);
     }
 
     /**
@@ -55,6 +52,10 @@ class ArrayKeyValueMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments)
     {
+        if (!is_array($subject) && !$subject instanceof \ArrayAccess) {
+            return false;
+        }
+
         $key = $arguments[0];
         $value  = $arguments[1];
 
@@ -74,14 +75,18 @@ class ArrayKeyValueMatcher extends BasicMatcher
      */
     protected function getFailureException($name, $subject, array $arguments)
     {
+        if (!is_array($subject) && !$subject instanceof \ArrayAccess) {
+            return new FailureException(sprintf(
+                'Expected array or instance of \ArrayAccess, got %s',
+                $this->presenter->presentValue(is_object($subject) ? get_class($subject) : gettype($subject))
+            ));
+        }
+
         $key = $arguments[0];
-        $expectedValue = $arguments[1];
-        $actualValue = $subject[$key];
 
         if (!$this->offsetExists($key, $subject)) {
-            return new FailureException(sprintf('Expected %s to have value %s for %s key, but no key was set.',
+            return new FailureException(sprintf('Expected %s to have key %s, but it didn\'t.',
                 $this->presenter->presentValue($subject),
-                $this->presenter->presentValue($expectedValue),
                 $this->presenter->presentString($key)
             ));
         }
@@ -89,9 +94,9 @@ class ArrayKeyValueMatcher extends BasicMatcher
         return new FailureException(sprintf(
             'Expected %s to have value %s for %s key, but found %s.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentValue($expectedValue),
+            $this->presenter->presentValue($arguments[1]),
             $this->presenter->presentString($key),
-            $this->presenter->presentValue($actualValue)
+            $this->presenter->presentValue($subject[$key])
         ));
     }
 


### PR DESCRIPTION
I see several problems with the current implementation of the ArrayKeyValueMatcher:

- `$this->method()->shouldHaveKeyWithValue('foo', 'bar')` will throw exception telling that no matcher was found for "haveKeyWithValue", even if the matcher is registered. This is because the matcher is only used when the method returns an array or an ArrayObject. This is not convenient at all, as I expect my method body to be empty (and thus return `null`) when I'm writing my spec. PhpSpec should tell me that expecting result was an array or instance or ArrayObject and that he received something else.
- When my method returns an array that doesn't contain the expected key, PhpSpec will raise a notice error: `Undefined index on line 79`. BTW, this error was no captured earlier because of the use of `shouldThrow()` without argument. It indeed throws an exception but not the good one! 

This PR covers these lacks.

Another concern of mine is what to expect when I do `$this->method()->shouldNotHaveKeyWithValue('abc', 123)` and `$this->method()` returns `[]`? Should it fail because the method didn't return an array with the expected key? Was the key expected at all (as we are asserting the content of the key, I'd say yes, we expect the value of the key not to be `123`, but we at least expect the key to exist, don't you think?)?