### PR TITLE
Add --ignore-pending run command flag & config file support

### DIFF
--- a/docs/cookbook/configuration.rst
+++ b/docs/cookbook/configuration.rst
@@ -186,6 +186,12 @@ You can also set your tests to stop on failure by setting ``stop_on_failure``:
 
     stop_on_failure: true
 
+You can cause pending specs not to cause a non-zero exit code by setting ``ignore_pending``:
+
+.. code-block:: yaml
+
+    ignore_pending: true
+
 Extensions
 ----------
 

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -1,17 +1,14 @@
 <?php
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
-use Behat\Gherkin\Node\TableNode;
 use Fake\Prompter;
 use Fake\ReRunner;
 use Matcher\ApplicationOutputMatcher;
-use Matcher\ExitStatusMatcher;
+use Matcher\ApplicationStatusCodeMatcher;
 use Matcher\ValidJUnitXmlMatcher;
 use PhpSpec\Console\Application;
 use PhpSpec\Matcher\MatchersProviderInterface;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
 /**
@@ -291,6 +288,7 @@ class ApplicationContext implements Context, MatchersProviderInterface
     {
         return array(
             new ApplicationOutputMatcher(),
+            new ApplicationStatusCodeMatcher(),
             new ValidJUnitXmlMatcher()
         );
     }

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -202,6 +202,14 @@ class ApplicationContext implements Context, MatchersProviderInterface
     }
 
     /**
+     * @Then :number example(s) should be pending
+     */
+    public function exampleShouldBePending($number)
+    {
+        expect($this->tester)->toHaveOutput("($number pending)");
+    }
+
+    /**
      * @Then :number example(s) should have been run
      */
     public function examplesShouldHaveBeenRun($number)

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -86,6 +86,7 @@ class ApplicationContext implements Context, MatchersProviderInterface
      * @When I run phpspec (non interactively)
      * @When I run phpspec using the :formatter format
      * @When I run phpspec with the :option option
+     * @When I run phpspec using the :formatter format and :option option
      * @When /I run phpspec with option (?P<option>.*)/
      * @When /I run phpspec (?P<interactive>interactively)$/
      * @When /I run phpspec (?P<interactive>interactively) with the (?P<option>.*) option/
@@ -199,14 +200,6 @@ class ApplicationContext implements Context, MatchersProviderInterface
     public function exampleShouldHaveBeenSkipped($number)
     {
         expect($this->tester)->toHaveOutput("($number skipped)");
-    }
-
-    /**
-     * @Then :number example(s) should be pending
-     */
-    public function exampleShouldBePending($number)
-    {
-        expect($this->tester)->toHaveOutput("($number pending)");
     }
 
     /**

--- a/features/bootstrap/Matcher/ApplicationOutputMatcher.php
+++ b/features/bootstrap/Matcher/ApplicationOutputMatcher.php
@@ -33,12 +33,13 @@ class ApplicationOutputMatcher implements MatcherInterface
     public function positiveMatch($name, $subject, array $arguments)
     {
         $expected = $this->normalize($arguments[0]);
-        $actual = $this->normalize($subject->getDisplay());
+        $output   = $subject->getDisplay();
+        $actual   = $this->normalize($output);
         if (strpos($actual, $expected) === false) {
             throw new FailureException(sprintf(
-                "Application output did not contain expected '%s'. Actual output:\n'%s'" ,
+                "Application output did not contain expected '%s'. Actual output:\n'%s'",
                 $expected,
-                $subject->getDisplay()
+                $output
             ));
         }
     }

--- a/features/bootstrap/Matcher/ApplicationStatusCodeMatcher.php
+++ b/features/bootstrap/Matcher/ApplicationStatusCodeMatcher.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Matcher;
+
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Matcher\MatcherInterface;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+
+/**
+ * Matcher class to test the status code from a console command
+ *
+ * @package Matcher
+ */
+class ApplicationStatusCodeMatcher implements MatcherInterface
+{
+
+    /**
+     * Checks if matcher supports provided subject and matcher name.
+     *
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return Boolean
+     */
+    public function supports($name, $subject, array $arguments)
+    {
+        return ($name == 'haveStatusCode' && $subject instanceof ApplicationTester);
+    }
+
+
+    /**
+     * Evaluates positive match.
+     *
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     */
+    public function positiveMatch($name, $subject, array $arguments)
+    {
+        $expected = $arguments[0];
+        $actual = $subject->getStatusCode();
+        if ($expected !== $actual) {
+            throw new FailureException(sprintf(
+                "Application status code did not contain expected '%s'. Actual output:\n'%s'" ,
+                $expected,
+                $actual
+            ));
+        }
+    }
+
+
+    /**
+     * Evaluates negative match.
+     *
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     */
+    public function negativeMatch($name, $subject, array $arguments)
+    {
+        $expected = $arguments[0];
+        $actual = $subject->getStatusCode();
+        if ($expected === $actual) {
+            throw new FailureException(sprintf(
+                "Application status code did not contain expected '%s'. Actual output:\n'%s'" ,
+                $expected,
+                $actual
+            ));
+        }
+    }
+
+
+    /**
+     * Returns matcher priority.
+     *
+     * @return integer
+     */
+    public function getPriority()
+    {
+        return 51;
+    }
+}

