### PR TITLE
Fix: Remove unused private variable

### DIFF
--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -28,10 +28,7 @@ class MatchersMaintainer implements MaintainerInterface
      * @var \PhpSpec\Formatter\Presenter\PresenterInterface
      */
     private $presenter;
-    /**
-     * @var \PhpSpec\Wrapper\Unwrapper
-     */
-    private $unwrapper;
+
     /**
      * @var MatcherInterface[]
      */


### PR DESCRIPTION
This PR

* [x] removes an unused private variable