### PR TITLE
Refactoring of the Presenter objects

### DIFF
--- a/spec/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenterSpec.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Formatter\Presenter\Differ\Differ;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Prophecy\Argument\ArgumentsWildcard;
+use Prophecy\Call\Call;
+use Prophecy\Exception\Call\UnexpectedCallException;
+use Prophecy\Prophecy\MethodProphecy;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class CallArgumentsPresenterSpec extends ObjectBehavior
+{
+    function let(Differ $differ)
+    {
+        $this->beConstructedWith($differ);
+    }
+
+    function it_should_return_empty_string_if_there_are_no_method_prophecies(
+        UnexpectedCallException $exception, ObjectProphecy $objectProphecy
+    ) {
+        $exception->getObjectProphecy()->willReturn($objectProphecy);
+        $exception->getArguments()->shouldBeCalled();
+        $exception->getMethodName()->willReturn('method');
+
+        $objectProphecy->getMethodProphecies('method')->willReturn(array());
+
+        $this->presentDifference($exception)->shouldReturn('');
+    }
+
+    function it_should_return_empty_string_if_method_prophecies_all_contain_calls(
+        UnexpectedCallException $exception, ObjectProphecy $objectProphecy, MethodProphecy $prophecy,
+        Call $call, ArgumentsWildcard $wildcard
+    ) {
+        $exception->getObjectProphecy()->willReturn($objectProphecy);
+        $exception->getArguments()->shouldBeCalled();
+        $exception->getMethodName()->willReturn('method');
+
+        $objectProphecy->getMethodProphecies(Argument::any())->willReturn(array($prophecy));
+        $objectProphecy->findProphecyMethodCalls('method', $wildcard)->willReturn(array($call));
+
+        $prophecy->getArgumentsWildcard()->willReturn($wildcard);
+
+        $this->presentDifference($exception)->shouldReturn('');
+    }
+
+    function it_should_return_empty_string_if_argument_counts_do_not_match(
+        UnexpectedCallException $exception, ObjectProphecy $objectProphecy, MethodProphecy $prophecy,
+        ArgumentsWildcard $wildcard
+    ) {
+        $exception->getObjectProphecy()->willReturn($objectProphecy);
+        $exception->getArguments()->willReturn(array('a', 'b'));
+        $exception->getMethodName()->shouldBeCalled();
+
+        $objectProphecy->getMethodProphecies(Argument::any())->willReturn(array($prophecy));
+        $objectProphecy->findProphecyMethodCalls(Argument::any(), Argument::any())->willReturn(array());
+
+        $prophecy->getArgumentsWildcard()->willReturn($wildcard);
+        $wildcard->getTokens()->willReturn(array('a'));
+
+        $this->presentDifference($exception)->shouldReturn('');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenterSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class GenericPhpSpecExceptionPresenterSpec extends ObjectBehavior
+{
+    function let(ExceptionElementPresenter $elementPresenter)
+    {
+        $this->beConstructedWith($elementPresenter);
+    }
+
+    function it_is_a_phpspec_exception_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Exception\PhpSpecExceptionPresenter');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenterSpec.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class HtmlPhpSpecExceptionPresenterSpec extends ObjectBehavior
+{
+    function it_is_a_phpspec_exception_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Exception\PhpSpecExceptionPresenter');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenterSpec.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Formatter\Presenter\Value\ExceptionTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class SimpleExceptionElementPresenterSpec extends ObjectBehavior
+{
+    function let(ExceptionTypePresenter $typePresenter, ValuePresenter $valuePresenter)
+    {
+        $this->beConstructedWith($typePresenter, $valuePresenter);
+    }
+
+    function it_is_an_exception_element_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter');
+    }
+
+    function it_should_return_a_simple_exception_thrown_message(
+        ExceptionTypePresenter $typePresenter, \Exception $exception
+    ) {
+        $typePresenter->present($exception)->willReturn('exc');
+        $this->presentExceptionThrownMessage($exception)->shouldReturn('Exception exc has been thrown.');
+    }
+
+    function it_should_present_a_code_line()
+    {
+        $this->presentCodeLine('3', '4')->shouldReturn('3 4');
+    }
+
+    function it_should_present_a_highlighted_line_unchanged()
+    {
+        $this->presentHighlight('foo')->shouldReturn('foo');
+    }
+
+    function it_should_present_the_header_of_an_exception_trace_unchanged()
+    {
+        $this->presentExceptionTraceHeader('foo')->shouldReturn('foo');
+    }
+
+    function it_should_present_every_argument_in_an_exception_trace_method_as_a_value(ValuePresenter $valuePresenter)
+    {
+        $args = array('foo', 42);
+        $valuePresenter->presentValue('foo')->shouldBeCalled();
+        $valuePresenter->presentValue(42)->shouldBeCalled();
+
+        $this->presentExceptionTraceMethod('', '', '', $args);
+    }
+
+    function it_should_present_an_exception_trace_method(ValuePresenter $valuePresenter)
+    {
+        $valuePresenter->presentValue('a')->willReturn('zaz');
+        $valuePresenter->presentValue('b')->willReturn('zbz');
+
+        $this->presentExceptionTraceMethod('class', 'type', 'method', array('a', 'b'))
+            ->shouldReturn('   classtypemethod(zaz, zbz)');
+    }
+
+    function it_should_present_every_argument_in_an_exception_trace_function_as_a_value(ValuePresenter $valuePresenter)
+    {
+        $args = array('foo', 42);
+        $valuePresenter->presentValue('foo')->shouldBeCalled();
+        $valuePresenter->presentValue(42)->shouldBeCalled();
+
+        $this->presentExceptionTraceFunction('', $args);
+    }
+
+    function it_should_present_an_exception_trace_function(ValuePresenter $valuePresenter)
+    {
+        $valuePresenter->presentValue('a')->willReturn('zaz');
+        $valuePresenter->presentValue('b')->willReturn('zbz');
+
+        $this->presentExceptionTraceFunction('function', array('a', 'b'))
+            ->shouldReturn('   function(zaz, zbz)');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenterSpec.php
@@ -5,6 +5,7 @@ namespace spec\PhpSpec\Formatter\Presenter\Exception;
 use PhpSpec\Formatter\Presenter\Differ\Differ;
 use PhpSpec\Formatter\Presenter\Exception\CallArgumentsPresenter;
 use PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter;
+use PhpSpec\Formatter\Presenter\Exception\PhpSpecExceptionPresenter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -12,9 +13,14 @@ class SimpleExceptionPresenterSpec extends ObjectBehavior
 {
     function let(
         Differ $differ, ExceptionElementPresenter $exceptionElementPresenter,
-        CallArgumentsPresenter $callArgumentsPresenter
+        CallArgumentsPresenter $callArgumentsPresenter, PhpSpecExceptionPresenter $phpspecExceptionPresenter
     ) {
-        $this->beConstructedWith($differ, $exceptionElementPresenter, $callArgumentsPresenter);
+        $this->beConstructedWith(
+            $differ,
+            $exceptionElementPresenter,
+            $callArgumentsPresenter,
+            $phpspecExceptionPresenter
+        );
     }
 
     function it_is_an_exception_presenter()

--- a/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenterSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Formatter\Presenter\Differ\Differ;
+use PhpSpec\Formatter\Presenter\Exception\CallArgumentsPresenter;
+use PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class SimpleExceptionPresenterSpec extends ObjectBehavior
+{
+    function let(
+        Differ $differ, ExceptionElementPresenter $exceptionElementPresenter,
+        CallArgumentsPresenter $callArgumentsPresenter
+    ) {
+        $this->beConstructedWith($differ, $exceptionElementPresenter, $callArgumentsPresenter);
+    }
+
+    function it_is_an_exception_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Exception\ExceptionPresenter');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenterSpec.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter;
+use PhpSpec\Formatter\Presenter\Value\ExceptionTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TaggingExceptionElementPresenterSpec extends ObjectBehavior
+{
+    function let(ExceptionTypePresenter $exceptionTypePresenter, ValuePresenter $valuePresenter)
+    {
+        $this->beConstructedWith($exceptionTypePresenter, $valuePresenter);
+    }
+
+    function it_is_an_exception_element_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter');
+    }
+
+    function it_should_tag_an_exception_thrown_message(
+        ExceptionTypePresenter $exceptionTypePresenter,
+        \Exception $exception
+    ) {
+        $exceptionTypePresenter->present($exception)->willReturn('exc');
+        $this->presentExceptionThrownMessage($exception)->shouldReturn('Exception <label>exc</label> has been thrown.');
+    }
+
+    function it_should_present_a_tagged_code_line()
+    {
+        $this->presentCodeLine('3', 'foo')->shouldReturn('<lineno>3</lineno> <code>foo</code>');
+    }
+
+    function it_should_present_a_tagged_highlighted_line()
+    {
+        $this->presentHighlight('foo')->shouldReturn('<hl>foo</hl>');
+    }
+
+    function it_should_present_a_tagged_header_of_an_exception_trace()
+    {
+        $this->presentExceptionTraceHeader('foo')->shouldReturn('<trace>foo</trace>');
+    }
+
+    function it_should_present_a_tagged_exception_trace_method(ValuePresenter $valuePresenter)
+    {
+        $valuePresenter->presentValue('a')->willReturn('zaz');
+        $valuePresenter->presentValue('b')->willReturn('zbz');
+
+        $result = '   <trace><trace-class>class</trace-class><trace-type>type</trace-type>'.
+            '<trace-func>method</trace-func>(<trace-args><value>zaz</value>, <value>zbz</value></trace-args>)</trace>';
+
+        $this->presentExceptionTraceMethod('class', 'type', 'method', array('a', 'b'))->shouldReturn($result);
+    }
+
+    function it_should_present_a_tagged_exception_trace_function(ValuePresenter $valuePresenter)
+    {
+        $valuePresenter->presentValue('a')->willReturn('zaz');
+        $valuePresenter->presentValue('b')->willReturn('zbz');
+
+        $result = '   <trace><trace-func>function</trace-func>'.
+            '(<trace-args><value>zaz</value>, <value>zbz</value></trace-args>)</trace>';
+
+        $this->presentExceptionTraceFunction('function', array('a', 'b'))->shouldReturn($result);
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/SimplePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/SimplePresenterSpec.php
@@ -40,6 +40,10 @@ class SimplePresenterSpec extends ObjectBehavior
     ) {
         $value = 'blah';
 
+        $presenter1->getPriority()->willReturn(3);
+        $presenter2->getPriority()->willReturn(2);
+        $presenter3->getPriority()->willReturn(1);
+
         $this->addTypePresenter($presenter1);
         $this->addTypePresenter($presenter2);
         $this->addTypePresenter($presenter3);
@@ -47,10 +51,27 @@ class SimplePresenterSpec extends ObjectBehavior
         $presenter1->supports($value)->willReturn(false)->shouldBeCalled();
         $presenter2->supports($value)->willReturn(true)->shouldBeCalled();
         $presenter2->present(Argument::any())->shouldBeCalled();
+        $presenter3->supports($value)->shouldNotBeCalled();
 
         $this->presentValue($value);
+    }
 
-        $presenter3->supports($value)->shouldNotHaveBeenCalled();
+    function it_should_order_presenters_by_their_priority_in_descending_order(
+        TypePresenter $presenter1, TypePresenter $presenter2
+    ) {
+        $value = 'foo';
+
+        $presenter1->getPriority()->willReturn(10);
+        $presenter2->getPriority()->willReturn(20);
+
+        $this->addTypePresenter($presenter1);
+        $this->addTypePresenter($presenter2);
+
+        $presenter1->supports($value)->shouldBeCalled()->willReturn(true);
+        $presenter2->supports($value)->shouldBeCalled();
+        $presenter1->present(Argument::any())->shouldBeCalled();
+
+        $this->presentValue($value);
     }
 
     function it_should_call_present_on_a_supporting_type_presenter(TypePresenter $typePresenter)

--- a/spec/PhpSpec/Formatter/Presenter/SimplePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/SimplePresenterSpec.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\PhpSpec\Formatter\Presenter;
+
+use PhpSpec\Formatter\Presenter\Value\TypePresenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class SimplePresenterSpec extends ObjectBehavior
+{
+    function it_is_a_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Presenter');
+    }
+
+    function it_returns_a_string_unchanged()
+    {
+        $message = 'this is a string';
+        $this->presentString($message)->shouldReturn($message);
+    }
+
+    function it_should_accept_a_type_presenter(TypePresenter $typePresenter)
+    {
+        $this->addTypePresenter($typePresenter)->shouldReturn(null);
+    }
+
+    function it_should_call_supports_on_value_presenters_until_one_returns_true(
+        TypePresenter $presenter1, TypePresenter $presenter2, TypePresenter $presenter3
+    ) {
+        $value = 'blah';
+
+        $this->addTypePresenter($presenter1);
+        $this->addTypePresenter($presenter2);
+        $this->addTypePresenter($presenter3);
+
+        $presenter1->supports($value)->willReturn(false)->shouldBeCalled();
+        $presenter2->supports($value)->willReturn(true)->shouldBeCalled();
+        $presenter2->present(Argument::any())->shouldBeCalled();
+
+        $this->presentValue($value);
+
+        $presenter3->supports($value)->shouldNotHaveBeenCalled();
+    }
+
+    function it_should_call_present_on_a_supporting_type_presenter(TypePresenter $typePresenter)
+    {
+        $value = 'blah';
+
+        $typePresenter->supports($value)->willReturn(true);
+        $typePresenter->present($value)->shouldBeCalled();
+
+        $this->addTypePresenter($typePresenter);
+        $this->presentValue($value);
+    }
+
+    function it_should_return_the_type_presenter_presented_value(TypePresenter $typePresenter)
+    {
+        $value = 'blah';
+        $presented = $value.'presented';
+
+        $typePresenter->supports($value)->willReturn(true);
+        $typePresenter->present($value)->willReturn($presented);
+
+        $this->addTypePresenter($typePresenter);
+        $this->presentValue($value)->shouldReturn($presented);
+    }
+
+    function it_returns_a_default_when_no_type_presenters_support_the_value()
+    {
+        $this->presentValue('blah')->shouldReturn('[string:blah]');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/SimplePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/SimplePresenterSpec.php
@@ -13,12 +13,18 @@
 
 namespace spec\PhpSpec\Formatter\Presenter;
 
-use PhpSpec\Formatter\Presenter\Value\TypePresenter;
+use PhpSpec\Formatter\Presenter\Exception\ExceptionPresenter;
+use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class SimplePresenterSpec extends ObjectBehavior
 {
+    function let(ValuePresenter $valuePresenter, ExceptionPresenter $exceptionPresenter)
+    {
+        $this->beConstructedWith($valuePresenter, $exceptionPresenter);
+    }
+
     function it_is_a_presenter()
     {
         $this->shouldImplement('PhpSpec\Formatter\Presenter\Presenter');
@@ -30,75 +36,18 @@ class SimplePresenterSpec extends ObjectBehavior
         $this->presentString($message)->shouldReturn($message);
     }
 
-    function it_should_accept_a_type_presenter(TypePresenter $typePresenter)
-    {
-        $this->addTypePresenter($typePresenter)->shouldReturn(null);
-    }
-
-    function it_should_call_supports_on_value_presenters_until_one_returns_true(
-        TypePresenter $presenter1, TypePresenter $presenter2, TypePresenter $presenter3
+    function it_should_be_a_proxy_for_an_exception_presenter(
+        ExceptionPresenter $exceptionPresenter, \Exception $exception
     ) {
-        $value = 'blah';
-
-        $presenter1->getPriority()->willReturn(3);
-        $presenter2->getPriority()->willReturn(2);
-        $presenter3->getPriority()->willReturn(1);
-
-        $this->addTypePresenter($presenter1);
-        $this->addTypePresenter($presenter2);
-        $this->addTypePresenter($presenter3);
-
-        $presenter1->supports($value)->willReturn(false)->shouldBeCalled();
-        $presenter2->supports($value)->willReturn(true)->shouldBeCalled();
-        $presenter2->present(Argument::any())->shouldBeCalled();
-        $presenter3->supports($value)->shouldNotBeCalled();
-
-        $this->presentValue($value);
+        $result = 'this is the result';
+        $exceptionPresenter->presentException($exception, true)->willReturn($result);
+        $this->presentException($exception, true)->shouldReturn($result);
     }
 
-    function it_should_order_presenters_by_their_priority_in_descending_order(
-        TypePresenter $presenter1, TypePresenter $presenter2
+    function it_should_be_a_proxy_for_a_value_presenter(
+        ValuePresenter $valuePresenter
     ) {
-        $value = 'foo';
-
-        $presenter1->getPriority()->willReturn(10);
-        $presenter2->getPriority()->willReturn(20);
-
-        $this->addTypePresenter($presenter1);
-        $this->addTypePresenter($presenter2);
-
-        $presenter1->supports($value)->shouldBeCalled()->willReturn(true);
-        $presenter2->supports($value)->shouldBeCalled();
-        $presenter1->present(Argument::any())->shouldBeCalled();
-
-        $this->presentValue($value);
-    }
-
-    function it_should_call_present_on_a_supporting_type_presenter(TypePresenter $typePresenter)
-    {
-        $value = 'blah';
-
-        $typePresenter->supports($value)->willReturn(true);
-        $typePresenter->present($value)->shouldBeCalled();
-
-        $this->addTypePresenter($typePresenter);
-        $this->presentValue($value);
-    }
-
-    function it_should_return_the_type_presenter_presented_value(TypePresenter $typePresenter)
-    {
-        $value = 'blah';
-        $presented = $value.'presented';
-
-        $typePresenter->supports($value)->willReturn(true);
-        $typePresenter->present($value)->willReturn($presented);
-
-        $this->addTypePresenter($typePresenter);
-        $this->presentValue($value)->shouldReturn($presented);
-    }
-
-    function it_returns_a_default_when_no_type_presenters_support_the_value()
-    {
-        $this->presentValue('blah')->shouldReturn('[string:blah]');
+        $valuePresenter->presentValue('foo')->willReturn('zfooz');
+        $this->presentValue('foo')->shouldReturn('zfooz');
     }
 }

--- a/spec/PhpSpec/Formatter/Presenter/TaggingPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/TaggingPresenterSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter;
+
+use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TaggingPresenterSpec extends ObjectBehavior
+{
+    function let(Presenter $presenter)
+    {
+        $this->beConstructedWith($presenter);
+    }
+
+    function it_is_a_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Presenter');
+    }
+
+    function it_should_tag_strings()
+    {
+        $this->presentString('foo')->shouldReturn('<value>foo</value>');
+    }
+
+    function it_should_tag_values_from_the_decorated_presenter(Presenter $presenter)
+    {
+        $presenter->presentValue('foo')->willReturn('zfooz');
+        $this->presentValue('foo')->shouldReturn('<value>zfooz</value>');
+    }
+
+    function it_should_return_presented_exceptions_from_the_decorated_presenter_unchanged(
+        Presenter $presenter, \Exception $exception
+    ) {
+        $presenter->presentException($exception, true)->willReturn('exc');
+        $this->presentException($exception, true)->shouldReturn('exc');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenterSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ArrayTypePresenterSpec extends ObjectBehavior
+{
+    function it_is_a_type_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\TypePresenter');
+    }
+
+    function it_should_support_array_values()
+    {
+        $this->supports(array())->shouldReturn(true);
+    }
+
+    function it_should_present_an_empty_array_as_a_string()
+    {
+        $this->present(array())->shouldReturn('[array:0]');
+    }
+
+    function it_should_present_a_populated_array_as_a_string()
+    {
+        $this->present(array('a', 'b'))->shouldReturn('[array:2]');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
@@ -5,11 +5,11 @@ namespace spec\PhpSpec\Formatter\Presenter\Value;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-class ExceptionTypePresenterSpec extends ObjectBehavior
+class BaseExceptionTypePresenterSpec extends ObjectBehavior
 {
     function it_is_a_type_presenter()
     {
-        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\TypePresenter');
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\ExceptionTypePresenter');
     }
 
     function it_should_support_exceptions()

--- a/spec/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenterSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class BooleanTypePresenterSpec extends ObjectBehavior
+{
+    function it_is_a_type_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\TypePresenter');
+    }
+
+    function it_should_support_boolean_values()
+    {
+        $this->supports(true)->shouldReturn(true);
+        $this->supports(false)->shouldReturn(true);
+    }
+
+    function it_should_present_a_true_boolean_as_a_string()
+    {
+        $this->present(true)->shouldReturn('true');
+    }
+
+    function it_should_present_a_false_boolean_as_a_string()
+    {
+        $this->present(false)->shouldReturn('false');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/CallableTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/CallableTypePresenterSpec.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class CallableTypePresenterSpec extends ObjectBehavior
+{
+    function let(Presenter $presenter)
+    {
+        $this->beConstructedWith($presenter);
+    }
+
+    function it_is_a_type_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\TypePresenter');
+    }
+
+    function it_should_support_callable_values()
+    {
+        $this->supports(function () {})->shouldReturn(true);
+    }
+
+    function it_should_present_a_closure()
+    {
+        $this->present(function () {})->shouldReturn('[closure]');
+    }
+
+    function it_should_present_function_callable_as_string()
+    {
+        $this->present('date')->shouldReturn('[date()]');
+    }
+
+    function it_should_present_a_method_as_string(
+        WithMethod $object, Presenter $presenter
+    ) {
+        $className = get_class($object->getWrappedObject());
+
+        $presenter->presentValue($object->getWrappedObject())->willReturn(sprintf('[obj:%s]', $className));
+
+        $this->present(array($object, 'specMethod'))
+            ->shouldReturn(sprintf('[obj:%s]::specMethod()', $className));
+    }
+
+    function it_should_present_a_magic_method_as_string(
+        WithMagicCall $object, Presenter $presenter
+    ) {
+        $className = get_class($object->getWrappedObject());
+
+        $presenter->presentValue($object->getWrappedObject())->willReturn(sprintf('[obj:%s]', $className));
+
+        $this->present(array($object, 'undefinedMethod'))
+            ->shouldReturn(sprintf('[obj:%s]::undefinedMethod()', $className));
+    }
+
+    function it_should_present_a_static_method_as_string(WithMethod $object)
+    {
+        $className = get_class($object->getWrappedObject());
+        $this->present(array($className, 'specMethod'))
+            ->shouldReturn(sprintf('%s::specMethod()', $className));
+    }
+
+    function it_should_present_a_static_magic_method_as_string()
+    {
+        $className = __NAMESPACE__ . '\\WithStaticMagicCall';
+        $this->present(array($className, 'undefinedMethod'))
+            ->shouldReturn(sprintf('%s::undefinedMethod()', $className));
+    }
+
+    function it_should_present_an_invokable_object_as_string(WithMagicInvoke $object)
+    {
+        $className = get_class($object->getWrappedObject());
+        $this->present($object)->shouldReturn(sprintf('[obj:%s]', $className));
+    }
+
+    function it_should_present_invokable_objects_as_objects()
+    {
+        $invokable = new ObjectBehavior();
+        $invokable->setSpecificationSubject($this);
+        $this->present($invokable)->shouldReturn('[obj:PhpSpec\Formatter\Presenter\Value\CallableTypePresenter]');
+    }
+}
+
+class WithMethod
+{
+    function specMethod()
+    {
+    }
+}
+
+class WithStaticMethod
+{
+    function specMethod()
+    {
+    }
+}
+
+class WithMagicInvoke
+{
+    function __invoke()
+    {
+    }
+}
+
+class WithStaticMagicCall
+{
+    static function __callStatic($method, $name)
+    {
+    }
+}
+
+class WithMagicCall
+{
+    function __call($method, $name)
+    {
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenterSpec.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\Formatter\Presenter\Value\TypePresenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ComposedValuePresenterSpec extends ObjectBehavior
+{
+    function it_is_a_value_presenter()
+    {
+        $this->shouldHaveType('PhpSpec\Formatter\Presenter\Value\ComposedValuePresenter');
+    }
+
+    function it_should_accept_a_type_presenter(TypePresenter $typePresenter)
+    {
+        $this->addTypePresenter($typePresenter)->shouldReturn(null);
+    }
+
+    function it_should_call_supports_on_value_presenters_until_one_returns_true(
+        TypePresenter $presenter1, TypePresenter $presenter2, TypePresenter $presenter3
+    ) {
+        $value = 'blah';
+
+        $presenter1->getPriority()->willReturn(3);
+        $presenter2->getPriority()->willReturn(2);
+        $presenter3->getPriority()->willReturn(1);
+
+        $this->addTypePresenter($presenter1);
+        $this->addTypePresenter($presenter2);
+        $this->addTypePresenter($presenter3);
+
+        $presenter1->supports($value)->willReturn(false)->shouldBeCalled();
+        $presenter2->supports($value)->willReturn(true)->shouldBeCalled();
+        $presenter2->present(Argument::any())->shouldBeCalled();
+        $presenter3->supports($value)->shouldNotBeCalled();
+
+        $this->presentValue($value);
+    }
+
+    function it_should_order_presenters_by_their_priority_in_descending_order(
+        TypePresenter $presenter1, TypePresenter $presenter2
+    ) {
+        $value = 'foo';
+
+        $presenter1->getPriority()->willReturn(10);
+        $presenter2->getPriority()->willReturn(20);
+
+        $this->addTypePresenter($presenter1);
+        $this->addTypePresenter($presenter2);
+
+        $presenter1->supports($value)->shouldBeCalled()->willReturn(true);
+        $presenter2->supports($value)->shouldBeCalled();
+        $presenter1->present(Argument::any())->shouldBeCalled();
+
+        $this->presentValue($value);
+    }
+
+    function it_should_call_present_on_a_supporting_type_presenter(TypePresenter $typePresenter)
+    {
+        $value = 'blah';
+
+        $typePresenter->supports($value)->willReturn(true);
+        $typePresenter->present($value)->shouldBeCalled();
+
+        $this->addTypePresenter($typePresenter);
+        $this->presentValue($value);
+    }
+
+    function it_should_return_the_type_presenter_presented_value(TypePresenter $typePresenter)
+    {
+        $value = 'blah';
+        $presented = $value.'presented';
+
+        $typePresenter->supports($value)->willReturn(true);
+        $typePresenter->present($value)->willReturn($presented);
+
+        $this->addTypePresenter($typePresenter);
+        $this->presentValue($value)->shouldReturn($presented);
+    }
+
+    function it_returns_a_default_when_no_type_presenters_support_the_value()
+    {
+        $this->presentValue('blah')->shouldReturn('[string:blah]');
+    }
+
+    function it_should_present_a_simple_type_as_typed_value()
+    {
+        $this->presentValue(42)->shouldReturn('[integer:42]');
+        $this->presentValue(42.0)->shouldReturn('[double:42]');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/ExceptionTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/ExceptionTypePresenterSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ExceptionTypePresenterSpec extends ObjectBehavior
+{
+    function it_is_a_type_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\TypePresenter');
+    }
+
+    function it_should_support_exceptions()
+    {
+        $this->supports(new \Exception())->shouldReturn(true);
+    }
+
+    function it_should_present_an_exception_as_a_string()
+    {
+        $this->present(new \Exception('foo'))
+            ->shouldReturn('[exc:Exception("foo")]');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/NullTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/NullTypePresenterSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class NullTypePresenterSpec extends ObjectBehavior
+{
+    function it_is_a_type_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\TypePresenter');
+    }
+
+    function it_should_support_null_values()
+    {
+        $this->supports(null)->shouldReturn(true);
+    }
+
+    function it_should_present_null_as_a_string()
+    {
+        $this->present(null)->shouldReturn('null');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenterSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ObjectTypePresenterSpec extends ObjectBehavior
+{
+    function it_is_a_type_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\TypePresenter');
+    }
+
+    function it_should_support_object_values()
+    {
+        $this->supports(new \stdClass())->shouldReturn(true);
+    }
+
+    function it_should_present_an_object_as_a_string()
+    {
+        $this->present(new \stdClass())->shouldReturn('[obj:stdClass]');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenterSpec.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class QuotingStringTypePresenterSpec extends ObjectBehavior
+{
+    function it_is_a_string_type_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\StringTypePresenter');
+    }
+
+    function it_should_support_string_values()
+    {
+        $this->supports('')->shouldReturn(true);
+        $this->supports('foo')->shouldReturn(true);
+    }
+
+    function it_should_present_a_string_as_a_quoted_string()
+    {
+        $this->present('')->shouldReturn('""');
+        $this->present('foo')->shouldReturn('"foo"');
+    }
+}

--- a/spec/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenterSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace spec\PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\Formatter\Presenter\Value\StringTypePresenter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TruncatingStringTypePresenterSpec extends ObjectBehavior
+{
+    function let(StringTypePresenter $stringTypePresenter)
+    {
+        $this->beConstructedWith($stringTypePresenter);
+    }
+
+    function it_is_a_string_type_presenter()
+    {
+        $this->shouldImplement('PhpSpec\Formatter\Presenter\Value\StringTypePresenter');
+    }
+
+    function it_should_support_string_values(StringTypePresenter $stringTypePresenter)
+    {
+        $stringTypePresenter->supports('foo')->willReturn(true);
+        $this->supports('foo')->shouldReturn(true);
+    }
+
+    function it_should_pass_short_values_directly_to_the_decorated_string_type_presenter(
+        StringTypePresenter $stringTypePresenter
+    ) {
+        $stringTypePresenter->present('foo')->willReturn('zfooz');
+        $this->present('foo')->shouldReturn('zfooz');
+    }
+
+    function it_should_return_long_values_truncated(
+        StringTypePresenter $stringTypePresenter
+    ) {
+        $stringTypePresenter->present('some_string_longer_than_t...')
+            ->willReturn('some_string_longer_than_t...');
+        $this->present('some_string_longer_than_twenty_five_chars')->shouldReturn('some_string_longer_than_t...');
+    }
+
+    function it_presents_only_first_line_of_multiline_string(StringTypePresenter $stringTypePresenter)
+    {
+        $stringTypePresenter->present('some...')->willReturn('some...');
+        $this->present("some\nmultiline\nvalue")->shouldReturn('some...');
+    }
+}

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Assembler;
+
+use PhpSpec\Formatter\Presenter\Differ\ArrayEngine;
+use PhpSpec\Formatter\Presenter\Differ\Differ;
+use PhpSpec\Formatter\Presenter\Differ\ObjectEngine;
+use PhpSpec\Formatter\Presenter\Differ\StringEngine;
+use PhpSpec\Formatter\Presenter\Exception\CallArgumentsPresenter;
+use PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter;
+use PhpSpec\Formatter\Presenter\Exception\TaggingExceptionElementPresenter;
+use PhpSpec\Formatter\Presenter\SimplePresenter;
+use PhpSpec\Formatter\Presenter\TaggedPresenter;
+use PhpSpec\Formatter\Presenter\TaggingPresenter;
+use PhpSpec\Formatter\Presenter\Value\ArrayTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\BaseExceptionTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\BooleanTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\CallableTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\ComposedValuePresenter;
+use PhpSpec\Formatter\Presenter\Value\NullTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\ObjectTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\QuotingStringTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\TruncatingStringTypePresenter;
+use PhpSpec\ServiceContainer;
+use SebastianBergmann\Exporter\Exporter;
+
+class PresenterAssembler
+{
+    /**
+     * @param ServiceContainer $container
+     */
+    public function assemble(ServiceContainer $container)
+    {
+        $this->assembleDiffer($container);
+        $this->assembleDifferEngines($container);
+        $this->assemblePresenter($container);
+        $this->assembleTypePresenters($container);
+    }
+
+    /**
+     * @param ServiceContainer $container
+     */
+    private function assembleDiffer(ServiceContainer $container)
+    {
+        $container->setShared('formatter.presenter.differ', function (ServiceContainer $c) {
+            $differ = new Differ();
+
+            array_map(
+                array($differ, 'addEngine'),
+                $c->getByPrefix('formatter.presenter.differ.engines')
+            );
+
+            return $differ;
+        });
+    }
+
+    /**
+     * @param ServiceContainer $container
+     */
+    private function assembleDifferEngines(ServiceContainer $container)
+    {
+        $container->set('formatter.presenter.differ.engines.string', function () {
+            return new StringEngine();
+        });
+
+        $container->set('formatter.presenter.differ.engines.array', function () {
+            return new ArrayEngine();
+        });
+
+        $container->set('formatter.presenter.differ.engines.object', function (ServiceContainer $c) {
+            return new ObjectEngine(
+                new Exporter(),
+                $c->get('formatter.presenter.differ.engines.string')
+            );
+        });
+    }
+
+    /**
+     * @param ServiceContainer $container
+     */
+    private function assemblePresenter(ServiceContainer $container)
+    {
+        $container->setShared('formatter.presenter', function (ServiceContainer $c) {
+            return new TaggingPresenter(
+                new SimplePresenter(
+                    $c->get('formatter.presenter.value_presenter'),
+                    new SimpleExceptionPresenter(
+                        $c->get('formatter.presenter.differ'),
+                        $c->get('formatter.presenter.exception_presenter'),
+                        new CallArgumentsPresenter($c->get('formatter.presenter.differ'))
+                    )
+                )
+            );
+        });
+
+        $container->setShared('formatter.presenter.value_presenter', function () {
+            return new ComposedValuePresenter();
+        });
+
+        $container->setShared('formatter.presenter.exception_presenter', function (ServiceContainer $c) {
+            return new TaggingExceptionElementPresenter(
+                $c->get('formatter.presenter.value.exception_type_presenter'),
+                $c->get('formatter.presenter.value_presenter')
+            );
+        });
+    }
+
+    /**
+     * @param ServiceContainer $container
+     */
+    private function assembleTypePresenters(ServiceContainer $container)
+    {
+        $container->setShared('formatter.presenter.value.array_type_presenter', function () {
+            return new ArrayTypePresenter();
+        });
+
+        $container->setShared('formatter.presenter.value.boolean_type_presenter', function () {
+            return new BooleanTypePresenter();
+        });
+
+        $container->setShared('formatter.presenter.value.callable_type_presenter', function (ServiceContainer $c) {
+            return new CallableTypePresenter($c->get('formatter.presenter'));
+        });
+
+        $container->setShared('formatter.presenter.value.exception_type_presenter', function () {
+            return new BaseExceptionTypePresenter();
+        });
+
+        $container->setShared('formatter.presenter.value.null_type_presenter', function () {
+            return new NullTypePresenter();
+        });
+
+        $container->setShared('formatter.presenter.value.object_type_presenter', function () {
+            return new ObjectTypePresenter();
+        });
+
+        $container->setShared('formatter.presenter.value.string_type_presenter', function () {
+            return new TruncatingStringTypePresenter(new QuotingStringTypePresenter());
+        });
+
+        $container->addConfigurator(function (ServiceContainer $c) {
+            array_map(
+                array($c->get('formatter.presenter.value_presenter'), 'addTypePresenter'),
+                $c->getByPrefix('formatter.presenter.value')
+            );
+        });
+    }
+}

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -18,6 +18,7 @@ use PhpSpec\Formatter\Presenter\Differ\Differ;
 use PhpSpec\Formatter\Presenter\Differ\ObjectEngine;
 use PhpSpec\Formatter\Presenter\Differ\StringEngine;
 use PhpSpec\Formatter\Presenter\Exception\CallArgumentsPresenter;
+use PhpSpec\Formatter\Presenter\Exception\GenericPhpSpecExceptionPresenter;
 use PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter;
 use PhpSpec\Formatter\Presenter\Exception\TaggingExceptionElementPresenter;
 use PhpSpec\Formatter\Presenter\SimplePresenter;
@@ -98,7 +99,8 @@ class PresenterAssembler
                     new SimpleExceptionPresenter(
                         $c->get('formatter.presenter.differ'),
                         $c->get('formatter.presenter.exception_presenter'),
-                        new CallArgumentsPresenter($c->get('formatter.presenter.differ'))
+                        new CallArgumentsPresenter($c->get('formatter.presenter.differ')),
+                        $c->get('formatter.presenter.exception.phpspec')
                     )
                 )
             );
@@ -113,6 +115,12 @@ class PresenterAssembler
                 $c->get('formatter.presenter.value.exception_type_presenter'),
                 $c->get('formatter.presenter.value_presenter')
             );
+        });
+
+        $container->setShared('formatter.presenter.exception.phpspec', function (ServiceContainer $c) {
+           return new GenericPhpSpecExceptionPresenter(
+               $c->get('formatter.presenter.exception_presenter')
+           );
         });
     }
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -423,7 +423,7 @@ class ContainerAssembler
                 $io = new SpecFormatter\Html\IO();
                 $template = new SpecFormatter\Html\Template($io);
                 $factory = new SpecFormatter\Html\ReportItemFactory($template);
-                $presenter = new SpecFormatter\Html\HtmlPresenter($c->get('formatter.presenter.differ'));
+                $presenter = $c->get('formatter.presenter.html');
 
                 return new SpecFormatter\HtmlFormatter(
                     $factory,

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -15,6 +15,7 @@ namespace PhpSpec\Console;
 
 use PhpSpec\CodeAnalysis\MagicAwareAccessInspector;
 use PhpSpec\CodeAnalysis\VisibilityAccessInspector;
+use PhpSpec\Console\Assembler\PresenterAssembler;
 use PhpSpec\Process\Prerequisites\SuitePrerequisites;
 use SebastianBergmann\Exporter\Exporter;
 use PhpSpec\Process\ReRunner;
@@ -290,33 +291,8 @@ class ContainerAssembler
      */
     private function setupPresenter(ServiceContainer $container)
     {
-        $container->setShared('formatter.presenter', function (ServiceContainer $c) {
-            return new SpecFormatter\Presenter\TaggedPresenter($c->get('formatter.presenter.differ'));
-        });
-
-        $container->setShared('formatter.presenter.differ', function (ServiceContainer $c) {
-            $differ = new SpecFormatter\Presenter\Differ\Differ();
-
-            array_map(
-                array($differ, 'addEngine'),
-                $c->getByPrefix('formatter.presenter.differ.engines')
-            );
-
-            return $differ;
-        });
-
-        $container->set('formatter.presenter.differ.engines.string', function () {
-            return new SpecFormatter\Presenter\Differ\StringEngine();
-        });
-        $container->set('formatter.presenter.differ.engines.array', function () {
-            return new SpecFormatter\Presenter\Differ\ArrayEngine();
-        });
-        $container->set('formatter.presenter.differ.engines.object', function (ServiceContainer $c) {
-            return new SpecFormatter\Presenter\Differ\ObjectEngine(
-                new Exporter(),
-                $c->get('formatter.presenter.differ.engines.string')
-            );
-        });
+        $presenterAssembler = new PresenterAssembler();
+        $presenterAssembler->assemble($container);
     }
 
     /**

--- a/src/PhpSpec/Formatter/Html/HtmlPresenter.php
+++ b/src/PhpSpec/Formatter/Html/HtmlPresenter.php
@@ -17,6 +17,9 @@ use PhpSpec\Formatter\Presenter\StringPresenter;
 use Exception;
 use PhpSpec\Exception\Exception as PhpSpecException;
 
+/**
+ * @deprecated Use /PhpSpec/Formatter/Presenter/SimplePresenter with an HtmlPhpSpecExceptionPresenter instead
+ */
 class HtmlPresenter extends StringPresenter
 {
     /**

--- a/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Exception\Exception;
+
+abstract class AbstractPhpSpecExceptionPresenter
+{
+    /**
+     * @param Exception $exception
+     * @return string
+     */
+    public function presentException(Exception $exception)
+    {
+        list($file, $line) = $this->getExceptionExamplePosition($exception);
+
+        return $this->presentFileCode($file, $line);
+    }
+
+    /**
+     * @param Exception $exception
+     * @return array
+     */
+    private function getExceptionExamplePosition(Exception $exception)
+    {
+        $cause = $exception->getCause();
+
+        foreach ($exception->getTrace() as $call) {
+            if (!isset($call['file'])) {
+                continue;
+            }
+
+            if (!empty($cause) && $cause->getFilename() === $call['file']) {
+                return array($call['file'], $call['line']);
+            }
+        }
+
+        return array($exception->getFile(), $exception->getLine());
+    }
+
+    /**
+     * @param string  $file
+     * @param integer $lineno
+     * @param integer $context
+     *
+     * @return string
+     */
+    abstract protected function presentFileCode($file, $lineno, $context = 6);
+}

--- a/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Formatter\Presenter\Differ\Differ;
+use Prophecy\Argument\Token\ExactValueToken;
+use Prophecy\Exception\Call\UnexpectedCallException;
+use Prophecy\Prophecy\MethodProphecy;
+
+class CallArgumentsPresenter
+{
+    /**
+     * @var Differ
+     */
+    private $differ;
+
+    /**
+     * @param Differ $differ
+     */
+    public function __construct(Differ $differ)
+    {
+        $this->differ = $differ;
+    }
+
+    /**
+     * @param UnexpectedCallException $exception
+     * @return string
+     */
+    public function presentDifference(UnexpectedCallException $exception)
+    {
+        $actualArguments = $exception->getArguments();
+        $methodProphecies = $exception->getObjectProphecy()->getMethodProphecies($exception->getMethodName());
+
+        if ($this->noMethodPropheciesForUnexpectedCall($methodProphecies)) {
+            return '';
+        }
+
+        $presentedMethodProphecy = $this->findFirstUnexpectedArgumentsCallProphecy($methodProphecies, $exception);
+        if (is_null($presentedMethodProphecy)) {
+            return '';
+        }
+
+        $expectedTokens = $presentedMethodProphecy->getArgumentsWildcard()->getTokens();
+        if ($this->parametersCountMismatch($expectedTokens, $actualArguments)) {
+            return '';
+        }
+
+        $expectedArguments = $this->convertArgumentTokensToDiffableValues($expectedTokens);
+        $text = $this->generateArgumentsDifferenceText($actualArguments, $expectedArguments);
+
+        return $text;
+    }
+
+    /**
+     * @param MethodProphecy[] $methodProphecies
+     * @return bool
+     */
+    private function noMethodPropheciesForUnexpectedCall(array $methodProphecies)
+    {
+        return count($methodProphecies) === 0;
+    }
+
+    /**
+     * @param MethodProphecy[] $methodProphecies
+     * @param UnexpectedCallException $exception
+     *
+     * @return MethodProphecy
+     */
+    private function findFirstUnexpectedArgumentsCallProphecy(
+        array $methodProphecies,
+        UnexpectedCallException $exception
+    ) {
+        $objectProphecy = $exception->getObjectProphecy();
+
+        foreach ($methodProphecies as $methodProphecy) {
+            $calls = $objectProphecy->findProphecyMethodCalls(
+                $exception->getMethodName(),
+                $methodProphecy->getArgumentsWildcard()
+            );
+
+            if (count($calls)) {
+                continue;
+            }
+
+            return $methodProphecy;
+        }
+    }
+
+    /**
+     * @param array $expectedTokens
+     * @param array $actualArguments
+     *
+     * @return bool
+     */
+    private function parametersCountMismatch(array $expectedTokens, array $actualArguments)
+    {
+        return count($expectedTokens) !== count($actualArguments);
+    }
+
+    /**
+     * @param array $tokens
+     *
+     * @return array
+     */
+    private function convertArgumentTokensToDiffableValues(array $tokens)
+    {
+        $values = array();
+        foreach ($tokens as $token) {
+            if ($token instanceof ExactValueToken) {
+                $values[] = $token->getValue();
+            } else {
+                $values[] = (string)$token;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array $actualArguments
+     * @param array $expectedArguments
+     *
+     * @return string
+     */
+    private function generateArgumentsDifferenceText(array $actualArguments, array $expectedArguments)
+    {
+        $text = '';
+        foreach($actualArguments as $i => $actualArgument) {
+            $expectedArgument = $expectedArguments[$i];
+            $actualArgument = is_null($actualArgument) ? 'null' : $actualArgument;
+            $expectedArgument = is_null($expectedArgument) ? 'null' : $expectedArgument;
+
+            $text .= $this->differ->compare($expectedArgument, $actualArgument);
+        }
+
+        return $text;
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Exception/ExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/ExceptionElementPresenter.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Exception;
+
+
+interface ExceptionElementPresenter
+{
+    /**
+     * @param \Exception $exception
+     * @return string
+     */
+    public function presentExceptionThrownMessage(\Exception $exception);
+
+    /**
+     * @param string $number
+     * @param string $line
+     * @return string
+     */
+    public function presentCodeLine($number, $line);
+
+    /**
+     * @param string $line
+     * @return string
+     */
+    public function presentHighlight($line);
+
+    /**
+     * @param string $header
+     * @return string
+     */
+    public function presentExceptionTraceHeader($header);
+
+    /**
+     * @param string $class
+     * @param string $type
+     * @param string $method
+     * @param array $args
+     * @return string
+     */
+    public function presentExceptionTraceMethod($class, $type, $method, array $args);
+
+    /**
+     * @param string $function
+     * @param array $args
+     * @return string
+     */
+    public function presentExceptionTraceFunction($function, array $args);
+}

--- a/src/PhpSpec/Formatter/Presenter/Exception/ExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/ExceptionPresenter.php
@@ -11,17 +11,14 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Formatter\Presenter;
+namespace PhpSpec\Formatter\Presenter\Exception;
 
-use PhpSpec\Formatter\Presenter\Exception\ExceptionPresenter;
-use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
-
-interface Presenter extends ExceptionPresenter, ValuePresenter
+interface ExceptionPresenter
 {
     /**
-     * @param string $string
-     *
+     * @param \Exception $exception
+     * @param bool $verbose
      * @return string
      */
-    public function presentString($string);
+    public function presentException(\Exception $exception, $verbose = false);
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
@@ -13,9 +13,7 @@
 
 namespace PhpSpec\Formatter\Presenter\Exception;
 
-final class GenericPhpSpecExceptionPresenter
-    extends AbstractPhpSpecExceptionPresenter
-    implements PhpSpecExceptionPresenter
+final class GenericPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresenter implements PhpSpecExceptionPresenter
 {
     /**
      * @var ExceptionElementPresenter

--- a/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Exception\Exception;
+
+final class GenericPhpSpecExceptionPresenter implements PhpSpecExceptionPresenter
+{
+    /**
+     * @var ExceptionElementPresenter
+     */
+    private $exceptionElementPresenter;
+
+    /**
+     * @param ExceptionElementPresenter $exceptionElementPresenter
+     */
+    public function __construct(ExceptionElementPresenter $exceptionElementPresenter)
+    {
+        $this->exceptionElementPresenter = $exceptionElementPresenter;
+    }
+
+    /**
+     * @param Exception $exception
+     * @return string
+     */
+    public function presentException(Exception $exception)
+    {
+        list($file, $line) = $this->getExceptionExamplePosition($exception);
+
+        return $this->presentFileCode($file, $line);
+    }
+
+    /**
+     * @param Exception $exception
+     * @return array
+     */
+    private function getExceptionExamplePosition(Exception $exception)
+    {
+        $cause = $exception->getCause();
+
+        foreach ($exception->getTrace() as $call) {
+            if (!isset($call['file'])) {
+                continue;
+            }
+
+            if (!empty($cause) && $cause->getFilename() === $call['file']) {
+                return array($call['file'], $call['line']);
+            }
+        }
+
+        return array($exception->getFile(), $exception->getLine());
+    }
+
+    /**
+     * @param string  $file
+     * @param integer $lineno
+     * @param integer $context
+     *
+     * @return string
+     */
+    private function presentFileCode($file, $lineno, $context = 6)
+    {
+        $lines  = explode(PHP_EOL, file_get_contents($file));
+        $offset = max(0, $lineno - ceil($context / 2));
+        $lines  = array_slice($lines, $offset, $context);
+
+        $text = PHP_EOL;
+        foreach ($lines as $line) {
+            $offset++;
+
+            if ($offset == $lineno) {
+                $text .= $this->exceptionElementPresenter->presentHighlight(sprintf('%4d', $offset).' '.$line);
+            } else {
+                $text .= $this->exceptionElementPresenter->presentCodeLine(sprintf('%4d', $offset), $line);
+            }
+
+            $text .= PHP_EOL;
+        }
+
+        return $text;
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
@@ -13,9 +13,7 @@
 
 namespace PhpSpec\Formatter\Presenter\Exception;
 
-final class HtmlPhpSpecExceptionPresenter
-    extends AbstractPhpSpecExceptionPresenter
-    implements PhpSpecExceptionPresenter
+final class HtmlPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresenter implements PhpSpecExceptionPresenter
 {
     /**
      * @param string  $file

--- a/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
@@ -13,23 +13,10 @@
 
 namespace PhpSpec\Formatter\Presenter\Exception;
 
-final class GenericPhpSpecExceptionPresenter
+final class HtmlPhpSpecExceptionPresenter
     extends AbstractPhpSpecExceptionPresenter
     implements PhpSpecExceptionPresenter
 {
-    /**
-     * @var ExceptionElementPresenter
-     */
-    private $exceptionElementPresenter;
-
-    /**
-     * @param ExceptionElementPresenter $exceptionElementPresenter
-     */
-    public function __construct(ExceptionElementPresenter $exceptionElementPresenter)
-    {
-        $this->exceptionElementPresenter = $exceptionElementPresenter;
-    }
-
     /**
      * @param string  $file
      * @param integer $lineno
@@ -44,16 +31,16 @@ final class GenericPhpSpecExceptionPresenter
         $lines  = array_slice($lines, $offset, $context);
 
         $text = PHP_EOL;
+
         foreach ($lines as $line) {
             $offset++;
 
-            if ($offset == $lineno) {
-                $text .= $this->exceptionElementPresenter->presentHighlight(sprintf('%4d', $offset).' '.$line);
-            } else {
-                $text .= $this->exceptionElementPresenter->presentCodeLine(sprintf('%4d', $offset), $line);
-            }
-
-            $text .= PHP_EOL;
+            $text .= sprintf(
+                '<span class="linenum">%d</span><span class="%s">%s</span>' . PHP_EOL,
+                $offset,
+                $offset == $lineno ? 'offending' : 'normal',
+                $line
+            );
         }
 
         return $text;

--- a/src/PhpSpec/Formatter/Presenter/Exception/PhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/PhpSpecExceptionPresenter.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Exception;
+
+
+use PhpSpec\Exception\Exception;
+
+interface PhpSpecExceptionPresenter
+{
+    /**
+     * @param Exception $exception
+     * @return string
+     */
+    public function presentException(Exception $exception);
+}

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Formatter\Presenter\Value\ExceptionTypePresenter;
+use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
+
+final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
+{
+    /**
+     * @var ExceptionTypePresenter
+     */
+    private $exceptionTypePresenter;
+
+    /**
+     * @var ValuePresenter
+     */
+    private $valuePresenter;
+
+    /**
+     * @param ExceptionTypePresenter $exceptionTypePresenter
+     * @param ValuePresenter $valuePresenter
+     */
+    public function __construct(ExceptionTypePresenter $exceptionTypePresenter, ValuePresenter $valuePresenter)
+    {
+        $this->exceptionTypePresenter = $exceptionTypePresenter;
+        $this->valuePresenter = $valuePresenter;
+    }
+
+    /**
+     * @param \Exception $exception
+     * @return string
+     */
+    public function presentExceptionThrownMessage(\Exception $exception)
+    {
+        return sprintf(
+            'Exception %s has been thrown.',
+            $this->exceptionTypePresenter->present($exception)
+        );
+    }
+
+    /**
+     * @param string $number
+     * @param string $line
+     * @return string
+     */
+    public function presentCodeLine($number, $line)
+    {
+        return sprintf('%s %s', $number, $line);
+    }
+
+    /**
+     * @param string $line
+     * @return string
+     */
+    public function presentHighlight($line)
+    {
+        return $line;
+    }
+
+    /**
+     * @param string $header
+     * @return string
+     */
+    public function presentExceptionTraceHeader($header)
+    {
+        return $header;
+    }
+
+    /**
+     * @param string $class
+     * @param string $type
+     * @param string $method
+     * @param array $args
+     * @return string
+     */
+    public function presentExceptionTraceMethod($class, $type, $method, array $args)
+    {
+        $args = array_map(array($this->valuePresenter, 'presentValue'), $args);
+
+        return sprintf("   %s%s%s(%s)", $class, $type, $method, implode(', ', $args));
+    }
+
+    /**
+     * @param string $function
+     * @param array $args
+     * @return string
+     */
+    public function presentExceptionTraceFunction($function, array $args)
+    {
+        $args = array_map(array($this->valuePresenter, 'presentValue'), $args);
+
+        return sprintf('   %s(%s)', $function, implode(', ', $args));
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -59,7 +59,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         CallArgumentsPresenter $callArgumentsPresenter
     ) {
         $this->differ = $differ;
-        $this->exceptionTypePresenter = $exceptionElementPresenter;
+        $this->exceptionElementPresenter = $exceptionElementPresenter;
         $this->callArgumentsPresenter = $callArgumentsPresenter;
 
         $this->phpspecPath = dirname(dirname(__DIR__));

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -1,0 +1,317 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Exception;
+
+use PhpSpec\Exception\Example\ErrorException;
+use PhpSpec\Exception\Example\NotEqualException;
+use PhpSpec\Exception\Example\PendingException;
+use PhpSpec\Exception\Exception as PhpSpecException;
+use PhpSpec\Formatter\Presenter\Differ\Differ;
+use Prophecy\Exception\Call\UnexpectedCallException;
+use Prophecy\Exception\Exception as ProphecyException;
+
+final class SimpleExceptionPresenter implements ExceptionPresenter
+{
+    /**
+     * @var Differ
+     */
+    private $differ;
+
+    /**
+     * @var string
+     */
+    private $phpspecPath;
+
+    /**
+     * @var string
+     */
+    private $runnerPath;
+
+    /**
+     * @var ExceptionElementPresenter
+     */
+    private $exceptionElementPresenter;
+
+    /**
+     * @var CallArgumentsPresenter
+     */
+    private $callArgumentsPresenter;
+
+    /**
+     * @param Differ $differ
+     * @param ExceptionElementPresenter $exceptionElementPresenter
+     * @param CallArgumentsPresenter $callArgumentsPresenter
+     */
+    public function __construct(
+        Differ $differ,
+        ExceptionElementPresenter $exceptionElementPresenter,
+        CallArgumentsPresenter $callArgumentsPresenter
+    ) {
+        $this->differ = $differ;
+        $this->exceptionTypePresenter = $exceptionElementPresenter;
+        $this->callArgumentsPresenter = $callArgumentsPresenter;
+
+        $this->phpspecPath = dirname(dirname(__DIR__));
+        $this->runnerPath  = $this->phpspecPath.DIRECTORY_SEPARATOR.'Runner';
+    }
+
+    /**
+     * @param \Exception $exception
+     * @param bool $verbose
+     * @return string
+     */
+    public function presentException(\Exception $exception, $verbose = false)
+    {
+        $presentation = $this->getInitialPresentation($exception);
+
+        if (!$verbose || $exception instanceof PendingException) {
+            return $presentation;
+        }
+
+        return $this->getVerbosePresentation($exception, $presentation);
+    }
+
+    /**
+     * @param \Exception $exception
+     * @return string
+     */
+    private function getInitialPresentation(\Exception $exception)
+    {
+        if ($exception instanceof PhpSpecException) {
+            $presentation = wordwrap($exception->getMessage(), 120);
+            return $presentation;
+        }
+
+        if ($exception instanceof ProphecyException) {
+            $presentation = $exception->getMessage();
+            return $presentation;
+        }
+
+        return $this->exceptionElementPresenter->presentExceptionThrownMessage($exception);
+    }
+
+    /**
+     * @param \Exception $exception
+     * @param string $presentation
+     * @return string
+     */
+    private function getVerbosePresentation(\Exception $exception, $presentation)
+    {
+        if ($exception instanceof NotEqualException) {
+            if ($diff = $this->presentExceptionDifference($exception)) {
+                $presentation .= PHP_EOL . $diff;
+            }
+        }
+
+        if ($exception instanceof PhpSpecException && !$exception instanceof ErrorException) {
+            list($file, $line) = $this->getExceptionExamplePosition($exception);
+
+            $presentation .= PHP_EOL . $this->presentFileCode($file, $line);
+        }
+
+        if ($exception instanceof UnexpectedCallException) {
+            $presentation .= $this->callArgumentsPresenter->presentDifference($exception);
+        }
+
+        if (trim($trace = $this->presentExceptionStackTrace($exception))) {
+            $presentation .= "\n".$trace;
+        }
+
+        return $presentation;
+    }
+
+    /**
+     * @param NotEqualException $exception
+     *
+     * @return string
+     */
+    private function presentExceptionDifference(NotEqualException $exception)
+    {
+        return $this->differ->compare($exception->getExpected(), $exception->getActual());
+    }
+
+    /**
+     * @param PhpSpecException $exception
+     *
+     * @return array
+     */
+    private function getExceptionExamplePosition(PhpSpecException $exception)
+    {
+        $cause = $exception->getCause();
+
+        foreach ($exception->getTrace() as $call) {
+            if (!isset($call['file'])) {
+                continue;
+            }
+
+            if (!empty($cause) && $cause->getFilename() === $call['file']) {
+                return array($call['file'], $call['line']);
+            }
+        }
+
+        return array($exception->getFile(), $exception->getLine());
+    }
+
+    /**
+     * @param string  $file
+     * @param integer $lineno
+     * @param integer $context
+     *
+     * @return string
+     */
+    private function presentFileCode($file, $lineno, $context = 6)
+    {
+        $lines  = explode(PHP_EOL, file_get_contents($file));
+        $offset = max(0, $lineno - ceil($context / 2));
+        $lines  = array_slice($lines, $offset, $context);
+
+        $text = PHP_EOL;
+        foreach ($lines as $line) {
+            $offset++;
+
+            if ($offset == $lineno) {
+                $text .= $this->exceptionElementPresenter->presentHighlight(sprintf('%4d', $offset).' '.$line);
+            } else {
+                $text .= $this->exceptionElementPresenter->presentCodeLine(sprintf('%4d', $offset), $line);
+            }
+
+            $text .= PHP_EOL;
+        }
+
+        return $text;
+    }
+
+    /**
+     * @param \Exception $exception
+     *
+     * @return string
+     */
+    private function presentExceptionStackTrace(\Exception $exception)
+    {
+        $offset = 0;
+        $text = PHP_EOL;
+
+        $text .= $this->presentExceptionTraceLocation($offset++, $exception->getFile(), $exception->getLine());
+        $text .= $this->presentExceptionTraceFunction(
+            'throw new '.get_class($exception),
+            array($exception->getMessage())
+        );
+
+        foreach ($exception->getTrace() as $call) {
+            // skip internal framework calls
+            if ($this->shouldStopTracePresentation($call)) {
+                break;
+            }
+            if ($this->shouldSkipTracePresentation($call)) {
+                continue;
+            }
+
+            if (isset($call['file'])) {
+                $text .= $this->presentExceptionTraceLocation($offset++, $call['file'], $call['line']);
+            } else {
+                $text .= $this->presentExceptionTraceHeader(sprintf("%2d [internal]", $offset++));
+            }
+
+            if (isset($call['class'])) {
+                $text .= $this->presentExceptionTraceMethod(
+                    $call['class'],
+                    $call['type'],
+                    $call['function'],
+                    isset($call['args']) ? $call['args'] : array()
+                );
+            } elseif (isset($call['function'])) {
+                $text .= $this->presentExceptionTraceFunction(
+                    $call['function'],
+                    isset($call['args']) ? $call['args'] : array()
+                );
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * @param string $header
+     *
+     * @return string
+     */
+    private function presentExceptionTraceHeader($header)
+    {
+        return $this->exceptionElementPresenter->presentExceptionTraceHeader($header) . PHP_EOL;
+    }
+
+    /**
+     * @param string $class
+     * @param string $type
+     * @param string $method
+     * @param array  $args
+     *
+     * @return string
+     */
+    private function presentExceptionTraceMethod($class, $type, $method, array $args)
+    {
+        return $this->exceptionElementPresenter->presentExceptionTraceMethod($class, $type, $method, $args) . PHP_EOL;
+    }
+
+    /**
+     * @param string $function
+     * @param array  $args
+     *
+     * @return string
+     */
+    private function presentExceptionTraceFunction($function, array $args)
+    {
+        return $this->exceptionElementPresenter->presentExceptionTraceFunction($function, $args) . PHP_EOL;
+    }
+
+    /**
+     * @param int    $offset
+     * @param string $file
+     * @param int    $line
+     *
+     * @return string
+     */
+    private function presentExceptionTraceLocation($offset, $file, $line)
+    {
+        return $this->presentExceptionTraceHeader(sprintf(
+            "%2d %s:%d",
+            $offset,
+            str_replace(getcwd().DIRECTORY_SEPARATOR, '', $file),
+            $line
+        ));
+    }
+
+    /**
+     * @param array $call
+     * @return bool
+     */
+    private function shouldStopTracePresentation(array $call)
+    {
+        return isset($call['file']) && false !== strpos($call['file'], $this->runnerPath);
+    }
+
+    /**
+     * @param array $call
+     * @return bool
+     */
+    private function shouldSkipTracePresentation(array $call)
+    {
+        if (isset($call['file']) && 0 === strpos($call['file'], $this->phpspecPath)) {
+            return true;
+        }
+
+        return isset($call['class']) && 0 === strpos($call['class'], "PhpSpec\\");
+    }
+
+}

--- a/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
@@ -16,7 +16,7 @@ namespace PhpSpec\Formatter\Presenter\Exception;
 use PhpSpec\Formatter\Presenter\Value\ExceptionTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
-final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
+final class TaggingExceptionElementPresenter implements ExceptionElementPresenter
 {
     /**
      * @var ExceptionTypePresenter
@@ -45,7 +45,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
     public function presentExceptionThrownMessage(\Exception $exception)
     {
         return sprintf(
-            'Exception %s has been thrown.',
+            'Exception <label>%s</label> has been thrown.',
             $this->exceptionTypePresenter->present($exception)
         );
     }
@@ -57,7 +57,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      */
     public function presentCodeLine($number, $line)
     {
-        return sprintf('%s %s', $number, $line);
+        return sprintf('<lineno>%s</lineno> <code>%s</code>', $number, $line);
     }
 
     /**
@@ -66,7 +66,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      */
     public function presentHighlight($line)
     {
-        return $line;
+        return sprintf('<hl>%s</hl>', $line);
     }
 
     /**
@@ -75,7 +75,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      */
     public function presentExceptionTraceHeader($header)
     {
-        return $header;
+        return sprintf('<trace>%s</trace>', $header);
     }
 
     /**
@@ -87,7 +87,10 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      */
     public function presentExceptionTraceMethod($class, $type, $method, array $args)
     {
-        return sprintf('   %s%s%s(%s)', $class, $type, $method, $this->presentExceptionTraceArguments($args));
+        $template = '   <trace><trace-class>%s</trace-class><trace-type>%s</trace-type>'.
+            '<trace-func>%s</trace-func>(<trace-args>%s</trace-args>)</trace>';
+
+        return sprintf($template, $class, $type, $method, $this->presentExceptionTraceArguments($args));
     }
 
     /**
@@ -97,7 +100,9 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      */
     public function presentExceptionTraceFunction($function, array $args)
     {
-        return sprintf('   %s(%s)', $function, $this->presentExceptionTraceArguments($args));
+        $template = '   <trace><trace-func>%s</trace-func>(<trace-args>%s</trace-args>)</trace>';
+
+        return sprintf($template, $function, $this->presentExceptionTraceArguments($args));
     }
 
     /**
@@ -106,6 +111,12 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      */
     private function presentExceptionTraceArguments(array $args)
     {
-        return implode(', ', array_map(array($this->valuePresenter, 'presentValue'), $args));
+        $valuePresenter = $this->valuePresenter;
+
+        $taggedArgs = array_map(function ($arg) use ($valuePresenter) {
+            return sprintf('<value>%s</value>', $valuePresenter->presentValue($arg));
+        }, $args);
+
+        return implode(', ', $taggedArgs);
     }
 }

--- a/src/PhpSpec/Formatter/Presenter/Presenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Presenter.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter;
+
+interface Presenter
+{
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public function presentValue($value);
+
+    /**
+     * @param \Exception $exception
+     * @param bool       $verbose
+     *
+     * @return string
+     */
+    public function presentException(\Exception $exception, $verbose = false);
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    public function presentString($string);
+}

--- a/src/PhpSpec/Formatter/Presenter/PresenterInterface.php
+++ b/src/PhpSpec/Formatter/Presenter/PresenterInterface.php
@@ -13,27 +13,9 @@
 
 namespace PhpSpec\Formatter\Presenter;
 
-interface PresenterInterface
+/**
+ * @deprecated
+ */
+interface PresenterInterface extends Presenter
 {
-    /**
-     * @param mixed $value
-     *
-     * @return string
-     */
-    public function presentValue($value);
-
-    /**
-     * @param \Exception $exception
-     * @param bool       $verbose
-     *
-     * @return string
-     */
-    public function presentException(\Exception $exception, $verbose = false);
-
-    /**
-     * @param string $string
-     *
-     * @return string
-     */
-    public function presentString($string);
 }

--- a/src/PhpSpec/Formatter/Presenter/PresenterInterface.php
+++ b/src/PhpSpec/Formatter/Presenter/PresenterInterface.php
@@ -14,7 +14,7 @@
 namespace PhpSpec\Formatter\Presenter;
 
 /**
- * @deprecated
+ * @deprecated Use PhpSpec\Formatter\Presenter\Presenter instead
  */
 interface PresenterInterface extends Presenter
 {

--- a/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
@@ -13,14 +13,30 @@
 
 namespace PhpSpec\Formatter\Presenter;
 
-use PhpSpec\Formatter\Presenter\Value\TypePresenter;
+use PhpSpec\Formatter\Presenter\Exception\ExceptionPresenter;
+use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 final class SimplePresenter implements Presenter
 {
     /**
-     * @var TypePresenter[]
+     * @var ValuePresenter
      */
-    private $typePresenters = array();
+    private $valuePresenter;
+
+    /**
+     * @var ExceptionPresenter
+     */
+    private $exceptionPresenter;
+
+    /**
+     * @param ValuePresenter $valuePresenter
+     * @param ExceptionPresenter $exceptionPresenter
+     */
+    public function __construct(ValuePresenter $valuePresenter, ExceptionPresenter $exceptionPresenter)
+    {
+        $this->valuePresenter = $valuePresenter;
+        $this->exceptionPresenter = $exceptionPresenter;
+    }
 
     /**
      * @param mixed $value
@@ -29,13 +45,7 @@ final class SimplePresenter implements Presenter
      */
     public function presentValue($value)
     {
-        foreach ($this->typePresenters as $typePresenter) {
-            if ($typePresenter->supports($value)) {
-                return $typePresenter->present($value);
-            }
-        }
-
-        return sprintf('[%s:%s]', strtolower(gettype($value)), $value);
+        return $this->valuePresenter->presentValue($value);
     }
 
     /**
@@ -46,7 +56,7 @@ final class SimplePresenter implements Presenter
      */
     public function presentException(\Exception $exception, $verbose = false)
     {
-        // TODO: Implement presentException() method.
+        return $this->exceptionPresenter->presentException($exception, $verbose);
     }
 
     /**
@@ -57,17 +67,5 @@ final class SimplePresenter implements Presenter
     public function presentString($string)
     {
         return $string;
-    }
-
-    /**
-     * @param TypePresenter $typePresenter
-     */
-    public function addTypePresenter(TypePresenter $typePresenter)
-    {
-        $this->typePresenters[] = $typePresenter;
-
-        @usort($this->typePresenters, function ($presenter1, $presenter2) {
-            return $presenter2->getPriority() - $presenter1->getPriority();
-        });
     }
 }

--- a/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
@@ -16,7 +16,7 @@ namespace PhpSpec\Formatter\Presenter;
 use PhpSpec\Formatter\Presenter\Exception\ExceptionPresenter;
 use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
-final class SimplePresenter implements Presenter
+final class SimplePresenter implements PresenterInterface
 {
     /**
      * @var ValuePresenter

--- a/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter;
+
+use PhpSpec\Formatter\Presenter\Value\TypePresenter;
+
+final class SimplePresenter implements Presenter
+{
+    /**
+     * @var TypePresenter[]
+     */
+    private $typePresenters = array();
+
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public function presentValue($value)
+    {
+        foreach ($this->typePresenters as $typePresenter) {
+            if ($typePresenter->supports($value)) {
+                return $typePresenter->present($value);
+            }
+        }
+
+        return sprintf('[%s:%s]', strtolower(gettype($value)), $value);
+    }
+
+    /**
+     * @param \Exception $exception
+     * @param bool $verbose
+     *
+     * @return string
+     */
+    public function presentException(\Exception $exception, $verbose = false)
+    {
+        // TODO: Implement presentException() method.
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    public function presentString($string)
+    {
+        return $string;
+    }
+
+    /**
+     * @param TypePresenter $typePresenter
+     */
+    public function addTypePresenter(TypePresenter $typePresenter)
+    {
+        $this->typePresenters[] = $typePresenter;
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
@@ -65,5 +65,9 @@ final class SimplePresenter implements Presenter
     public function addTypePresenter(TypePresenter $typePresenter)
     {
         $this->typePresenters[] = $typePresenter;
+
+        @usort($this->typePresenters, function ($presenter1, $presenter2) {
+            return $presenter2->getPriority() - $presenter1->getPriority();
+        });
     }
 }

--- a/src/PhpSpec/Formatter/Presenter/StringPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/StringPresenter.php
@@ -19,6 +19,7 @@ use PhpSpec\Exception\Example\NotEqualException;
 use PhpSpec\Exception\Example\ErrorException;
 use PhpSpec\Exception\Example\PendingException;
 use Prophecy\Argument\Token\ExactValueToken;
+use Prophecy\Argument\Token\TokenInterface;
 use Prophecy\Exception\Call\UnexpectedCallException;
 use Prophecy\Exception\Exception as ProphecyException;
 use Prophecy\Prophecy\MethodProphecy;
@@ -439,7 +440,7 @@ class StringPresenter implements PresenterInterface
     }
 
     /**
-     * @param array $expectedTokens
+     * @param TokenInterface[] $expectedTokens
      * @param array $actualArguments
      *
      * @return bool
@@ -450,7 +451,7 @@ class StringPresenter implements PresenterInterface
     }
 
     /**
-     * @param array $tokens
+     * @param TokenInterface[] $tokens
      *
      * @return array
      */

--- a/src/PhpSpec/Formatter/Presenter/StringPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/StringPresenter.php
@@ -23,6 +23,9 @@ use Prophecy\Exception\Call\UnexpectedCallException;
 use Prophecy\Exception\Exception as ProphecyException;
 use Prophecy\Prophecy\MethodProphecy;
 
+/**
+ * @deprecated Use PhpSpec\Formatter\Presenter\SimplePresenter instead
+ */
 class StringPresenter implements PresenterInterface
 {
     /**

--- a/src/PhpSpec/Formatter/Presenter/TaggedPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/TaggedPresenter.php
@@ -13,6 +13,9 @@
 
 namespace PhpSpec\Formatter\Presenter;
 
+/**
+ * @deprecated Use PhpSpec\Formatter\Presenter\TaggingPresenter instead
+ */
 class TaggedPresenter extends StringPresenter
 {
     public function presentString($string)

--- a/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter;
+
+final class TaggingPresenter implements Presenter
+{
+    /**
+     * @var Presenter
+     */
+    private $presenter;
+
+    /**
+     * @param Presenter $presenter
+     */
+    public function __construct(Presenter $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    /**
+     * @param \Exception $exception
+     * @param bool $verbose
+     * @return string
+     */
+    public function presentException(\Exception $exception, $verbose = false)
+    {
+        return $this->presenter->presentException($exception, $verbose);
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    public function presentString($string)
+    {
+        return sprintf('<value>%s</value>', $string);
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function presentValue($value)
+    {
+        return $this->presentString($this->presenter->presentValue($value));
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\Formatter\Presenter;
 
-final class TaggingPresenter implements Presenter
+final class TaggingPresenter implements PresenterInterface
 {
     /**
      * @var Presenter

--- a/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class ArrayTypePresenter implements TypePresenter
+{
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return 'array' === strtolower(gettype($value));
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        return sprintf('[array:%d]', count($value));
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
@@ -32,4 +32,12 @@ final class ArrayTypePresenter implements TypePresenter
     {
         return sprintf('[array:%d]', count($value));
     }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 20;
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class BaseExceptionTypePresenter implements ExceptionTypePresenter
+{
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return $value instanceof \Exception;
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        return sprintf(
+            '[exc:%s("%s")]',
+            get_class($value),
+            $value->getMessage()
+        );
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 60;
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class BooleanTypePresenter implements TypePresenter
+{
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return 'boolean' === strtolower(gettype($value));
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        return $value ? 'true' : 'false';
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
@@ -32,4 +32,12 @@ final class BooleanTypePresenter implements TypePresenter
     {
         return $value ? 'true' : 'false';
     }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 40;
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
@@ -60,4 +60,12 @@ final class CallableTypePresenter implements TypePresenter
 
         return sprintf('[%s()]', $value);
     }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 70;
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+use PhpSpec\Formatter\Presenter\Presenter;
+
+final class CallableTypePresenter implements TypePresenter
+{
+    /**
+     * @var Presenter
+     */
+    private $presenter;
+
+    /**
+     * @param Presenter $presenter
+     */
+    public function __construct(Presenter $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return is_callable($value);
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        if (is_array($value)) {
+            $type = is_object($value[0]) ? $this->presenter->presentValue($value[0]) : $value[0];
+            return sprintf('%s::%s()', $type, $value[1]);
+        }
+
+        if ($value instanceof \Closure) {
+            return '[closure]';
+        }
+
+        if (is_object($value)) {
+            return sprintf('[obj:%s]', get_class($value));
+        }
+
+        return sprintf('[%s()]', $value);
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class ComposedValuePresenter implements ValuePresenter
+{
+    /**
+     * @var TypePresenter[]
+     */
+    private $typePresenters = array();
+
+    /**
+     * @param TypePresenter $typePresenter
+     */
+    public function addTypePresenter(TypePresenter $typePresenter)
+    {
+        $this->typePresenters[] = $typePresenter;
+
+        @usort($this->typePresenters, function ($presenter1, $presenter2) {
+            return $presenter2->getPriority() - $presenter1->getPriority();
+        });
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function presentValue($value)
+    {
+        foreach ($this->typePresenters as $typePresenter) {
+            if ($typePresenter->supports($value)) {
+                return $typePresenter->present($value);
+            }
+        }
+
+        return sprintf('[%s:%s]', strtolower(gettype($value)), $value);
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/ExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ExceptionTypePresenter.php
@@ -36,4 +36,12 @@ final class ExceptionTypePresenter implements TypePresenter
             $value->getMessage()
         );
     }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 60;
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/ExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ExceptionTypePresenter.php
@@ -13,35 +13,6 @@
 
 namespace PhpSpec\Formatter\Presenter\Value;
 
-final class ExceptionTypePresenter implements TypePresenter
+interface ExceptionTypePresenter extends TypePresenter
 {
-    /**
-     * @param mixed $value
-     * @return bool
-     */
-    public function supports($value)
-    {
-        return $value instanceof \Exception;
-    }
-
-    /**
-     * @param mixed $value
-     * @return string
-     */
-    public function present($value)
-    {
-        return sprintf(
-            '[exc:%s("%s")]',
-            get_class($value),
-            $value->getMessage()
-        );
-    }
-
-    /**
-     * @return int
-     */
-    public function getPriority()
-    {
-        return 60;
-    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/ExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ExceptionTypePresenter.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class ExceptionTypePresenter implements TypePresenter
+{
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return $value instanceof \Exception;
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        return sprintf(
+            '[exc:%s("%s")]',
+            get_class($value),
+            $value->getMessage()
+        );
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
@@ -32,4 +32,12 @@ final class NullTypePresenter implements TypePresenter
     {
         return 'null';
     }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 50;
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class NullTypePresenter implements TypePresenter
+{
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return null === $value;
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        return 'null';
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
@@ -32,4 +32,12 @@ final class ObjectTypePresenter implements TypePresenter
     {
         return sprintf('[obj:%s]', get_class($value));
     }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 30;
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class ObjectTypePresenter implements TypePresenter
+{
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return 'object' === strtolower(gettype($value));
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        return sprintf('[obj:%s]', get_class($value));
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
@@ -32,4 +32,12 @@ final class QuotingStringTypePresenter implements StringTypePresenter
     {
         return sprintf('"%s"', $value);
     }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 10;
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class QuotingStringTypePresenter implements StringTypePresenter
+{
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return 'string' === strtolower(gettype($value));
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        return sprintf('"%s"', $value);
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/StringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/StringTypePresenter.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+interface StringTypePresenter extends TypePresenter
+{
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -47,4 +47,12 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
         $lines = explode("\n", $value);
         return $this->stringTypePresenter->present(sprintf('%s...', substr($lines[0], 0, 25)));
     }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return $this->stringTypePresenter->getPriority();
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+final class TruncatingStringTypePresenter implements StringTypePresenter
+{
+    /**
+     * @var StringTypePresenter
+     */
+    private $stringTypePresenter;
+
+    public function __construct(StringTypePresenter $stringTypePresenter)
+    {
+        $this->stringTypePresenter = $stringTypePresenter;
+    }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value)
+    {
+        return $this->stringTypePresenter->supports($value);
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value)
+    {
+        if (25 > strlen($value) && false === strpos($value, "\n")) {
+            return $this->stringTypePresenter->present($value);
+        }
+
+        $lines = explode("\n", $value);
+        return $this->stringTypePresenter->present(sprintf('%s...', substr($lines[0], 0, 25)));
+    }
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+
+interface TypePresenter
+{
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function supports($value);
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function present($value);
+}

--- a/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
@@ -27,4 +27,9 @@ interface TypePresenter
      * @return string
      */
     public function present($value);
+
+    /**
+     * @return int
+     */
+    public function getPriority();
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
@@ -1,9 +1,14 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: shane
- * Date: 21/07/15
- * Time: 08:44
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace PhpSpec\Formatter\Presenter\Value;

--- a/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: shane
+ * Date: 21/07/15
+ * Time: 08:44
+ */
+
+namespace PhpSpec\Formatter\Presenter\Value;
+
+
+interface ValuePresenter
+{
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function presentValue($value);
+}


### PR DESCRIPTION
Breaking the existing large presenter object up into smaller collaborating objects will make it easier to modify the behaviour of individual parts, either as part of phpspec core or by extensions. One such change that this would enable would be to stop truncating strings in failure output when a verbose flag is passed.

Scrutinizer will not pass until https://github.com/phpspec/phpspec/pull/748 is merged.