--- a/features/bootstrap/Matcher/ApplicationStatusCodeMatcher.php
+++ b/features/bootstrap/Matcher/ApplicationStatusCodeMatcher.php
@@ -6,7 +6,6 @@ use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Matcher\MatcherInterface;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
-
 /**
  * Matcher class to test the status code from a console command
  *
@@ -14,7 +13,6 @@ use Symfony\Component\Console\Tester\ApplicationTester;
  */
 class ApplicationStatusCodeMatcher implements MatcherInterface
 {
-
     /**
      * Checks if matcher supports provided subject and matcher name.
      *
@@ -26,9 +24,9 @@ class ApplicationStatusCodeMatcher implements MatcherInterface
      */
     public function supports($name, $subject, array $arguments)
     {
+
         return ($name == 'haveStatusCode' && $subject instanceof ApplicationTester);
     }
-
 
     /**
      * Evaluates positive match.
@@ -40,16 +38,15 @@ class ApplicationStatusCodeMatcher implements MatcherInterface
     public function positiveMatch($name, $subject, array $arguments)
     {
         $expected = $arguments[0];
-        $actual = $subject->getStatusCode();
+        $actual   = $subject->getStatusCode();
         if ($expected !== $actual) {
             throw new FailureException(sprintf(
-                "Application status code did not contain expected '%s'. Actual output:\n'%s'" ,
+                "Application status code did not contain expected '%s'. Actual output:\n'%s'",
                 $expected,
                 $actual
             ));
         }
     }
-
 
     /**
      * Evaluates negative match.
@@ -61,16 +58,15 @@ class ApplicationStatusCodeMatcher implements MatcherInterface
     public function negativeMatch($name, $subject, array $arguments)
     {
         $expected = $arguments[0];
-        $actual = $subject->getStatusCode();
+        $actual   = $subject->getStatusCode();
         if ($expected === $actual) {
             throw new FailureException(sprintf(
-                "Application status code did not contain expected '%s'. Actual output:\n'%s'" ,
+                "Application status code did not contain expected '%s'. Actual output:\n'%s'",
                 $expected,
                 $actual
             ));
         }
     }
-
 
     /**
      * Returns matcher priority.
@@ -79,6 +75,7 @@ class ApplicationStatusCodeMatcher implements MatcherInterface
      */
     public function getPriority()
     {
+
         return 51;
     }
 }

--- a/features/runner/developer_ignores_pending_specs.feature
+++ b/features/runner/developer_ignores_pending_specs.feature
@@ -1,0 +1,42 @@
+Feature: Developer ignores pending test warnings
+  So that I can automate tasks without failures for pending specs
+  As a Developer
+  I should be able to ignore pending spec warnings
+
+  Scenario: Run command with --ignore-pending flag set, using the dot formatter
+    Given the spec file "spec/Runner/SpecExample/MarkdownSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\SpecExample;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+      use PhpSpec\Exception\Example\SkippingException;
+
+      class MarkdownSpec extends ObjectBehavior
+      {
+          function it_converts_plain_text_table_to_html_table()
+          {
+              // Nothing here, so pending warning triggered
+          }
+      }
+
+      """
+    And the class file "src/Runner/SpecExample/Markdown.php" contains:
+      """
+      <?php
+
+      namespace Runner\SpecExample;
+
+      class Markdown
+      {
+          public function toHtml($text)
+          {
+          }
+      }
+
+      """
+    When I run phpspec interactively with the "ignore-pending" option
+    Then 1 example should be pending
+    But the suite should pass

--- a/features/runner/developer_ignores_pending_specs.feature
+++ b/features/runner/developer_ignores_pending_specs.feature
@@ -4,39 +4,84 @@ Feature: Developer ignores pending test warnings
   I should be able to ignore pending spec warnings
 
   Scenario: Run command with --ignore-pending flag set, using the dot formatter
-    Given the spec file "spec/Runner/SpecExample/MarkdownSpec.php" contains:
+    Given the spec file "spec/Runner/IgnoresPendingExample1/MarkdownSpec.php" contains:
       """
       <?php
 
