### PR TITLE
Run a named spec using fully qualified class name

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -299,4 +299,18 @@ class ApplicationContext implements Context, MatchersProviderInterface
 
         $this->lastExitCode = $this->tester->run($arguments, array('interactive' => false));
     }
+
+    /**
+     * @When I run phpspec with the spec :spec and the config :config
+     */
+    public function iRunPhpspecWithTheSpecAndTheConfig($spec, $config)
+    {
+        $arguments = array (
+            'command' => 'run',
+            1 => $spec,
+            '--config' => $config
+        );
+
+        $this->lastExitCode = $this->tester->run($arguments, array('interactive' => false));
+    }
 }

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -286,4 +286,17 @@ class ApplicationContext implements Context, MatchersProviderInterface
             new ValidJUnitXmlMatcher()
         );
     }
+
+    /**
+     * @When I run phpspec with the spec :spec
+     */
+    public function iRunPhpspecWithTheSpec($spec)
+    {
+        $arguments = array (
+            'command' => 'run',
+            1 => $spec
+        );
+
+        $this->lastExitCode = $this->tester->run($arguments, array('interactive' => false));
+    }
 }

--- a/features/runner/developer_runs_specs.feature
+++ b/features/runner/developer_runs_specs.feature
@@ -163,3 +163,42 @@ Feature: Developer runs the specs
       """
     When I run phpspec with the spec "Runner\TestNamespace\Example1"
     Then the suite should pass
+
+  Scenario: Fully qualified PSR4 class name can run specs
+    Given the spec file "spec/Runner/Namespace/Example2Spec.php" contains:
+      """
+      <?php
+      namespace spec\Psr4\Runner\TestNamespace;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class Example2Spec extends ObjectBehavior
+      {
+          function it_is_initializable()
+          {
+              $this->shouldHaveType('Psr4\Runner\TestNamespace\Example2');
+          }
+      }
+
+      """
+    And the class file "src/Psr4/Runner/TestNamespace/Example2.php" contains:
+      """
+      <?php
+
+      namespace Psr4\Runner\TestNamespace;
+
+      class Example2
+      {
+      }
+
+      """
+    And the config file located in "Psr4" contains:
+      """
+      suites:
+        behat_suite:
+          namespace: Psr4
+          psr4_prefix: Psr4
+      """
+    When I run phpspec with the spec "Psr4\Runner\TestNamespace\Example2" and the config "Psr4/phpspec.yml"
+    Then the suite should pass

--- a/features/runner/developer_runs_specs.feature
+++ b/features/runner/developer_runs_specs.feature
@@ -130,3 +130,36 @@ Feature: Developer runs the specs
       """
     When I run phpspec
     Then I should see "Letgo is called"
+
+
+  Scenario: Fully qualified class name can run specs
+    Given the spec file "spec/Runner/Namespace/Example1Spec.php" contains:
+      """
+      <?php
+      namespace spec\Runner\TestNamespace;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class Example1Spec extends ObjectBehavior
+      {
+          function it_is_initializable()
+          {
+              $this->shouldHaveType('Runner\TestNamespace\Example1');
+          }
+      }
+
+      """
+    And the class file "src/Runner/TestNamespace/Example1.php" contains:
+      """
+      <?php
+
+      namespace Runner\TestNamespace;
+
+      class Example1
+      {
+      }
+
+      """
+    When I run phpspec with the spec "Runner\TestNamespace\Example1"
+    Then the suite should pass

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -514,6 +514,13 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->supportsQuery('Console\\Application')->shouldReturn(true);
     }
 
