### PR TITLE
Fix: SuitePrerequisites vs. SuitePrerequisitesInterface

### DIFF
--- a/src/PhpSpec/Listener/RerunListener.php
+++ b/src/PhpSpec/Listener/RerunListener.php
@@ -26,13 +26,13 @@ class RerunListener implements EventSubscriberInterface
     private $reRunner;
 
     /**
-     * @var SuitePrerequisites
+     * @var SuitePrerequisitesInterface
      */
     private $suitePrerequisites;
 
     /**
      * @param ReRunner $reRunner
-     * @param SuitePrerequisites $suitePrerequisites
+     * @param SuitePrerequisitesInterface $suitePrerequisites
      */
     public function __construct(ReRunner $reRunner, SuitePrerequisitesInterface $suitePrerequisites)
     {


### PR DESCRIPTION
This PR

* [x] fixes docblocks which refer to an implementation (`SuitePrerequisites `), while the corresponding interface is probably intended to be used (`SuitePrerequisitesInterface`)