-      namespace spec\Runner\SpecExample;
+      namespace spec\Runner\IgnoresPendingExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
-      use PhpSpec\Exception\Example\SkippingException;
 
       class MarkdownSpec extends ObjectBehavior
       {
-          function it_converts_plain_text_table_to_html_table()
+          function it_does_nothing()
           {
-              // Nothing here, so pending warning triggered
           }
       }
 
       """
-    And the class file "src/Runner/SpecExample/Markdown.php" contains:
+#    And the class file "src/Runner/IgnoresPendingExample1/Markdown.php" contains:
+#      """
+#      <?php
+#
+#      namespace Runner\IgnoresPendingExample1;
+#
+#      class Markdown
+#      {
+#      }
+#      """
+    When I run phpspec using the "pretty" format and "ignore-pending" option
+    Then I should see:
+      """
+        9  - does nothing
+              todo: write pending example
+
+
+      1 specs
+      1 examples (1 pending)
+      """
+    But the suite should pass
+
+
+  Scenario: ignore-pending is specified in the config
+    Given the config file contains:
+      """
+      ignore_pending: true
+      """
+    And the spec file "spec/Runner/IgnoresPendingExample2/MarkdownSpec.php" contains:
       """
       <?php
 
-      namespace Runner\SpecExample;
+      namespace spec\Runner\IgnoresPendingExample2;
 
-      class Markdown
+      use PhpSpec\ObjectBehavior;
+
+      class MarkdownSpec extends ObjectBehavior
       {
-          public function toHtml($text)
+          function it_does_nothing()
           {
           }
       }
 
       """
-    When I run phpspec interactively with the "ignore-pending" option
-    Then 1 example should be pending
+    And the class file "src/Runner/IgnoresPendingExample2/Markdown.php" contains:
+      """
+      <?php
+
+      namespace Runner\IgnoresPendingExample2;
+
+      class Markdown
+      {
+      }
+      """
+    When I run phpspec using the "pretty" format
+    Then I should see:
+      """
+        9  - does nothing
+              todo: write pending example
+
+
+      1 specs
+      1 examples (1 pending)
+      """
     But the suite should pass

--- a/features/runner/developer_ignores_pending_specs.feature
+++ b/features/runner/developer_ignores_pending_specs.feature
@@ -20,16 +20,6 @@ Feature: Developer ignores pending test warnings
       }
 
       """
-#    And the class file "src/Runner/IgnoresPendingExample1/Markdown.php" contains:
-#      """
-#      <?php
-#
-#      namespace Runner\IgnoresPendingExample1;
-#
-#      class Markdown
-#      {
-#      }
-#      """
     When I run phpspec using the "pretty" format and "ignore-pending" option
     Then I should see:
       """
@@ -64,16 +54,6 @@ Feature: Developer ignores pending test warnings
       }
 
       """
-    And the class file "src/Runner/IgnoresPendingExample2/Markdown.php" contains:
-      """
-      <?php
-
-      namespace Runner\IgnoresPendingExample2;
-
-      class Markdown
-      {
-      }
-      """
     When I run phpspec using the "pretty" format
     Then I should see:
       """
@@ -85,3 +65,33 @@ Feature: Developer ignores pending test warnings
       1 examples (1 pending)
       """
     But the suite should pass
