### PR TITLE
Fixed wrongly calculating lines in php7.

### DIFF
--- a/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
@@ -62,7 +62,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar($bar)
+            public function bar( $bar)
             {
             }
         }
@@ -91,7 +91,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar($bar)
+            public function bar( $bar)
             {
                 new class($argument) implements InterfaceName
                 {
@@ -120,7 +120,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         class Foo
         {
-            public function bar($bar,$baz)
+            public function bar( $bar,  $baz)
             {
             }
         }
@@ -177,4 +177,38 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         $typeHintIndex->addInvalid('Foo', 'bar', '$bar', $e)->shouldHaveBeenCalled();
         $typeHintIndex->add('Foo', 'bar', '$bar', Argument::any())->shouldNotHaveBeenCalled();
     }
+
+    function it_preserves_line_numbers()
+    {
+        $this->rewrite('
+        <?php
+
+        class Foo
+        {
+            public function(
+                $foo,
+                array $bar,
+                Foo\Bar $arg3,
+                $arg4
+            )
+            {
+            }
+        }
+        ')->shouldReturn('
+        <?php
+
+        class Foo
+        {
+            public function(
+                $foo,
+                array $bar,
+                 $arg3,
+                $arg4
+            )
+            {
+            }
+        }
+        ');
+    }
+
 }

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -155,7 +155,10 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         $typehint = '';
         for ($i = $index - 1; in_array($tokens[$i][0], $this->typehintTokens); $i--) {
             $typehint = $tokens[$i][1] . $typehint;
-            unset($tokens[$i]);
+
+            if (T_WHITESPACE !== $tokens[$i][0]) {
+                unset($tokens[$i]);
+            }
         }
 
         if ($typehint = trim($typehint)) {


### PR DESCRIPTION
A little fix that forbids to remove T_WHITESPACE when removing typehints.

It fixes problem with wrongly calculating lines:
#858 and #848 