### PR TITLE
[WIP] Added new interface and one implementation for discussion

### DIFF
--- a/src/PhpSpec/Matcher/MatcherInterface.php
+++ b/src/PhpSpec/Matcher/MatcherInterface.php
@@ -50,4 +50,12 @@ interface MatcherInterface
      * @return integer
      */
     public function getPriority();
+
+    /**
+     * Returns an array of matcher names this implementation can provide
+     *
+     * @return array
+     */
+    public function providesMatchers();
+
 }

--- a/src/PhpSpec/Matcher/TypeMatcher.php
+++ b/src/PhpSpec/Matcher/TypeMatcher.php
@@ -96,4 +96,12 @@ class TypeMatcher extends BasicMatcher
             $this->presenter->presentValue($subject)
         ));
     }
+
+    /***
+     * @return array
+     */
+    public function providesMatchers()
+    {
+        return self::$keywords;
+    }
 }


### PR DESCRIPTION
This is literally to provoke discussion on a proposed change.

I've been in discussion with @ciaranmcnulty and @MarcelloDuarte about improving PhpSpec's integration with IDEs, specifically with PhpStorm. PhpStorm uses stub files to tell the IDE what to code complete on when it can't be inferred from the dependency tree, typically this is because of magic methods.

The specific problem I'm looking to address initially is code completion in the spec file on matchers.  In order to do this, we need to be able to programmatically generate a list of matchers that are available at any given time. At the moment I don't see any predictable way of generating this list, some matchers have class constants, some have hard coded arrays etc, so I'm proposing that we add a new method to the `MatcherInterface` that exposes the keywords that this matcher can handle.

This PR gives an example of this new interface method, along with one sample implementation in a matcher. 