### PR TITLE
Shortcut syntax for named constructors

### DIFF
--- a/docs/cookbook/construction.rst
+++ b/docs/cookbook/construction.rst
@@ -122,6 +122,14 @@ You can tell **phpspec** this is how you want to construct the object as follows
 Where the first argument is the method name and the second an array of the values
 to pass to that method.
 
+To be more descriptive, shorter syntaxes are available. All of the following are equivalent:
+
+.. code-block: php
+
+    $this->beConstructedNamed('Bob');
+    $this->beConstructedThroughNamed('Bob');
+    $this->beConstructedThrough('Named', array('Bob'));
+
 Overriding
 ----------
 

--- a/features/code_generation/developer_generates_named_constructor.feature
+++ b/features/code_generation/developer_generates_named_constructor.feature
@@ -283,3 +283,109 @@ Feature: Developer generates a named constructor
     }
 
     """
+
+  Scenario: Generating a named constructor using beConstructedThrough*
+    Given the spec file "spec/CodeGeneration/ShortSyntax/UserSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\CodeGeneration\ShortSyntax;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class UserSpec extends ObjectBehavior
+      {
+          function it_registers_a_user()
+          {
+              $this->beConstructedThroughRegister('firstname', 'lastname');
+              $this->getFirstname()->shouldBe('firstname');
+          }
+      }
+
+      """
+    And the class file "src/CodeGeneration/ShortSyntax/User.php" contains:
+      """
+      <?php
+
+      namespace CodeGeneration\ShortSyntax;
+
+      class User
+      {
+      }
+
+      """
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then the class in "src/CodeGeneration/ShortSyntax/User.php" should contain:
+      """
+      <?php
+
+      namespace CodeGeneration\ShortSyntax;
+
+      class User
+      {
+
+          public static function register($argument1, $argument2)
+          {
+              $user = new User();
+
+              // TODO: write logic here
+
+              return $user;
+          }
+      }
+
+      """
+
+  Scenario: Generating a named constructor using beConstructed*
+    Given the spec file "spec/CodeGeneration/ShortSyntax2/UserSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\CodeGeneration\ShortSyntax2;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class UserSpec extends ObjectBehavior
+      {
+          function it_registers_a_user()
+          {
+              $this->beConstructedFromString('firstname', 'lastname');
+              $this->getFirstname()->shouldBe('firstname');
+          }
+      }
+
+      """
+    And the class file "src/CodeGeneration/ShortSyntax2/User.php" contains:
+      """
+      <?php
+
+      namespace CodeGeneration\ShortSyntax2;
+
+      class User
+      {
+      }
+
+      """
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then the class in "src/CodeGeneration/ShortSyntax2/User.php" should contain:
+      """
+      <?php
+
+      namespace CodeGeneration\ShortSyntax2;
+
+      class User
+      {
+
+          public static function fromString($argument1, $argument2)
+          {
+              $user = new User();
+
+              // TODO: write logic here
+
+              return $user;
+          }
+      }
+
+      """

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -190,6 +190,14 @@ class Subject implements ArrayAccess, WrapperInterface
             return $this->callExpectation($method, $arguments);
         }
 
+        if (preg_match('/^beConstructedThrough(?P<method>[0-9A-Z]+)/i', $method, $matches)) {
+            return $this->beConstructedThrough(lcfirst($matches['method']), $arguments);
+        }
+
+        if (preg_match('/^beConstructed(?P<method>[0-9A-Z]+)/i', $method, $matches)) {
+            return $this->beConstructedThrough(lcfirst($matches['method']), $arguments);
+        }
+
         return $this->caller->call($method, $arguments);
     }
 


### PR DESCRIPTION
I've noticed people find it hard to remember to pass the arguments to `beConstructedThrough` as an array. This introduces a shortcut syntax (similar to `during*`) that allows expressions like:

```php
$this->beConstructedNamed('Bob');  // calls ::named('Bob')
$this->beConstructedFromInt(42);  // calls ::fromInt(42)
$this->beConstructedThroughGetInstance(); // calls ::getInstance()
```