### PR TITLE
Use environment variable for home directory, instead of the server superglobal.

### DIFF
--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -291,7 +291,7 @@ class ContainerAssembler
         if (!empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
             $home = $_SERVER['HOMEDRIVE'].$_SERVER['HOMEPATH'];
         } else {
-            $home = $_SERVER['HOME'];
+            $home = getenv('HOME');
         }
 
         $container->setParam('code_generator.templates.paths', array(


### PR DESCRIPTION
This should fix issue #760 (and issue #227) where PR #206 doesn't.

Interestingly, it is already being used by the [Application class](https://github.com/phpspec/phpspec/blob/af867af3105c5292083263eeca9310a14e1f34d4/src/PhpSpec/Console/Application.php#L176).
