### PR TITLE
Remove broken example that is actually not needed

### DIFF
--- a/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/StringPresenterSpec.php
@@ -4,6 +4,7 @@ namespace spec\PhpSpec\Formatter\Presenter;
 
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Formatter\Presenter\Differ\Differ;
+use PhpSpec\Wrapper\Subject;
 
 class StringPresenterSpec extends ObjectBehavior
 {
@@ -105,13 +106,6 @@ class StringPresenterSpec extends ObjectBehavior
     function it_presents_string_as_string()
     {
         $this->presentString('some string')->shouldReturn('some string');
-    }
-
-    function its_presentValue_displays_invokable_objects_as_objects()
-    {
-        $invokable = new ObjectBehavior();
-        $invokable->setSpecificationSubject($this);
-        $this->presentValue($invokable)->shouldReturn('[obj:PhpSpec\Formatter\Presenter\StringPresenter]');
     }
 }
 


### PR DESCRIPTION
I believe this example is duplicated by `it_presents_invokable_object_as_string` in the same spec.

@docteurklein I don't suppose you remember the original intention of this spec?

During work on PHP7 support I found this example is actually broken - it passes `$this` to a method that is type hinted as requiring a `Subject`, but our typehint error handling hides the problem.