### PR TITLE
Disable superglobal rule checking

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,6 +20,10 @@ tools:
 build_failure_conditions:
     - 'issues.label("coding-style").exists'
 
+checks:
+  php:
+    avoid_superglobals: false
+
 filter:
   excluded_paths:
     - docs/*


### PR DESCRIPTION
A recently added Scrutinizer rule is making builds fail because it believes that superglobals are bad.