### PR TITLE
Fix loop when generating classes and autoloader is not present 

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,6 +2,11 @@ default:
   suites:
     application:
       contexts: [ ApplicationContext, FilesystemContext ]
+      filters: { tags: ~@isolated }
+    isolated:
+      contexts: [ IsolatedProcessContext, FilesystemContext ]
+      filters: { tags: @isolated }
+
   formatters:
     progress: ~
 
@@ -9,5 +14,5 @@ smoke:
   suites:
     smoke:
       contexts: [ IsolatedProcessContext, FilesystemContext ]
-      filters: { tags: @smoke }
+      filters: { tags: @smoke && ~@isolated }
 

--- a/features/bootstrap/FilesystemContext.php
+++ b/features/bootstrap/FilesystemContext.php
@@ -38,6 +38,12 @@ class FilesystemContext implements Context, MatchersProviderInterface
         $this->filesystem->remove($this->workingDirectory);
         $this->filesystem->mkdir($this->workingDirectory);
         chdir($this->workingDirectory);
+
+        $this->filesystem->mkdir($this->workingDirectory . '/vendor');
+        $this->filesystem->copy(
+            __DIR__ . '/autoloader/autoload.php',
+            $this->workingDirectory . '/vendor/autoload.php'
+        );
     }
 
     /**
@@ -100,6 +106,14 @@ class FilesystemContext implements Context, MatchersProviderInterface
     public function theConfigFileInFolderContains($folder, PyStringNode $contents)
     {
         $this->theFileContains($folder.DIRECTORY_SEPARATOR.'phpspec.yml', $contents);
+    }
+
+    /**
+     * @Given I have not configured an autoloader
+     */
+    public function iHaveNotConfiguredAnAutoloader()
+    {
+        $this->filesystem->remove($this->workingDirectory . '/vendor/autoload.php');
     }
 
     /**

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -69,15 +69,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
      */
     public function theTestsShouldBeRerun()
     {
-        expect(substr_count($this->lastOutput, 'for you?'))->toBe(2);
-    }
-
-    /**
-     * @Given I have not configured an autoloader
-     */
-    public function iHaveNotConfiguredAnAutoloader()
-    {
-        // this is actually the default behaviour
+        expect(substr_count($this->lastOutput, 'specs'))->toBe(2);
     }
 
     /**

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -54,8 +54,6 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
 
         $process->run();
         $this->lastOutput = $process->getOutput();
-
-        expect((bool)$process->getErrorOutput())->toBe(false);
     }
 
     /**

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -73,4 +73,20 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     {
         expect(substr_count($this->lastOutput, 'for you?'))->toBe(2);
     }
+
+    /**
+     * @Given I have not configured an autoloader
+     */
+    public function iHaveNotConfiguredAnAutoloader()
+    {
+        // this is actually the default behaviour
+    }
+
+    /**
+     * @Then I should see an error about the missing autoloader
+     */
+    public function iShouldSeeAnErrorAboutTheMissingAutoloader()
+    {
+        expect($this->lastOutput)->toMatch('/autoload/');
+    }
 }

--- a/features/bootstrap/autoloader/autoload.php
+++ b/features/bootstrap/autoloader/autoload.php
@@ -1,0 +1,5 @@
+<?php
+spl_autoload_register(function ($classname) {
+    $classname = __DIR__ . '/../src/' . str_replace("\\", "/", trim($classname, "\\")) . ".php";
+    if (file_exists($classname)) { include $classname; }
+});

