### PR TITLE
ValidatingExtensionTrait first implementation

### DIFF
--- a/features/extensions/developer_uses_incorrect_extension.feature
+++ b/features/extensions/developer_uses_incorrect_extension.feature
@@ -1,0 +1,56 @@
+@php-version @php5.4
+Feature: Developer uses incorrect extension
+  As a Developer
+  I want to use my extension
+  In order to avoid spending a lot of time debugging I want to see a clear error message
+
+  Scenario: Using extension with incorrect matcher
+    Given the config file contains:
+    """
+    extensions:
+      - Example3\PhpSpec\IncorrectMatcherExtension\Extension
+    """
+
+    And the class file "src/Example3/PhpSpec/IncorrectMatcherExtension/Extension.php" contains:
+    """
+    <?php
+
+    namespace Example3\PhpSpec\IncorrectMatcherExtension;
+
+    use PhpSpec\Extension\ExtensionInterface;
+    use PhpSpec\Extension\ValidatingExtensionTrait;
+    use PhpSpec\ServiceContainer;
+
+    class Extension implements ExtensionInterface
+    {
+        use ValidatingExtensionTrait;
+
+        /**
+         * @param ServiceContainer $container
+         */
+        public function load(ServiceContainer $container)
+        {
+          $this->setContainer($container);
+          $this->set('matchers.doSomething', function (ServiceContainer $c) {
+              return new \StdClass();
+          });
+        }
+    }
+    """
+
+    And the spec file "spec/Example3/DummySpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Example3;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class DummySpec extends ObjectBehavior
+    {
+    }
+    """
+
+    When I run phpspec
+    Then the suite should not pass

--- a/spec/PhpSpec/Util/ExampleValidatingExtension.php
+++ b/spec/PhpSpec/Util/ExampleValidatingExtension.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace spec\PhpSpec\Util;
+
+use PhpSpec\Extension\ValidatingExtensionTrait;
+
+class ExampleValidatingExtension
+{
+    use ValidatingExtensionTrait;
+}

--- a/spec/PhpSpec/Util/ValidatingExtensionSpec.php
+++ b/spec/PhpSpec/Util/ValidatingExtensionSpec.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace spec\PhpSpec\Util;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use PhpSpec\ServiceContainer;
+use PhpSpec\Matcher\IdentityMatcher;
+use PhpSpec\Exception\Example\SkippingException;
+use PhpSpec\Extension\ValidatingExtensionTrait;
+
+class ValidatingExtensionSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beAnInstanceOf('spec\PhpSpec\Util\ExampleValidatingExtension');
+    }
+
+    function it_is_initializable()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $this->shouldHaveType('spec\PhpSpec\Util\ExampleValidatingExtension');
+    }
+
+    function it_should_throw_if_container_is_not_set()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $this->shouldThrow()->duringSet('', null);
+    }
+
+    function it_should_validate_unprefixed_service(ServiceContainer $c)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $matcher = new \StdClass();
+        $id = 'abc';
+
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_validate_service_with_new_prefix(ServiceContainer $c)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $matcher = new \StdClass();
+        $id = 'new.service';
+
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_validate_callable_service_with_new_prefix(ServiceContainer $c)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $matcher = function (ServiceContainer $c) {
+            return new \StdClass();
+        };
+        $id = 'new.service';
+
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_validate_correct_matcher_service(ServiceContainer $c, IdentityMatcher $matcher)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $id = 'matchers.abc';
+
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_validate_correct_callable_matcher_service(
+        ServiceContainer $c, IdentityMatcher $identityMatcher
+    ) {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $matcher = function (ServiceContainer $c) use ($identityMatcher) {
+            return $identityMatcher->getWrappedObject();
+        };
+        $id = 'matchers.abc';
+
+        $c->set($id, $matcher)->shouldBeCalled();
+
+        $this->setContainer($c);
+        $this->set($id, $matcher);
+    }
+
+    function it_should_not_validate_incorrect_matcher_service(ServiceContainer $c)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $matcher = new \StdClass();
+        $id = 'matchers.abc';
+
+        $this->setContainer($c);
+        $this->shouldThrow()->duringSet($id, $matcher);
+    }
+
+    function it_should_not_validate_incorrect_callable_matcher_service(ServiceContainer $c)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new SkippingException('Traits implemented since PHP 5.4');
+        }
+
+        $matcher = function (ServiceContainer $c) {
+            return new \StdClass();
+        };
+        $id = 'matchers.abc';
+
+        $this->setContainer($c);
+        $this->shouldThrow()->duringSet($id, $matcher);
+    }
+}
+

--- a/src/PhpSpec/Extension/ValidatingExtensionTrait.php
+++ b/src/PhpSpec/Extension/ValidatingExtensionTrait.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Extension;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+trait ValidatingExtensionTrait
+{
+    /**
+     * @var \PhpSpec\ServiceContainer
+     */
+    private $container;
+
+    /**
+     * @var array
+     */
+    private $map = [
+        'matchers' => 'PhpSpec\Matcher\MatcherInterface',
+    ];
+
+    /**
+     * @param \PhpSpec\ServiceContainer $container
+     */
+    public function setContainer($container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param string          $id
+     * @param object|callable $value
+     *
+     * @throws \InvalidArgumentException if service does not implement correct interface
+     */
+    public function set($id, $value)
+    {
+        if (!isset($this->container)) {
+            throw new RuntimeException(sprintf(
+                'ValidatingExtensionTrait::setContainer() call required.',
+                $id
+            ));
+        }
+
+        $this->validate($id, $value);
+        $this->container->set($id, $value);
+    }
+
+    /**
+     * Validates a service and then calls parent set() method.
+     *
+     * @param string          $id
+     * @param object|callable $value
+     *
+     * @throws \InvalidArgumentException if service does not implement appropriate interface
+     */
+    private function validate($id, $value)
+    {
+        $prefix = $this->getPrefixAndSid($id)[0];
+        if (null === $prefix) {
+            return true;
+        }
+
+        if (in_array($prefix, array_keys($this->map))) {
+            if (is_callable($value)) {
+                $tmpObj = call_user_func($value, $this->container);
+                if (!($tmpObj instanceof $this->map[$prefix])) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Callable service "%s" has to implement correct interface.',
+                        $id
+                    ));
+                };
+            } elseif (is_object($value)) {
+                if (!($value instanceof $this->map[$prefix])) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Service "%s" has to implement correct interface.',
+                        $id
+                    ));
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Retrieves the prefix and sid of a given service
+     *
+     * Copied from PhpSpec\ServiceContainer.
+     *
+     * @param string $id
+     *
+     * @return array
+     */
+    private function getPrefixAndSid($id)
+    {
+        if (count($parts = explode('.', $id)) < 2) {
+            return array(null, $id);
+        }
+
+        $sid    = array_pop($parts);
+        $prefix = implode('.', $parts);
+
+        return array($prefix, $sid);
+    }
+
+}


### PR DESCRIPTION
This PR contains a trait that can help to validate services injected inside an extension.

Right now it only validates matchers but it can be extended by assigning new values to the map stored `$map` private property.

The whole concept was to allow validation of injected service only for user created services injected in the extension. The services injected within `setupMatchers` method in `ContainerAssembler` class are left intact.
