### PR TITLE
add an empty line at the end of generated files

### DIFF
--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -17,6 +17,7 @@ Feature: Developer generates a class
       {
       }
 
+
       """
 
   @issue269
@@ -40,6 +41,7 @@ Feature: Developer generates a class
     {
     }
 
+
     """
 
   @issue127
@@ -56,6 +58,7 @@ Feature: Developer generates a class
       {
       }
 
+
       """
 
   @issue127
@@ -71,6 +74,7 @@ Feature: Developer generates a class
       class Text_Markdown
       {
       }
+
 
       """
 
@@ -129,6 +133,7 @@ Feature: Developer generates a class
     class ForgotPassword
     {
     }
+
 
     """
 

--- a/features/code_generation/developer_generates_collaborator.feature
+++ b/features/code_generation/developer_generates_collaborator.feature
@@ -84,6 +84,7 @@ Feature: Developer generates a collaborator
       {
       }
 
+
       """
 
   Scenario: Not being prompted when typehint is in spec namespace

--- a/features/code_generation/developer_generates_spec.feature
+++ b/features/code_generation/developer_generates_spec.feature
@@ -6,23 +6,24 @@ Feature: Developer generates a spec
   Scenario: Generating a spec
     When I start describing the "CodeGeneration/SpecExample1/Markdown" class
     Then a new spec should be generated in the "spec/CodeGeneration/SpecExample1/MarkdownSpec.php":
-      """
-      <?php
+    """
+    <?php
 
-      namespace spec\CodeGeneration\SpecExample1;
+    namespace spec\CodeGeneration\SpecExample1;
 
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
 
-      class MarkdownSpec extends ObjectBehavior
-      {
-          function it_is_initializable()
-          {
-              $this->shouldHaveType('CodeGeneration\SpecExample1\Markdown');
-          }
-      }
+    class MarkdownSpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('CodeGeneration\SpecExample1\Markdown');
+        }
+    }
 
-      """
+
+    """
 
 
   @issue687
@@ -53,6 +54,7 @@ Feature: Developer generates a spec
             $this->shouldHaveType('CodeGeneration\SpecExample2\Markdown');
         }
     }
+
 
     """
 
@@ -86,76 +88,80 @@ Feature: Developer generates a spec
         }
     }
 
+
     """
 
   @issue127
   Scenario: Generating a spec with PSR0 must convert classname underscores to directory separator
     When I start describing the "CodeGeneration/SpecExample1/Text_Markdown" class
     Then a new spec should be generated in the "spec/CodeGeneration/SpecExample1/Text/MarkdownSpec.php":
-      """
-      <?php
+    """
+    <?php
 
-      namespace spec\CodeGeneration\SpecExample1;
+    namespace spec\CodeGeneration\SpecExample1;
 
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
 
-      class Text_MarkdownSpec extends ObjectBehavior
-      {
-          function it_is_initializable()
-          {
-              $this->shouldHaveType('CodeGeneration\SpecExample1\Text_Markdown');
-          }
-      }
+    class Text_MarkdownSpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('CodeGeneration\SpecExample1\Text_Markdown');
+        }
+    }
 
-      """
+
+    """
 
   @issue127
   Scenario: Generating a spec with PSR0 must not convert namespace underscores to directory separator
     When I start describing the "CodeGeneration/Spec_Example2/Text_Markdown" class
     Then a new spec should be generated in the "spec/CodeGeneration/Spec_Example2/Text/MarkdownSpec.php":
-      """
-      <?php
+    """
+    <?php
 
-      namespace spec\CodeGeneration\Spec_Example2;
+    namespace spec\CodeGeneration\Spec_Example2;
 
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
 
-      class Text_MarkdownSpec extends ObjectBehavior
-      {
-          function it_is_initializable()
-          {
-              $this->shouldHaveType('CodeGeneration\Spec_Example2\Text_Markdown');
-          }
-      }
+    class Text_MarkdownSpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('CodeGeneration\Spec_Example2\Text_Markdown');
+        }
+    }
 
-      """
+
+    """
 
   Scenario: Generating a spec for a class with psr4 prefix
     Given the config file contains:
-      """
-      suites:
-        behat_suite:
-          namespace: Behat\CodeGeneration
-          psr4_prefix: Behat\CodeGeneration
-      """
+    """
+    suites:
+      behat_suite:
+        namespace: Behat\CodeGeneration
+        psr4_prefix: Behat\CodeGeneration
+    """
     When I start describing the "Behat/CodeGeneration/Markdown" class
     Then a new spec should be generated in the "spec/MarkdownSpec.php":
-      """
-      <?php
+    """
+    <?php
 
-      namespace spec\Behat\CodeGeneration;
+    namespace spec\Behat\CodeGeneration;
 
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
 
-      class MarkdownSpec extends ObjectBehavior
-      {
-          function it_is_initializable()
-          {
-              $this->shouldHaveType('Behat\CodeGeneration\Markdown');
-          }
-      }
+    class MarkdownSpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('Behat\CodeGeneration\Markdown');
+        }
+    }
 
-      """
+
+    """

--- a/features/config/developer_can_use_config_dir_in_paths.feature
+++ b/features/config/developer_can_use_config_dir_in_paths.feature
@@ -5,98 +5,102 @@ Feature: Config directory can be used in spec and src paths
 
   Scenario: Using %paths.config% variable in spec_path
     Given the config file located in "Awesome" contains:
