### PR TITLE
#741 Place methods specifically after the last one

### DIFF
--- a/features/code_generation/developer_generates_method.feature
+++ b/features/code_generation/developer_generates_method.feature
@@ -204,3 +204,60 @@ Feature: Developer generates a method
       }
 
       """
+
+  Scenario: Generating a method in a class with existing methods and new lines
+    Given the spec file "spec/MyNamespace/ExistingMethodSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\MyNamespace;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class ExistingMethodSpec extends ObjectBehavior
+      {
+          function it_should_do_something()
+          {
+              $this->foo()->shouldReturn('bar');
+          }
+      }
+      """
+    And the class file "src/MyNamespace/ExistingMethod.php" contains:
+      """
+      <?php
+
+      namespace MyNamespace;
+
+      class ExistingMethod
+      {
+          public function existing()
+          {
+              return 'something';
+          }
+
+      }
+
+      """
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then the class in "src/MyNamespace/ExistingMethod.php" should contain:
+      """
+      <?php
+
+      namespace MyNamespace;
+
+      class ExistingMethod
+      {
+          public function existing()
+          {
+              return 'something';
+          }
+
+          public function foo()
+          {
+              // TODO: write logic here
+          }
+
+      }
+
+      """

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -54,7 +54,8 @@ final class TokenizedCodeWriter implements CodeWriter
     public function insertMethodLastInClass($class, $method)
     {
         if ($this->analyser->classHasMethods($class)) {
-            return $this->writeAtEndOfClass($class, $method, true);
+            $line = $this->analyser->getEndLineOfLastMethod($class);
+            return $this->insertStringAfterLine($class, $method, $line);
         }
 
         return $this->writeAtEndOfClass($class, $method);

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -32,6 +32,17 @@ final class ClassFileAnalyser
 
     /**
      * @param string $class
+     * @return int
+     */
+    public function getEndLineOfLastMethod($class)
+    {
+        $tokens = $this->getTokensForClass($class);
+        $index = $this->findIndexOfMethodEnd($tokens, $this->findIndexOfLastMethod($tokens));
+        return $tokens[$index][2];
+    }
+
+    /**
+     * @param string $class
      * @return bool
      */
     public function classHasMethods($class)
@@ -69,7 +80,20 @@ final class ClassFileAnalyser
     private function findIndexOfFirstMethod(array $tokens)
     {
         for ($i = 0, $max = count($tokens); $i < $max; $i++) {
-            if (is_array($tokens[$i]) && $tokens[$i][0] === T_FUNCTION) {
+            if ($this->tokenIsFunction($tokens[$i])) {
+                return $i;
+            }
+        }
+    }
+
+    /**
+     * @param array $tokens
+     * @return int
+     */
+    private function findIndexOfLastMethod(array $tokens)
+    {
+        for ($i = count($tokens) - 1; $i >= 0; $i--) {
+            if ($this->tokenIsFunction($tokens[$i])) {
                 return $i;
             }
         }
@@ -198,5 +222,14 @@ final class ClassFileAnalyser
                 }
             }
         }
+    }
+
+    /**
+     * @param mixed $token
+     * @return bool
+     */
+    private function tokenIsFunction($token)
+    {
+        return is_array($token) && $token[0] === T_FUNCTION;
     }
 }


### PR DESCRIPTION
Fixes an issue raised in #741 which seems to have been caused by the existing method in a SUT being followed by a newline. This adds specific detection for the end of the last method of the class, ignoring any trailing newlines.