### PR TITLE
Do not remove typehints not related to specs

### DIFF
--- a/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
@@ -70,6 +70,31 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ');
     }
 
+    function it_removes_typehints_from_single_argument_methods_that_starts_with_its()
+    {
+        $this->rewrite('
+        <?php
+
+        class Foo
+        {
+            public function its_do_bar(\Foo\Bar $bar)
+            {
+            }
+        }
+
+        ')->shouldReturn('
+        <?php
+
+        class Foo
+        {
+            public function its_do_bar($bar)
+            {
+            }
+        }
+
+        ');
+    }
+
     function it_removes_typehints_for_multiple_arguments_in_methods()
     {
         $this->rewrite('

--- a/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
@@ -27,7 +27,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar()
+            public function it_do_bar()
             {
             }
         }
@@ -37,7 +37,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar()
+            public function it_do_bar()
             {
             }
         }
@@ -52,7 +52,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar(\Foo\Bar $bar)
+            public function it_do_bar(\Foo\Bar $bar)
             {
             }
         }
@@ -62,7 +62,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar($bar)
+            public function it_do_bar($bar)
             {
             }
         }
@@ -77,7 +77,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar(Bar $bar, Baz $baz)
+            public function it_do_bar(Bar $bar, Baz $baz)
             {
             }
         }
@@ -87,8 +87,41 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar($bar,$baz)
+            public function it_do_bar($bar,$baz)
             {
+            }
+        }
+
+        ');
+    }
+
+    function it_do_not_removes_type_hints_of_a_function_that_do_not_starts_with_it()
+    {
+        $this->rewrite('
+        <?php
+
+        class Foo
+        {
+            public function it_do_bar(Bar $bar, Baz $baz)
+            {
+                new class($argument) implements InterfaceName
+                {
+                    public function foo(Foo $foo) {}
+                };
+            }
+        }
+
+        ')->shouldReturn('
+        <?php
+
+        class Foo
+        {
+            public function it_do_bar($bar,$baz)
+            {
+                new class($argument) implements InterfaceName
+                {
+                    public function foo(Foo $foo) {}
+                };
             }
         }
 
@@ -108,15 +141,15 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar(Foo\Bar $bar, Baz $baz)
+            public function it_do_bar(Foo\Bar $bar, Baz $baz)
             {
             }
         }
 
         ');
 
-        $typeHintIndex->add('Foo', 'bar', '$bar', 'Foo\Bar')->shouldHaveBeenCalled();
-        $typeHintIndex->add('Foo', 'bar', '$baz', 'Baz')->shouldHaveBeenCalled();
+        $typeHintIndex->add('Foo', 'it_do_bar', '$bar', 'Foo\Bar')->shouldHaveBeenCalled();
+        $typeHintIndex->add('Foo', 'it_do_bar', '$baz', 'Baz')->shouldHaveBeenCalled();
     }
 
     function it_indexes_invalid_typehints(
@@ -134,14 +167,14 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar(int $bar)
+            public function it_do_bar(int $bar)
             {
             }
         }
 
         ');
 
-        $typeHintIndex->addInvalid('Foo', 'bar', '$bar', $e)->shouldHaveBeenCalled();
-        $typeHintIndex->add('Foo', 'bar', '$bar', Argument::any())->shouldNotHaveBeenCalled();
+        $typeHintIndex->addInvalid('Foo', 'it_do_bar', '$bar', $e)->shouldHaveBeenCalled();
+        $typeHintIndex->add('Foo', 'it_do_bar', '$bar', Argument::any())->shouldNotHaveBeenCalled();
     }
 }

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -182,7 +182,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
      */
     private function functionShouldBeRead(array $tokens, $index)
     {
-        return strpos($this->getFunctionName($tokens, $index), 'it_') === 0;
+        return preg_match('/^(it|its)[^a-zA-Z]/', $this->getFunctionName($tokens, $index));
     }
 
     /**

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -102,7 +102,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                     if ($this->tokenHasType($token, T_STRING) && !$this->currentClass) {
                         $this->currentClass = $token[1];
                     }
-                    elseif($this->tokenHasType($token, T_FUNCTION)) {
+                    elseif($this->tokenHasType($token, T_FUNCTION) && $this->functionShouldBeRead($tokens, $index)) {
                         $this->state = self::STATE_READING_FUNCTION;
                     }
                     break;
@@ -170,5 +170,39 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     private function tokenHasType($token, $type)
     {
         return is_array($token) && $type == $token[0];
+    }
+
+    /**
+     * Returns true if the function should be read with the rewriter.
+     *
+     * @param array $tokens
+     * @param int $index
+     *
+     * @return bool
+     */
+    private function functionShouldBeRead(array $tokens, $index)
+    {
+        return strpos($this->getFunctionName($tokens, $index), 'it_') === 0;
+    }
+
+    /**
+     * Return name of the function at this index.
+     *
+     * @param array $tokens
+     * @param int $index
+     *
+     * @return string|null
+     */
+    private function getFunctionName(array $tokens, $index)
+    {
+        for (; $index < count($tokens); $index++) {
+            $token = $tokens[$index];
+
+            if ($this->tokenHasType($token, T_STRING)) {
+                return $token[1];
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This PR aims to fix #813. The rewriter do not removes the typehints of non-spec methods.

It might be interesting to merge the method selection with the one which is in the [ResourceLoader](https://github.com/phpspec/phpspec/blob/master/src/PhpSpec/Loader/ResourceLoader.php#L69).