### PR TITLE
Fix re-runner on Windows

### DIFF
--- a/spec/PhpSpec/Process/ReRunner/WindowsPassthruRerunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/WindowsPassthruRerunnerSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\PhpSpec\Process\ReRunner;
+
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\Context\ExecutionContextInterface;
+use Prophecy\Argument;
+use Symfony\Component\Process\PhpExecutableFinder;
+
+class WindowsPassthruRerunnerSpec extends ObjectBehavior
+{
+    function let(PhpExecutableFinder $executableFinder, ExecutionContextInterface $executionContext)
+    {
+        $this->beConstructedThrough('withExecutionContext', array($executableFinder, $executionContext));
+    }
+
+    function it_is_a_rerunner()
+    {
+        $this->shouldHaveType('PhpSpec\Process\ReRunner');
+    }
+
+    function it_is_not_supported_when_php_process_is_not_found(PhpExecutableFinder $executableFinder)
+    {
+        $executableFinder->find()->willReturn(false);
+
+        $this->isSupported()->shouldReturn(false);
+    }
+}

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -669,6 +669,12 @@ class ContainerAssembler
                 $c->get('process.executioncontext')
             );
         });
+        $container->setShared('process.rerunner.platformspecific.windowspassthru', function (ServiceContainer $c) {
+            return ReRunner\WindowsPassthruReRunner::withExecutionContext(
+                $c->get('process.phpexecutablefinder'),
+                $c->get('process.executioncontext')
+            );
+        });
         $container->setShared('process.phpexecutablefinder', function () {
             return new PhpExecutableFinder();
         });

--- a/src/PhpSpec/Process/ReRunner/PassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PassthruReRunner.php
@@ -44,7 +44,7 @@ class PassthruReRunner extends PhpExecutableReRunner
         return (php_sapi_name() == 'cli')
             && $this->getExecutablePath()
             && function_exists('passthru')
-            && strtolower(substr(PHP_OS, 0, 3)) != "win";
+            && (stripos(PHP_OS, "win") !== 0);
     }
 
     public function reRunSuite()

--- a/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
@@ -44,7 +44,7 @@ class WindowsPassthruReRunner extends PhpExecutableReRunner
         return (php_sapi_name() == 'cli')
             && $this->getExecutablePath()
             && function_exists('passthru')
-            && strtolower(substr(PHP_OS, 0, 3)) == "win";
+            && (stripos(PHP_OS, "win") === 0);
     }
 
     public function reRunSuite()

--- a/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
@@ -16,7 +16,7 @@ namespace PhpSpec\Process\ReRunner;
 use PhpSpec\Process\Context\ExecutionContextInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
 
-class PassthruReRunner extends PhpExecutableReRunner
+class WindowsPassthruReRunner extends PhpExecutableReRunner
 {
     /**
      * @var ExecutionContextInterface
@@ -44,13 +44,14 @@ class PassthruReRunner extends PhpExecutableReRunner
         return (php_sapi_name() == 'cli')
             && $this->getExecutablePath()
             && function_exists('passthru')
-            && strtolower(substr(PHP_OS, 0, 3)) != "win";
+            && strtolower(substr(PHP_OS, 0, 3)) == "win";
     }
 
     public function reRunSuite()
     {
         $args = $_SERVER['argv'];
-        $command = $this->buildArgString() . escapeshellcmd($this->getExecutablePath()).' '.join(' ', array_map('escapeshellarg', $args));
+        $command = $this->buildArgString() . '"' . $this->getExecutablePath().'" '.join(' ', array_map('escapeshellarg', $args));
+
         passthru($command, $exitCode);
         exit($exitCode);
     }
@@ -60,7 +61,7 @@ class PassthruReRunner extends PhpExecutableReRunner
         $argstring = '';
 
         foreach ($this->executionContext->asEnv() as $key => $value) {
-            $argstring .= $key . '=' . escapeshellarg($value) . ' ';
+            $argstring .= 'SET ' . $key . '=' . $value . ' && ';
         }
 
         return $argstring;


### PR DESCRIPTION
Create a new WindowsPassthruRerunner that fixes the command line on windows & ensure it gets used on windows instead of the standard PassthruRerunner. Fixes #773 

The escapeshellarg and escapeshellcmd calls are removed from the new Windows re-runner as they tend to mangle the JSON and the command on windows. I'm not too sure about doing this - but all the data they escape comes from internal processes which makes me a bit more comfortable about it - though they may not be acceptable of course, and a different solution may be needed.

I had a compounded issue with the fact that there is a space in the path to my PHP executable, which this also fixes.