### PR TITLE
Refactor/scope bootstrap script

### DIFF
--- a/bin/phpspec
+++ b/bin/phpspec
@@ -1,26 +1,28 @@
 #!/usr/bin/env php
 <?php
 
-define('PHPSPEC_VERSION', '3.0.x@dev');
+call_user_func(function ($version) {
 
-if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
-    require $autoload;
-} elseif (is_file($autoload = getcwd() . '/../../autoload.php')) {
-    require $autoload;
-}
+    if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
+        require $autoload;
+    } elseif (is_file($autoload = getcwd() . '/../../autoload.php')) {
+        require $autoload;
+    }
 
-if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
-    require($autoload);
-} elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
-    require($autoload);
-} else {
-    fwrite(STDERR,
-        'You must set up the project dependencies, run the following commands:' . PHP_EOL .
-        'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
-        'php composer.phar install' . PHP_EOL
-    );
-    exit(1);
-}
+    if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
+        require($autoload);
+    } elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
+        require($autoload);
+    } else {
+        fwrite(STDERR,
+            'You must set up the project dependencies, run the following commands:' . PHP_EOL .
+            'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+            'php composer.phar install' . PHP_EOL
+        );
+        exit(1);
+    }
 
-$app = new PhpSpec\Console\Application(PHPSPEC_VERSION);
-$app->run();
+    $app = new PhpSpec\Console\Application($version);
+    $app->run();
+
+}, ['3.0.x@dev']);

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -25,4 +25,4 @@ call_user_func(function ($version) {
     $app = new PhpSpec\Console\Application($version);
     $app->run();
 
-}, ['3.0.x@dev']);
+}, '3.0.x@dev');


### PR DESCRIPTION
We create global variables called `$app` and `$autoload`, as well as defining a constant.

There's no actual need to do these things so we can remove them in `3.0.0`