### PR TITLE
Make underscores have no special meaning when using PSR4 prefix

### DIFF
--- a/spec/PhpSpec/Locator/PSR0/PSR0ResourceSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0ResourceSpec.php
@@ -11,6 +11,8 @@ class PSR0ResourceSpec extends ObjectBehavior
     function let(Locator $locator)
     {
         $this->beConstructedWith(array('usr', 'lib', 'config'), $locator);
+
+        $locator->isPSR4()->willReturn(false);
     }
 
     function it_uses_last_segment_as_name()
@@ -91,5 +93,17 @@ class PSR0ResourceSpec extends ObjectBehavior
         $locator->getSpecNamespace()->willReturn('spec\Local\\');
 
         $this->getSpecClassname()->shouldReturn('spec\Local\usr\lib\configSpec');
+    }
+
+    function it_does_not_split_underscores_when_locator_has_psr4_prefix($locator)
+    {
+        $this->beConstructedWith(array('usr', 'lib', 'config_test'), $locator);
+
+        $locator->getFullSrcPath()->willReturn('/local/');
+        $locator->getFullSpecPath()->willReturn('/local/spec/');
+        $locator->isPSR4()->willReturn(true);
+
+        $this->getSrcFilename()->shouldReturn('/local/usr/lib/config_test.php');
+        $this->getSpecFilename()->shouldReturn('/local/spec/usr/lib/config_testSpec.php');
     }
 }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -167,6 +167,14 @@ class PSR0Locator implements ResourceLocatorInterface
     }
 
     /**
+     * @return boolean
+     */
+    public function isPSR4()
+    {
+        return $this->psr4Prefix !== null;
+    }
+
+    /**
      * @param string $query
      *
      * @return ResourceInterface[]

--- a/src/PhpSpec/Locator/PSR0/PSR0Resource.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Resource.php
@@ -57,6 +57,10 @@ class PSR0Resource implements ResourceInterface
      */
     public function getSrcFilename()
     {
+        if ($this->locator->isPSR4()) {
+            return $this->locator->getFullSrcPath().implode(DIRECTORY_SEPARATOR, $this->parts).'.php';
+        }
+
         $nsParts   = $this->parts;
         $classname = array_pop($nsParts);
         $parts     = array_merge($nsParts, explode('_', $classname));
@@ -88,6 +92,11 @@ class PSR0Resource implements ResourceInterface
      */
     public function getSpecFilename()
     {
+        if ($this->locator->isPSR4()) {
+            return $this->locator->getFullSpecPath().
+                implode(DIRECTORY_SEPARATOR, $this->parts).'Spec.php';
+        }
+
         $nsParts   = $this->parts;
         $classname = array_pop($nsParts);
         $parts     = array_merge($nsParts, explode('_', $classname));


### PR DESCRIPTION
When using PSR4 I noticed that when trying to spec a class like `MyNs\Foo\Bar_V1` it would split the `_` into a dir separator, this does not match the expected behaviour for PSR4 because the significance of the underscore was removed in that PSR.

This PR makes the `PSR0Resource` ignore (not split) underscores in class names when the `psr4Prefix` is used. This could have some BC implications for anyone relying on the splitting when using `psr4Prefix`. I will let you make the call on that one, to me seemed reasonable to follow the PSR spec.

I am new to PHPSpec so I may have broken rules when updating the spec, happy to fix anything bad in there :)