### PR TITLE
Add missing colon to the construction cookboox examples

### DIFF
--- a/docs/cookbook/construction.rst
+++ b/docs/cookbook/construction.rst
@@ -124,7 +124,7 @@ to pass to that method.
 
 To be more descriptive, shorter syntaxes are available. All of the following are equivalent:
 
-.. code-block: php
+.. code-block:: php
 
     $this->beConstructedNamed('Bob');
     $this->beConstructedThroughNamed('Bob');


### PR DESCRIPTION
This is my first PR ever. Please be gentle.

Added a missing colon so the documentation examples on the site actually show.