+    function it_supports_psr4_namespace_queries(Filesystem $filesystem)
+    {
+        $this->beConstructedWith('Test\\Namespace\\PhpSpec', 'spec', $this->srcPath, $this->specPath, $filesystem, 'Test\\Namespace');
+        $filesystem->pathExists($this->specPath.'/spec/PhpSpec/Console/ApplicationSpec.php')->willReturn(true);
+        $this->supportsQuery('Test\\Namespace\\PhpSpec\\Console\\Application')->shouldReturn(true);
+    }
+
     private function convert_to_path($path)
     {
         if ('/' === DIRECTORY_SEPARATOR) {

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -500,6 +500,20 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->shouldThrow($exception)->during('__construct', array('p\pf\N\S', 'spec', $this->srcPath, $this->specPath, null, 'wrong\prefix'));
     }
 
+    function it_supports_psr0_namespace_queries(Filesystem $filesystem)
+    {
+        $this->beConstructedWith('', 'spec', $this->srcPath, $this->specPath, $filesystem);
+        $filesystem->pathExists($this->specPath.'/spec/PhpSpec/Console/ApplicationSpec.php')->willReturn(true);
+        $this->supportsQuery('PhpSpec\\Console\\Application')->shouldReturn(true);
+    }
+
+    function it_supports_psr0_namespace_queries_with_a_namespace_prefix(Filesystem $filesystem)
+    {
+        $this->beConstructedWith('PhpSpec', 'spec', $this->srcPath, $this->specPath, $filesystem);
+        $filesystem->pathExists($this->specPath.'/spec/PhpSpec/Console/ApplicationSpec.php')->willReturn(true);
+        $this->supportsQuery('Console\\Application')->shouldReturn(true);
+    }
+
     private function convert_to_path($path)
     {
         if ('/' === DIRECTORY_SEPARATOR) {

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -359,10 +359,12 @@ class PSR0Locator implements ResourceLocatorInterface
         $replacedQuery = str_replace(array('\\', '/'), $sepr, $query);
 
         if (false !== strpos($query, '\\')) {
-            // check for a namespace first
-            $namespace = str_replace(array('\\', '/'), $sepr, $this->specNamespace);
-            $path = realpath($namespace . $replacedQuery . 'Spec.php');
-            if ($path) {
+            $namespacedQuery = null === $this->psr4Prefix ?
+                $replacedQuery :
+                substr($replacedQuery, strlen($this->srcNamespace));
+
+            $path = $this->fullSpecPath . $namespacedQuery . 'Spec.php';
+            if ($this->filesystem->pathExists($path)) {
                 return $path;
             }
         }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -154,8 +154,7 @@ class PSR0Locator implements ResourceLocatorInterface
      */
     public function supportsQuery($query)
     {
-        $sepr = DIRECTORY_SEPARATOR;
-        $path = rtrim(realpath(str_replace(array('\\', '/'), $sepr, $query)), $sepr);
+        $path = $this->getQueryPath($query);
 
         if (null === $path) {
             return false;
@@ -173,11 +172,10 @@ class PSR0Locator implements ResourceLocatorInterface
      */
     public function findResources($query)
     {
-        $sepr = DIRECTORY_SEPARATOR;
-        $path = rtrim(realpath(str_replace(array('\\', '/'), $sepr, $query)), $sepr);
+        $path = $this->getQueryPath($query);
 
         if ('.php' !== substr($path, -4)) {
-            $path .= $sepr;
+            $path .= DIRECTORY_SEPARATOR;
         }
 
         if ($path && 0 === strpos($path, $this->fullSrcPath)) {
@@ -349,5 +347,26 @@ class PSR0Locator implements ResourceLocatorInterface
                 'https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md'
             );
         }
+    }
+
+    /**
+     * @param $query
+     * @return string
+     */
+    private function getQueryPath($query)
+    {
+        $sepr = DIRECTORY_SEPARATOR;
+        $replacedQuery = str_replace(array('\\', '/'), $sepr, $query);
+
+        if (false !== strpos($query, '\\')) {
+            // check for a namespace first
+            $namespace = str_replace(array('\\', '/'), $sepr, $this->specNamespace);
+            $path = realpath($namespace . $replacedQuery . 'Spec.php');
+            if ($path) {
+                return $path;
+            }
+        }
+
+        return rtrim(realpath($replacedQuery), $sepr);
     }
 }


### PR DESCRIPTION
Attempts to address https://github.com/phpspec/phpspec/issues/700 by checking whether the spec argument passed to the run command can be translated into a fully qualified class name for an existing spec file. If it can then the identified spec is executed, otherwise the original behaviour is used.