### PR TITLE
Added variadic arguments docBlock to ObjectBehavior and Wrapper\Subject

### DIFF
--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -28,7 +28,7 @@ use ArrayAccess;
  * wrap the results into PhpSpec subjects. This results will then be able to
  * be matched against expectations.
  *
- * @method void beConstructedWith()
+ * @method void beConstructedWith(...$arguments)
  * @method void beConstructedThrough($factoryMethod, array $constructorArguments)
  * @method void beAnInstanceOf($class)
  * @method void shouldHaveType($type)

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -81,7 +81,7 @@ class Subject implements ArrayAccess, WrapperInterface
     }
 
     /**
-     *
+     * @param ...$arguments
      */
     public function beConstructedWith()
     {


### PR DESCRIPTION
`$this->beConstructedWith($collaborator);`
PhpStorm was complaining "Method call uses 1 parameters, but method signature uses 0 parameters"