### PR TITLE
Fix running spec with given spec path same as src path

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -87,14 +87,16 @@ class ApplicationContext implements Context, MatchersProviderInterface
      * @When I run phpspec (non interactively)
      * @When I run phpspec using the :formatter format
      * @When I run phpspec with the :option option
+     * @When I run phpspec with :spec specs to run
      * @When /I run phpspec with option (?P<option>.*)/
      * @When /I run phpspec (?P<interactive>interactively)$/
      * @When /I run phpspec (?P<interactive>interactively) with the (?P<option>.*) option/
      */
-    public function iRunPhpspec($formatter = null, $option = null, $interactive=null)
+    public function iRunPhpspec($formatter = null, $option = null, $interactive = null, $spec = null)
     {
         $arguments = array (
-            'command' => 'run'
+            'command' => 'run',
+            'spec' => $spec
         );
 
         if ($formatter) {

--- a/features/runner/developer_runs_specs_with_spec_path.feature
+++ b/features/runner/developer_runs_specs_with_spec_path.feature
@@ -1,0 +1,52 @@
+Feature: Developer runs specs with the given specs path configured to be the same as source path
+  As a Developer
+  I want to run the specs from given directory
+  In order to get feedback on a state of requested part of my application
+
+  Scenario: Reporting success when running a spec with correctly implemented class, passing spec path as an argument
+    Given the config file contains:
+      """
+      suites:
+        code_generator_suite:
+          namespace: Runner\SpecPathExample
+          psr4_prefix: Runner\SpecPathExample
+          src_path: src/Runner/SpecPathExample
+          spec_path: src/Runner/SpecPathExample
+
+      """
+    And the spec file "src/Runner/SpecPathExample/spec/MarkdownSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\SpecPathExample;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class MarkdownSpec extends ObjectBehavior
+      {
+          function it_converts_plain_text_to_html_paragraphs()
+          {
+              $this->toHtml('Hi, there')->shouldReturn('<p>Hi, there</p>');
+          }
+      }
+
+      """
+    And the class file "src/Runner/SpecPathExample/Markdown.php" contains:
+      """
+      <?php
+
+      namespace Runner\SpecPathExample;
+
+      class Markdown
+      {
+          public function toHtml($text)
+          {
+              return sprintf('<p>%s</p>', $text);
+          }
+      }
+
+      """
+    When I run phpspec with "src/Runner/SpecPathExample/spec" specs to run
+    Then 1 example should have been run
+    And the suite should pass

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -181,6 +181,10 @@ class PSR0Locator implements ResourceLocatorInterface
             $path .= $sepr;
         }
 
+        if ($path && 0 === strpos($path, $this->fullSpecPath)) {
+            return $this->findSpecResources($path);
+        }
+
         if ($path && 0 === strpos($path, $this->fullSrcPath)) {
             $path = $this->fullSpecPath.substr($path, strlen($this->fullSrcPath));
             $path = preg_replace('/\.php/', 'Spec.php', $path);
@@ -192,10 +196,6 @@ class PSR0Locator implements ResourceLocatorInterface
             $path = $this->fullSpecPath.substr($path, strlen($this->srcPath));
             $path = preg_replace('/\.php/', 'Spec.php', $path);
 
-            return $this->findSpecResources($path);
-        }
-
-        if ($path && 0 === strpos($path, $this->specPath)) {
             return $this->findSpecResources($path);
         }
 


### PR DESCRIPTION
This PR tries to solve issue https://github.com/phpspec/phpspec/issues/792 
Basically when user configured `spec_path` to be the same as `src_path` and tried to run `phpspec spec-path` he got a message: 
```
0 specs
0 examples 
0ms
```
while running simply `phpspec` without any argument, specs were run.