### PR TITLE
Adding SpecGen to the list of extensions

### DIFF
--- a/docs/cookbook/extensions.rst
+++ b/docs/cookbook/extensions.rst
@@ -51,6 +51,7 @@ Code generation
 
  * `Typehinted Methods <https://github.com/ciaranmcnulty/phpspec-typehintedmethods>`_
  * `Example Generation <https://github.com/richardmiller/ExemplifyExtension>`_
+ * `SpecGen <https://github.com/memio/spec-gen>`_
 
 Additional Formatters
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
[SpecGen](https://github.com/memio/spec-gen) is an extension that aims at improving phpspec's code generation:

* method generation:
    * it inserts method at the end of the class
    * it typehints object (uses interface when possible), array and callable arguments
    * it names object arguments after their type (strips `Interface` suffix from names)
    * it names scalar arguments after a generic name (`argument`)
    * it adds number on names that could collide (e.g. `$argument1, $argument2`)
* constructor generation, same as method except:
    * it inserts constructor at the begining of the class
    * it inserts properties with initialization for each constructor arguments

Is the documentation open for more extensions? What are the criterion to be accepted?