### PR TITLE
ValidatingExtensionTrait first implementation

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -189,6 +189,14 @@ class ApplicationContext implements Context, MatchersProviderInterface
     }
 
     /**
+     * @Then the suite should not pass
+     */
+    public function theSuiteShouldNotPass()
+    {
+        expect($this->lastExitCode)->notToBeLike(0);
+    }
+
+    /**
      * @Then :number example(s) should have been skipped
      */
     public function exampleShouldHaveBeenSkipped($number)

--- a/features/extensions/developer_uses_extension.feature
+++ b/features/extensions/developer_uses_extension.feature
@@ -1,0 +1,155 @@
+Feature: Developer uses extensions
+  As a Developer
+  I want to use my extension with vali
+  In order to avoid spending a lot of time debugging I want to see a clear error message
+
+  Scenario: Using an empty extension
+    Given the config file contains:
+    """
+    extensions:
+      - Example1\PhpSpec\EmptyExtension\Extension
+    """
+
+    And the class file "src/Example1/PhpSpec/EmptyExtension/Extension.php" contains:
+    """
+    <?php
+
+    namespace Example1\PhpSpec\EmptyExtension;
+
+    use PhpSpec\Extension\ExtensionInterface;
+    use PhpSpec\Extension\ValidatingExtensionTrait;
+    use PhpSpec\ServiceContainer;
+
+    class Extension implements ExtensionInterface
+    {
+        use ValidatingExtensionTrait;
+
+        /**
+         * @param ServiceContainer $container
+         */
+        public function load(ServiceContainer $container)
+        {
+        }
+    }
+    """
+
+    And the spec file "spec/Example1/DummySpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Example1;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class DummySpec extends ObjectBehavior
+    {
+    }
+    """
+
+    When I run phpspec
+    Then the suite should pass
+
+
+  Scenario: Using extension with correct matcher
+    Given the config file contains:
+    """
+    extensions:
+      - Example2\PhpSpec\IncorrectMatcherExtension\Extension
+    """
+
+    And the class file "src/Example2/PhpSpec/IncorrectMatcherExtension/Extension.php" contains:
+    """
+    <?php
+
+    namespace Example2\PhpSpec\IncorrectMatcherExtension;
+
+    use PhpSpec\Extension\ExtensionInterface;
+    use PhpSpec\Extension\ValidatingExtensionTrait;
+    use PhpSpec\ServiceContainer;
+    use PhpSpec\Matcher\IdentityMatcher;
+
+    class Extension implements ExtensionInterface
+    {
+        use ValidatingExtensionTrait;
+
+        /**
+         * @param ServiceContainer $container
+         */
+        public function load(ServiceContainer $container)
+        {
+          $this->setContainer($container);
+          $this->set('matchers.anotherIdentityMatcher', function (ServiceContainer $c) {
+              return new IdentityMatcher($c->get('formatter.presenter'));
+          });
+        }
+    }
+    """
+
+    And the spec file "spec/Example2/DummySpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Example2;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class DummySpec extends ObjectBehavior
+    {
+    }
+    """
+
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: Using extension with incorrect matcher
+    Given the config file contains:
+    """
+    extensions:
+      - Example3\PhpSpec\IncorrectMatcherExtension\Extension
+    """
+
+    And the class file "src/Example3/PhpSpec/IncorrectMatcherExtension/Extension.php" contains:
+    """
+    <?php
+
+    namespace Example3\PhpSpec\IncorrectMatcherExtension;
+
+    use PhpSpec\Extension\ExtensionInterface;
+    use PhpSpec\Extension\ValidatingExtensionTrait;
+    use PhpSpec\ServiceContainer;
+
+    class Extension implements ExtensionInterface
+    {
+        use ValidatingExtensionTrait;
+
+        /**
+         * @param ServiceContainer $container
+         */
+        public function load(ServiceContainer $container)
+        {
+          $this->setContainer($container);
+          $this->set('matchers.doSomething', function (ServiceContainer $c) {
+              return new \StdClass();
+          });
+        }
+    }
+    """
+
+    And the spec file "spec/Example3/DummySpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Example3;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class DummySpec extends ObjectBehavior
+    {
+    }
+    """
+
+    When I run phpspec
+    Then the suite should not pass

--- a/spec/PhpSpec/Extension/ValidatingExtensionSpec.php
+++ b/spec/PhpSpec/Extension/ValidatingExtensionSpec.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace spec\PhpSpec\Extension;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use PhpSpec\ServiceContainer;
+use PhpSpec\Matcher\IdentityMatcher;
+
+class ValidatingExtensionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('PhpSpec\Extension\ValidatingExtension');
+    }
+
+    function it_should_validate_unprefixed_service(ServiceContainer $c)
+    {
+        $matcher = new \StdClass();
+        $id = 'abc';
+        $prefix = '';
+        $sid = 'abc';
+
+        $c->getPrefixAndSid($id)->willReturn(array($prefix, $sid));
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_validate_a_complete_new_service(ServiceContainer $c)
+    {
+        $matcher = new \StdClass();
+        $id = 'new.service';
+        $prefix = 'new';
+        $sid = 'service';
+
+        $c->getPrefixAndSid($id)->willReturn(array($prefix, $sid));
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_validate_a_complete_new_service_defined_with_callable(ServiceContainer $c)
+    {
+        $matcher = function (ServiceContainer $c) {
+            return new \StdClass();
+        };
+        $id = 'new.service';
+        $prefix = 'new';
+        $sid = 'service';
+
+        $c->getPrefixAndSid($id)->willReturn(array($prefix, $sid));
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_validate_correct_matcher_service(ServiceContainer $c, IdentityMatcher $matcher)
+    {
+        $id = 'matchers.abc';
+        $prefix = 'matchers';
+        $sid = 'abc';
+
+        $c->getPrefixAndSid($id)->willReturn(array($prefix, $sid));
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_validate_correct_matcher_service_defined_with_callable(
+        ServiceContainer $c, IdentityMatcher $identityMatcher
+    ) {
+        $matcher = function (ServiceContainer $c) use ($identityMatcher) {
+            return $identityMatcher->getWrappedObject();
+        };
+        $id = 'matchers.abc';
+        $prefix = 'matchers';
+        $sid = 'abc';
+
+        $c->getPrefixAndSid($id)->willReturn(array($prefix, $sid));
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_not_validate_incorrect_matcher_service(ServiceContainer $c)
+    {
+        $matcher = new \StdClass();
+        $id = 'matchers.abc';
+        $prefix = 'matchers';
+        $sid = 'abc';
+
+        $c->getPrefixAndSid($id)->willReturn(array($prefix, $sid));
+
+        $this->setContainer($c);
+        $this->shouldThrow()->duringSet($id, $matcher);
+    }
+
+    function it_should_not_validate_incorrect_matcher_service_defined_with_collable(ServiceContainer $c)
+    {
+        $matcher = function (ServiceContainer $c) {
+            return new \StdClass();
+        };
+        $id = 'matchers.abc';
+        $prefix = 'matchers';
+        $sid = 'abc';
+
+        $c->getPrefixAndSid($id)->willReturn(array($prefix, $sid));
+
+        $this->setContainer($c);
+        $this->shouldThrow()->duringSet($id, $matcher);
+    }
+}

--- a/src/PhpSpec/Extension/ValidatingExtension.php
+++ b/src/PhpSpec/Extension/ValidatingExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Extension;
+
+class ValidatingExtension
+{
+    use ValidatingExtensionTrait;
+}

--- a/src/PhpSpec/Extension/ValidatingExtensionTrait.php
+++ b/src/PhpSpec/Extension/ValidatingExtensionTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Extension;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+trait ValidatingExtensionTrait
+{
+    /**
+     * @var \PhpSpec\ServiceContainer
+     */
+    private $container;
+
+    /**
+     * @var array
+     */
+    private $map = [
+        'formatter.formatters' => 'PhpSpec\Formatter\BasicFormatter',
+        'matchers' => 'PhpSpec\Matcher\MatcherInterface',
+    ];
+
+    /**
+     * @param \PhpSpec\ServiceContainer $container
+     */
+    public function setContainer($container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param string          $id
+     * @param object|callable $value
+     *
+     * @throws \InvalidArgumentException if service does not implement correct interface
+     */
+    public function set($id, $value)
+    {
+        if (!isset($this->container)) {
+            throw new RuntimeException(sprintf(
+                'ValidatingExtensionTrait::setContainer() call required.',
+                $id
+            ));
+        }
+
+        $this->validate($id, $value);
+        $this->container->set($id, $value);
+    }
+
+    /**
+     * Validates a service and then calls parent set() method.
+     *
+     * @param string          $id
+     * @param object|callable $value
+     *
+     * @throws \InvalidArgumentException if service does not implement appropriate interface
+     */
+    private function validate($id, $value)
+    {
+        $prefix = $this->container->getPrefixAndSid($id)[0];
+        if (null === $prefix) {
+            return true;
+        }
+
+        if (in_array($prefix, array_keys($this->map))) {
+            if (is_callable($value)) {
+                $tmpObj = call_user_func($value, $this->container);
+                if (!($tmpObj instanceof $this->map[$prefix])) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Callable service "%s" has to implement correct interface.',
+                        $id
+                    ));
+                };
+            } elseif (is_object($value)) {
+                if (!($value instanceof $this->map[$prefix])) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Service "%s" has to implement correct interface.',
+                        $id
+                    ));
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -234,7 +234,7 @@ class ServiceContainer
      *
      * @return array
      */
-    private function getPrefixAndSid($id)
+    public function getPrefixAndSid($id)
     {
         if (count($parts = explode('.', $id)) < 2) {
             return array(null, $id);


### PR DESCRIPTION
Hi,
I think that developing  extensions is quite difficult right now. That's because when you declare an incorrect service, for example matcher with `StdClass()` in your extension `load()` method:

     /**
     * @param ServiceContainer $container
     */
    public function load(ServiceContainer $container)
    {
        $container->set('matchers.abc', function (ServiceContainer $c) {
            return new \StdClass();
        });
    }

then `phpspec` will silently die. It took me quite a while to debug this.
The trait in this PR aims to make writing extensions a little easier.

 