### PR TITLE
Removing use of @param annotations

### DIFF
--- a/docs/manual/prophet-objects.rst
+++ b/docs/manual/prophet-objects.rst
@@ -95,6 +95,10 @@ lets you create the stub in an easier way. Instead using a type hint which
         }
     }
 
+**phpspec** 2.* supports the use of `@param` annotations instead of parametric
+typehints for this purpose. However, this functionality is removed in
+**phpspec** 3.0.
+
 Mocks
 -----
 

--- a/docs/manual/prophet-objects.rst
+++ b/docs/manual/prophet-objects.rst
@@ -73,8 +73,8 @@ We can tell **phpspec** what we want it to return though.
 Now you can write the code that will get this example to pass. As well as
 refactoring your implementation you should see if you can refactor your specs
 once they are passing. In this case we can tidy it up a bit as **phpspec**
-lets you create the stub in an easier way. Instead using a type hint which
-**phpspec** will use to determine the type of the stub:
+lets you create the stub in an easier way. If you use a typehint, **phpspec**
+determine the required type of the collaborator:
 
 .. code-block:: php
 

--- a/docs/manual/prophet-objects.rst
+++ b/docs/manual/prophet-objects.rst
@@ -73,32 +73,8 @@ We can tell **phpspec** what we want it to return though.
 Now you can write the code that will get this example to pass. As well as
 refactoring your implementation you should see if you can refactor your specs
 once they are passing. In this case we can tidy it up a bit as **phpspec**
-lets you create the stub in an easier way. You can pass in a variable to
-the example and use an `@param` docblock to tell it what type it should have:
-
-.. code-block:: php
-
-     <?php
-
-    namespace spec;
-
-    use PhpSpec\ObjectBehavior;
-
-    class MarkdownSpec extends ObjectBehavior
-    {
-        /**
-         * @param Markdown\Reader $reader
-         */
-        function it_converts_text_from_an_external_source($reader)
-        {
-            $reader->getMarkdown()->willReturn("Hi, there");
-
-            $this->toHtmlFromReader($reader)->shouldReturn("<p>Hi, there</p>");
-        }
-    }
-
-We can improve this further by instead using a type hint which **phpspec**
-will use to determine the type of the stub:
+lets you create the stub in an easier way. Instead using a type hint which
+**phpspec** will use to determine the type of the stub:
 
 .. code-block:: php
 

--- a/docs/manual/upgrading-to-phpspec-3.rst
+++ b/docs/manual/upgrading-to-phpspec-3.rst
@@ -7,20 +7,33 @@ suite or an extension, based on BC-breaking changes made so far.
 Upgrading for Users
 -------------------
 
-So far, there are no changes that need to be made to get a typical test suite
-written for phpspec 2 to work with 3.0. We suggest trying the upgrade and
-running your tests to see what happens.
-
-If you are using 3rd party phpspec extensions, you may have to increase the
+If you are using 3rd party **phpspec** extensions, you may have to increase the
 version numbers for those as well.
 
 As PHP 5.5 and below are no longer supported language versions, you will need
-to upgrade to PHP 5.6 or 7.0+ to use phpspec 3.
+to upgrade to PHP 5.6 or 7.0+ to use **phpspec** 3.
+
+Where you have used `@param` annotations for spec examples, to indicate the
+required type for a collaborator, you will need to remove these and use
+explicit typehinting in the method signature instead. For example:
+
+.. code-block:: php
+
+    /**
+     * @param \stdClass $collaborator
+     */
+    function it_does_something_with_a_stdclass($collaborator)
+
+Change to:
+
+.. code-block:: php
+
+    function it_does_something_with_a_stdclass(\stdClass $collaborator)
 
 Upgrading for Extension Authors
 -------------------------------
 
-Several interfaces have been renamed in phpspec 3.0.  Here is a quick guide to
+Several interfaces have been renamed in **phpspec** 3.0.  Here is a quick guide to
 changes you will need to make in your code.
 
 - *PhpSpec\Console\IO* is now *PhpSpec\Console\ConsoleIO*

