### PR TITLE
Grant us the ability to run suites by SuiteName

### DIFF
--- a/spec/PhpSpec/Locator/Suite/SuiteLocatorSpec.php
+++ b/spec/PhpSpec/Locator/Suite/SuiteLocatorSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace spec\PhpSpec\Locator\Suite;
+
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Util\Filesystem;
+
+use SplFileInfo;
+
+class SuiteLocatorSpec extends ObjectBehavior
+{
+    private $srcPath;
+    private $specPath;
+
+    function let( Filesystem $fs )
+    {
+        $this->srcPath  = realpath( __DIR__ . '/../../../../src' );
+        $this->specPath = realpath( __DIR__ . '/../../../../' );
+    }
+
+    function it_is_a_locator()
+    {
+        $this->shouldBeAnInstanceOf( 'PhpSpec\Locator\ResourceLocatorInterface' );
+    }
+
+    function its_priority_is_zero()
+    {
+        $this->getPriority()->shouldReturn( 0 );
+    }
+
+
+    function it_supports_queries_that_use_suite_name( Filesystem $fs, SplFileInfo $file )
+    {
+        $this->beConstructedWith( 'SuiteName', '', 'spec', dirname( __DIR__ ), __DIR__, $fs );
+
+        $this->supportsQuery( 'SuiteName' )->shouldBe( true );
+    }
+
+    function it_returns_an_empty_array_when_suite_name_does_not_exist( Filesystem $fs, SplFileInfo $file )
+    {
+        $this->beConstructedWith( 'SuiteName', '', 'spec', dirname( __DIR__ ), __DIR__, $fs );
+
+        $this->supportsQuery( 'OtherName' )->shouldBe( false );
+    }
+}

--- a/spec/PhpSpec/Locator/Suite/SuiteLocatorSpec.php
+++ b/spec/PhpSpec/Locator/Suite/SuiteLocatorSpec.php
@@ -12,34 +12,34 @@ class SuiteLocatorSpec extends ObjectBehavior
     private $srcPath;
     private $specPath;
 
-    function let( Filesystem $fs )
+    function let(Filesystem $fs)
     {
-        $this->srcPath  = realpath( __DIR__ . '/../../../../src' );
-        $this->specPath = realpath( __DIR__ . '/../../../../' );
+        $this->srcPath = realpath(__DIR__ . '/../../../../src');
+        $this->specPath = realpath(__DIR__ . '/../../../../');
     }
 
     function it_is_a_locator()
     {
-        $this->shouldBeAnInstanceOf( 'PhpSpec\Locator\ResourceLocatorInterface' );
+        $this->shouldBeAnInstanceOf('PhpSpec\Locator\ResourceLocatorInterface');
     }
 
     function its_priority_is_zero()
     {
-        $this->getPriority()->shouldReturn( 0 );
+        $this->getPriority()->shouldReturn(0);
     }
 
 
-    function it_supports_queries_that_use_suite_name( Filesystem $fs, SplFileInfo $file )
+    function it_supports_queries_that_use_suite_name(Filesystem $fs, SplFileInfo $file)
     {
-        $this->beConstructedWith( 'SuiteName', '', 'spec', dirname( __DIR__ ), __DIR__, $fs );
+        $this->beConstructedWith('SuiteName', '', 'spec', dirname(__DIR__), __DIR__, $fs);
 
-        $this->supportsQuery( 'SuiteName' )->shouldBe( true );
+        $this->supportsQuery('SuiteName')->shouldBe(true);
     }
 
