### PR TITLE
Fix: Add missing param annotation to docblock

### DIFF
--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -60,6 +60,7 @@ class PSR0Locator implements ResourceLocatorInterface
      * @param string     $srcPath
      * @param string     $specPath
      * @param Filesystem $filesystem
+     * @param string     $psr4Prefix
      */
     public function __construct(
         $srcNamespace = '',


### PR DESCRIPTION
This PR

* [x] adds a missing parameter annotation to a constructor docblock