--- a/features/code_generation/developer_generates_collaborator_method.feature
+++ b/features/code_generation/developer_generates_collaborator_method.feature
@@ -53,59 +53,6 @@ Feature: Developer generates a collaborator's method
                                                                      [Y/n]
       """
 
-
-  Scenario: Being prompted to generate a collaborator method based on docblocks
-    Given the spec file "spec/CodeGeneration/CollaboratorMethodExample2/MarkdownSpec.php" contains:
-      """
-      <?php
-
-      namespace spec\CodeGeneration\CollaboratorMethodExample2;
-
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
-
-      class MarkdownSpec extends ObjectBehavior
-      {
-          /**
-           * @param \CodeGeneration\CollaboratorMethodExample2\Parser $parser
-           */
-          function it_interacts_with_a_collaborator($parser)
-          {
-              $parser->getSuccess()->willReturn(true);
-          }
-      }
-
-      """
-    And the class file "src/CodeGeneration/CollaboratorMethodExample2/Markdown.php" contains:
-      """
-      <?php
-
-      namespace CodeGeneration\CollaboratorMethodExample2;
-
-      class Markdown
-      {
-      }
-
-      """
-    And the class file "src/CodeGeneration/CollaboratorMethodExample2/Parser.php" contains:
-      """
-      <?php
-
-      namespace CodeGeneration\CollaboratorMethodExample2;
-
-      interface Parser
-      {
-      }
-
-      """
-    When I run phpspec and answer "n" when asked if I want to generate the code
-    Then I should be prompted with:
-      """
-      Would you like me to generate a method signature
-        `CodeGeneration\CollaboratorMethodExample2\Parser::getSuccess()` for you?
-                                                                     [Y/n]
-      """
-
   Scenario: Asking for the method signature to be generated
     Given the spec file "spec/CodeGeneration/CollaboratorMethodExample3/MarkdownSpec.php" contains:
       """

--- a/features/formatter/developer_is_shown_diffs.feature
+++ b/features/formatter/developer_is_shown_diffs.feature
@@ -396,7 +396,7 @@ Feature: Developer is shown diffs
       """
             method call:
               - methodTwo("value")
-            on Double\Diffs\DiffExample7\ClassBeingMocked\P14 was not expected, expected calls were:
+            on Double\Diffs\DiffExample7\ClassBeingMocked\P13 was not expected, expected calls were:
               - methodOne(exact("value"))
       """
 
@@ -460,7 +460,7 @@ Feature: Developer is shown diffs
       """
             method call:
               - methodTwo("another value")
-            on Double\Diffs\DiffExample8\ClassBeingMocked\P15 was not expected, expected calls were:
+            on Double\Diffs\DiffExample8\ClassBeingMocked\P14 was not expected, expected calls were:
               - methodTwo(exact("value"))
               - methodOne(exact("another value"))
       """

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -120,16 +120,6 @@ final class CollaboratorsMaintainer implements Maintainer
      */
     private function generateCollaborators(CollaboratorManager $collaborators, \ReflectionFunctionAbstract $function, \ReflectionClass $classRefl)
     {
-        if ($comment = $function->getDocComment()) {
-            $comment = str_replace("\r\n", "\n", $comment);
-            foreach (explode("\n", trim($comment)) as $line) {
-                if (preg_match(self::$docex, $line, $match)) {
-                    $collaborator = $this->getOrCreateCollaborator($collaborators, $match[2]);
-                    $collaborator->beADoubleOf($match[1]);
-                }
-            }
-        }
-
         foreach ($function->getParameters() as $parameter) {
 
             $collaborator = $this->getOrCreateCollaborator($collaborators, $parameter->getName());


### PR DESCRIPTION
Removing parsing of docblocks, and the inference of types from @param annotations