-    function it_returns_an_empty_array_when_suite_name_does_not_exist( Filesystem $fs, SplFileInfo $file )
+    function it_returns_an_empty_array_when_suite_name_does_not_exist(Filesystem $fs, SplFileInfo $file)
     {
-        $this->beConstructedWith( 'SuiteName', '', 'spec', dirname( __DIR__ ), __DIR__, $fs );
+        $this->beConstructedWith('SuiteName', '', 'spec', dirname(__DIR__), __DIR__, $fs);
 
-        $this->supportsQuery( 'OtherName' )->shouldBe( false );
+        $this->supportsQuery('OtherName')->shouldBe(false);
     }
 }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -360,6 +360,21 @@ class ContainerAssembler
                 }
 
                 $c->set(
+                    sprintf('locator.locators.%s_suitename', $name ),
+                    function () use( $name, $config ){
+                        return new Locator\Suite\SuiteLocator(
+                            $name,
+                            $config['namespace'],
+                            $config['spec_prefix'],
+                            $config['src_path'],
+                            $config['spec_path'],
+                            null,
+                            $config['psr4_prefix']
+                        );
+                    }
+                );
+
+                $c->set(
                     sprintf('locator.locators.%s_suite', $name),
                     function () use ($config) {
                         return new Locator\PSR0\PSR0Locator(

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -361,7 +361,7 @@ class ContainerAssembler
 
                 $c->set(
                     sprintf('locator.locators.%s_suitename', $name ),
-                    function () use( $name, $config ){
+                    function () use ($name, $config) {
                         return new Locator\Suite\SuiteLocator(
                             $name,
                             $config['namespace'],

--- a/src/PhpSpec/Locator/Suite/SuiteLocator.php
+++ b/src/PhpSpec/Locator/Suite/SuiteLocator.php
@@ -14,48 +14,47 @@
 namespace PhpSpec\Locator\Suite;
 
 use PhpSpec\Locator\PSR0\PSR0Locator;
-use PhpSpec\Locator\ResourceInterface;
 use PhpSpec\Locator\ResourceLocatorInterface;
 use PhpSpec\Util\Filesystem;
-use InvalidArgumentException;
 
 class SuiteLocator extends PSR0Locator implements ResourceLocatorInterface
 {
-    private $suiteName;
+	private $suiteName;
 
-    /**
-     * @param string     $srcNamespace
-     * @param string     $specNamespacePrefix
-     * @param string     $srcPath
-     * @param string     $specPath
-     * @param Filesystem $filesystem
-     * @param string     $psr4Prefix
-     */
-    public function __construct(
-        $name = '',
-        $srcNamespace = '',
-        $specNamespacePrefix = 'spec',
-        $srcPath = 'src',
-        $specPath = '.',
-        Filesystem $filesystem = null,
-        $psr4Prefix = null
-    ) {
-        $this->suiteName = $name;
-        parent::__construct( $srcNamespace, $specNamespacePrefix, $srcPath, $specPath, $filesystem, $psr4Prefix );
-    }
+	/**
+	 * @param string $srcNamespace
+	 * @param string $specNamespacePrefix
+	 * @param string $srcPath
+	 * @param string $specPath
+	 * @param Filesystem $filesystem
+	 * @param string $psr4Prefix
+	 */
+	public function __construct(
+		$name = '',
+		$srcNamespace = '',
+		$specNamespacePrefix = 'spec',
+		$srcPath = 'src',
+		$specPath = '.',
+		Filesystem $filesystem = null,
+		$psr4Prefix = null
+	)
+	{
+		$this->suiteName = $name;
+		parent::__construct( $srcNamespace, $specNamespacePrefix, $srcPath, $specPath, $filesystem, $psr4Prefix );
+	}
 
-    /**
-     * @param string $query
-     *
-     * @return bool
-     */
-    public function supportsQuery($query)
-    {
-        return $query == $this->suiteName;
-    }
+	/**
+	 * @param string $query
+	 *
+	 * @return bool
+	 */
+	public function supportsQuery( $query )
+	{
+		return $query == $this->suiteName;
+	}
 
-     public function findResources($query)
-     {
-         return parent::getAllResources();
-     }
+	public function findResources( $query )
+	{
+		return parent::getAllResources();
+	}
 }

--- a/src/PhpSpec/Locator/Suite/SuiteLocator.php
+++ b/src/PhpSpec/Locator/Suite/SuiteLocator.php
@@ -37,8 +37,7 @@ class SuiteLocator extends PSR0Locator implements ResourceLocatorInterface
 		$specPath = '.',
 		Filesystem $filesystem = null,
 		$psr4Prefix = null
-	)
-	{
+	) {
 		$this->suiteName = $name;
 		parent::__construct( $srcNamespace, $specNamespacePrefix, $srcPath, $specPath, $filesystem, $psr4Prefix );
 	}
@@ -48,12 +47,12 @@ class SuiteLocator extends PSR0Locator implements ResourceLocatorInterface
 	 *
 	 * @return bool
 	 */
-	public function supportsQuery( $query )
+	public function supportsQuery($query)
 	{
 		return $query == $this->suiteName;
 	}
 
-	public function findResources( $query )
+	public function findResources($query)
 	{
 		return parent::getAllResources();
 	}

--- a/src/PhpSpec/Locator/Suite/SuiteLocator.php
+++ b/src/PhpSpec/Locator/Suite/SuiteLocator.php
@@ -14,6 +14,7 @@
 namespace PhpSpec\Locator\Suite;
 
 use PhpSpec\Locator\PSR0\PSR0Locator;
+use PhpSpec\Locator\ResourceInterface;
 use PhpSpec\Locator\ResourceLocatorInterface;
 use PhpSpec\Util\Filesystem;
 
@@ -53,6 +54,11 @@ class SuiteLocator extends PSR0Locator implements ResourceLocatorInterface
         return $query == $this->suiteName;
     }
 
+    /**
+     * @param string $query
+     *
+     * @return ResourceInterface[]
+     */
     public function findResources($query)
     {
         return parent::getAllResources();

--- a/src/PhpSpec/Locator/Suite/SuiteLocator.php
+++ b/src/PhpSpec/Locator/Suite/SuiteLocator.php
@@ -19,41 +19,42 @@ use PhpSpec\Util\Filesystem;
 
 class SuiteLocator extends PSR0Locator implements ResourceLocatorInterface
 {
-	private $suiteName;
+    private $suiteName;
 
-	/**
-	 * @param string $srcNamespace
-	 * @param string $specNamespacePrefix
-	 * @param string $srcPath
-	 * @param string $specPath
-	 * @param Filesystem $filesystem
-	 * @param string $psr4Prefix
-	 */
-	public function __construct(
-		$name = '',
-		$srcNamespace = '',
-		$specNamespacePrefix = 'spec',
-		$srcPath = 'src',
-		$specPath = '.',
-		Filesystem $filesystem = null,
-		$psr4Prefix = null
-	) {
-		$this->suiteName = $name;
-		parent::__construct( $srcNamespace, $specNamespacePrefix, $srcPath, $specPath, $filesystem, $psr4Prefix );
-	}
+    /**
+     * @param string $srcNamespace
+     * @param string $specNamespacePrefix
+     * @param string $srcPath
+     * @param string $specPath
+     * @param Filesystem $filesystem
+     * @param string $psr4Prefix
+     */
+    public function __construct(
+        $name = '',
+        $srcNamespace = '',
+        $specNamespacePrefix = 'spec',
+        $srcPath = 'src',
+        $specPath = '.',
+        Filesystem $filesystem = null,
+        $psr4Prefix = null
+    )
+    {
+        $this->suiteName = $name;
+        parent::__construct($srcNamespace, $specNamespacePrefix, $srcPath, $specPath, $filesystem, $psr4Prefix);
+    }
 
-	/**
-	 * @param string $query
-	 *
-	 * @return bool
-	 */
-	public function supportsQuery($query)
-	{
-		return $query == $this->suiteName;
-	}
+    /**
+     * @param string $query
+     *
+     * @return bool
+     */
+    public function supportsQuery($query)
+    {
+        return $query == $this->suiteName;
+    }
 
-	public function findResources($query)
-	{
-		return parent::getAllResources();
-	}
+    public function findResources($query)
+    {
+        return parent::getAllResources();
+    }
 }

--- a/src/PhpSpec/Locator/Suite/SuiteLocator.php
+++ b/src/PhpSpec/Locator/Suite/SuiteLocator.php
@@ -56,7 +56,6 @@ class SuiteLocator extends PSR0Locator implements ResourceLocatorInterface
 
      public function findResources($query)
      {
-         var_dump( "Finding Resources for $query" );
          return parent::getAllResources();
      }
 }

--- a/src/PhpSpec/Locator/Suite/SuiteLocator.php
+++ b/src/PhpSpec/Locator/Suite/SuiteLocator.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Locator\Suite;
+
+use PhpSpec\Locator\PSR0\PSR0Locator;
+use PhpSpec\Locator\ResourceInterface;
+use PhpSpec\Locator\ResourceLocatorInterface;
+use PhpSpec\Util\Filesystem;
+use InvalidArgumentException;
+
+class SuiteLocator extends PSR0Locator implements ResourceLocatorInterface
+{
+    private $suiteName;
+
+    /**
+     * @param string     $srcNamespace
+     * @param string     $specNamespacePrefix
+     * @param string     $srcPath
+     * @param string     $specPath
+     * @param Filesystem $filesystem
+     * @param string     $psr4Prefix
+     */
+    public function __construct(
+        $name = '',
+        $srcNamespace = '',
+        $specNamespacePrefix = 'spec',
+        $srcPath = 'src',
+        $specPath = '.',
+        Filesystem $filesystem = null,
+        $psr4Prefix = null
+    ) {
+        $this->suiteName = $name;
+        parent::__construct( $srcNamespace, $specNamespacePrefix, $srcPath, $specPath, $filesystem, $psr4Prefix );
+    }
+
+    /**
+     * @param string $query
+     *
+     * @return bool
+     */
+    public function supportsQuery($query)
+    {
+        return $query == $this->suiteName;
+    }
+
+     public function findResources($query)
+     {
+         var_dump( "Finding Resources for $query" );
+         return parent::getAllResources();
+     }
+}


### PR DESCRIPTION
For example, if I have this config:

```
suites:
    Application:
        namespace: Application
        spec_prefix: Spec
        src_path: module/Application/src/
        spec_path: module/Application/bundle
    CirclicalUser:
        namespace: CirclicalUser
        spec_prefix: Spec
        src_path: module/CirclicalUser/src/
        spec_path: module/CirclicalUser/bundle
```

I would like to be able to run this command:

> ./phpspec run CirclicalUser

In order to execute all examples in CirclicalUser's specs.

This PR achieves this.

Thanks for considering it!