+
+
+  Scenario: ignore-pending is not specified in either the command line or the config
+    Given the spec file "spec/Runner/IgnoresPendingExample3/MarkdownSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\IgnoresPendingExample3;
+
+      use PhpSpec\ObjectBehavior;
+
+      class MarkdownSpec extends ObjectBehavior
+      {
+          function it_does_nothing()
+          {
+          }
+      }
+
+      """
+    When I run phpspec using the "pretty" format
+    Then I should see:
+      """
+        9  - does nothing
+              todo: write pending example
+
+
+      1 specs
+      1 examples (1 pending)
+      """
+    But the suite should not pass

--- a/spec/PhpSpec/Config/OptionsConfigSpec.php
+++ b/spec/PhpSpec/Config/OptionsConfigSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Config;
 
+use PhpSpec\Config\OptionsConfig;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -9,42 +10,56 @@ class OptionsConfigSpec extends ObjectBehavior
 {
     function it_says_rerun_is_enabled_when_setting_is_true()
     {
-        $this->beConstructedWith(false, false, true, false, false);
+        $this->beConstructedWith(false, false, true, false, false, false);
 
         $this->isReRunEnabled()->shouldReturn(true);
     }
 
     function it_says_rerun_is_not_enabled_when_setting_is_false()
     {
-        $this->beConstructedWith(false, false, false, false, false);
+        $this->beConstructedWith(false, false, false, false, false, false);
 
         $this->isReRunEnabled()->shouldReturn(false);
     }
 
     function it_says_faking_is_enabled_when_setting_is_true()
     {
-        $this->beConstructedWith(false, false, false, true, false);
+        $this->beConstructedWith(false, false, false, true, false, false);
 
         $this->isFakingEnabled()->shouldReturn(true);
     }
 
     function it_says_faking_is_not_enabled_when_setting_is_false()
     {
-        $this->beConstructedWith(false, false, false, false, false);
+        $this->beConstructedWith(false, false, false, false, false, false);
 
         $this->isFakingEnabled()->shouldReturn(false);
     }
 
+    function it_says_ignore_pending_is_false_when_setting_is_false()
+    {
+        $this->beConstructedWith(false, false, false, false, false, false);
+
+        $this->isIgnorePendingEnabled()->shouldReturn(false);
+    }
+
+    function it_says_ignore_pending_is_true_when_setting_is_false()
+    {
+        $this->beConstructedWith(false, false, false, false, '/path/to/file', true);
+        /** @var OptionsConfig $this */
+        $this->isIgnorePendingEnabled()->shouldReturn(true);
+    }
+
     function it_says_bootstrap_path_is_false_when_setting_is_false()
     {
-        $this->beConstructedWith(false, false, false, false, false);
+        $this->beConstructedWith(false, false, false, false, false, false);
 
         $this->getBootstrapPath()->shouldReturn(false);
     }
 
     function it_returns_bootstrap_path_when_one_is_specified()
     {
-        $this->beConstructedWith(false, false, false, false, '/path/to/file');
+        $this->beConstructedWith(false, false, false, false, '/path/to/file', false);
 
         $this->getBootstrapPath()->shouldReturn('/path/to/file');
     }

--- a/spec/PhpSpec/Console/ResultConverterSpec.php
+++ b/spec/PhpSpec/Console/ResultConverterSpec.php
@@ -2,12 +2,18 @@
 
 namespace spec\PhpSpec\Console;
 
+use PhpSpec\Console\IO;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use PhpSpec\Event\ExampleEvent;
 
 class ResultConverterSpec extends ObjectBehavior
 {
+    function let(IO $io)
+    {
+        $this->beConstructedWith($io);
+    }
+
     function it_converts_passed_result_code_into_0()
     {
         $this->convert(ExampleEvent::PASSED)->shouldReturn(0);
@@ -18,9 +24,18 @@ class ResultConverterSpec extends ObjectBehavior
         $this->convert(ExampleEvent::SKIPPED)->shouldReturn(0);
     }
 
-    function it_converts_pending_result_code_into_1()
+    function it_converts_pending_result_code_into_1_if_ignore_pending_is_false(IO $io)
     {
+        $io->isIgnorePendingEnabled()->willReturn(false);
+
         $this->convert(ExampleEvent::PENDING)->shouldReturn(1);
+    }
+
+    function it_converts_pending_result_code_into_1_if_ignore_pending_is_true(IO $io)
+    {
+        $io->isIgnorePendingEnabled()->willReturn(true);
+
+        $this->convert(ExampleEvent::PENDING)->shouldReturn(0);
     }
 
     function it_converts_failed_result_code_into_1()

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -40,24 +40,33 @@ class OptionsConfig
     private $bootstrapPath;
 
     /**
-     * @param bool $stopOnFailureEnabled
-     * @param bool $codeGenerationEnabled
-     * @param bool $reRunEnabled
-     * @param bool $fakingEnabled
+     * @var bool
+     */
+    private $ignorePending;
+
+
+    /**
+     * @param bool        $stopOnFailureEnabled
+     * @param bool        $codeGenerationEnabled
+     * @param bool        $reRunEnabled
+     * @param bool        $fakingEnabled
      * @param string|bool $bootstrapPath
+     * @param bool        $ignorePending
      */
     public function __construct(
         $stopOnFailureEnabled,
         $codeGenerationEnabled,
         $reRunEnabled,
         $fakingEnabled,
-        $bootstrapPath
+        $bootstrapPath,
+        $ignorePending
     ) {
         $this->stopOnFailureEnabled  = $stopOnFailureEnabled;
         $this->codeGenerationEnabled = $codeGenerationEnabled;
-        $this->reRunEnabled = $reRunEnabled;
-        $this->fakingEnabled = $fakingEnabled;
-        $this->bootstrapPath = $bootstrapPath;
+        $this->reRunEnabled          = $reRunEnabled;
+        $this->fakingEnabled         = $fakingEnabled;
+        $this->bootstrapPath         = $bootstrapPath;
+        $this->ignorePending         = $ignorePending;
     }
 
     /**

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -95,6 +95,11 @@ class OptionsConfig
         return $this->fakingEnabled;
     }
 
+    public function isIgnorePendingEnabled()
+    {
+        return $this->ignorePending;
+    }
+
     public function getBootstrapPath()
     {
         return $this->bootstrapPath;

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Console\Command;
 
+use PhpSpec\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -21,6 +22,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Main command, responsible for running the specs
+ *
+ * @method Application getApplication()
  */
 class RunCommand extends Command
 {
@@ -69,6 +72,12 @@ class RunCommand extends Command
                         'b',
                         InputOption::VALUE_REQUIRED,
                         'Bootstrap php file that is run before the specs'
+                    ),
+                    new InputOption(
+                        'ignore-pending',
+                        null,
+                        InputOption::VALUE_NONE,
+                        'Causes pending tests not to cause a non-zero return code'
                     )
                 ))
             ->setDescription('Runs specifications')

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -143,10 +143,6 @@ EOF
             'formatter.name',
             $input->getOption('format') ?: $container->getParam('formatter.name')
         );
-        $container->setParam(
-            'ignore-pending',
-            $input->getOption('ignore-pending') ?: $container->getParam('ignore_pending')
-        );
         $container->configure();
 
         $locator = $input->getArgument('spec');

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -143,6 +143,10 @@ EOF
             'formatter.name',
             $input->getOption('format') ?: $container->getParam('formatter.name')
         );
+        $container->setParam(
+            'ignore-pending',
+            $input->getOption('ignore-pending') ?: $container->getParam('ignore_pending')
+        );
         $container->configure();
 
         $locator = $input->getArgument('spec');

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -81,8 +81,10 @@ class ContainerAssembler
 
     private function setupResultConverter(ServiceContainer $container)
     {
-        $container->setShared('console.result_converter', function () {
-            return new ResultConverter();
+        $ignorePending = $container->getParam('ignore-pending', false);
+
+        $container->setShared('console.result_converter', function () use ($ignorePending) {
+            return new ResultConverter($ignorePending);
         });
     }
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -15,22 +15,22 @@ namespace PhpSpec\Console;
 
 use PhpSpec\CodeAnalysis\MagicAwareAccessInspector;
 use PhpSpec\CodeAnalysis\VisibilityAccessInspector;
-use PhpSpec\Process\Prerequisites\SuitePrerequisites;
-use SebastianBergmann\Exporter\Exporter;
-use PhpSpec\Process\ReRunner;
-use PhpSpec\Util\MethodAnalyser;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use PhpSpec\ServiceContainer;
 use PhpSpec\CodeGenerator;
+use PhpSpec\Config\OptionsConfig;
 use PhpSpec\Formatter as SpecFormatter;
 use PhpSpec\Listener;
 use PhpSpec\Loader;
 use PhpSpec\Locator;
 use PhpSpec\Matcher;
+use PhpSpec\Process\Prerequisites\SuitePrerequisites;
+use PhpSpec\Process\ReRunner;
 use PhpSpec\Runner;
+use PhpSpec\ServiceContainer;
+use PhpSpec\Util\MethodAnalyser;
 use PhpSpec\Wrapper;
-use PhpSpec\Config\OptionsConfig;
 use RuntimeException;
+use SebastianBergmann\Exporter\Exporter;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class ContainerAssembler
@@ -82,10 +82,11 @@ class ContainerAssembler
 
     private function setupResultConverter(ServiceContainer $container)
     {
-        $ignorePending = $container->getParam('ignore-pending', false);
+        /** @var IO $io */
+        $io = $container->get('console.io');
 
-        $container->setShared('console.result_converter', function () use ($ignorePending) {
-            return new ResultConverter($ignorePending);
+        $container->setShared('console.result_converter', function () use ($io) {
+            return new ResultConverter($io);
         });
     }
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -82,11 +82,8 @@ class ContainerAssembler
 
     private function setupResultConverter(ServiceContainer $container)
     {
-        /** @var IO $io */
-        $io = $container->get('console.io');
-
-        $container->setShared('console.result_converter', function () use ($io) {
-            return new ResultConverter($io);
+        $container->setShared('console.result_converter', function () use ($container) {
+            return new ResultConverter($container->get('console.io'));
         });
     }
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -72,7 +72,8 @@ class ContainerAssembler
                     $c->getParam('code_generation', true),
                     $c->getParam('rerun', true),
                     $c->getParam('fake', false),
-                    $c->getParam('bootstrap', false)
+                    $c->getParam('bootstrap', false),
+                    $c->getParam('ignore_pending', false)
                 ),
                 $c->get('console.prompter')
             );

--- a/src/PhpSpec/Console/IO.php
+++ b/src/PhpSpec/Console/IO.php
@@ -308,6 +308,11 @@ class IO implements IOInterface
         return $this->input->getOption('fake') || $this->config->isFakingEnabled();
     }
 
+    public function isIgnorePendingEnabled()
+    {
+        return $this->input->getOption('ignore-pending') || $this->config->isIgnorePendingEnabled();
+    }
+
     public function getBootstrapPath()
     {
         if ($path = $this->input->getOption('bootstrap')) {

--- a/src/PhpSpec/Console/ResultConverter.php
+++ b/src/PhpSpec/Console/ResultConverter.php
@@ -25,7 +25,6 @@ class ResultConverter
      */
     private $io;
 
-
     /**
      * ResultConverter constructor.
      *
@@ -35,7 +34,6 @@ class ResultConverter
     {
         $this->io = $io;
     }
-
 
     /**
      * Convert Example result into exit code

--- a/src/PhpSpec/Console/ResultConverter.php
+++ b/src/PhpSpec/Console/ResultConverter.php
@@ -21,6 +21,23 @@ use PhpSpec\Event\ExampleEvent;
 class ResultConverter
 {
     /**
+     * @var IO
+     */
+    private $io;
+
+
+    /**
+     * ResultConverter constructor.
+     *
+     * @param IO $io
+     */
+    public function __construct(IO $io)
+    {
+        $this->io = $io;
+    }
+
+
+    /**
      * Convert Example result into exit code
      *
      * @param mixed $result
@@ -33,6 +50,12 @@ class ResultConverter
             case ExampleEvent::PASSED:
             case ExampleEvent::SKIPPED:
                 return 0;
+
+            case ExampleEvent::PENDING:
+                if ($this->io->isIgnorePendingEnabled()) {
+                    return 0;
+                }
+                break;
         }
 
         return 1;


### PR DESCRIPTION
Added behat feature file including scenarios to cover command line flag & config file, & also without this flag/config

Updated ResultConverter to use flag/config to prevent non-zero exit code being returned.

Should we also need some way of setting `--ignore-pending=false` if the config file has it set to true?