### PR TITLE
Allow to describe a class providing a namespace with leading backslash

### DIFF
--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -457,6 +457,16 @@ class PSR0LocatorSpec extends ObjectBehavior
         $resource->getSpecClassname()->shouldReturn('spec\Console\ApplicationSpec');
     }
 
+    function it_creates_resource_from_spec_class_with_leading_backslash(Filesystem $fs)
+    {
+        $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
+
+        $resource = $this->createResource('\PhpSpec\Console\Application');
+
+        $resource->getSrcClassname()->shouldReturn('PhpSpec\Console\Application');
+        $resource->getSpecClassname()->shouldReturn('spec\PhpSpec\Console\ApplicationSpec');
+    }
+
     function it_throws_an_exception_on_non_PSR0_resource(Filesystem $fs)
     {
         $this->beConstructedWith($fs, '', 'spec', $this->srcPath, $this->specPath);

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -229,6 +229,7 @@ class PSR0Locator implements ResourceLocator
      */
     public function createResource($classname)
     {
+        $classname = ltrim($classname, '\\');
         $this->validatePsr0Classname($classname);
 
         $classname = str_replace('/', '\\', $classname);


### PR DESCRIPTION
Fixes issue: https://github.com/phpspec/phpspec/issues/928