### PR TITLE
write stats once finished

### DIFF
--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -61,13 +61,21 @@ class DotFormatter extends ConsoleFormatter
                 break;
         }
 
-        if ($eventsCount % 50 === 0) {
+        $remainder = $eventsCount % 50;
+        $lastRow = $eventsCount === $this->examplesCount;
+
+        if ($remainder === 0 || $lastRow) {
             $length = strlen((string) $this->examplesCount);
             $format = sprintf(' %%%dd / %%%dd', $length, $length);
+
+            if ($lastRow) {
+                $io->write(str_repeat(' ', 50 - $remainder));
+            }
+
             $io->write(sprintf($format, $eventsCount, $this->examplesCount));
 
             if ($eventsCount !== $this->examplesCount) {
-                $io->writeLn();
+                $io->writeln();
             }
         }
     }


### PR DESCRIPTION
Stats were not printed by the dot formatter on the last line.

before:
![screen shot 2016-02-19 at 14 27 24](https://cloud.githubusercontent.com/assets/625392/13178080/f3de1fea-d714-11e5-8ad0-e2e0c800749d.png)
after:
![screen shot 2016-02-19 at 14 27 12](https://cloud.githubusercontent.com/assets/625392/13178082/f7b782e6-d714-11e5-98d2-bc701f009691.png)