-      """
-      suites:
-        behat_suite:
-          namespace: MilkyWay\OrionCygnusArm
-          spec_path: %paths.config%
-      """
+    """
+    suites:
+      behat_suite:
+        namespace: MilkyWay\OrionCygnusArm
+        spec_path: %paths.config%
+    """
     When I start describing the "MilkyWay/OrionCygnusArm/LocalBubble" class with the "Awesome/phpspec.yml" custom config
     Then a new spec should be generated in the "Awesome/spec/MilkyWay/OrionCygnusArm/LocalBubbleSpec.php":
-      """
-      <?php
+    """
+    <?php
 
-      namespace spec\MilkyWay\OrionCygnusArm;
+    namespace spec\MilkyWay\OrionCygnusArm;
 
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
 
-      class LocalBubbleSpec extends ObjectBehavior
-      {
-          function it_is_initializable()
-          {
-              $this->shouldHaveType('MilkyWay\OrionCygnusArm\LocalBubble');
-          }
-      }
+    class LocalBubbleSpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('MilkyWay\OrionCygnusArm\LocalBubble');
+        }
+    }
 
-      """
+
+    """
 
   Scenario: Not using %paths.config% variable in spec_path
     Given the config file located in "Awesome" contains:
-      """
-      suites:
-        behat_suite:
-          namespace: MilkyWay\OrionCygnusArm
-      """
+    """
+    suites:
+      behat_suite:
+        namespace: MilkyWay\OrionCygnusArm
+    """
     When I start describing the "MilkyWay/OrionCygnusArm/ButterflyCluster" class with the "Awesome/phpspec.yml" custom config
     Then a new spec should be generated in the "spec/MilkyWay/OrionCygnusArm/ButterflyClusterSpec.php":
-      """
-      <?php
+    """
+    <?php
 
-      namespace spec\MilkyWay\OrionCygnusArm;
+    namespace spec\MilkyWay\OrionCygnusArm;
 
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
 
-      class ButterflyClusterSpec extends ObjectBehavior
-      {
-          function it_is_initializable()
-          {
-              $this->shouldHaveType('MilkyWay\OrionCygnusArm\ButterflyCluster');
-          }
-      }
+    class ButterflyClusterSpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('MilkyWay\OrionCygnusArm\ButterflyCluster');
+        }
+    }
 
-      """
+
+    """
 
   Scenario: Using %paths.config% variable in src_path
     Given the config file located in "Awesome" contains:
-      """
-      suites:
-        behat_suite:
-          namespace: MilkyWay\OrionCygnusArm
-          src_path: %paths.config%/src
-      """
+    """
+    suites:
+      behat_suite:
+        namespace: MilkyWay\OrionCygnusArm
+        src_path: %paths.config%/src
+    """
     And I have started describing the "MilkyWay/OrionCygnusArm/Pleiades/Alcyone" class with the "Awesome/phpspec.yml" custom config
     When I run phpspec with the "Awesome/phpspec.yml" custom config and answer "y" when asked if I want to generate the code
     Then a new class should be generated in the "Awesome/src/MilkyWay/OrionCygnusArm/Pleiades/Alcyone.php":
-      """
-      <?php
+    """
+    <?php
 
-      namespace MilkyWay\OrionCygnusArm\Pleiades;
+    namespace MilkyWay\OrionCygnusArm\Pleiades;
 
-      class Alcyone
-      {
-      }
+    class Alcyone
+    {
+    }
 
-      """
+
+    """
 
   Scenario: Not using %paths.config% variable in src_path
     Given the config file located in "Awesome" contains:
-      """
-      suites:
-        behat_suite:
-          namespace: MilkyWay\OrionCygnusArm
-      """
+    """
+    suites:
+      behat_suite:
+        namespace: MilkyWay\OrionCygnusArm
+    """
     And I have started describing the "MilkyWay/OrionCygnusArm/BehiveCluster" class with the "Awesome/phpspec.yml" custom config
     When I run phpspec with the "Awesome/phpspec.yml" custom config and answer "y" when asked if I want to generate the code
     Then a new class should be generated in the "src/MilkyWay/OrionCygnusArm/BehiveCluster.php":
-      """
-      <?php
+    """
+    <?php
 
-      namespace MilkyWay\OrionCygnusArm;
+    namespace MilkyWay\OrionCygnusArm;
 
-      class BehiveCluster
-      {
-      }
+    class BehiveCluster
+    {
+    }
 
-      """
+
+    """

--- a/src/PhpSpec/CodeGenerator/Generator/templates/class.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/class.template
@@ -3,3 +3,4 @@
 class %name%
 {
 }
+

--- a/src/PhpSpec/CodeGenerator/Generator/templates/interface.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/interface.template
@@ -3,3 +3,4 @@
 interface %name%
 {
 }
+

--- a/src/PhpSpec/CodeGenerator/Generator/templates/specification.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/specification.template
@@ -12,3 +12,4 @@ class %name% extends ObjectBehavior
         $this->shouldHaveType('%subject%');
     }
 }
+


### PR DESCRIPTION
[PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#22-files) requires each PHP files to be ended with an empty line. This PR enforces this rule.