### PR TITLE
Remove default formatters from config

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -9,8 +9,6 @@ default:
     smoke:
       contexts: [ IsolatedProcessContext, FilesystemContext ]
       filters: { tags: @smoke && ~@isolated }
-  formatters:
-    progress: ~
 
 no-smoke:
   suites:

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,1 +1,0 @@
-formatter.name: pretty


### PR DESCRIPTION
These are in there from someone's personal preference, and are not my preferred formatters.

Rather than impose my own preferences I've removed them so that users can use config of their choice.