### PR TITLE
Add resource name to specification template.

### DIFF
--- a/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
@@ -40,24 +40,26 @@ class SpecificationGeneratorSpec extends ObjectBehavior
     function it_generates_spec_class_from_resource_and_puts_it_into_appropriate_folder(
         $io, $tpl, $fs, ResourceInterface $resource
     ) {
-        $resource->getSpecName()->willReturn('App');
-        $resource->getSpecFilename()->willReturn('/project/spec/Acme/App.php');
+        $resource->getSpecName()->willReturn('AppSpec');
+        $resource->getSpecFilename()->willReturn('/project/spec/Acme/AppSpec.php');
         $resource->getSpecNamespace()->willReturn('spec\Acme');
         $resource->getSrcClassname()->willReturn('Acme\App');
+        $resource->getName()->willReturn('App');
 
         $values = array(
-            '%filepath%'  => '/project/spec/Acme/App.php',
-            '%name%'      => 'App',
+            '%filepath%'  => '/project/spec/Acme/AppSpec.php',
+            '%name%'      => 'AppSpec',
             '%namespace%' => 'spec\Acme',
-            '%subject%'   => 'Acme\App'
+            '%subject%'   => 'Acme\App',
+            '%subject_class%'  => 'App'
         );
 
         $tpl->render('specification', $values)->willReturn(null);
         $tpl->renderString(Argument::type('string'), $values)->willReturn('generated code');
 
-        $fs->pathExists('/project/spec/Acme/App.php')->willReturn(false);
+        $fs->pathExists('/project/spec/Acme/AppSpec.php')->willReturn(false);
         $fs->isDirectory('/project/spec/Acme')->willReturn(true);
-        $fs->putFileContents('/project/spec/Acme/App.php', 'generated code')->shouldBeCalled();
+        $fs->putFileContents('/project/spec/Acme/AppSpec.php', 'generated code')->shouldBeCalled();
 
         $this->generate($resource);
     }
@@ -65,39 +67,42 @@ class SpecificationGeneratorSpec extends ObjectBehavior
     function it_uses_template_provided_by_templating_system_if_there_is_one(
         $io, $tpl, $fs, ResourceInterface $resource
     ) {
-        $resource->getSpecName()->willReturn('App');
-        $resource->getSpecFilename()->willReturn('/project/spec/Acme/App.php');
+        $resource->getSpecName()->willReturn('AppSpec');
+        $resource->getSpecFilename()->willReturn('/project/spec/Acme/AppSpec.php');
         $resource->getSpecNamespace()->willReturn('spec\Acme');
         $resource->getSrcClassname()->willReturn('Acme\App');
+        $resource->getName()->willReturn('App');
 
         $values = array(
-            '%filepath%'  => '/project/spec/Acme/App.php',
-            '%name%'      => 'App',
+            '%filepath%'  => '/project/spec/Acme/AppSpec.php',
+            '%name%'      => 'AppSpec',
             '%namespace%' => 'spec\Acme',
-            '%subject%'   => 'Acme\App'
+            '%subject%'   => 'Acme\App',
+            '%subject_class%'  => 'App'
         );
 
         $tpl->render('specification', $values)->willReturn('template code');
         $tpl->renderString(Argument::type('string'), $values)->willReturn('generated code');
 
-        $fs->pathExists('/project/spec/Acme/App.php')->willReturn(false);
+        $fs->pathExists('/project/spec/Acme/AppSpec.php')->willReturn(false);
         $fs->isDirectory('/project/spec/Acme')->willReturn(true);
-        $fs->putFileContents('/project/spec/Acme/App.php', 'template code')->shouldBeCalled();
+        $fs->putFileContents('/project/spec/Acme/AppSpec.php', 'template code')->shouldBeCalled();
 
         $this->generate($resource);
     }
 
     function it_creates_folder_for_spec_if_needed($io, $tpl, $fs, ResourceInterface $resource)
     {
-        $resource->getSpecName()->willReturn('App');
-        $resource->getSpecFilename()->willReturn('/project/spec/Acme/App.php');
+        $resource->getSpecName()->willReturn('AppAppSpec');
+        $resource->getSpecFilename()->willReturn('/project/spec/Acme/AppSpec.php');
         $resource->getSpecNamespace()->willReturn('spec\Acme');
         $resource->getSrcClassname()->willReturn('Acme\App');
+        $resource->getName()->willReturn('App');
 
-        $fs->pathExists('/project/spec/Acme/App.php')->willReturn(false);
+        $fs->pathExists('/project/spec/Acme/AppSpec.php')->willReturn(false);
         $fs->isDirectory('/project/spec/Acme')->willReturn(false);
         $fs->makeDirectory('/project/spec/Acme')->shouldBeCalled();
-        $fs->putFileContents('/project/spec/Acme/App.php', Argument::any())->willReturn(null);
+        $fs->putFileContents('/project/spec/Acme/AppSpec.php', Argument::any())->willReturn(null);
 
         $this->generate($resource);
     }
@@ -105,12 +110,12 @@ class SpecificationGeneratorSpec extends ObjectBehavior
     function it_asks_confirmation_if_spec_already_exists(
         $io, $tpl, $fs, ResourceInterface $resource
     ) {
-        $resource->getSpecName()->willReturn('App');
-        $resource->getSpecFilename()->willReturn('/project/spec/Acme/App.php');
+        $resource->getSpecName()->willReturn('AppSpec');
+        $resource->getSpecFilename()->willReturn('/project/spec/Acme/AppSpec.php');
         $resource->getSpecNamespace()->willReturn('spec\Acme');
         $resource->getSrcClassname()->willReturn('Acme\App');
 
-        $fs->pathExists('/project/spec/Acme/App.php')->willReturn(true);
+        $fs->pathExists('/project/spec/Acme/AppSpec.php')->willReturn(true);
         $io->askConfirmation(Argument::type('string'), false)->willReturn(false);
 
         $fs->putFileContents(Argument::cetera())->shouldNotBeCalled();

--- a/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
@@ -50,10 +50,11 @@ class SpecificationGenerator extends PromptingGenerator
     protected function renderTemplate(ResourceInterface $resource, $filepath)
     {
         $values = array(
-            '%filepath%'  => $filepath,
-            '%name%'      => $resource->getSpecName(),
-            '%namespace%' => $resource->getSpecNamespace(),
-            '%subject%'   => $resource->getSrcClassname()
+            '%filepath%'      => $filepath,
+            '%name%'          => $resource->getSpecName(),
+            '%namespace%'     => $resource->getSpecNamespace(),
+            '%subject%'       => $resource->getSrcClassname(),
+            '%subject_class%' => $resource->getName()
         );
 
         if (!$content = $this->getTemplateRenderer()->render('specification', $values)) {


### PR DESCRIPTION
This PR aims to make the resource name available to the specification-template to allow for:

```
<?php

namespace %namespace%;

use %subject%;
use PhpSpec\ObjectBehavior;
use Prophecy\Argument;

class %name% extends ObjectBehavior
{
    function it_is_initializable()
    {
        $this->shouldHaveType(%resource%::class);
    }
}
```