### PR TITLE
A new spec to test an inline matcher that throws an exception

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -189,6 +189,14 @@ class ApplicationContext implements Context, MatchersProviderInterface
     }
 
     /**
+     * @Then the suite should not pass
+     */
+    public function theSuiteShouldNotPass()
+    {
+        expect($this->lastExitCode)->notToBeLike(0);
+    }
+
+    /**
      * @Then :number example(s) should have been skipped
      */
     public function exampleShouldHaveBeenSkipped($number)

--- a/features/matchers/developer_uses_inline_matcher.feature
+++ b/features/matchers/developer_uses_inline_matcher.feature
@@ -109,3 +109,53 @@ Feature: Developer uses identity matcher
     When I run phpspec
     Then the suite should pass
 
+  Scenario: Inline matcher throwing an exception
+    Given the spec file "spec/Matchers/InlineExample3/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\InlineExample3;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+      use PhpSpec\Exception\Example\FailureException;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_uses_inline_matcher_that_throws_an_exception()
+          {
+              $this->shouldDoSomething('abc');
+          }
+
+          function getMatchers()
+          {
+              return array ('doSomething' => function($subject, $param) {
+                  throw new FailureException(sprintf(
+                    'a very important message with subject "%s" and param "%s".',
+                    $subject, $param
+                ));
+              });
+          }
+
+      }
+
+      """
+    And the class file "src/Matchers/InlineExample3/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\InlineExample3;
+
+      class Calculator
+      {
+          public function __toString()
+          {
+              return 'Hi';
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should not pass
+    Then I should see "a very important message"
+


### PR DESCRIPTION
Hello, 

Here is a new scenario to test an inline matcher that throws an exception.

I'm not sure but I think it is not covered right now.

