### PR TITLE
Add string contain matcher

### DIFF
--- a/docs/cookbook/matchers.rst
+++ b/docs/cookbook/matchers.rst
@@ -7,7 +7,7 @@ instead of verifying output. You use the matchers prefixed by ``should`` or
 ``shouldNot`` as appropriate.
 
 
-**phpspec** has 13 built-in matchers, described in more detail here. Many of these
+**phpspec** has 14 built-in matchers, described in more detail here. Many of these
 matchers have aliases which you can use to make your specifications easy to
 read.
 
@@ -370,6 +370,29 @@ with a specific key using the ArrayKey matcher.
         function it_should_have_a_release_date_for_france()
         {
             $this->getReleaseDates()->shouldHaveKey('France');
+        }
+    }
+
+
+StringContain Matcher
+---------------------
+
+The StringContain matcher lets you specify that a method should return a string
+containing a given substring. This matcher is case sensitive.
+
+.. code-block:: php
+
+    <?php
+
+    namespace spec;
+
+    use PhpSpec\ObjectBehavior;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function it_should_have_a_title_that_contains_wizard()
+        {
+            $this->getTitle()->shouldContain('Wizard');
         }
     }
 

--- a/features/matchers/developer_uses_string_contain_matcher.feature
+++ b/features/matchers/developer_uses_string_contain_matcher.feature
@@ -1,0 +1,41 @@
+Feature: Developer uses string-contain matcher
+  As a Developer
+  I want a string-contain matcher
+  In order to confirm a string contains an expected substring
+
+  Scenario: "Contain" alias matches using the string-contain matcher
+    Given the spec file "spec/Matchers/StringContainExample1/MovieSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Matchers\StringContainExample1;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function it_should_have_a_title_that_contains_days()
+        {
+            $this->getTitle()->shouldContain('days');
+        }
+    }
+    """
+
+    And the class file "src/Matchers/StringContainExample1/Movie.php" contains:
+    """
+    <?php
+
+    namespace Matchers\StringContainExample1;
+
+    class Movie
+    {
+        public function getTitle()
+        {
+            return 'The future days of past';
+        }
+    }
+    """
+
+    When I run phpspec
+    Then the suite should pass

--- a/spec/PhpSpec/Matcher/StringContainMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/StringContainMatcherSpec.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace spec\PhpSpec\Matcher;
+
+use PhpSpec\Formatter\Presenter\PresenterInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class StringContainMatcherSpec extends ObjectBehavior
+{
+    function let(PresenterInterface $presenter)
+    {
+        $presenter->presentString(Argument::type('string'))->willReturnArgument();
+
+        $this->beConstructedWith($presenter);
+    }
+
+    function it_is_a_matcher()
+    {
+        $this->shouldBeAnInstanceOf('PhpSpec\Matcher\MatcherInterface');
+    }
+
+    function it_supports_contain_keyword_string_subject_and_argument()
+    {
+        $this->supports('contain', 'hello world', array('llo'))->shouldReturn(true);
+    }
+
+    function it_does_not_support_non_string_keyword()
+    {
+        $this->supports('contain', array(), array())->shouldReturn(false);
+    }
+
+    function it_does_not_support_missing_argument()
+    {
+        $this->supports('contain', 'hello world', array())->shouldReturn(false);
+    }
+
+    function it_does_not_support_non_string_argument()
+    {
+        $this->supports('contain', 'hello world', array(array()))->shouldReturn(false);
+    }
+
+    function it_matches_strings_that_contain_specified_substring()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('contains', 'hello world', array('ello'));
+    }
+
+    function it_does_not_match_strings_that_do_not_contain_specified_substring()
+    {
+        $this->shouldThrow()->duringPositiveMatch('contains', 'hello world', array('row'));
+    }
+
+    function it_matches_strings_that_do_not_contain_specified_substring()
+    {
+        $this->shouldNotThrow()->duringNegativeMatch('contains', 'hello world', array('row'));
+    }
+
+    function it_does_not_match_strings_that_do_contain_specified_substring()
+    {
+        $this->shouldThrow()->duringNegativeMatch('contains', 'hello world', array('ello'));
+    }
+}

--- a/spec/PhpSpec/Matcher/StringContainMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/StringContainMatcherSpec.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace spec\PhpSpec\Matcher;
 
 use PhpSpec\Formatter\Presenter\PresenterInterface;

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -603,6 +603,9 @@ class ContainerAssembler
         $container->set('matchers.string_regex', function (ServiceContainer $c) {
             return new Matcher\StringRegexMatcher($c->get('formatter.presenter'));
         });
+        $container->set('matchers.string_contain', function (ServiceContainer $c) {
+            return new Matcher\StringContainMatcher($c->get('formatter.presenter'));
+        });
     }
 
     /**

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace PhpSpec\Matcher;
+
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\PresenterInterface;
+
+final class StringContainMatcher extends BasicMatcher
+{
+    /**
+     * @var PresenterInterface
+     */
+    private $presenter;
+
+    /**
+     * @param PresenterInterface $presenter
+     */
+    public function __construct(PresenterInterface $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($name, $subject, array $arguments)
+    {
+        return 'contain' === $name
+            && is_string($subject)
+            && 1 === count($arguments)
+            && is_string($arguments[0]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function matches($subject, array $arguments)
+    {
+        return false !== strpos($subject, $arguments[0]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFailureException($name, $subject, array $arguments)
+    {
+        return new FailureException(sprintf(
+            'Expected %s to contain %s, but it does not.',
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getNegativeFailureException($name, $subject, array $arguments)
+    {
+        return new FailureException(sprintf(
+            'Expected %s not to contain %s, but it does.',
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
+        ));
+    }
+}

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace PhpSpec\Matcher;
 
 use PhpSpec\Exception\Example\FailureException;


### PR DESCRIPTION
This PR adds matcher which helps to check if the string contains given substring.
It allows to write: `$this->getSlug()->shouldContain('foo');` and can help to write more readable and simpler examples.