### PR TITLE
Makes ThrowMatcher show the full error message in the console if the thrown exception is an instance of Error.

### DIFF
--- a/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
@@ -56,4 +56,22 @@ class ThrowMatcherSpec extends ObjectBehavior
 
         $this->negativeMatch('throw', $arr, array('\Error'))->during('ksort', array());
     }
+
+    function it_throws_a_failure_exception_with_the_thrown_exceptions_message_if_a_positive_match_failed(Presenter $presenter)
+    {
+        $actually_thrown_error = new \Error('This is a test Error');
+
+        $callable = function () use ($actually_thrown_error) { throw $actually_thrown_error; };
+
+        $expected_error = new \PhpSpec\Exception\Example\FailureException(
+            'Expected exception of class Exception, but got Error with the message: "This is a test Error"'
+        );
+
+        $incorrectly_matched_exception = new \Exception('This is the exception I expect to be thrown.');
+
+        $presenter->presentValue($actually_thrown_error)->willReturn('Error');
+        $presenter->presentValue($incorrectly_matched_exception)->willReturn('Exception');
+
+        $this->shouldThrow($expected_error)->during('verifyPositive', [$callable, [], $incorrectly_matched_exception]);
+    }
 }

--- a/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
@@ -59,6 +59,10 @@ class ThrowMatcherSpec extends ObjectBehavior
 
     function it_throws_a_failure_exception_with_the_thrown_exceptions_message_if_a_positive_match_failed(Presenter $presenter)
     {
+        if (!class_exists('\Error')) {
+            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
+        }
+
         $actually_thrown_error = new \Error('This is a test Error');
 
         $callable = function () use ($actually_thrown_error) { throw $actually_thrown_error; };

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -121,11 +121,25 @@ class ThrowMatcher implements Matcher
         }
 
         if (!$exceptionThrown instanceof $exception) {
+            $format = 'Expected exception of class %s, but got %s.';
+
+            // Show full error message if the thrown exception is an instance of Error.
+            // See https://github.com/phpspec/phpspec/issues/908
+            if (class_exists('\Error') && $exceptionThrown instanceof \Error) {
+                // TODO: Can we can use $this->presenter->presentValue() rather
+                // than adding the raw Error message in quotes here? Currently
+                // not included since presentValue() truncates the string to 25
+                // characters but we want to show the full Error message for
+                // debugging purposes.
+                $format = 'Expected exception of class %s, but got %s with the message: "%s"';
+            }
+
             throw new FailureException(
                 sprintf(
-                    'Expected exception of class %s, but got %s.',
+                    $format,
                     $this->presenter->presentValue($exception),
-                    $this->presenter->presentValue($exceptionThrown)
+                    $this->presenter->presentValue($exceptionThrown),
+                    $exceptionThrown->getMessage()
                 )
             );
         }

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -125,7 +125,7 @@ class ThrowMatcher implements Matcher
 
             // Show full error message if the thrown exception is an instance of Error.
             // See https://github.com/phpspec/phpspec/issues/908
-            if (class_exists('\Error') && $exceptionThrown instanceof \Error) {
+            if ($exceptionThrown instanceof \Error) {
                 // TODO: Can we can use $this->presenter->presentValue() rather
                 // than adding the raw Error message in quotes here? Currently
                 // not included since presentValue() truncates the string to 25

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -123,14 +123,7 @@ class ThrowMatcher implements Matcher
         if (!$exceptionThrown instanceof $exception) {
             $format = 'Expected exception of class %s, but got %s.';
 
-            // Show full error message if the thrown exception is an instance of Error.
-            // See https://github.com/phpspec/phpspec/issues/908
             if ($exceptionThrown instanceof \Error) {
-                // TODO: Can we can use $this->presenter->presentValue() rather
-                // than adding the raw Error message in quotes here? Currently
-                // not included since presentValue() truncates the string to 25
-                // characters but we want to show the full Error message for
-                // debugging purposes.
                 $format = 'Expected exception of class %s, but got %s with the message: "%s"';
             }
 


### PR DESCRIPTION
Useful since PHP 7's Error class is thrown for a number of problems and it's useful for developers to see the full error message for Error instances for debugging purposes.

Related to https://github.com/phpspec/phpspec/issues/908