### PR TITLE
Fix BootstrapListener to be most priority listener

### DIFF
--- a/src/PhpSpec/Listener/BootstrapListener.php
+++ b/src/PhpSpec/Listener/BootstrapListener.php
@@ -19,7 +19,7 @@ class BootstrapListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return array('beforeSuite' => 'beforeSuite');
+        return array('beforeSuite' => array('beforeSuite', 1100));
     }
 
     public function beforeSuite()


### PR DESCRIPTION
There is an issue when bootstrap config option is set and some class described
then class is created and phpspec can't autoload it during rerun because of BootstrapListener priority is less then ReRunListener priority.

I know i need to write test for this case, can somebody give me some tips how i can reproduce this case with behat?