### PR TITLE
Reads from stderr or stdout for new fatal message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_script:
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty --tags '~@php-version'`php php_version_tags.php`
+   - ./vendor/bin/behat --format=pretty --strict --tags '~@php-version'`php php_version_tags.php`

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
 before_script:
-  - echo "<?php if (PHP_VERSION_ID >= 50400) echo ',@php5.4'; if (PHP_VERSION_ID >= 70000) echo ',@php7';" > php_version_tags.php
+  - echo "<?php if (PHP_VERSION_ID >= 50400) echo ',@php5.4'; if (PHP_VERSION_ID >= 70000) echo ',@php7'; if (defined('HHVM_VERSION')) echo ',@hhvm';" > php_version_tags.php
 
 script:
    - bin/phpspec run --format=pretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_script:
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty --strict --tags '~@php-version'`php php_version_tags.php`
+   - ./vendor/bin/behat --format=pretty --tags '~@php-version'`php php_version_tags.php`

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
 before_script:
-  - echo "<?php if (PHP_VERSION_ID >= 50400) echo ',@php5.4'; if (PHP_VERSION_ID >= 70000) echo ',@php7'; if (defined('HHVM_VERSION')) echo ',@hhvm';" > php_version_tags.php
+  - echo "<?php if (defined('HHVM_VERSION')) { echo ',@hhvm'; } else { if (PHP_VERSION_ID >= 50400) echo ',@php5.4'; if (PHP_VERSION_ID >= 70000) echo ',@php7'; }" > php_version_tags.php
 
 script:
    - bin/phpspec run --format=pretty

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -96,12 +96,6 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
-        if (defined('HHVM_VERSION')) {
-            var_dump(PHP_VERSION_ID);
-            var_dump(PHP_VERSION);
-            var_dump(PHP_RELEASE_VERSION);
-        }
-
         $this->lastOutput = $process->getErrorOutput();
 
     }

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -96,7 +96,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
-        $this->lastOutput = defined('HHVM_VERSION') ? $process->getOutput() : $process->getErrorOutput();
+        $this->lastOutput = $process->getErrorOutput();
 
     }
 

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -100,18 +100,6 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     }
 
     /**
-     * @When I run phpspec with the :formatter formatter on hhvm
-     */
-    public function iRunPhpspecWithTheFormatterOnHhvm($formatter)
-    {
-        $process = new Process(
-            $this->buildPhpSpecCmd() . " --format=$formatter run"
-        );
-        $process->run();
-        $this->lastOutput = $process->getOutput();
-    }
-
-    /**
      * @Then I should see :message
      */
     public function iShouldSee($message)

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -96,6 +96,12 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
+        if (defined('HHVM_VERSION')) {
+            var_dump(PHP_VERSION_ID);
+            var_dump(PHP_VERSION);
+            var_dump(PHP_RELEASE_VERSION);
+        }
+
         $this->lastOutput = $process->getErrorOutput();
 
     }

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -81,7 +81,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     public function iRunPhpspec()
     {
         $process = new Process(
-            $this->buildPhpSpecCmd() . ' run 2>&1'
+            $this->buildPhpSpecCmd() . ' run'
         );
         $process->run();
         $this->lastOutput = $process->getOutput();
@@ -93,7 +93,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     public function iRunPhpspecWithThe($formatter)
     {
         $process = new Process(
-            $this->buildPhpSpecCmd() . " --format=$formatter run 1>&2"
+            $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
         $this->lastOutput = $process->getErrorOutput();

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -81,7 +81,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     public function iRunPhpspec()
     {
         $process = new Process(
-            $this->buildPhpSpecCmd() . ' run'
+            $this->buildPhpSpecCmd() . ' run 2>&1'
         );
         $process->run();
         $this->lastOutput = $process->getOutput();
@@ -93,7 +93,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     public function iRunPhpspecWithThe($formatter)
     {
         $process = new Process(
-            $this->buildPhpSpecCmd() . " --format=$formatter run"
+            $this->buildPhpSpecCmd() . " --format=$formatter run 1>&2"
         );
         $process->run();
         $this->lastOutput = $process->getErrorOutput();

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -101,6 +101,19 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @When I run phpspec on HHVM with the :formatter formatter
+     */
+    public function iRunPhpspecOnHhvmWithThe($formatter)
+    {
+        $process = new Process(
+            $this->buildPhpSpecCmd() . " --format=$formatter run"
+        );
+        $process->run();
+        $this->lastOutput = $process->getOutput();
+
+    }
+
+    /**
      * @Then I should see :message
      */
     public function iShouldSee($message)

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -96,10 +96,19 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
-        var_dump('-STDOUT-' . $process->getOutput());
-        var_dump('-STDERR-' . $process->getErrorOutput());
-
         $this->lastOutput = $process->getErrorOutput();
+    }
+
+    /**
+     * @When I run phpspec with the :formatter formatter on hhvm
+     */
+    public function iRunPhpspecWithTheFormatterOnHhvm($formatter)
+    {
+        $process = new Process(
+            $this->buildPhpSpecCmd() . " --format=$formatter run"
+        );
+        $process->run();
+        $this->lastOutput = $process->getOutput();
     }
 
     /**

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -96,7 +96,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
-        $this->lastOutput = $process->getOutput();
+        $this->lastOutput = $process->getErrorOutput();
     }
 
     /**

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -96,7 +96,8 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
-        $this->lastOutput = $process->getErrorOutput();
+        $this->lastOutput = defined('HHVM_VERSION') ? $process->getOutput() : $process->getErrorOutput();
+
     }
 
     /**

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -96,6 +96,9 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
+        var_dump('-STDOUT-' . $process->getOutput());
+        var_dump('-STDERR-' . $process->getErrorOutput());
+
         $this->lastOutput = $process->getErrorOutput();
     }
 

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -44,7 +44,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     Then I should see "Fatal error happened while executing the following"
     And  I should see "it fatals when calling an undeclared function"
 
-  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7 @hhvm
+  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """
@@ -82,4 +82,44 @@ Feature: Developer is notified of which scenario caused a fatal error
 
       """
     When I run phpspec with the "junit" formatter
+    Then I should see "Call to undefined function"
+
+  @isolated @php-version @hhvm
+  Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stdout for hhvm.
+    Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
+    """
+      <?php
+
+      namespace spec\Message\Fatal;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class Fatal2Spec extends ObjectBehavior
+      {
+          function it_fatals_when_calling_an_undeclared_function()
+          {
+              anything();
+          }
+      }
+
+      """
+    And the class file "src/Message/Fatal/Fatal2.php" contains:
+    """
+      <?php
+
+      namespace Message\Fatal;
+
+      class Fatal2
+      {
+          public function __construct($param)
+          {
+              if ($param == 'throw') {
+                  throw new \Exception();
+              }
+          }
+      }
+
+      """
+    When I run phpspec with the "junit" formatter on hhvm
     Then I should see "Call to undefined function"

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -44,7 +44,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     Then I should see "Fatal error happened while executing the following"
     And  I should see "it fatals when calling an undeclared function"
 
-  @isolated
+  @isolated @hhvm
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -83,3 +83,44 @@ Feature: Developer is notified of which scenario caused a fatal error
       """
     When I run phpspec with the "junit" formatter
     Then I should see "Call to undefined function"
+
+
+  @isolated @hhvm
+  Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stdout.
+    Given the spec file "spec/Message/Fatal/FatalHhvmSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Message\Fatal;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class FatalHhvmSpec extends ObjectBehavior
+      {
+          function it_fatals_when_calling_an_undeclared_function()
+          {
+              anything();
+          }
+      }
+
+      """
+    And the class file "src/Message/Fatal/FatalHhvm.php" contains:
+      """
+      <?php
+
+      namespace Message\Fatal;
+
+      class FatalHhvm
+      {
+          public function __construct($param)
+          {
+              if ($param == 'throw') {
+                  throw new \Exception();
+              }
+          }
+      }
+
+      """
+    When I run phpspec on HHVM with the "junit" formatter
+    Then I should see "Call to undefined function"

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -44,7 +44,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     Then I should see "Fatal error happened while executing the following"
     And  I should see "it fatals when calling an undeclared function"
 
-  @isolated @hhvm
+  @isolated @php-version @php5.4 @php7
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -4,7 +4,7 @@ Feature: Developer is notified of which scenario caused a fatal error
   So that I can better trace where my changes caused a fatal error
 
   @isolated
-  Scenario: Spec attempts to call an undeclared function
+  Scenario: Spec attempts to call an undeclared function and outputs to stdout
     Given the spec file "spec/Message/Fatal/FatalSpec.php" contains:
       """
       <?php
@@ -45,7 +45,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     And  I should see "it fatals when calling an undeclared function"
 
   @isolated
-  Scenario: Fatal error writer message not shown when formatter does not support it
+  Scenario: Fatal error writer message not shown when formatter does not support it outputs to stderr
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """
       <?php

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -83,11 +83,11 @@ Feature: Developer is notified of which scenario caused a fatal error
       """
     When I run phpspec with the "junit" formatter
     Then I should see "Call to undefined function"
-
-  @isolated @hhvm
+  
+	@isolated @php-version @hhvm
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stdout for hhvm.
-    Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
-    """
+    Given the spec file "spec/Message/Fatal/FatalHhvmSpec.php" contains:
+      """
       <?php
 
       namespace spec\Message\Fatal;
@@ -95,7 +95,7 @@ Feature: Developer is notified of which scenario caused a fatal error
       use PhpSpec\ObjectBehavior;
       use Prophecy\Argument;
 
-      class Fatal2Spec extends ObjectBehavior
+      class FatalHhvmSpec extends ObjectBehavior
       {
           function it_fatals_when_calling_an_undeclared_function()
           {
@@ -104,13 +104,13 @@ Feature: Developer is notified of which scenario caused a fatal error
       }
 
       """
-    And the class file "src/Message/Fatal/Fatal2.php" contains:
-    """
+    And the class file "src/Message/Fatal/FatalHhvm.php" contains:
+      """
       <?php
 
       namespace Message\Fatal;
 
-      class Fatal2
+      class FatalHhvm
       {
           public function __construct($param)
           {

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -84,7 +84,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     When I run phpspec with the "junit" formatter
     Then I should see "Call to undefined function"
 
-  @isolated @php-version @hhvm
+  @isolated @hhvm
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stdout for hhvm.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
     """

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -44,7 +44,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     Then I should see "Fatal error happened while executing the following"
     And  I should see "it fatals when calling an undeclared function"
 
-  @isolated
+  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -44,8 +44,8 @@ Feature: Developer is notified of which scenario caused a fatal error
     Then I should see "Fatal error happened while executing the following"
     And  I should see "it fatals when calling an undeclared function"
 
-  @isolated
-  Scenario: Fatal error writer message not shown when formatter does not support it outputs to stderr
+  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7 @hhvm
+  Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """
       <?php

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -44,7 +44,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     Then I should see "Fatal error happened while executing the following"
     And  I should see "it fatals when calling an undeclared function"
 
-  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
+  @isolated
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """
@@ -82,44 +82,4 @@ Feature: Developer is notified of which scenario caused a fatal error
 
       """
     When I run phpspec with the "junit" formatter
-    Then I should see "Call to undefined function"
-  
-	@isolated @php-version @hhvm
-  Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stdout for hhvm.
-    Given the spec file "spec/Message/Fatal/FatalHhvmSpec.php" contains:
-      """
-      <?php
-
-      namespace spec\Message\Fatal;
-
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
-
-      class FatalHhvmSpec extends ObjectBehavior
-      {
-          function it_fatals_when_calling_an_undeclared_function()
-          {
-              anything();
-          }
-      }
-
-      """
-    And the class file "src/Message/Fatal/FatalHhvm.php" contains:
-      """
-      <?php
-
-      namespace Message\Fatal;
-
-      class FatalHhvm
-      {
-          public function __construct($param)
-          {
-              if ($param == 'throw') {
-                  throw new \Exception();
-              }
-          }
-      }
-
-      """
-    When I run phpspec with the "junit" formatter on hhvm
     Then I should see "Call to undefined function"

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -44,7 +44,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     Then I should see "Fatal error happened while executing the following"
     And  I should see "it fatals when calling an undeclared function"
 
-  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
+  @isolated
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -3,7 +3,7 @@ Feature: Developer is shown a parse error
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
-  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
+  @isolated
   Scenario: Spec attempts to call an undeclared function and outputs to stderr
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -39,7 +39,7 @@ Feature: Developer is shown a parse error
       }
 
       """
-    When I run phpspec
+    When I run phpspec with the "progress" formatter
     Then I should see "syntax error"
 
   @isolated @php-version @hhvm

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -1,4 +1,4 @@
-@isolated
+@isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
 Feature: Developer is shown a parse error
   As a Developer
   I want to know if a parse error was thrown
@@ -26,6 +26,45 @@ Feature: Developer is shown a parse error
       """
     And the spec file "src/Message/Fatal/Parse.php" contains:
       """
+      <?php
+
+      namespace Message\Parse;
+
+      class Parse
+      {
+          public function cool()
+          {
+              return true;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see "syntax error"
+
+  @isolated @php-version @hhvm
+  Scenario: Spec attempts to call an undeclared function and outputs to stdout on hhvm
+    Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
+    """
+      <?php
+
+      namespace spec\Message\Fatal;
+
+      use Parse;
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class ParseSpec extends ObjectBehavior
+      {
+          function it_thro ws_a_syntax_error()
+          {
+              $this->cool();
+          }
+      }
+
+      """
+    And the spec file "src/Message/Fatal/Parse.php" contains:
+    """
       <?php
 
       namespace Message\Parse;

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -4,7 +4,7 @@ Feature: Developer is shown a parse error
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
-  Scenario: Spec attempts to call an undeclared function
+  Scenario: Spec attempts to call an undeclared function and outputs to stderr
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """
       <?php

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -3,7 +3,7 @@ Feature: Developer is shown a parse error
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
-  @isolated
+  @isolated @php-version @php5.4 @php7
   Scenario: Spec attempts to call an undeclared function and outputs to stderr
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -42,7 +42,7 @@ Feature: Developer is shown a parse error
     When I run phpspec with the "junit" formatter
     Then I should see "syntax error"
 
-  @isolated @php-version @hhvm
+  @isolated @hhvm
   Scenario: Spec attempts to call an undeclared function and outputs to stdout on hhvm
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
     """
@@ -81,7 +81,7 @@ Feature: Developer is shown a parse error
     When I run phpspec with the "junit" formatter on hhvm
     Then I should see "syntax error"
 
-  @isolated @php-version @hhvm
+  @isolated @hhvm
   Scenario: Spec attempts to call an undeclared function and outputs to stdout on hhvm
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
     """

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -41,3 +41,42 @@ Feature: Developer is shown a parse error
       """
     When I run phpspec with the "junit" formatter
     Then I should see "syntax error"
+
+  @isolated @hhvm
+  Scenario: Spec attempts to call an undeclared function and outputs to stdout
+    Given the spec file "spec/Message/Fatal/ParseHhvmSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Message\Fatal;
+
+      use Parse;
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class ParseHhvmSpec extends ObjectBehavior
+      {
+          function it_thro ws_a_syntax_error()
+          {
+              $this->cool();
+          }
+      }
+
+      """
+    And the spec file "src/Message/Fatal/ParseHhvm.php" contains:
+      """
+      <?php
+
+      namespace Message\Parse;
+
+      class ParseHhvm
+      {
+          public function cool()
+          {
+              return true;
+          }
+      }
+
+      """
+    When I run phpspec on HHVM with the "junit" formatter
+    Then I should see "syntax error"

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -1,9 +1,9 @@
-@isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
 Feature: Developer is shown a parse error
   As a Developer
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
+  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
   Scenario: Spec attempts to call an undeclared function and outputs to stderr
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """
@@ -39,7 +39,7 @@ Feature: Developer is shown a parse error
       }
 
       """
-    When I run phpspec with the "progress" formatter
+    When I run phpspec with the "junit" formatter
     Then I should see "syntax error"
 
   @isolated @php-version @hhvm

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -3,7 +3,7 @@ Feature: Developer is shown a parse error
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
-  @isolated
+  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
   Scenario: Spec attempts to call an undeclared function and outputs to stderr
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """
@@ -40,6 +40,45 @@ Feature: Developer is shown a parse error
 
       """
     When I run phpspec with the "junit" formatter
+    Then I should see "syntax error"
+
+  @isolated @php-version @hhvm
+  Scenario: Spec attempts to call an undeclared function and outputs to stdout on hhvm
+    Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
+    """
+      <?php
+
+      namespace spec\Message\Fatal;
+
+      use Parse;
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class ParseSpec extends ObjectBehavior
+      {
+          function it_thro ws_a_syntax_error()
+          {
+              $this->cool();
+          }
+      }
+
+      """
+    And the spec file "src/Message/Fatal/Parse.php" contains:
+    """
+      <?php
+
+      namespace Message\Parse;
+
+      class Parse
+      {
+          public function cool()
+          {
+              return true;
+          }
+      }
+
+      """
+    When I run phpspec with the "junit" formatter on hhvm
     Then I should see "syntax error"
 
   @isolated @php-version @hhvm

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -3,7 +3,7 @@ Feature: Developer is shown a parse error
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
-  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
+  @isolated @php-version @php5.3 @php5.4 @hhvm
   Scenario: Spec attempts to call an undeclared function and outputs to stderr
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """
@@ -40,82 +40,4 @@ Feature: Developer is shown a parse error
 
       """
     When I run phpspec with the "junit" formatter
-    Then I should see "syntax error"
-
-  @isolated @hhvm
-  Scenario: Spec attempts to call an undeclared function and outputs to stdout on hhvm
-    Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
-    """
-      <?php
-
-      namespace spec\Message\Fatal;
-
-      use Parse;
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
-
-      class ParseSpec extends ObjectBehavior
-      {
-          function it_thro ws_a_syntax_error()
-          {
-              $this->cool();
-          }
-      }
-
-      """
-    And the spec file "src/Message/Fatal/Parse.php" contains:
-    """
-      <?php
-
-      namespace Message\Parse;
-
-      class Parse
-      {
-          public function cool()
-          {
-              return true;
-          }
-      }
-
-      """
-    When I run phpspec with the "junit" formatter on hhvm
-    Then I should see "syntax error"
-
-  @isolated @hhvm
-  Scenario: Spec attempts to call an undeclared function and outputs to stdout on hhvm
-    Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
-    """
-      <?php
-
-      namespace spec\Message\Fatal;
-
-      use Parse;
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
-
-      class ParseSpec extends ObjectBehavior
-      {
-          function it_thro ws_a_syntax_error()
-          {
-              $this->cool();
-          }
-      }
-
-      """
-    And the spec file "src/Message/Fatal/Parse.php" contains:
-    """
-      <?php
-
-      namespace Message\Parse;
-
-      class Parse
-      {
-          public function cool()
-          {
-              return true;
-          }
-      }
-
-      """
-    When I run phpspec
     Then I should see "syntax error"

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -3,7 +3,7 @@ Feature: Developer is shown a parse error
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
-  @isolated @php-version @php5.3 @php5.4 @hhvm
+  @isolated @php-version @php5.3 @php5.4 @php5.5 @php5.6 @php7
   Scenario: Spec attempts to call an undeclared function and outputs to stderr
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -99,7 +99,7 @@ class ConsoleFormatter extends BasicFormatter implements FatalPresenter
             (null !== $error && $currentExample->getCurrentExample()) ||
             (is_null($currentExample->getCurrentExample()) && defined('HHVM_VERSION'))
         ) {
-            ini_set('display_errors', "stdout");
+            ini_set('display_errors', "stderr");
             $failedOpen = ($this->io->isDecorated()) ? '<failed>' : '';
             $failedClosed = ($this->io->isDecorated()) ? '</failed>' : '';
             $failedCross = ($this->io->isDecorated()) ? '✘' : '';

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -99,7 +99,7 @@ class ConsoleFormatter extends BasicFormatter implements FatalPresenter
             (null !== $error && $currentExample->getCurrentExample()) ||
             (is_null($currentExample->getCurrentExample()) && defined('HHVM_VERSION'))
         ) {
-            ini_set('display_errors', 0);
+            ini_set('display_errors', 'stdout');
             $failedOpen = ($this->io->isDecorated()) ? '<failed>' : '';
             $failedClosed = ($this->io->isDecorated()) ? '</failed>' : '';
             $failedCross = ($this->io->isDecorated()) ? '✘' : '';

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -99,7 +99,7 @@ class ConsoleFormatter extends BasicFormatter implements FatalPresenter
             (null !== $error && $currentExample->getCurrentExample()) ||
             (is_null($currentExample->getCurrentExample()) && defined('HHVM_VERSION'))
         ) {
-            ini_set('display_errors', 'stdout');
+            ini_set('display_errors', "stderr");
             $failedOpen = ($this->io->isDecorated()) ? '<failed>' : '';
             $failedClosed = ($this->io->isDecorated()) ? '</failed>' : '';
             $failedCross = ($this->io->isDecorated()) ? '✘' : '';

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -99,7 +99,7 @@ class ConsoleFormatter extends BasicFormatter implements FatalPresenter
             (null !== $error && $currentExample->getCurrentExample()) ||
             (is_null($currentExample->getCurrentExample()) && defined('HHVM_VERSION'))
         ) {
-            ini_set('display_errors', "stderr");
+            ini_set('display_errors', "stdout");
             $failedOpen = ($this->io->isDecorated()) ? '<failed>' : '';
             $failedClosed = ($this->io->isDecorated()) ? '</failed>' : '';
             $failedCross = ($this->io->isDecorated()) ? '✘' : '';

--- a/src/PhpSpec/Process/Shutdown/Shutdown.php
+++ b/src/PhpSpec/Process/Shutdown/Shutdown.php
@@ -24,6 +24,7 @@ final class Shutdown
 
     public function registerShutdown()
     {
+        ini_set('display_errors', "stderr");
         error_reporting(error_reporting() & ~E_ERROR);
         register_shutdown_function(array($this, 'runShutdown'));
     }

--- a/src/PhpSpec/Process/Shutdown/Shutdown.php
+++ b/src/PhpSpec/Process/Shutdown/Shutdown.php
@@ -24,7 +24,6 @@ final class Shutdown
 
     public function registerShutdown()
     {
-        ini_set('display_errors', "stderr");
         error_reporting(error_reporting() & ~E_ERROR);
         register_shutdown_function(array($this, 'runShutdown'));
     }


### PR DESCRIPTION
Isolated Context now reads from ErrorOutput for formatters that do not use the Fatal Presenter and StdOutput for the new Fatal Error message.