### PR TITLE
Make smoke tests part of default behat profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,9 @@ matrix:
       env: DEPENDENCIES='dev'
     - php: 5.6
     - php: hhvm
-    - php: hhvm-nightly
     - php: 7.0
   allow_failures:
     - php: 7.0
-    - php: hhvm-nightly
     - env: DEPENDENCIES='dev'
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,17 @@ matrix:
     - php: 5.3
     - php: 5.3.3
       env: DEPENDENCIES='low'
-           SMOKE='true'
     - php: 5.4
     - php: 5.5
     - php: 5.6
       env: DEPENDENCIES='dev'
     - php: 5.6
-      env: SMOKE='true'
     - php: hhvm
-      env: SMOKE='true'
+    - php: hhvm-nightly
     - php: 7.0
   allow_failures:
     - php: 7.0
+    - php: hhvm-nightly
     - env: DEPENDENCIES='dev'
   fast_finish: true
 
@@ -46,4 +45,4 @@ before_script:
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty `if [ "$SMOKE" == "true" ]; then echo '--profile=smoke'; fi;` --tags '~@php-version'`php php_version_tags.php`
+   - ./vendor/bin/behat --format=pretty --profile=smoke --tags '~@php-version'`php php_version_tags.php`

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ before_script:
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty --profile=smoke --tags '~@php-version'`php php_version_tags.php`
+   - ./vendor/bin/behat --format=pretty --tags '~@php-version'`php php_version_tags.php`

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -6,13 +6,12 @@ default:
     isolated:
       contexts: [ IsolatedProcessContext, FilesystemContext ]
       filters: { tags: @isolated }
-
-  formatters:
-    progress: ~
-
-smoke:
-  suites:
     smoke:
       contexts: [ IsolatedProcessContext, FilesystemContext ]
       filters: { tags: @smoke && ~@isolated }
+  formatters:
+    progress: ~
 
+no-smoke:
+  suites:
+    smoke: ~

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -21,7 +21,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     {
         chdir(sys_get_temp_dir());
         if (!@`which expect`) {
-            throw new \Exception('Smoke tests require the `expect` command line application');
+            throw new \Exception('Smoke tests require the `expect` command line application. Try running with --profile=no-smoke');
         }
     }
 


### PR DESCRIPTION
Thanks to the recent changes by @stof there is no real penalty to running smoke tests as part of the suite on travis.

This makes them part of the default profile with a warning for users who try and run them on systems without `expects`