### PR TITLE
Document line number locators

### DIFF
--- a/docs/cookbook/console.rst
+++ b/docs/cookbook/console.rst
@@ -76,8 +76,15 @@ Will run all the specs in the `spec` directory.
 
     $ bin/phpspec run spec/ClassNameSpec.php
 
-Will run only the ClassNameSpec. You can run just the specs in a directory
-with:
+Will run only the ClassNameSpec.
+
+.. code-block:: bash
+
+    $ bin/phpspec run spec/ClassNameSpec.php:56
+
+Will run only specification defined in the ClassNameSpec on line 56.
+
+You can run just the specs in a directory with:
 
 .. code-block:: bash
 

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -87,6 +87,10 @@ Will run all the specifications in the spec directory.
 
 Will run only the ClassNameSpec.
 
+  <info>php %command.full_name% spec/ClassNameSpec.php:56</info>
+
+Will run only specification defined in the ClassNameSpec on line 56.
+
 You can choose the bootstrap file with the bootstrap option e.g.:
 
   <info>php %command.full_name% --bootstrap=bootstrap.php</info>


### PR DESCRIPTION
Adds missing docs and `run` help output. Fixes: https://github.com/phpspec/phpspec/issues/926