### PR TITLE
Update class and interface template

### DIFF
--- a/src/PhpSpec/CodeGenerator/Generator/templates/class.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/class.template
@@ -1,5 +1,4 @@
 <?php%namespace_block%
 
 class %name%
-{
-}
+{}

--- a/src/PhpSpec/CodeGenerator/Generator/templates/interface.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/interface.template
@@ -1,5 +1,4 @@
 <?php%namespace_block%
 
 interface %name%
-{
-}
+{}


### PR DESCRIPTION
Classes used to have one extra line before first method/constructor in the class:

```php
<?php

namespace App\Domain;

class Book
{

    public function getTitle()
    {
        // TODO: write logic here
    }
}
```

After my update, it looks like this:

```php
<?php

namespace App\Domain;

class Book
{
    public function getTitle()
    {
        // TODO: write logic here
    }
}
```