--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -131,3 +131,10 @@ Feature: Developer generates a class
     }
 
     """
+
+  @isolated
+  Scenario: Generating a class outside of autoloadable paths gives a warning
+    Given I have started describing the "CodeGeneration/ClassExample2/Markdown" class
+    But I have not configured an autoloader
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then I should see an error about the missing autoloader

--- a/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
@@ -3,6 +3,7 @@
 namespace spec\PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\Context\ExecutionContextInterface;
 use Prophecy\Argument;
 
 use PhpSpec\Console\IO;
@@ -12,9 +13,9 @@ use PhpSpec\Locator\ResourceInterface;
 
 class ClassGeneratorSpec extends ObjectBehavior
 {
-    function let(IO $io, TemplateRenderer $tpl, Filesystem $fs)
+    function let(IO $io, TemplateRenderer $tpl, Filesystem $fs, ExecutionContextInterface $executionContext)
     {
-        $this->beConstructedWith($io, $tpl, $fs);
+        $this->beConstructedWith($io, $tpl, $fs, $executionContext);
     }
 
     function it_is_a_generator()
@@ -116,5 +117,17 @@ class ClassGeneratorSpec extends ObjectBehavior
         $fs->putFileContents(Argument::cetera())->shouldNotBeCalled();
 
         $this->generate($resource);
+    }
+
+    function it_records_that_class_was_created_in_executioncontext(ResourceInterface $resource, ExecutionContextInterface $executionContext)
+    {
+        $resource->getName()->willReturn('App');
+        $resource->getSrcFilename()->willReturn('/project/src/Acme/App.php');
+        $resource->getSrcNamespace()->willReturn('Acme');
+        $resource->getSrcClassname()->willReturn('Acme\App');
+
+        $this->generate($resource);
+
+        $executionContext->addGeneratedType('Acme\App')->shouldHaveBeenCalled();
     }
 }

--- a/spec/PhpSpec/Listener/RerunListenerSpec.php
+++ b/spec/PhpSpec/Listener/RerunListenerSpec.php
@@ -4,14 +4,15 @@ namespace spec\PhpSpec\Listener;
 
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\Prerequisites\SuitePrerequisitesInterface;
 use PhpSpec\Process\ReRunner;
 use Prophecy\Argument;
 
 class RerunListenerSpec extends ObjectBehavior
 {
-    function let(ReRunner $reRunner)
+    function let(ReRunner $reRunner, SuitePrerequisitesInterface $suitePrerequisites)
     {
-        $this->beConstructedWith($reRunner);
+        $this->beConstructedWith($reRunner, $suitePrerequisites);
     }
 
     function it_subscribes_to_aftersuite()

--- a/spec/PhpSpec/Process/Context/JsonExecutionContextSpec.php
+++ b/spec/PhpSpec/Process/Context/JsonExecutionContextSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\PhpSpec\Process\Context;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class JsonExecutionContextSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedThrough('fromEnv', array(array('PHPSPEC_EXECUTION_CONTEXT' => '{"generated-types":[]}')));
+    }
+
+    function it_is_an_execution_context()
+    {
+        $this->shouldHaveType('PhpSpec\Process\Context\ExecutionContextInterface');
+    }
+
+    function it_contains_no_generated_classes_when_created()
+    {
+        $this->getGeneratedTypes()->shouldReturn(array());
+    }
+
+    function it_remembers_what_classes_were_generated()
+    {
+        $this->addGeneratedType('PhpSpec\Foo');
+
+        $this->getGeneratedTypes()->shouldReturn(array('PhpSpec\Foo'));
+    }
+
+    function it_can_be_serialized_as_env_array()
+    {
+        $this->addGeneratedType('PhpSpec\Foo');
+
+        $this->asEnv()->shouldReturn(array('PHPSPEC_EXECUTION_CONTEXT' => '{"generated-types":["PhpSpec\\\\Foo"]}'));
+    }
+}

--- a/spec/PhpSpec/Process/Prerequisites/SuitePrerequisitesSpec.php
+++ b/spec/PhpSpec/Process/Prerequisites/SuitePrerequisitesSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace spec\PhpSpec\Process\Prerequisites;
+
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\Context\ExecutionContextInterface;
+use Prophecy\Argument;
+
+class SuitePrerequisitesSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $executionContext)
+    {
+        $this->beConstructedWith($executionContext);
+    }
+
+    function it_does_nothing_when_types_exist(ExecutionContextInterface $executionContext)
+    {
+        $executionContext->getGeneratedTypes()->willReturn(array('stdClass'));
+
+        $this->guardPrerequisites();
+    }
+
+    function it_throws_execption_when_types_do_not_exist(ExecutionContextInterface $executionContext)
+    {
+        $executionContext->getGeneratedTypes()->willReturn(array('stdClassXXX'));
+
+        $this->shouldThrow('PhpSpec\Process\Prerequisites\PrerequisiteFailedException')->duringGuardPrerequisites();
+    }
+}

--- a/spec/PhpSpec/Process/ReRunner/PassthruRerunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/PassthruRerunnerSpec.php
@@ -22,7 +22,7 @@ class PassthruRerunnerSpec extends ObjectBehavior
 {
     function let(PhpExecutableFinder $executableFinder, ExecutionContextInterface $executionContext)
     {
-        $this->beConstructedThrough('withExecutionContext', [$executableFinder, $executionContext]);
+        $this->beConstructedThrough('withExecutionContext', array($executableFinder, $executionContext));
     }
 
     function it_is_a_rerunner()

--- a/spec/PhpSpec/Process/ReRunner/PassthruRerunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/PassthruRerunnerSpec.php
@@ -14,14 +14,15 @@
 namespace spec\PhpSpec\Process\ReRunner;
 
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\Context\ExecutionContextInterface;
 use Prophecy\Argument;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class PassthruRerunnerSpec extends ObjectBehavior
 {
-    function let(PhpExecutableFinder $executableFinder)
+    function let(PhpExecutableFinder $executableFinder, ExecutionContextInterface $executionContext)
     {
-        $this->beConstructedWith($executableFinder);
+        $this->beConstructedThrough('withExecutionContext', [$executableFinder, $executionContext]);
     }
 
     function it_is_a_rerunner()

--- a/spec/PhpSpec/Process/ReRunner/PcntlReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/PcntlReRunnerSpec.php
@@ -3,14 +3,15 @@
 namespace spec\PhpSpec\Process\ReRunner;
 
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\Context\ExecutionContextInterface;
 use Prophecy\Argument;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class PcntlReRunnerSpec extends ObjectBehavior
 {
-    function let(PhpExecutableFinder $executableFinder)
+    function let(PhpExecutableFinder $executableFinder, ExecutionContextInterface $executionContext)
     {
-        $this->beConstructedWith($executableFinder);
+        $this->beConstructedThrough('withExecutionContext', [$executableFinder, $executionContext]);
     }
 
     function it_is_a_rerunner()

--- a/spec/PhpSpec/Process/ReRunner/PcntlReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/PcntlReRunnerSpec.php
@@ -11,7 +11,7 @@ class PcntlReRunnerSpec extends ObjectBehavior
 {
     function let(PhpExecutableFinder $executableFinder, ExecutionContextInterface $executionContext)
     {
-        $this->beConstructedThrough('withExecutionContext', [$executableFinder, $executionContext]);
+        $this->beConstructedThrough('withExecutionContext', array($executableFinder, $executionContext));
     }
 
     function it_is_a_rerunner()

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -15,6 +15,8 @@ namespace PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\Console\IO;
 use PhpSpec\CodeGenerator\TemplateRenderer;
+use PhpSpec\Process\Context\JsonExecutionContext;
+use PhpSpec\Process\Context\ExecutionContextInterface;
 use PhpSpec\Util\Filesystem;
 use PhpSpec\Locator\ResourceInterface;
 
@@ -37,17 +39,22 @@ abstract class PromptingGenerator implements GeneratorInterface
      * @var \PhpSpec\Util\Filesystem
      */
     private $filesystem;
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
 
     /**
      * @param IO               $io
      * @param TemplateRenderer $templates
      * @param Filesystem       $filesystem
      */
-    public function __construct(IO $io, TemplateRenderer $templates, Filesystem $filesystem = null)
+    public function __construct(IO $io, TemplateRenderer $templates, Filesystem $filesystem = null, ExecutionContextInterface $executionContext = null)
     {
         $this->io         = $io;
         $this->templates  = $templates;
         $this->filesystem = $filesystem ?: new Filesystem();
+        $this->executionContext = $executionContext ?: new JsonExecutionContext();
     }
 
     /**
@@ -68,6 +75,7 @@ abstract class PromptingGenerator implements GeneratorInterface
 
         $this->createDirectoryIfItDoesExist($filepath);
         $this->generateFileAndRenderTemplate($resource, $filepath);
+        $this->executionContext->addGeneratedType($resource->getSrcClassname());
     }
 
     /**

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -14,6 +14,7 @@
 namespace PhpSpec\Console;
 
 use PhpSpec\Console\Prompter\Factory;
+use PhpSpec\Process\Context\JsonExecutionContext;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -67,6 +68,10 @@ class Application extends BaseApplication
                 $c->get('console.output'),
                 $helperSet
             );
+        });
+
+        $this->container->setShared('process.executioncontext', function () {
+            return JsonExecutionContext::fromEnv($_SERVER);
         });
 
         $assembler = new ContainerAssembler();

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -632,7 +632,10 @@ class ContainerAssembler
             return $reRunner;
         });
         $container->setShared('process.rerunner.platformspecific.passthru', function (ServiceContainer $c) {
-            return new ReRunner\PassthruReRunner($c->get('process.phpexecutablefinder'));
+            $reRunner = new ReRunner\PassthruReRunner($c->get('process.phpexecutablefinder'));
+            $reRunner->setExecutionContext($c->get('process.executioncontext'));
+
+            return $reRunner;
         });
         $container->setShared('process.phpexecutablefinder', function () {
             return new PhpExecutableFinder();

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -626,16 +626,16 @@ class ContainerAssembler
             );
         });
         $container->setShared('process.rerunner.platformspecific.pcntl', function (ServiceContainer $c) {
-            $reRunner = new ReRunner\PcntlReRunner($c->get('process.phpexecutablefinder'));
-            $reRunner->setExecutionContext($c->get('process.executioncontext'));
-
-            return $reRunner;
+            return ReRunner\PcntlReRunner::withExecutionContext(
+                $c->get('process.phpexecutablefinder'),
+                $c->get('process.executioncontext')
+            );
         });
         $container->setShared('process.rerunner.platformspecific.passthru', function (ServiceContainer $c) {
-            $reRunner = new ReRunner\PassthruReRunner($c->get('process.phpexecutablefinder'));
-            $reRunner->setExecutionContext($c->get('process.executioncontext'));
-
-            return $reRunner;
+            return ReRunner\PassthruReRunner::withExecutionContext(
+                $c->get('process.phpexecutablefinder'),
+                $c->get('process.executioncontext')
+            );
         });
         $container->setShared('process.phpexecutablefinder', function () {
             return new PhpExecutableFinder();

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -15,6 +15,7 @@ namespace PhpSpec\Console;
 
 use PhpSpec\CodeAnalysis\MagicAwareAccessInspector;
 use PhpSpec\CodeAnalysis\VisibilityAccessInspector;
+use PhpSpec\Process\Prerequisites\SuitePrerequisites;
 use SebastianBergmann\Exporter\Exporter;
 use PhpSpec\Process\ReRunner;
 use PhpSpec\Util\MethodAnalyser;
@@ -173,7 +174,13 @@ class ContainerAssembler
         });
         $container->setShared('event_dispatcher.listeners.rerun', function (ServiceContainer $c) {
             return new Listener\RerunListener(
-                $c->get('process.rerunner')
+                $c->get('process.rerunner'),
+                $c->get('process.prerequisites')
+            );
+        });
+        $container->setShared('process.prerequisites', function (ServiceContainer $c) {
+            return new SuitePrerequisites(
+                $c->get('process.executioncontext')
             );
         });
         $container->setShared('event_dispatcher.listeners.method_returned_null', function (ServiceContainer $c) {

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -219,13 +219,17 @@ class ContainerAssembler
         $container->set('code_generator.generators.class', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\ClassGenerator(
                 $c->get('console.io'),
-                $c->get('code_generator.templates')
+                $c->get('code_generator.templates'),
+                null,
+                $c->get('process.executioncontext')
             );
         });
         $container->set('code_generator.generators.interface', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\InterfaceGenerator(
                 $c->get('console.io'),
-                $c->get('code_generator.templates')
+                $c->get('code_generator.templates'),
+                null,
+                $c->get('process.executioncontext')
             );
         });
         $container->set('code_generator.generators.method', function (ServiceContainer $c) {
@@ -615,7 +619,10 @@ class ContainerAssembler
             );
         });
         $container->setShared('process.rerunner.platformspecific.pcntl', function (ServiceContainer $c) {
-            return new ReRunner\PcntlReRunner($c->get('process.phpexecutablefinder'));
+            $reRunner = new ReRunner\PcntlReRunner($c->get('process.phpexecutablefinder'));
+            $reRunner->setExecutionContext($c->get('process.executioncontext'));
+
+            return $reRunner;
         });
         $container->setShared('process.rerunner.platformspecific.passthru', function (ServiceContainer $c) {
             return new ReRunner\PassthruReRunner($c->get('process.phpexecutablefinder'));

--- a/src/PhpSpec/Listener/RerunListener.php
+++ b/src/PhpSpec/Listener/RerunListener.php
@@ -14,6 +14,7 @@
 namespace PhpSpec\Listener;
 
 use PhpSpec\Event\SuiteEvent;
+use PhpSpec\Process\Prerequisites\SuitePrerequisitesInterface;
 use PhpSpec\Process\ReRunner;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -25,11 +26,18 @@ class RerunListener implements EventSubscriberInterface
     private $reRunner;
 
     /**
-     * @param ReRunner $reRunner
+     * @var SuitePrerequisites
      */
-    public function __construct(ReRunner $reRunner)
+    private $suitePrerequisites;
+
+    /**
+     * @param ReRunner $reRunner
+     * @param SuitePrerequisites $suitePrerequisites
+     */
+    public function __construct(ReRunner $reRunner, SuitePrerequisitesInterface $suitePrerequisites)
     {
         $this->reRunner = $reRunner;
+        $this->suitePrerequisites = $suitePrerequisites;
     }
 
     /**
@@ -37,7 +45,18 @@ class RerunListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array('afterSuite' => array('afterSuite', -1000));
+        return array(
+            'beforeSuite' => array('beforeSuite', 1000),
+            'afterSuite' => array('afterSuite', -1000)
+        );
+    }
+
+    /**
+     * @param SuiteEvent $suiteEvent
+     */
+    public function beforeSuite(SuiteEvent $suiteEvent)
+    {
+        $this->suitePrerequisites->guardPrerequisites();
     }
 
     /**

--- a/src/PhpSpec/Process/Context/ExecutionContextInterface.php
+++ b/src/PhpSpec/Process/Context/ExecutionContextInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Process\Context;
+
+interface ExecutionContextInterface
+{
+    /**
+     * @param string $type
+     */
+    public function addGeneratedType($type);
+
+    /**
+     * @return array
+     */
+    public function asEnv();
+}

--- a/src/PhpSpec/Process/Context/JsonExecutionContext.php
+++ b/src/PhpSpec/Process/Context/JsonExecutionContext.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Process\Context;
+
+final class JsonExecutionContext implements ExecutionContextInterface
+{
+    const ENV_NAME = 'PHPSPEC_EXECUTION_CONTEXT';
+    /**
+     * @var array
+     */
+    private $generatedTypes;
+
+    /**
+     * @param array $env
+     *
+     * @return JsonExecutionContext
+     */
+    public static function fromEnv($env)
+    {
+        $executionContext = new JsonExecutionContext();
+
+        if (array_key_exists(self::ENV_NAME, $env)) {
+            $serialized = json_decode($env[self::ENV_NAME], true);
+            $executionContext->generatedTypes = $serialized['generated-types'];
+        }
+        else {
+            $executionContext->generatedTypes = array();
+        }
+
+        return $executionContext;
+    }
+
+    /**
+     * @param string $generatedType
+     */
+    public function addGeneratedType($generatedType)
+    {
+        $this->generatedTypes[] = $generatedType;
+    }
+
+    /**
+     * @return array
+     */
+    public function getGeneratedTypes()
+    {
+        return $this->generatedTypes;
+    }
+
+    /**
+     * @return string
+     */
+    public function asEnv()
+    {
+        return array(
+            self::ENV_NAME => json_encode(
+                array(
+                    'generated-types' => $this->generatedTypes
+                )
+            )
+        );
+    }
+}

--- a/src/PhpSpec/Process/Prerequisites/PrerequisiteFailedException.php
+++ b/src/PhpSpec/Process/Prerequisites/PrerequisiteFailedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpSpec\Process\Prerequisites;
+
+
+class PrerequisiteFailedException extends \Exception
+{
+} 

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Process\Prerequisites;
+
+use PhpSpec\Process\Context\ExecutionContextInterface;
+
+final class SuitePrerequisites implements SuitePrerequisitesInterface
+{
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @param ExecutionContextInterface $executionContext
+     */
+    public function __construct(ExecutionContextInterface $executionContext)
+    {
+        $this->executionContext = $executionContext;
+    }
+
+    /**
+     * @throws PrerequisiteFailedException
+     */
+    public function guardPrerequisites()
+    {
+        $undefinedTypes = array();
+
+        foreach ($this->executionContext->getGeneratedTypes() as $type) {
+            if (!class_exists($type) && !interface_exists($type)) {
+                $undefinedTypes[] = $type;
+            }
+        }
+
+        if ($undefinedTypes) {
+            throw new PrerequisiteFailedException(sprintf(
+                "The type%s %s was generated but could not be loaded. Do you need to configure an autoloader?\n",
+                count($undefinedTypes) > 1 ? 's' : '',
+                join(', ', $undefinedTypes)
+            ));
+        }
+    }
+}

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
@@ -45,9 +45,10 @@ final class SuitePrerequisites implements SuitePrerequisitesInterface
 
         if ($undefinedTypes) {
             throw new PrerequisiteFailedException(sprintf(
-                "The type%s %s was generated but could not be loaded. Do you need to configure an autoloader?\n",
+                "The type%s %s %s generated but could not be loaded. Do you need to configure an autoloader?\n",
                 count($undefinedTypes) > 1 ? 's' : '',
-                join(', ', $undefinedTypes)
+                join(', ', $undefinedTypes),
+                count($undefinedTypes) > 1 ? 'were' : 'was'
             ));
         }
     }

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisitesInterface.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisitesInterface.php
@@ -11,22 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Process\Context;
+namespace PhpSpec\Process\Prerequisites;
 
-interface ExecutionContextInterface
+interface SuitePrerequisitesInterface
 {
     /**
-     * @param string $type
+     * @throws PrerequisiteFailedException
      */
-    public function addGeneratedType($type);
-
-    /**
-     * @return array
-     */
-    public function getGeneratedTypes();
-
-    /**
-     * @return array
-     */
-    public function asEnv();
+    public function guardPrerequisites();
 }

--- a/src/PhpSpec/Process/ReRunner/PassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PassthruReRunner.php
@@ -13,8 +13,23 @@
 
 namespace PhpSpec\Process\ReRunner;
 
+use PhpSpec\Process\Context\ExecutionContextInterface;
+
 class PassthruReRunner extends PhpExecutableReRunner
 {
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @param ExecutionContextInterface $executionContext
+     */
+    public function setExecutionContext(ExecutionContextInterface $executionContext)
+    {
+        $this->executionContext = $executionContext;
+    }
+
     /**
      * @return boolean
      */
@@ -28,8 +43,19 @@ class PassthruReRunner extends PhpExecutableReRunner
     public function reRunSuite()
     {
         $args = $_SERVER['argv'];
-        $command = escapeshellcmd($this->getExecutablePath()).' '.join(' ', array_map('escapeshellarg', $args));
+        $command = $this->buildArgString() . escapeshellcmd($this->getExecutablePath()).' '.join(' ', array_map('escapeshellarg', $args));
         passthru($command, $exitCode);
         exit($exitCode);
+    }
+
+    private function buildArgString()
+    {
+        $argstring = '';
+
+        foreach ($this->executionContext->asEnv() as $key => $value) {
+            $argstring .= $key . '=' . escapeshellarg($value) . ' ';
+        }
+
+        return $argstring;
     }
 }

--- a/src/PhpSpec/Process/ReRunner/PassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PassthruReRunner.php
@@ -14,6 +14,7 @@
 namespace PhpSpec\Process\ReRunner;
 
 use PhpSpec\Process\Context\ExecutionContextInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 class PassthruReRunner extends PhpExecutableReRunner
 {
@@ -23,11 +24,16 @@ class PassthruReRunner extends PhpExecutableReRunner
     private $executionContext;
 
     /**
+     * @param PhpExecutableFinder $phpExecutableFinder
      * @param ExecutionContextInterface $executionContext
+     * @return static
      */
-    public function setExecutionContext(ExecutionContextInterface $executionContext)
+    public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContextInterface $executionContext)
     {
-        $this->executionContext = $executionContext;
+        $reRunner = new static($phpExecutableFinder);
+        $reRunner->executionContext = $executionContext;
+
+        return $reRunner;
     }
 
     /**

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -13,8 +13,24 @@
 
 namespace PhpSpec\Process\ReRunner;
 
+use PhpSpec\Process\Context\ExecutionContextInterface;
+
 class PcntlReRunner extends PhpExecutableReRunner
 {
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @param ExecutionContextInterface $executionContext
+     */
+    public function setExecutionContext(ExecutionContextInterface $executionContext)
+    {
+        $this->executionContext = $executionContext;
+    }
+
     /**
      * @return bool
      */
@@ -32,6 +48,8 @@ class PcntlReRunner extends PhpExecutableReRunner
     public function reRunSuite()
     {
         $args = $_SERVER['argv'];
-        pcntl_exec($this->getExecutablePath(), $args);
+        $env = $this->executionContext ? $this->executionContext->asEnv() : array();
+
+        pcntl_exec($this->getExecutablePath(), $args, array_merge($env, $_SERVER));
     }
 }

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -14,6 +14,7 @@
 namespace PhpSpec\Process\ReRunner;
 
 use PhpSpec\Process\Context\ExecutionContextInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 class PcntlReRunner extends PhpExecutableReRunner
 {
@@ -23,11 +24,16 @@ class PcntlReRunner extends PhpExecutableReRunner
     private $executionContext;
 
     /**
+     * @param PhpExecutableFinder $phpExecutableFinder
      * @param ExecutionContextInterface $executionContext
+     * @return static
      */
-    public function setExecutionContext(ExecutionContextInterface $executionContext)
+    public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContextInterface $executionContext)
     {
-        $this->executionContext = $executionContext;
+        $reRunner = new static($phpExecutableFinder);
+        $reRunner->executionContext = $executionContext;
+
+        return $reRunner;
     }
 
     /**

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -17,7 +17,6 @@ use PhpSpec\Process\Context\ExecutionContextInterface;
 
 class PcntlReRunner extends PhpExecutableReRunner
 {
-
     /**
      * @var ExecutionContextInterface
      */


### PR DESCRIPTION

![screen shot 2015-06-08 at 08 06 25](https://cloud.githubusercontent.com/assets/237866/8029457/4ed85c00-0db5-11e5-97d9-0582a2927d23.png)
Fixes the common infinite loop error where the project autoloader cannot load classes that have been generated so offers to generate them again.

Previous attempts tried to do this in the same process, but were stymied by the fact composer caches misses on class_exists.

This solution passes a context between executions and checks in the new process that the types are now loadable.

Closes #698