### PR TITLE
Add ext-tokenizer to composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "symfony/process":          "^2.6",
         "symfony/finder":           "~2.1",
         "symfony/yaml":             "~2.1",
-        "doctrine/instantiator":    "^1.0.1"
+        "doctrine/instantiator":    "^1.0.1",
+        "ext-tokenizer":            "*"
     },
 
     "require-dev": {


### PR DESCRIPTION
Sometimes, php is distributed with ext-tokenizer disabled ( this was a case for me when trying to run phpspec from a temporary workstation with cygwin ). Without it, it will fail with following message:

Fatal error: Call to undefined function token_get_all() in [...]/src/PhpSpec/Locator/PSR0/PSR0Locator.php on line 277.
