### PR TITLE
Do not remove typehints inside a method definition

### DIFF
--- a/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
@@ -70,6 +70,39 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ');
     }
 
+    function it_do_not_remove_typehints_in_methods()
+    {
+        $this->rewrite('
+        <?php
+
+        class Foo
+        {
+            public function bar(\Foo\Bar $bar)
+            {
+                new class($argument) implements InterfaceName
+                {
+                    public function foo(Foo $foo) {}
+                };
+            }
+        }
+
+        ')->shouldReturn('
+        <?php
+
+        class Foo
+        {
+            public function bar($bar)
+            {
+                new class($argument) implements InterfaceName
+                {
+                    public function foo(Foo $foo) {}
+                };
+            }
+        }
+
+        ');
+    }
+
     function it_removes_typehints_for_multiple_arguments_in_methods()
     {
         $this->rewrite('

--- a/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
@@ -70,7 +70,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ');
     }
 
-    function it_do_not_remove_typehints_in_methods()
+    function it_does_not_remove_typehints_in_methods()
     {
         $this->rewrite('
         <?php

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -84,7 +84,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
             switch ($this->state) {
                 case self::STATE_READING_ARGUMENTS:
                     if (')' == $token) {
-                        $this->state = self::STATE_READING_FUNCTION_BODY;
+                        $this->state = self::STATE_READING_CLASS;
                     }
                     elseif ($this->tokenHasType($token, T_VARIABLE)) {
                         $this->extractTypehints($tokens, $index, $token);
@@ -99,7 +99,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                     }
                     break;
                 case self::STATE_READING_CLASS:
-                    if('{' == $token) {
+                    if ('{' == $token && $this->currentFunction) {
                         $this->state = self::STATE_READING_FUNCTION_BODY;
                         $this->currentBodyLevel = 1;
                     }
@@ -117,13 +117,10 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                     elseif ('}' == $token) {
                         $this->currentBodyLevel--;
 
-                        if ($this->currentBodyLevel == 0) {
+                        if ($this->currentBodyLevel === 0) {
                             $this->currentFunction = '';
+                            $this->state = self::STATE_READING_CLASS;
                         }
-                    }
-
-                    if (!$this->currentFunction) {
-                        $this->state = self::STATE_READING_CLASS;
                     }
 
                     break;

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -21,11 +21,13 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     const STATE_READING_CLASS = 1;
     const STATE_READING_FUNCTION = 2;
     const STATE_READING_ARGUMENTS = 3;
+    const STATE_READING_FUNCTION_BODY = 4;
 
     private $state = self::STATE_DEFAULT;
 
     private $currentClass;
     private $currentFunction;
+    private $currentBodyLevel;
 
     private $typehintTokens = array(
         T_WHITESPACE, T_STRING, T_NS_SEPARATOR
@@ -79,12 +81,10 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     private function stripTypeHints($tokens)
     {
         foreach ($tokens as $index => $token) {
-
             switch ($this->state) {
                 case self::STATE_READING_ARGUMENTS:
                     if (')' == $token) {
-                        $this->state = self::STATE_READING_CLASS;
-                        $this->currentFunction = '';
+                        $this->state = self::STATE_READING_FUNCTION_BODY;
                     }
                     elseif ($this->tokenHasType($token, T_VARIABLE)) {
                         $this->extractTypehints($tokens, $index, $token);
@@ -99,12 +99,33 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                     }
                     break;
                 case self::STATE_READING_CLASS:
-                    if ($this->tokenHasType($token, T_STRING) && !$this->currentClass) {
+                    if('{' == $token) {
+                        $this->state = self::STATE_READING_FUNCTION_BODY;
+                        $this->currentBodyLevel = 1;
+                    }
+                    elseif ($this->tokenHasType($token, T_STRING) && !$this->currentClass) {
                         $this->currentClass = $token[1];
                     }
                     elseif($this->tokenHasType($token, T_FUNCTION)) {
                         $this->state = self::STATE_READING_FUNCTION;
                     }
+                    break;
+                case self::STATE_READING_FUNCTION_BODY:
+                    if ('{' == $token) {
+                        $this->currentBodyLevel++;
+                    }
+                    elseif ('}' == $token) {
+                        $this->currentBodyLevel--;
+
+                        if ($this->currentBodyLevel == 0) {
+                            $this->currentFunction = '';
+                        }
+                    }
+
+                    if (!$this->currentFunction) {
+                        $this->state = self::STATE_READING_CLASS;
+                    }
+
                     break;
                 default:
                     if ($this->tokenHasType($token, T_CLASS)) {


### PR DESCRIPTION
This PR fixes #814 by simply not removing typehints found inside a method definition.