### PR TITLE
fix case typo

### DIFF
--- a/src/PhpSpec/CodeAnalysis/AccessInspectorInterface.php
+++ b/src/PhpSpec/CodeAnalysis/AccessInspectorInterface.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Phpspec\CodeAnalysis;
+namespace PhpSpec\CodeAnalysis;
 
 interface AccessInspectorInterface
 {

--- a/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\Runner\Maintainer;
 
-use Phpspec\CodeAnalysis\AccessInspectorInterface;
+use PhpSpec\CodeAnalysis\AccessInspectorInterface;
 use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\SpecificationInterface;
 use PhpSpec\Runner\MatcherManager;

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -14,7 +14,7 @@
 namespace PhpSpec\Wrapper\Subject;
 
 use PhpSpec\CodeAnalysis\MagicAwareAccessInspector;
-use Phpspec\CodeAnalysis\AccessInspectorInterface;
+use PhpSpec\CodeAnalysis\AccessInspectorInterface;
 use PhpSpec\CodeAnalysis\VisibilityAccessInspector;
 use PhpSpec\Exception\ExceptionFactory;
 use PhpSpec\Loader\Node\ExampleNode;

--- a/src/PhpSpec/Wrapper/Wrapper.php
+++ b/src/PhpSpec/Wrapper/Wrapper.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\Wrapper;
 
-use Phpspec\CodeAnalysis\AccessInspectorInterface;
+use PhpSpec\CodeAnalysis\AccessInspectorInterface;
 use PhpSpec\Exception\ExceptionFactory;
 use PhpSpec\Runner\MatcherManager;
 use PhpSpec\Formatter\Presenter\PresenterInterface;


### PR DESCRIPTION
currently facing an exception like:

```
 ╳  exception 'RuntimeException' with message 'Case mismatch between loaded and declared class names: PhpSpec\CodeAnalysis\AccessInspectorInterface vs Phpspec\CodeAnalysis\AccessInspectorInterface' in vendor/symfony/symfony/src/Symfony/Component/Debug/DebugClassLoader.php:179
  ╳  Stack trace:
  ╳  #0 [internal function]: Symfony\Component\Debug\DebugClassLoader->loadClass('PhpSpec\\CodeAna...')
  ╳  #1 vendor/phpspec/phpspec/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php(17): spl_autoload_call('PhpSpec\\CodeAna...')
```