### PR TITLE
Use AppVeyor for continuous integration on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,50 @@
+build: false
+shallow_clone: true
+platform: x86
+clone_folder: c:\projects\phpspec
+
+environment:
+    matrix:
+        - PHP_DOWNLOAD_FILE: php-5.6.14-nts-Win32-VC11-x86.zip
+
+matrix:
+    allow_failures:
+        - PHP_DOWNLOAD_FILE: php-5.6.14-nts-Win32-VC11-x86.zip
+
+skip_commits:
+    message: /\[ci skip\]/
+
+cache:
+    - c:\php -> appveyor.yml
+    - '%LOCALAPPDATA%\Composer'
+    - vendor
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+
+install:
+    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+    - cd c:\php
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
+    - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - copy php.ini-production php.ini /Y
+    - echo date.timezone="UTC" >> php.ini
+    - echo extension_dir=ext >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_curl.dll >> php.ini
+    - echo extension=php_mbstring.dll >> php.ini
+    - echo extension=php_fileinfo.dll >> php.ini
+    - cd c:\projects\phpspec
+    - SET COMPOSER_ROOT_VERSION=dev-master
+    - composer update --no-progress --ansi
+
+test_script:
+    - cd c:\projects\phpspec
+    - php bin\phpspec run --format=pretty
+    - php vendor\phpunit\phpunit\phpunit --testdox
+    - php vendor\behat\behat\bin\behat --format=pretty --tags="~@php-version,@php5.4"


### PR DESCRIPTION
I thought there might be some benefits to testing PhpSpec on Windows. However, most of the failing test cases will most likely involve strict differences in how Windows works to Unix, but not necessarily cause blockers in the application - these being for example line endings or directory separators.

Here's what the output looks like: https://ci.appveyor.com/project/archfizz/phpspec/build/1.0.5/job/99y8hxkfbb42gvrt
If there's value in having this, then I can continue working on it.