### PR TITLE
Switch to the docker-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
 language: php
 
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - expect
+      
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 matrix:
   include:
     - php: 5.3
@@ -23,7 +34,6 @@ matrix:
   fast_finish: true
 
 before_install:
-  - if [ "$SMOKE" == "true" ]; then sudo apt-get install expect; fi;
   - composer selfupdate
 
 install:


### PR DESCRIPTION
expect can now be installed through the APT addon as it has been whitelisted