### PR TITLE
Fix code generation issue on Windows

### DIFF
--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -83,7 +83,7 @@ final class TokenizedCodeWriter implements CodeWriter
      */
     private function insertStringAfterLine($target, $toInsert, $line, $leadingNewline = true)
     {
-        $lines = explode(PHP_EOL, $target);
+        $lines = explode("\n", $target);
         $lastLines = array_slice($lines, $line);
         $toInsert = trim($toInsert, "\n\r");
         if ($leadingNewline) {

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -103,7 +103,7 @@ final class TokenizedCodeWriter implements CodeWriter
     private function insertStringBeforeLine($target, $toInsert, $line)
     {
         $line--;
-        $lines = explode(PHP_EOL, $target);
+        $lines = explode("\n", $target);
         $lastLines = array_slice($lines, $line);
         array_unshift($lastLines, trim($toInsert, "\n\r") . PHP_EOL);
         array_splice($lines, $line, count($lines), $lastLines);


### PR DESCRIPTION
The 'insertStringAfterLine' method first splits the input on the PHP_EOL constant. The trouble with this is that it won't work on systems where git is set up to clone line endings as-is, as PHP_EOL will still evaluate to \r\n and nothing will be split. The method then ends up being inserted at the end of the file, outside the class.

Exploding on "\n" will cover all line-ending cases (though it may leave some extra "\r" characters around in some cases). I'd appreciate some feedback on whether it should then try and trim these extra "\r" characters (if any), or whether it should be joining everything back up with "\n" instead of PHP_EOL or not, but I've just fixed the issue in this PR without consideration to any of that yet.