### PR TITLE
Support to run a spec file omitting file extension

### DIFF
--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -204,6 +204,15 @@ class PSR0LocatorSpec extends ObjectBehavior
         )->shouldReturn(true);
     }
 
+    function it_supports_file_queries_in_specPath_omitting_file_extension()
+    {
+        $this->beConstructedWith('PhpSpec', 'spec', $this->srcPath, $this->specPath);
+
+        $this->supportsQuery(
+            rtrim(realpath($this->specPath.'/spec/PhpSpec/ServiceContainerSpec.php'), '.php')
+        )->shouldReturn(true);
+    }
+
     function it_does_not_support_any_other_queries()
     {
         $this->beConstructedWith('PhpSpec', 'spec', $this->srcPath, $this->specPath);

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -390,6 +390,12 @@ class PSR0Locator implements ResourceLocatorInterface
             }
         }
 
+        if ($this->queryContainsSpecFileWithoutExtension($query)) {
+            if (false !== $path = realpath($replacedQuery . '.php')) {
+                return $path;
+            }
+        }
+
         return rtrim(realpath($replacedQuery), $sepr);
     }
 
@@ -421,5 +427,15 @@ class PSR0Locator implements ResourceLocatorInterface
     private function isWindowsPath($query)
     {
         return preg_match('/^\w:/', $query);
+    }
+
+    /**
+     * @param $query
+     *
+     * @return bool
+     */
+    private function queryContainsSpecFileWithoutExtension($query)
+    {
+        return 'Spec' === substr($query, -4);
     }
 }


### PR DESCRIPTION
Following [issue 876](https://github.com/phpspec/phpspec/issues/876) I think could be better to run a specific spec without defining the .php file extension. The existent behaviour should stay as it is.

For example, before, we needed to define the file extension:
`bin/phpspec run spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php`

Now, we don't need to define it:
`bin/phpspec run spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec`

Notice that, if file extension is defined, it should work as before.