### PR TITLE
Only rewrite Spec classes

### DIFF
--- a/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
@@ -25,7 +25,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         $this->rewrite('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar()
             {
@@ -35,7 +35,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ')->shouldReturn('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar()
             {
@@ -50,7 +50,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         $this->rewrite('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar(\Foo\Bar $bar)
             {
@@ -60,7 +60,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ')->shouldReturn('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar( $bar)
             {
@@ -75,7 +75,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         $this->rewrite('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar(\Foo\Bar $bar)
             {
@@ -89,7 +89,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ')->shouldReturn('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar( $bar)
             {
@@ -108,7 +108,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         $this->rewrite('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar(Bar $bar, Baz $baz)
             {
@@ -118,7 +118,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ')->shouldReturn('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar( $bar,  $baz)
             {
@@ -132,14 +132,14 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
     {
         $namespaceResolver->analyse(Argument::any())->shouldBeCalled();
 
-        $namespaceResolver->resolve('Foo')->willReturn('Foo');
+        $namespaceResolver->resolve('FooSpec')->willReturn('FooSpec');
         $namespaceResolver->resolve('Foo\Bar')->willReturn('Foo\Bar');
         $namespaceResolver->resolve('Baz')->willReturn('Baz');
 
         $this->rewrite('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar(Foo\Bar $bar, Baz $baz)
             {
@@ -148,8 +148,8 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         ');
 
-        $typeHintIndex->add('Foo', 'bar', '$bar', 'Foo\Bar')->shouldHaveBeenCalled();
-        $typeHintIndex->add('Foo', 'bar', '$baz', 'Baz')->shouldHaveBeenCalled();
+        $typeHintIndex->add('FooSpec', 'bar', '$bar', 'Foo\Bar')->shouldHaveBeenCalled();
+        $typeHintIndex->add('FooSpec', 'bar', '$baz', 'Baz')->shouldHaveBeenCalled();
     }
 
     function it_indexes_invalid_typehints(
@@ -159,13 +159,13 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         $e = new DisallowedScalarTypehintException();
         $namespaceResolver->analyse(Argument::any())->shouldBeCalled();
 
-        $namespaceResolver->resolve('Foo')->willReturn('Foo');
+        $namespaceResolver->resolve('FooSpec')->willReturn('FooSpec');
         $namespaceResolver->resolve('int')->willThrow($e);
 
         $this->rewrite('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function bar(int $bar)
             {
@@ -174,8 +174,8 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
 
         ');
 
-        $typeHintIndex->addInvalid('Foo', 'bar', '$bar', $e)->shouldHaveBeenCalled();
-        $typeHintIndex->add('Foo', 'bar', '$bar', Argument::any())->shouldNotHaveBeenCalled();
+        $typeHintIndex->addInvalid('FooSpec', 'bar', '$bar', $e)->shouldHaveBeenCalled();
+        $typeHintIndex->add('FooSpec', 'bar', '$bar', Argument::any())->shouldNotHaveBeenCalled();
     }
 
     function it_preserves_line_numbers()
@@ -183,7 +183,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         $this->rewrite('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function(
                 $foo,
@@ -197,7 +197,7 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ')->shouldReturn('
         <?php
 
-        class Foo
+        class FooSpec
         {
             public function(
                 $foo,
@@ -211,4 +211,42 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
         ');
     }
 
+    function it_do_not_remove_typehints_of_non_spec_classes()
+    {
+        $this->rewrite('
+        <?php
+
+        class FooSpec
+        {
+            public function bar(Bar $bar, Baz $baz)
+            {
+            }
+        }
+
+        class Bar
+        {
+            public function foo(Baz $baz)
+            {
+            }
+        }
+
+        ')->shouldReturn('
+        <?php
+
+        class FooSpec
+        {
+            public function bar( $bar,  $baz)
+            {
+            }
+        }
+
+        class Bar
+        {
+            public function foo(Baz $baz)
+            {
+            }
+        }
+
+        ');
+    }
 }

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -103,10 +103,14 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                         $this->state = self::STATE_READING_FUNCTION_BODY;
                         $this->currentBodyLevel = 1;
                     }
-                    elseif ($this->tokenHasType($token, T_STRING) && !$this->currentClass) {
+                    elseif ('}' == $token && $this->currentClass) {
+                        $this->state = self::STATE_DEFAULT;
+                        $this->currentClass = null;
+                    }
+                    elseif ($this->tokenHasType($token, T_STRING) && !$this->currentClass && $this->shouldExtractTokensOfClass($token[1])) {
                         $this->currentClass = $token[1];
                     }
-                    elseif($this->tokenHasType($token, T_FUNCTION)) {
+                    elseif($this->tokenHasType($token, T_FUNCTION) && $this->currentClass) {
                         $this->state = self::STATE_READING_FUNCTION;
                     }
                     break;
@@ -191,5 +195,15 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     private function tokenHasType($token, $type)
     {
         return is_array($token) && $type == $token[0];
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return bool
+     */
+    private function shouldExtractTokensOfClass($className)
+    {
+        return substr($className, -4) == 'Spec';
     }
 }


### PR DESCRIPTION
Some other classes can be found in Spec files for testing purposes. It should not remove the typehints of them because if they implement an interface, the contract will be broken.