### PR TITLE
Add the `shouldImplement` method in ObjectBehaviour's PhpDoc.

### DIFF
--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -32,6 +32,7 @@ use ArrayAccess;
  * @method void beConstructedThrough($factoryMethod, array $constructorArguments = array())
  * @method void beAnInstanceOf($class)
  * @method void shouldHaveType($type)
+ * @method void shouldImplement($interface)
  * @method Subject\Expectation\DuringCall shouldThrow($exception = null)
  */
 class ObjectBehavior implements


### PR DESCRIPTION
Because everybody love autocompletion and checking that an object implement a given interface.