### PR TITLE
Move `symfony/process` dependency to non-dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "sebastian/exporter":       "~1.0",
         "symfony/console":          "~2.3",
         "symfony/event-dispatcher": "~2.1",
+        "symfony/process":          "^2.6",
         "symfony/finder":           "~2.1",
         "symfony/yaml":             "~2.1",
         "doctrine/instantiator":    "^1.0.1"
@@ -33,8 +34,7 @@
         "behat/behat":           "^3.0.11",
         "bossa/phpspec2-expect": "~1.0",
         "symfony/filesystem":    "~2.1",
-        "phpunit/phpunit":       "~4.4",
-        "symfony/process":       "^2.6"
+        "phpunit/phpunit":       "~4.4"
     },
 
     "suggest": {


### PR DESCRIPTION
This PR moves the `symfony/process` dependency in the non-dev dependencies of PhpSpec.

Else, if the SUS do not require this package, PhpSpec won't run anymore because the `Symfony\Component\Process\PhpExecutableFinder` class is required for PhpSpec to run.
