### PR TITLE
Fix: Remove unused private method

### DIFF
--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -169,15 +169,4 @@ class ProgressFormatter extends ConsoleFormatter
 
         $this->updateProgressBar($io, $progress, $stats->getEventsCount());
     }
-
-    /**
-     * @return float
-     */
-    private function getSpecProgress()
-    {
-        $stats = $this->getStatisticsCollector();
-        $specProgress = $stats->getTotalSpecsCount() ? ($stats->getTotalSpecs() + 1) / $stats->getTotalSpecsCount() : 0;
-
-        return $specProgress;
-    }
 }


### PR DESCRIPTION
This PR

* [x] removes an unused private method