### PR TITLE
Fixes #852 Handle opening brace of string interpolation

### DIFF
--- a/spec/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriterSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriterSpec.php
@@ -62,6 +62,15 @@ class TokenizedCodeWriterSpec extends ObjectBehavior
         $this->shouldThrow($exception)->during('insertAfterMethod', array($class, 'methodOne', ''));
     }
 
+    function it_should_generate_a_method_in_a_class_with_a_string_containing_braces()
+    {
+        $class = $this->getClassWithBraceText();
+        $method = $this->getMethod();
+        $result = $this->getClassWithBraceTextAndNewMethod();
+
+        $this->insertMethodLastInClass($class, $method)->shouldReturn($result);
+    }
+
     private function getSingleMethodClass()
     {
         return <<<SINGLE_METHOD_CLASS
@@ -231,5 +240,44 @@ final class MyClass
     }
 }
 ONLY_NEW_METHOD_CLASS;
+    }
+
+    private function getClassWithBraceText()
+    {
+        return <<<'BRACE_TEXT_CLASS'
+<?php
+
+namespace MyNamespace;
+
+final class MyClass
+{
+    public function braceMethod()
+    {
+        return "{$foo}";
+    }
+}
+BRACE_TEXT_CLASS;
+    }
+
+    private function getClassWithBraceTextAndNewMethod()
+    {
+        return <<<'BRACE_TEXT_RESULT_CLASS'
+<?php
+
+namespace MyNamespace;
+
+final class MyClass
+{
+    public function braceMethod()
+    {
+        return "{$foo}";
+    }
+
+    public function newMethod()
+    {
+        return 'newSomething';
+    }
+}
+BRACE_TEXT_RESULT_CLASS;
     }
 }

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -120,17 +120,23 @@ final class TokenizedCodeWriter implements CodeWriter
     {
         $tokens = token_get_all($class);
         $searching = false;
+        $inString = false;
         $searchPattern = array();
 
         for ($i = count($tokens) - 1; $i >= 0; $i--) {
             $token = $tokens[$i];
 
-            if ($token === '}') {
+            if ($token === '}' && !$inString) {
                 $searching = true;
                 continue;
             }
 
             if (!$searching) {
+                continue;
+            }
+
+            if ($token === '"') {
+                $inString = !$inString;
                 continue;
             }
 

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -198,7 +198,7 @@ final class ClassFileAnalyser
         for ($i = $index, $max = count($tokens); $i < $max; $i++) {
             $token = $tokens[$i];
 
-            if ('{' === $token) {
+            if ('{' === $token || $this->isSpecialBraceToken($token)) {
                 $braceCount++;
                 continue;
             }
@@ -210,6 +210,15 @@ final class ClassFileAnalyser
                 }
             }
         }
+    }
+
+    private function isSpecialBraceToken($token)
+    {
+        if (!is_array($token)) {
+            return false;
+        }
+
+        return $token[1] === "{";
     }
 
     /**


### PR DESCRIPTION
When tokenizing a Class, a `{` character is normally treated as a vanilla string. When it appears within a double quoted string however, it takes on a special meaning and is represented differently in the tokenizer. This was not being handled in the code that detects method and class endings by matching brace counts.