### PR TITLE
Updating PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "behat/behat":           "^3.0.11",
         "symfony/filesystem":    "~2.7|~3.0",
-        "phpunit/phpunit":       "~4.4"
+        "phpunit/phpunit":       "~4.4|~5.0"
     },
 
     "suggest": {


### PR DESCRIPTION
Updates PHPUnit to `5.x` if possible, which will be installed if using PHP 7.