### PR TITLE
Enable code generation when --no-interaction is on

### DIFF
--- a/spec/PhpSpec/Console/ConsoleIOSpec.php
+++ b/spec/PhpSpec/Console/ConsoleIOSpec.php
@@ -35,11 +35,11 @@ class ConsoleIOSpec extends ObjectBehavior
         $this->isCodeGenerationEnabled()->shouldReturn(true);
     }
 
-    function it_is_not_code_generation_ready_if_input_is_not_interactive($input)
+    function it_is_code_generation_ready_if_input_is_not_interactive($input)
     {
         $input->isInteractive()->willReturn(false);
 
-        $this->isCodeGenerationEnabled()->shouldReturn(false);
+        $this->isCodeGenerationEnabled()->shouldReturn(true);
     }
 
     function it_is_not_code_generation_ready_if_command_line_option_is_set($input)

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -101,10 +101,6 @@ class ConsoleIO implements IO
      */
     public function isCodeGenerationEnabled()
     {
-        if (!$this->isInteractive()) {
-            return false;
-        }
-
         return $this->config->isCodeGenerationEnabled()
             && !$this->input->getOption('no-code-generation');
     }


### PR DESCRIPTION
This enables code generation even when `--no-interaction` is passed to PHPSpec. The CLI has a separate flag for disabling code generation (that is `--no-code-generation`), so there's no reason to imply that no code should be generated when the input is non-interactive.

Refs #903