### PR TITLE
Makes ThrowMatcher show the full error message in the console if the thrown exception is an instance of Error.

### DIFF
--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -121,11 +121,25 @@ class ThrowMatcher implements MatcherInterface
         }
 
         if (!$exceptionThrown instanceof $exception) {
+            $format = 'Expected exception of class %s, but got %s.';
+
+            // Show full error message if the thrown exception is an instance of Error.
+            // See https://github.com/phpspec/phpspec/issues/908
+            if (class_exists('\Error') && $exceptionThrown instanceof \Error) {
+                // TODO: Can we can use $this->presenter->presentValue() rather
+                // than adding the raw Error message in quotes here? Currently
+                // not included since presentValue() truncates the string to 25
+                // characters but we want to show the full Error message for
+                // debugging purposes.
+                $format = 'Expected exception of class %s, but got %s with the message: "%s"';
+            }
+
             throw new FailureException(
                 sprintf(
-                    'Expected exception of class %s, but got %s.',
+                    $format,
                     $this->presenter->presentValue($exception),
-                    $this->presenter->presentValue($exceptionThrown)
+                    $this->presenter->presentValue($exceptionThrown),
+                    $exceptionThrown->getMessage()
                 )
             );
         }

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -125,7 +125,7 @@ class ThrowMatcher implements MatcherInterface
 
             // Show full error message if the thrown exception is an instance of Error.
             // See https://github.com/phpspec/phpspec/issues/908
-            if (class_exists('\Error') && $exceptionThrown instanceof \Error) {
+            if ($exceptionThrown instanceof \Error) {
                 // TODO: Can we can use $this->presenter->presentValue() rather
                 // than adding the raw Error message in quotes here? Currently
                 // not included since presentValue() truncates the string to 25


### PR DESCRIPTION
Useful since PHP 7's Error class is thrown for a number of problems and it's useful for developers to see the full error message for Error instances for debugging purposes.

Related to https://github.com/phpspec/phpspec/issues/908

Note: The [guidelines for contributing](https://github.com/phpspec/phpspec/blob/master/CONTRIBUTING.md) for this repository imply that pull requests for the [`2.5` branch](https://github.com/phpspec/phpspec/tree/2.5) should maybe be limited to bug fixes, so feel free to delete this pull request since pull request https://github.com/phpspec/phpspec/pull/915 is idential, just on `master`.