### PR TITLE
Remove failing 5.3.3 travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 matrix:
   include:
     - php: 5.3
-    - php: 5.3.3
+    - php: 5.3
       env: DEPENDENCIES='low'
     - php: 5.4
     - php: 5.5

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2.x-dev"
+            "dev-master": "2.5.x-dev"
         }
     }
 }


### PR DESCRIPTION
5.3.3 build is missing some dependent libraries, and it's sufficient to test against 5.3 edge