### PR TITLE
specify the filename in psr locator exception message

### DIFF
--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -326,7 +326,7 @@ class PSR0LocatorSpec extends ObjectBehavior
         $fs->getFileContents($filePath)->willReturn('no class definition');
         $file->getRealPath()->willReturn($filePath);
 
-        $exception = new \RuntimeException('Spec file does not contains any class definition.');
+        $exception = new \RuntimeException(sprintf('Spec file "%s" does not contains any class definition.', $filePath));
 
         $this->shouldThrow($exception)->duringFindResources($this->srcPath);
     }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -282,7 +282,7 @@ class PSR0Locator implements ResourceLocatorInterface
 
     /**
      * @param $path
-     * 
+     *
      * @return null|string
      */
     private function findSpecClassname($path)
@@ -327,7 +327,7 @@ class PSR0Locator implements ResourceLocatorInterface
         $classname = $this->findSpecClassname($path);
 
         if (null === $classname) {
-            throw new \RuntimeException('Spec file does not contains any class definition.');
+            throw new \RuntimeException(sprintf('Spec file "%s" does not contains any class definition.', $path));
         }
 
         // Remove spec namespace from the begining of the classname.


### PR DESCRIPTION
visual comparison:

before:
![shot](https://cloud.githubusercontent.com/assets/109846/12115521/53c2a5dc-b3b3-11e5-8637-e1bc90d1775d.png)


after:
![shot](https://cloud.githubusercontent.com/assets/109846/12115549/8b4e6946-b3b3-11e5-8615-e68e291932fd.png)


This example uses an extremely long file name, which doesn't help to defend the PR, but anyway :)