### PR TITLE
Invalid collaborator type hinting error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
 before_script:
-  - echo "<?php if (PHP_VERSION_ID >= 50400) echo ',@php5.4';" > php_version_tags.php
+  - echo "<?php if (PHP_VERSION_ID >= 50400) echo ',@php5.4'; if (PHP_VERSION_ID >= 70000) echo ',@php7';" > php_version_tags.php
 
 script:
    - bin/phpspec run --format=pretty

--- a/features/invalid_usage/developer_uses_unsupported_collaborator_type_hinting.feature
+++ b/features/invalid_usage/developer_uses_unsupported_collaborator_type_hinting.feature
@@ -1,0 +1,86 @@
+Feature: Developer uses unsupported collaborator type hinting
+  As a developer
+  I should be shown special exception when I declare collaborators with unsupported type hinting
+
+  Scenario: Array collaborator type hinting
+    Given the spec file "spec/InvalidUsage/InvalidUsageExample1/StorageSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\InvalidUsage\InvalidUsageExample1;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class StorageSpec extends ObjectBehavior
+      {
+          function it_can_store_data(array $data)
+          {
+              $this->store($data)->shouldReturn(true);
+          }
+      }
+
+      """
+    And the class file "src/InvalidUsage/InvalidUsageExample1/Storage.php" contains:
+      """
+      <?php
+
+      namespace InvalidUsage\InvalidUsageExample1;
+
+      class Storage
+      {
+          public function store(array $data)
+          {
+              return true;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see:
+      """
+            collaborator cannot be array or callable: argument 0 defined in
+            spec\InvalidUsage\InvalidUsageExample1\StorageSpec::it_can_store_data.
+      """
+
+  @php-version @php5.4
+  Scenario: Callable collaborator type hinting
+    Given the spec file "spec/InvalidUsage/InvalidUsageExample2/InvokerSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\InvalidUsage\InvalidUsageExample2;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class InvokerSpec extends ObjectBehavior
+      {
+          function it_invokes_callable(callable $callback)
+          {
+              $this->invoke($callback)->shouldReturn(true);
+          }
+      }
+
+      """
+    And the class file "src/InvalidUsage/InvalidUsageExample2/Invoker.php" contains:
+      """
+      <?php
+
+      namespace InvalidUsage\InvalidUsageExample2;
+
+      class Invoker
+      {
+          public function invoke(callable $data, array $parameters = array())
+          {
+              return true;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see:
+      """
+            collaborator cannot be array or callable: argument 0 defined in
+            spec\InvalidUsage\InvalidUsageExample2\InvokerSpec::it_invokes_callable.
+      """

--- a/features/invalid_usage/developer_uses_unsupported_collaborator_type_hinting.feature
+++ b/features/invalid_usage/developer_uses_unsupported_collaborator_type_hinting.feature
@@ -39,7 +39,7 @@ Feature: Developer uses unsupported collaborator type hinting
     When I run phpspec
     Then I should see:
       """
-            collaborator cannot be array or callable: argument 0 defined in
+            collaborator must be an object: argument 0 defined in
             spec\InvalidUsage\InvalidUsageExample1\StorageSpec::it_can_store_data.
       """
 
@@ -81,6 +81,49 @@ Feature: Developer uses unsupported collaborator type hinting
     When I run phpspec
     Then I should see:
       """
-            collaborator cannot be array or callable: argument 0 defined in
+            collaborator must be an object: argument 0 defined in
             spec\InvalidUsage\InvalidUsageExample2\InvokerSpec::it_invokes_callable.
+      """
+
+
+  @php-version @php7
+  Scenario: Integer collaborator type hinting
+    Given the spec file "spec/InvalidUsage/InvalidUsageExample3/StorageSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\InvalidUsage\InvalidUsageExample3;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class StorageSpec extends ObjectBehavior
+      {
+          function it_can_store_data(int $data)
+          {
+              $this->store($data)->shouldReturn(true);
+          }
+      }
+
+      """
+    And the class file "src/InvalidUsage/InvalidUsageExample3/Storage.php" contains:
+      """
+      <?php
+
+      namespace InvalidUsage\InvalidUsageExample3;
+
+      class Storage
+      {
+          public function store(int $data)
+          {
+              return true;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see:
+      """
+            collaborator must be an object: argument 0 defined in
+            spec\InvalidUsage\InvalidUsageExample3\StorageSpec::it_can_store_data.
       """

--- a/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
+++ b/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace spec\PhpSpec\Exception\Wrapper;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class InvalidCollaboratorTypeExceptionSpec extends ObjectBehavior
+{
+    function let(\ReflectionParameter $parameter, \ReflectionFunctionAbstract $function)
+    {
+        $this->beConstructedWith($parameter, $function);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('PhpSpec\Exception\Wrapper\InvalidCollaboratorTypeException');
+        $this->shouldHaveType('PhpSpec\Exception\Wrapper\CollaboratorException');
+    }
+
+    function it_generates_correct_message_based_on_function_and_parameter(
+        \ReflectionParameter $parameter,
+        \ReflectionMethod $function,
+        \ReflectionClass $class
+    ) {
+        $parameter->getPosition()->willReturn(2);
+        $function->getDeclaringClass()->willReturn($class);
+        $class->getName()->willReturn('Acme\Foo');
+        $function->getName()->willReturn('bar');
+
+        $this->getMessage()->shouldStartWith('Collaborator cannot be array or callable: argument 2 defined in Acme\Foo::bar.');
+    }
+
+    function it_sets_cause(\ReflectionFunction $function)
+    {
+        $this->getCause()->shouldReturn($function);
+    }
+
+}

--- a/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
+++ b/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
@@ -28,7 +28,7 @@ class InvalidCollaboratorTypeExceptionSpec extends ObjectBehavior
         $class->getName()->willReturn('Acme\Foo');
         $function->getName()->willReturn('bar');
 
-        $this->getMessage()->shouldStartWith('Collaborator cannot be array or callable: argument 2 defined in Acme\Foo::bar.');
+        $this->getMessage()->shouldStartWith('Collaborator must be an object: argument 2 defined in Acme\Foo::bar.');
     }
 
     function it_sets_cause(\ReflectionFunction $function)

--- a/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
+++ b/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
@@ -20,8 +20,8 @@ class InvalidCollaboratorTypeException extends CollaboratorException
     public function __construct(\ReflectionParameter $parameter, \ReflectionFunctionAbstract $function)
     {
         $message = sprintf(
-            'Collaborator cannot be array or callable: argument %s defined in %s. ' .
-            'You can create arrays/callables manually.',
+            'Collaborator must be an object: argument %s defined in %s. ' .
+            'You can create non-object values manually.',
             $parameter->getPosition(),
             $this->fetchFunctionIdentifier($function)
         );

--- a/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
+++ b/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Exception\Wrapper;
+
+
+class InvalidCollaboratorTypeException extends CollaboratorException
+{
+
+    public function __construct(\ReflectionParameter $parameter, \ReflectionFunctionAbstract $function)
+    {
+        $message = sprintf(
+            'Collaborator cannot be array or callable: argument %s defined in %s. ' .
+            'You can create arrays/callables manually.',
+            $parameter->getPosition(),
+            $this->fetchFunctionIdentifier($function)
+        );
+        $this->setCause($function);
+
+        parent::__construct($message);
+    }
+
+    private function fetchFunctionIdentifier(\ReflectionFunctionAbstract $function)
+    {
+        $functionIdentifier = $function->getName();
+        if ($function instanceof \ReflectionMethod) {
+            $functionIdentifier = sprintf('%s::%s', $function->getDeclaringClass()->getName(), $function->getName());
+        }
+
+        return $functionIdentifier;
+    }
+
+
+}


### PR DESCRIPTION
When collaborator is defined with array or callable type hinting spec execution raises not really clear php warnings (something like *Argument 1 passed to method() must be array, object given*).

This PR makes such situations more clear (this can be espesially important for newcomers).

I've faced this problem when started working with phpspec, and I am not alone (see #710).