### PR TITLE
DI (option 2, phase 3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,18 @@
     ],
 
     "require": {
-        "php":                      "^5.6|^7.0",
-        "phpspec/prophecy":         "~1.5",
-        "phpspec/php-diff":         "~1.0.0",
-        "sebastian/exporter":       "~1.0",
-        "symfony/console":          "~2.7|~3.0",
-        "symfony/event-dispatcher": "~2.7|~3.0",
-        "symfony/process":          "^2.7|~3.0",
-        "symfony/finder":           "~2.7|~3.0",
-        "symfony/yaml":             "~2.7|~3.0",
-        "doctrine/instantiator":    "^1.0.1",
-        "ext-tokenizer":            "*"
+        "php":                                 "^5.6|^7.0",
+        "phpspec/prophecy":                    "~1.5",
+        "phpspec/php-diff":                    "~1.0.0",
+        "sebastian/exporter":                  "~1.0",
+        "symfony/console":                     "~2.7|~3.0",
+        "symfony/event-dispatcher":            "~2.7|~3.0",
+        "symfony/process":                     "^2.7|~3.0",
+        "symfony/finder":                      "~2.7|~3.0",
+        "symfony/yaml":                        "~2.7|~3.0",
+        "doctrine/instantiator":               "^1.0.1",
+        "container-interop/container-interop": "^1.1",
+        "ext-tokenizer":                       "*"
     },
 
     "require-dev": {

--- a/features/extensions/developer_uses_extension.feature
+++ b/features/extensions/developer_uses_extension.feature
@@ -15,7 +15,7 @@ Feature: Developer uses extension
     namespace Example1\PhpSpec\MatcherExtension;
 
     use PhpSpec\Extension as PhpSpecExtension;
-    use PhpSpec\ServiceContainer;
+    use PhpSpec\Container\ServiceContainer;
 
     class Extension implements PhpSpecExtension
     {

--- a/integration/PhpSpec/Console/Prompter/QuestionTest.php
+++ b/integration/PhpSpec/Console/Prompter/QuestionTest.php
@@ -2,6 +2,7 @@
 
 namespace integration\PhpSpec\Console\Prompter;
 
+use PhpSpec\Console\Manager as ConsoleManager;
 use PhpSpec\Console\Prompter\Question;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -36,7 +37,12 @@ class QuestionTest extends \PHPUnit_Framework_TestCase
         $this->output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
         $this->questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
 
-        $this->prompter = new Question($this->input, $this->output, $this->questionHelper);
+        $consoleManager = new ConsoleManager();
+        $consoleManager->setInput($this->input);
+        $consoleManager->setOutput($this->output);
+        $consoleManager->setQuestionHelper($this->questionHelper);
+
+        $this->prompter = new Question($consoleManager);
     }
 
     /**

--- a/spec/PhpSpec/Config/OptionsConfigSpec.php
+++ b/spec/PhpSpec/Config/OptionsConfigSpec.php
@@ -4,47 +4,49 @@ namespace spec\PhpSpec\Config;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\Console\Input\InputInterface;
 
 class OptionsConfigSpec extends ObjectBehavior
 {
-    function it_says_rerun_is_enabled_when_setting_is_true()
+    function it_says_rerun_is_enabled_when_setting_is_true(InputInterface $input)
     {
-        $this->beConstructedWith(false, false, true, false, false);
+        $this->beConstructedWith(['rerun' => true], $input);
+        $input->hasOption('no-rerun')->willReturn(false);
 
         $this->isReRunEnabled()->shouldReturn(true);
     }
 
-    function it_says_rerun_is_not_enabled_when_setting_is_false()
+    function it_says_rerun_is_not_enabled_when_setting_is_false(InputInterface $input)
     {
-        $this->beConstructedWith(false, false, false, false, false);
+        $this->beConstructedWith(['rerun' => false], $input);
 
         $this->isReRunEnabled()->shouldReturn(false);
     }
 
-    function it_says_faking_is_enabled_when_setting_is_true()
+    function it_says_faking_is_enabled_when_setting_is_true(InputInterface $input)
     {
-        $this->beConstructedWith(false, false, false, true, false);
+        $this->beConstructedWith(['fake' => true], $input);
 
         $this->isFakingEnabled()->shouldReturn(true);
     }
 
-    function it_says_faking_is_not_enabled_when_setting_is_false()
+    function it_says_faking_is_not_enabled_when_setting_is_false(InputInterface $input)
     {
-        $this->beConstructedWith(false, false, false, false, false);
+        $this->beConstructedWith(['fake' => false], $input);
 
         $this->isFakingEnabled()->shouldReturn(false);
     }
 
-    function it_says_bootstrap_path_is_false_when_setting_is_false()
+    function it_says_bootstrap_path_is_false_when_setting_is_false(InputInterface $input)
     {
-        $this->beConstructedWith(false, false, false, false, false);
+        $this->beConstructedWith(['bootstrap' => false], $input);
 
         $this->getBootstrapPath()->shouldReturn(false);
     }
 
-    function it_returns_bootstrap_path_when_one_is_specified()
+    function it_returns_bootstrap_path_when_one_is_specified(InputInterface $input)
     {
-        $this->beConstructedWith(false, false, false, false, '/path/to/file');
+        $this->beConstructedWith(['bootstrap' => '/path/to/file'], $input);
 
         $this->getBootstrapPath()->shouldReturn('/path/to/file');
     }

--- a/spec/PhpSpec/Console/ConsoleIOSpec.php
+++ b/spec/PhpSpec/Console/ConsoleIOSpec.php
@@ -7,13 +7,23 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use PhpSpec\Config\OptionsConfig;
 use PhpSpec\Config\Manager as ConfigManager;
+use PhpSpec\Console\Manager as ConsoleManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConsoleIOSpec extends ObjectBehavior
 {
-    function let(InputInterface $input, OutputInterface $output, ConfigManager $configManager, OptionsConfig $config, Prompter $prompter)
-    {
+    function let(
+        InputInterface $input,
+        OutputInterface $output,
+        ConsoleManager $consoleManager,
+        ConfigManager $configManager,
+        OptionsConfig $config,
+        Prompter $prompter
+    ) {
+        $consoleManager->getInput()->willReturn($input);
+        $consoleManager->getOutput()->willReturn($output);
+
         $input->isInteractive()->willReturn(true);
         $input->getOption('no-code-generation')->willReturn(false);
         $input->getOption('stop-on-failure')->willReturn(false);
@@ -22,7 +32,7 @@ class ConsoleIOSpec extends ObjectBehavior
         $config->isCodeGenerationEnabled()->willReturn(true);
         $config->isStopOnFailureEnabled()->willReturn(false);
 
-        $this->beConstructedWith($input, $output, $configManager, $prompter);
+        $this->beConstructedWith($consoleManager, $configManager, $prompter);
     }
 
     function it_has_io_interface()

--- a/spec/PhpSpec/Console/ConsoleIOSpec.php
+++ b/spec/PhpSpec/Console/ConsoleIOSpec.php
@@ -6,23 +6,23 @@ use PhpSpec\Console\Prompter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use PhpSpec\Config\OptionsConfig;
-
-use Symfony\Component\Console\Helper\DialogHelper;
+use PhpSpec\Config\Manager as ConfigManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConsoleIOSpec extends ObjectBehavior
 {
-    function let(InputInterface $input, OutputInterface $output, OptionsConfig $config, Prompter $prompter)
+    function let(InputInterface $input, OutputInterface $output, ConfigManager $configManager, OptionsConfig $config, Prompter $prompter)
     {
         $input->isInteractive()->willReturn(true);
         $input->getOption('no-code-generation')->willReturn(false);
         $input->getOption('stop-on-failure')->willReturn(false);
 
+        $configManager->optionsConfig()->willReturn($config);
         $config->isCodeGenerationEnabled()->willReturn(true);
         $config->isStopOnFailureEnabled()->willReturn(false);
 
-        $this->beConstructedWith($input, $output, $config, $prompter);
+        $this->beConstructedWith($input, $output, $configManager, $prompter);
     }
 
     function it_has_io_interface()

--- a/spec/PhpSpec/Console/ManagerSpec.php
+++ b/spec/PhpSpec/Console/ManagerSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace spec\PhpSpec\Console;
+
+use PhpSpec\Console\Manager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ManagerSpec extends ObjectBehavior
+{
+    function it_can_provide_the_input(InputInterface $input)
+    {
+        $this->setInput($input);
+        $this->getInput()->shouldBe($input);
+    }
+
+    function it_can_provide_the_output(OutputInterface $output)
+    {
+        $this->setOutput($output);
+        $this->getOutput()->shouldBe($output);
+    }
+
+    function it_can_provide_the_question_helper(QuestionHelper $questionHelper)
+    {
+        $this->setQuestionHelper($questionHelper);
+        $this->getQuestionHelper()->shouldBe($questionHelper);
+    }
+}

--- a/spec/PhpSpec/Container/ContainerExceptionSpec.php
+++ b/spec/PhpSpec/Container/ContainerExceptionSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\PhpSpec\Container;
+
+use Interop\Container\Exception\ContainerException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ContainerExceptionSpec extends ObjectBehavior
+{
+    function it_is_a_runtime_exception()
+    {
+        $this->shouldHaveType(\RuntimeException::class);
+    }
+
+    function it_is_a_container_interop_compliant_exception()
+    {
+        $this->shouldHaveType(ContainerException::class);
+    }
+}

--- a/spec/PhpSpec/Container/ServiceContainerSpec.php
+++ b/spec/PhpSpec/Container/ServiceContainerSpec.php
@@ -1,11 +1,17 @@
 <?php
 
-namespace spec\PhpSpec;
+namespace spec\PhpSpec\Container;
 
+use Interop\Container\ContainerInterface;
 use PhpSpec\ObjectBehavior;
 
 class ServiceContainerSpec extends ObjectBehavior
 {
+    function it_is_standards_compliant()
+    {
+        $this->shouldHaveType(ContainerInterface::class);
+    }
+
     function it_stores_parameters()
     {
         $this->setParam('some_param', 42);

--- a/spec/PhpSpec/Container/ServiceContainerSpec.php
+++ b/spec/PhpSpec/Container/ServiceContainerSpec.php
@@ -12,22 +12,6 @@ class ServiceContainerSpec extends ObjectBehavior
         $this->shouldHaveType(ContainerInterface::class);
     }
 
-    function it_stores_parameters()
-    {
-        $this->setParam('some_param', 42);
-        $this->getParam('some_param')->shouldReturn(42);
-    }
-
-    function it_returns_null_value_for_unexisting_parameter()
-    {
-        $this->getParam('unexisting')->shouldReturn(null);
-    }
-
-    function it_returns_custom_default_for_unexisting_parameter_if_provided()
-    {
-        $this->getParam('unexisting', 42)->shouldReturn(42);
-    }
-
     function it_stores_services($service)
     {
         $this->set('some_service', $service);
@@ -76,15 +60,5 @@ class ServiceContainerSpec extends ObjectBehavior
 
         $this->shouldThrow()->duringGet('collection1.some_service');
         $this->getByPrefix('collection1')->shouldHaveCount(0);
-    }
-
-    function it_supports_custom_service_configurators()
-    {
-        $this->addConfigurator(function ($c) {
-            $c->setParam('name', 'Jim');
-        });
-        $this->configure();
-
-        $this->getParam('name')->shouldReturn('Jim');
     }
 }

--- a/spec/PhpSpec/Container/ServiceNotFoundSpec.php
+++ b/spec/PhpSpec/Container/ServiceNotFoundSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace spec\PhpSpec\Container;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Interop\Container\Exception\NotFoundException;
+
+class ServiceNotFoundSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedThrough('constructFromServiceId', ['wrong-service-id']);
+    }
+
+    function it_is_an_invalid_argument_exception()
+    {
+        $this->shouldHaveType(\InvalidArgumentException::class);
+    }
+
+    function it_is_a_container_interop_compliant_exception()
+    {
+        $this->shouldHaveType(NotFoundException::class);
+    }
+
+    function it_has_a_nice_message()
+    {
+        $this->getMessage()->shouldBe('Service "wrong-service-id" not found in container');
+    }
+}

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -179,7 +179,7 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
         $this->supportsQuery(
-            realpath($this->srcPath.'/PhpSpec/ServiceContainer.php')
+            realpath($this->srcPath.'/PhpSpec/Container/ServiceContainer.php')
         )->shouldReturn(true);
     }
 
@@ -202,7 +202,7 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
         $this->supportsQuery(
-            realpath($this->specPath.'/spec/PhpSpec/ServiceContainerSpec.php')
+            realpath($this->specPath.'/spec/PhpSpec/Container/ServiceContainerSpec.php')
         )->shouldReturn(true);
     }
 
@@ -217,16 +217,16 @@ class PSR0LocatorSpec extends ObjectBehavior
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/ContainerSpec.php');
+        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/Container/ServiceContainerSpec.php');
 
         $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/'))->willReturn(true);
         $fs->findSpecFilesIn($this->specPath.$this->convert_to_path('/spec/PhpSpec/'))->willReturn(array($file));
-        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec; class Container {} ?>');
+        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec\\Container; class ServiceContainer {} ?>');
         $file->getRealPath()->willReturn($filePath);
 
         $resources = $this->findResources($this->srcPath);
         $resources->shouldHaveCount(1);
-        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\Container');
+        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\Container\ServiceContainer');
     }
 
     function it_finds_spec_resources_with_classname_underscores_via_srcPath(Filesystem $fs, SplFileInfo $file)
@@ -281,30 +281,30 @@ class PSR0LocatorSpec extends ObjectBehavior
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/ServiceContainerSpec.php');
+        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/Container/ServiceContainerSpec.php');
 
-        $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/ServiceContainerSpec.php'))->willReturn(true);
-        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec; class ServiceContainer {} ?>');
+        $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/Container/ServiceContainerSpec.php'))->willReturn(true);
+        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec\\Container; class ServiceContainer {} ?>');
         $file->getRealPath()->willReturn($filePath);
 
-        $resources = $this->findResources($this->srcPath.$this->convert_to_path('/PhpSpec/ServiceContainer.php'));
+        $resources = $this->findResources($this->srcPath.$this->convert_to_path('/PhpSpec/Container/ServiceContainer.php'));
         $resources->shouldHaveCount(1);
-        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\ServiceContainer');
+        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\Container\ServiceContainer');
     }
 
     function it_finds_single_spec_via_specPath(Filesystem $fs, SplFileInfo $file)
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/ServiceContainerSpec.php');
+        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/Container/ServiceContainerSpec.php');
 
-        $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/ServiceContainerSpec.php'))->willReturn(true);
-        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec; class ServiceContainer {} ?>');
+        $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/Container/ServiceContainerSpec.php'))->willReturn(true);
+        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec\\Container; class ServiceContainer {} ?>');
         $file->getRealPath()->willReturn($filePath);
 
         $resources = $this->findResources($filePath);
         $resources->shouldHaveCount(1);
-        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\ServiceContainer');
+        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\Container\ServiceContainer');
     }
 
     function it_returns_empty_array_if_nothing_found(Filesystem $fs)
@@ -369,28 +369,28 @@ class PSR0LocatorSpec extends ObjectBehavior
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $this->supportsClass('PhpSpec\ServiceContainer')->shouldReturn(true);
+        $this->supportsClass('PhpSpec\Container\ServiceContainer')->shouldReturn(true);
     }
 
     function it_supports_backslashed_classes_from_srcNamespace(Filesystem $fs)
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $this->supportsClass('PhpSpec/ServiceContainer')->shouldReturn(true);
+        $this->supportsClass('PhpSpec/Container/ServiceContainer')->shouldReturn(true);
     }
 
     function it_supports_classes_from_specNamespace(Filesystem $fs)
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $this->supportsClass('spec\PhpSpec\ServiceContainer')->shouldReturn(true);
+        $this->supportsClass('spec\PhpSpec\Container\ServiceContainer')->shouldReturn(true);
     }
 
     function it_supports_backslashed_classes_from_specNamespace(Filesystem $fs)
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $this->supportsClass('spec/PhpSpec/ServiceContainer')->shouldReturn(true);
+        $this->supportsClass('spec/PhpSpec/Container/ServiceContainer')->shouldReturn(true);
     }
 
     function it_supports_any_class_if_srcNamespace_is_empty(Filesystem $fs)

--- a/src/PhpSpec/Config/Manager.php
+++ b/src/PhpSpec/Config/Manager.php
@@ -1,0 +1,108 @@
+<?php
+namespace PhpSpec\Config;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Yaml\Yaml;
+use RuntimeException;
+
+class Manager
+{
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OptionsConfig
+     */
+    private $optionsConfig;
+
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+
+    public function optionsConfig()
+    {
+        if (!$this->optionsConfig) {
+            $optionsArray = $this->parseConfigurationFile($this->input);
+            $this->optionsConfig = new OptionsConfig($optionsArray, $this->input);
+        }
+        return $this->optionsConfig;
+    }
+
+    /**
+     * @param InputInterface $input
+     *
+     * @return array
+     *
+     * @throws \RuntimeException
+     */
+    private function parseConfigurationFile(InputInterface $input)
+    {
+        $paths = array('phpspec.yml','phpspec.yml.dist');
+
+        if ($customPath = $input->getParameterOption(array('-c','--config'))) {
+            if (!file_exists($customPath)) {
+                throw new RuntimeException('Custom configuration file not found at '.$customPath);
+            }
+            $paths = array($customPath);
+        }
+
+        $config = $this->extractConfigFromFirstParsablePath($paths);
+
+        if ($homeFolder = getenv('HOME')) {
+            $config = array_replace_recursive($this->parseConfigFromExistingPath($homeFolder.'/.phpspec.yml'), $config);
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param array $paths
+     *
+     * @return array
+     */
+    private function extractConfigFromFirstParsablePath(array $paths)
+    {
+        foreach ($paths as $path) {
+            $config = $this->parseConfigFromExistingPath($path);
+            if (!empty($config)) {
+                return $this->addPathsToEachSuiteConfig(dirname($path), $config);
+            }
+        }
+
+        return array();
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return array
+     */
+    private function parseConfigFromExistingPath($path)
+    {
+        if (!file_exists($path)) {
+            return array();
+        }
+
+        return Yaml::parse(file_get_contents($path));
+    }
+
+    /**
+     * @param string $configDir
+     * @param array $config
+     *
+     * @return array
+     */
+    private function addPathsToEachSuiteConfig($configDir, $config)
+    {
+        if (isset($config['suites']) && is_array($config['suites'])) {
+            foreach ($config['suites'] as $suiteKey => $suiteConfig) {
+                $config['suites'][$suiteKey] = str_replace('%paths.config%', $configDir, $suiteConfig);
+            }
+        }
+
+        return $config;
+    }
+}

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -13,81 +13,96 @@
 
 namespace PhpSpec\Config;
 
+use Symfony\Component\Console\Input\InputInterface;
+
 class OptionsConfig
 {
     /**
-     * @var bool
+     * @var array
      */
-    private $stopOnFailureEnabled;
+    private $optionsArray;
 
     /**
-     * @var bool
+     * @var InputInterface
      */
-    private $codeGenerationEnabled;
+    private $input;
 
     /**
-     * @var bool
+     * @param array          $optionsArray
+     * @param InputInterface $input
      */
-    private $reRunEnabled;
-
-    /**
-     * @var bool
-     */
-    private $fakingEnabled;
-    /**
-     * @var string|bool
-     */
-    private $bootstrapPath;
-
-    /**
-     * @param bool $stopOnFailureEnabled
-     * @param bool $codeGenerationEnabled
-     * @param bool $reRunEnabled
-     * @param bool $fakingEnabled
-     * @param string|bool $bootstrapPath
-     */
-    public function __construct(
-        $stopOnFailureEnabled,
-        $codeGenerationEnabled,
-        $reRunEnabled,
-        $fakingEnabled,
-        $bootstrapPath
-    ) {
-        $this->stopOnFailureEnabled  = $stopOnFailureEnabled;
-        $this->codeGenerationEnabled = $codeGenerationEnabled;
-        $this->reRunEnabled = $reRunEnabled;
-        $this->fakingEnabled = $fakingEnabled;
-        $this->bootstrapPath = $bootstrapPath;
+    public function __construct(array $optionsArray, InputInterface $input)
+    {
+        $this->optionsArray = $optionsArray;
+        $this->input = $input;
     }
 
-    /**
-     * @return bool
-     */
     public function isStopOnFailureEnabled()
     {
-        return $this->stopOnFailureEnabled;
+        return isset($this->optionsArray['stop_on_failure']) ? $this->optionsArray['stop_on_failure'] : false;
     }
 
-    /**
-     * @return bool
-     */
     public function isCodeGenerationEnabled()
     {
-        return $this->codeGenerationEnabled;
+        return isset($this->optionsArray['code_generation']) ? $this->optionsArray['code_generation'] : true;
     }
 
     public function isReRunEnabled()
     {
-        return $this->reRunEnabled;
+        if ($this->input->hasOption('no-rerun') && $this->input->getOption('no-rerun')) {
+            return $this->input->getOption('no-rerun');
+        }
+        return isset($this->optionsArray['rerun']) ? $this->optionsArray['rerun'] : true;
     }
 
     public function isFakingEnabled()
     {
-        return $this->fakingEnabled;
+        return isset($this->optionsArray['fake']) ? $this->optionsArray['fake'] : false;
     }
 
     public function getBootstrapPath()
     {
-        return $this->bootstrapPath;
+        return isset($this->optionsArray['bootstrap']) ? $this->optionsArray['bootstrap'] : false;
+    }
+
+    public function getExtensions()
+    {
+        return isset($this->optionsArray['extensions']) ? $this->optionsArray['extensions'] : [];
+    }
+
+    public function getFormatterName()
+    {
+        if ($this->input->hasOption('format') && $this->input->getOption('format')) {
+            return $this->input->getOption('format');
+        }
+        return isset($this->optionsArray['formatter.name']) ? $this->optionsArray['formatter.name'] : 'progress';
+    }
+
+    public function getCodeGeneratorTemplatePaths()
+    {
+        if (isset($this->optionsArray['code_generator.templates.paths'])) {
+            return $this->optionsArray['code_generator.templates.paths'];
+        }
+
+        if (!empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
+            $home = $_SERVER['HOMEDRIVE'].$_SERVER['HOMEPATH'];
+        } else {
+            $home = getenv('HOME');
+        }
+
+        return [
+            rtrim(getcwd(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'.phpspec',
+            rtrim($home, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'.phpspec',
+        ];
+    }
+
+    public function getSuites()
+    {
+        return isset($this->optionsArray['suites']) ? $this->optionsArray['suites'] : ['main' => ''];
+    }
+
+    public function getErrorLevel()
+    {
+        return isset($this->optionsArray['runner.maintainers.errors.level']) ? $this->optionsArray['runner.maintainers.errors.level'] : E_ALL ^ E_STRICT;
     }
 }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use PhpSpec\Console\Manager as ConsoleManager;
 use PhpSpec\Container\ServiceContainer;
 
 /**
@@ -58,15 +59,12 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        $helperSet = $this->getHelperSet();
-
         $assembler = new ServiceContainerConfigurer();
         $assembler->build($this->container);
 
         $this->container->get('phpspec.config-manager')->setInput($input);
-        $this->container->set('console.input', $input);
-        $this->container->set('console.output', $output);
-        $this->container->set('console.helper_set', $helperSet);
+        $consoleManager = $this->container->get('phpspec.console-manager');
+        $this->configureConsoleManager($consoleManager, $input, $output);
 
         $this->loadExtensions($this->container);
 
@@ -143,5 +141,12 @@ class Application extends BaseApplication
 
             $extension->load($container);
         }
+    }
+
+    private function configureConsoleManager(ConsoleManager $consoleManager, InputInterface $input, OutputInterface $output)
+    {
+        $consoleManager->setInput($input);
+        $consoleManager->setOutput($output);
+        $consoleManager->setQuestionHelper($this->getHelperSet()->get('question'));
     }
 }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -14,16 +14,14 @@
 namespace PhpSpec\Console;
 
 use PhpSpec\Container\ServiceContainerConfigurer;
+use PhpSpec\Extension;
 use PhpSpec\Loader\StreamWrapper;
 use PhpSpec\Process\Context\JsonExecutionContext;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Yaml\Yaml;
 use PhpSpec\Container\ServiceContainer;
-use PhpSpec\Extension;
-use RuntimeException;
 
 /**
  * The command line application entry point
@@ -61,18 +59,20 @@ class Application extends BaseApplication
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         $helperSet = $this->getHelperSet();
-        $this->container->set('console.input', $input);
-        $this->container->set('console.output', $output);
-        $this->container->set('console.helper_set', $helperSet);
-
-        $this->container->setShared('process.executioncontext', function () {
-            return JsonExecutionContext::fromEnv($_SERVER);
-        });
 
         $assembler = new ServiceContainerConfigurer();
         $assembler->build($this->container);
 
-        $this->loadConfigurationFile($input, $this->container);
+        $this->container->get('phpspec.config-manager')->setInput($input);
+        $this->container->set('console.input', $input);
+        $this->container->set('console.output', $output);
+        $this->container->set('console.helper_set', $helperSet);
+
+        $this->loadExtensions($this->container);
+
+        $this->container->setShared('process.executioncontext', function () {
+            return JsonExecutionContext::fromEnv($_SERVER);
+        });
 
         foreach ($this->container->getByPrefix('console.commands') as $command) {
             $this->add($command);
@@ -125,107 +125,23 @@ class Application extends BaseApplication
     }
 
     /**
-     * @param InputInterface   $input
      * @param ServiceContainer $container
      *
      * @throws \RuntimeException
      */
-    protected function loadConfigurationFile(InputInterface $input, ServiceContainer $container)
+    private function loadExtensions(ServiceContainer $container)
     {
-        $config = $this->parseConfigurationFile($input);
+        foreach ($container->get('phpspec.config-manager')->optionsConfig()->getExtensions() as $class) {
+            $extension = new $class();
 
-        foreach ($config as $key => $val) {
-            if ('extensions' === $key && is_array($val)) {
-                foreach ($val as $class) {
-                    $extension = new $class();
-
-                    if (!$extension instanceof Extension) {
-                        throw new RuntimeException(sprintf(
-                            'Extension class must implement PhpSpec\Extension. But `%s` is not.',
-                            $class
-                        ));
-                    }
-
-                    $extension->load($container);
-                }
-            } else {
-                $container->setParam($key, $val);
+            if (!$extension instanceof Extension) {
+                throw new \RuntimeException(sprintf(
+                    'Extension class must implement PhpSpec\Extension. But `%s` is not.',
+                    $class
+                ));
             }
+
+            $extension->load($container);
         }
-    }
-
-    /**
-     * @param InputInterface $input
-     *
-     * @return array
-     *
-     * @throws \RuntimeException
-     */
-    protected function parseConfigurationFile(InputInterface $input)
-    {
-        $paths = array('phpspec.yml','phpspec.yml.dist');
-
-        if ($customPath = $input->getParameterOption(array('-c','--config'))) {
-            if (!file_exists($customPath)) {
-                throw new RuntimeException('Custom configuration file not found at '.$customPath);
-            }
-            $paths = array($customPath);
-        }
-
-        $config = $this->extractConfigFromFirstParsablePath($paths);
-
-        if ($homeFolder = getenv('HOME')) {
-            $config = array_replace_recursive($this->parseConfigFromExistingPath($homeFolder.'/.phpspec.yml'), $config);
-        }
-
-        return $config;
-    }
-
-    /**
-     * @param array $paths
-     *
-     * @return array
-     */
-    private function extractConfigFromFirstParsablePath(array $paths)
-    {
-        foreach ($paths as $path) {
-            $config = $this->parseConfigFromExistingPath($path);
-            if (!empty($config)) {
-                return $this->addPathsToEachSuiteConfig(dirname($path), $config);
-            }
-        }
-
-        return array();
-    }
-
-    /**
-     * @param string $path
-     *
-     * @return array
-     */
-    private function parseConfigFromExistingPath($path)
-    {
-        if (!file_exists($path)) {
-            return array();
-        }
-
-        return Yaml::parse(file_get_contents($path));
-    }
-
-    /**
-     * @param string $configDir
-     * @param array $config
-     *
-     * @return array
-     */
-    private function addPathsToEachSuiteConfig($configDir, $config)
-    {
-        if (isset($config['suites']) && is_array($config['suites'])) {
-            foreach ($config['suites'] as $suiteKey => $suiteConfig) {
-                $config['suites'][$suiteKey] = str_replace('%paths.config%', $configDir, $suiteConfig);
-            }
-        }
-
-        return $config;
     }
 }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -68,10 +68,6 @@ class Application extends BaseApplication
 
         $this->loadExtensions($this->container);
 
-        $this->container->setShared('process.executioncontext', function () {
-            return JsonExecutionContext::fromEnv($_SERVER);
-        });
-
         foreach ($this->container->getByPrefix('console.commands') as $command) {
             $this->add($command);
         }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Console;
 
+use PhpSpec\Container\ServiceContainerConfigurer;
 use PhpSpec\Loader\StreamWrapper;
 use PhpSpec\Process\Context\JsonExecutionContext;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -20,7 +21,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
-use PhpSpec\ServiceContainer;
+use PhpSpec\Container\ServiceContainer;
 use PhpSpec\Extension;
 use RuntimeException;
 
@@ -68,7 +69,7 @@ class Application extends BaseApplication
             return JsonExecutionContext::fromEnv($_SERVER);
         });
 
-        $assembler = new ContainerAssembler();
+        $assembler = new ServiceContainerConfigurer();
         $assembler->build($this->container);
 
         $this->loadConfigurationFile($input, $this->container);

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -34,7 +34,7 @@ use PhpSpec\Formatter\Presenter\Value\NullTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\ObjectTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\QuotingStringTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\TruncatingStringTypePresenter;
-use PhpSpec\ServiceContainer;
+use PhpSpec\Container\ServiceContainer;
 use SebastianBergmann\Exporter\Exporter;
 
 class PresenterAssembler

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -138,12 +138,8 @@ EOF
     {
         $container = $this->getApplication()->getContainer();
 
-        $container->setParam(
-            'formatter.name',
-            $input->getOption('format') ?: $container->getParam('formatter.name')
-        );
+        $formatterName = $container->get('phpspec.config-manager')->optionsConfig()->getFormatterName();
 
-        $formatterName = $container->getParam('formatter.name', 'progress');
         $currentFormatter = $container->get('formatter.formatters.'.$formatterName);
 
         if ($currentFormatter instanceof FatalPresenter) {

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -15,7 +15,7 @@ namespace PhpSpec\Console\Command;
 
 use PhpSpec\Formatter\FatalPresenter;
 use PhpSpec\Process\Shutdown\UpdateConsoleAction;
-use PhpSpec\ServiceContainer;
+use PhpSpec\Container\ServiceContainer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -16,7 +16,7 @@ namespace PhpSpec\Console;
 use PhpSpec\IO\IO;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use PhpSpec\Config\OptionsConfig;
+use PhpSpec\Config\Manager as ConfigManager;
 
 /**
  * Class ConsoleIO deals with input and output from command line interaction
@@ -48,9 +48,9 @@ class ConsoleIO implements IO
     private $hasTempString = false;
 
     /**
-      * @var OptionsConfig
+      * @var ConfigManger
       */
-    private $config;
+    private $configManager;
 
     /**
      * @var integer
@@ -65,18 +65,18 @@ class ConsoleIO implements IO
     /**
      * @param InputInterface  $input
      * @param OutputInterface $output
-     * @param OptionsConfig   $config
+     * @param ConfigManager   $configManager
      * @param Prompter        $prompter
      */
     public function __construct(
         InputInterface $input,
         OutputInterface $output,
-        OptionsConfig $config,
+        ConfigManager $configManager,
         Prompter $prompter
     ) {
         $this->input   = $input;
         $this->output  = $output;
-        $this->config  = $config;
+        $this->configManager  = $configManager;
         $this->prompter = $prompter;
     }
 
@@ -105,7 +105,7 @@ class ConsoleIO implements IO
             return false;
         }
 
-        return $this->config->isCodeGenerationEnabled()
+        return $this->configManager->optionsConfig()->isCodeGenerationEnabled()
             && !$this->input->getOption('no-code-generation');
     }
 
@@ -114,7 +114,7 @@ class ConsoleIO implements IO
      */
     public function isStopOnFailureEnabled()
     {
-        return $this->config->isStopOnFailureEnabled()
+        return $this->configManager->optionsConfig()->isStopOnFailureEnabled()
             || $this->input->getOption('stop-on-failure');
     }
 
@@ -300,12 +300,12 @@ class ConsoleIO implements IO
 
     public function isRerunEnabled()
     {
-        return !$this->input->getOption('no-rerun') && $this->config->isReRunEnabled();
+        return !$this->input->getOption('no-rerun') && $this->configManager->optionsConfig()->isReRunEnabled();
     }
 
     public function isFakingEnabled()
     {
-        return $this->input->getOption('fake') || $this->config->isFakingEnabled();
+        return $this->input->getOption('fake') || $this->configManager->optionsConfig()->isFakingEnabled();
     }
 
     public function getBootstrapPath()
@@ -314,7 +314,7 @@ class ConsoleIO implements IO
             return $path;
         }
 
-        if ($path = $this->config->getBootstrapPath()) {
+        if ($path = $this->configManager->optionsConfig()->getBootstrapPath()) {
             return $path;
         }
         return false;

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -17,6 +17,7 @@ use PhpSpec\IO\IO;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use PhpSpec\Config\Manager as ConfigManager;
+use PhpSpec\Console\Manager as ConsoleManager;
 
 /**
  * Class ConsoleIO deals with input and output from command line interaction
@@ -28,14 +29,9 @@ class ConsoleIO implements IO
     const COL_MAX_WIDTH = 80;
 
     /**
-     * @var InputInterface
+     * @var ConsoleManager
      */
-    private $input;
-
-    /**
-     * @var OutputInterface
-     */
-    private $output;
+    private $consoleManager;
 
     /**
      * @var string
@@ -48,7 +44,7 @@ class ConsoleIO implements IO
     private $hasTempString = false;
 
     /**
-      * @var ConfigManger
+      * @var ConfigManager
       */
     private $configManager;
 
@@ -63,20 +59,17 @@ class ConsoleIO implements IO
     private $prompter;
 
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
+     * @param ConsoleManager  $consoleManager
      * @param ConfigManager   $configManager
      * @param Prompter        $prompter
      */
     public function __construct(
-        InputInterface $input,
-        OutputInterface $output,
+        ConsoleManager $consoleManager,
         ConfigManager $configManager,
         Prompter $prompter
     ) {
-        $this->input   = $input;
-        $this->output  = $output;
-        $this->configManager  = $configManager;
+        $this->consoleManager = $consoleManager;
+        $this->configManager = $configManager;
         $this->prompter = $prompter;
     }
 
@@ -85,7 +78,7 @@ class ConsoleIO implements IO
      */
     public function isInteractive()
     {
-        return $this->input->isInteractive();
+        return $this->getInput()->isInteractive();
     }
 
     /**
@@ -93,7 +86,7 @@ class ConsoleIO implements IO
      */
     public function isDecorated()
     {
-        return $this->output->isDecorated();
+        return $this->getOutput()->isDecorated();
     }
 
     /**
@@ -106,7 +99,7 @@ class ConsoleIO implements IO
         }
 
         return $this->configManager->optionsConfig()->isCodeGenerationEnabled()
-            && !$this->input->getOption('no-code-generation');
+            && !$this->getInput()->getOption('no-code-generation');
     }
 
     /**
@@ -115,7 +108,7 @@ class ConsoleIO implements IO
     public function isStopOnFailureEnabled()
     {
         return $this->configManager->optionsConfig()->isStopOnFailureEnabled()
-            || $this->input->getOption('stop-on-failure');
+            || $this->getInput()->getOption('stop-on-failure');
     }
 
     /**
@@ -123,7 +116,7 @@ class ConsoleIO implements IO
      */
     public function isVerbose()
     {
-        return OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity();
+        return OutputInterface::VERBOSITY_VERBOSE <= $this->getOutput()->getVerbosity();
     }
 
     /**
@@ -194,7 +187,7 @@ class ConsoleIO implements IO
             $message = $this->indentText($message, $indent);
         }
 
-        $this->output->write($message, $newline);
+        $this->getOutput()->write($message, $newline);
         $this->lastMessage = $message.($newline ? "\n" : '');
     }
 
@@ -300,17 +293,17 @@ class ConsoleIO implements IO
 
     public function isRerunEnabled()
     {
-        return !$this->input->getOption('no-rerun') && $this->configManager->optionsConfig()->isReRunEnabled();
+        return !$this->getInput()->getOption('no-rerun') && $this->configManager->optionsConfig()->isReRunEnabled();
     }
 
     public function isFakingEnabled()
     {
-        return $this->input->getOption('fake') || $this->configManager->optionsConfig()->isFakingEnabled();
+        return $this->getInput()->getOption('fake') || $this->configManager->optionsConfig()->isFakingEnabled();
     }
 
     public function getBootstrapPath()
     {
-        if ($path = $this->input->getOption('bootstrap')) {
+        if ($path = $this->getInput()->getOption('bootstrap')) {
             return $path;
         }
 
@@ -355,13 +348,29 @@ class ConsoleIO implements IO
             $message = $this->indentText($message, $indent);
         }
 
-        $this->output->writeln("<broken-bg>".str_repeat(" ", $this->getBlockWidth())."</broken-bg>");
+        $this->getOutput()->writeln("<broken-bg>".str_repeat(" ", $this->getBlockWidth())."</broken-bg>");
 
         foreach (explode("\n", $message) as $line) {
-            $this->output->writeln("<broken-bg>".str_pad($line, $this->getBlockWidth(), ' ')."</broken-bg>");
+            $this->getOutput()->writeln("<broken-bg>".str_pad($line, $this->getBlockWidth(), ' ')."</broken-bg>");
         }
 
-        $this->output->writeln("<broken-bg>".str_repeat(" ", $this->getBlockWidth())."</broken-bg>");
-        $this->output->writeln('');
+        $this->getOutput()->writeln("<broken-bg>".str_repeat(" ", $this->getBlockWidth())."</broken-bg>");
+        $this->getOutput()->writeln('');
+    }
+
+    /**
+     * @return OutputInterface
+     */
+    private function getOutput()
+    {
+        return $this->consoleManager->getOutput();
+    }
+
+    /**
+     * @return InputInterface
+     */
+    private function getInput()
+    {
+        return $this->consoleManager->getInput();
     }
 }

--- a/src/PhpSpec/Console/Manager.php
+++ b/src/PhpSpec/Console/Manager.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Manager
+{
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var QuestionHelper
+     */
+    private $questionHelper;
+
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function setQuestionHelper(QuestionHelper $questionHelper)
+    {
+        $this->questionHelper = $questionHelper;
+    }
+
+    /**
+     * @return InputInterface
+     */
+    public function getInput()
+    {
+        return $this->input;
+    }
+
+    /**
+     * @return OutputInterface
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    /**
+     * @return QuestionHelper
+     */
+    public function getQuestionHelper()
+    {
+        return $this->questionHelper;
+    }
+}

--- a/src/PhpSpec/Console/Prompter/Question.php
+++ b/src/PhpSpec/Console/Prompter/Question.php
@@ -14,38 +14,22 @@
 namespace PhpSpec\Console\Prompter;
 
 use PhpSpec\Console\Prompter;
-use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use PhpSpec\Console\Manager as ConsoleManager;
 
 final class Question implements Prompter
 {
     /**
-     * @var InputInterface
+     * @var ConsoleManager
      */
-    private $input;
+    private $consoleManager;
 
     /**
-     * @var OutputInterface
+     * @param ConsoleManager $consoleManager
      */
-    private $output;
-
-    /**
-     * @var QuestionHelper
-     */
-    private $helper;
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     * @param QuestionHelper  $helper
-     */
-    public function __construct(InputInterface $input, OutputInterface $output, QuestionHelper $helper)
+    public function __construct(ConsoleManager $consoleManager)
     {
-        $this->input = $input;
-        $this->output = $output;
-        $this->helper = $helper;
+        $this->consoleManager = $consoleManager;
     }
 
     /**
@@ -55,6 +39,9 @@ final class Question implements Prompter
      */
     public function askConfirmation($question, $default = true)
     {
-        return (bool)$this->helper->ask($this->input, $this->output, new ConfirmationQuestion($question, $default));
+        $input = $this->consoleManager->getInput();
+        $output = $this->consoleManager->getOutput();
+        $questionHelper = $this->consoleManager->getQuestionHelper();
+        return (bool)$questionHelper->ask($input, $output, new ConfirmationQuestion($question, $default));
     }
 }

--- a/src/PhpSpec/Container/ContainerException.php
+++ b/src/PhpSpec/Container/ContainerException.php
@@ -11,18 +11,10 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec;
+namespace PhpSpec\Container;
 
-use PhpSpec\Container\ServiceContainer;
+use Interop\Container\Exception\ContainerException as ContainerInteropException;
 
-/**
- * Interface Extension is used for PhpSpec extensions to interface with PhpSpec
- * through the service container
- */
-interface Extension
+class ContainerException extends \RuntimeException implements ContainerInteropException
 {
-    /**
-     * @param ServiceContainer $container
-     */
-    public function load(ServiceContainer $container);
 }

--- a/src/PhpSpec/Container/ServiceContainer.php
+++ b/src/PhpSpec/Container/ServiceContainer.php
@@ -25,11 +25,6 @@ class ServiceContainer implements ContainerInterface
     /**
      * @var array
      */
-    private $parameters = array();
-
-    /**
-     * @var array
-     */
     private $services = array();
 
     /**
@@ -41,30 +36,6 @@ class ServiceContainer implements ContainerInterface
      * @var array
      */
     private $configurators = array();
-
-    /**
-     * Sets a param in the container
-     *
-     * @param string $id
-     * @param mixed  $value
-     */
-    public function setParam($id, $value)
-    {
-        $this->parameters[$id] = $value;
-    }
-
-    /**
-     * Gets a param from the container or a default value.
-     *
-     * @param string $id
-     * @param mixed  $default
-     *
-     * @return mixed
-     */
-    public function getParam($id, $default = null)
-    {
-        return isset($this->parameters[$id]) ? $this->parameters[$id] : $default;
-    }
 
     /**
      * Sets a object or a callable for the object creation. A callable will be invoked

--- a/src/PhpSpec/Container/ServiceContainer.php
+++ b/src/PhpSpec/Container/ServiceContainer.php
@@ -11,15 +11,16 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec;
+namespace PhpSpec\Container;
 
+use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 
 /**
  * The Service Container is a lightweight container based on Pimple to handle
  * object creation of PhpSpec services.
  */
-class ServiceContainer
+class ServiceContainer implements ContainerInterface
 {
     /**
      * @var array
@@ -69,30 +70,27 @@ class ServiceContainer
      * Sets a object or a callable for the object creation. A callable will be invoked
      * every time get is called.
      *
-     * @param string          $id
+     * @param string          $serviceId
      * @param object|callable $value
      *
      * @throws \InvalidArgumentException if service is not an object or callable
      */
-    public function set($id, $value)
+    public function set($serviceId, $value)
     {
         if (!is_object($value) && !is_callable($value)) {
-            throw new InvalidArgumentException(sprintf(
-                'Service should be callable or object, but %s given.',
-                gettype($value)
-            ));
+            ServiceNotFound::constructFromServiceId($serviceId);
         }
 
-        list($prefix, $sid) = $this->getPrefixAndSid($id);
+        list($prefix, $sid) = $this->getPrefixAndSid($serviceId);
         if ($prefix) {
             if (!isset($this->prefixed[$prefix])) {
                 $this->prefixed[$prefix] = array();
             }
 
-            $this->prefixed[$prefix][$sid] = $id;
+            $this->prefixed[$prefix][$sid] = $serviceId;
         }
 
-        $this->services[$id] = $value;
+        $this->services[$serviceId] = $value;
     }
 
     /**
@@ -107,7 +105,7 @@ class ServiceContainer
     public function setShared($id, $callable)
     {
         if (!is_callable($callable)) {
-            throw new InvalidArgumentException(sprintf(
+            throw new ContainerException(sprintf(
                 'Service should be callable, "%s" given.',
                 gettype($callable)
             ));
@@ -127,19 +125,19 @@ class ServiceContainer
     /**
      * Retrieves a service from the container
      *
-     * @param string $id
+     * @param string $serviceId
      *
      * @return object
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function get($id)
+    public function get($serviceId)
     {
-        if (!array_key_exists($id, $this->services)) {
-            throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
+        if (!$this->has($serviceId)) {
+            throw ServiceNotFound::constructFromServiceId($serviceId);
         }
 
-        $value = $this->services[$id];
+        $value = $this->services[$serviceId];
         if (is_callable($value)) {
             return call_user_func($value, $this);
         }
@@ -148,12 +146,22 @@ class ServiceContainer
     }
 
     /**
-     * @param $id
+     * @param string $serviceId
      * @return bool
      */
-    public function isDefined($id)
+    public function has($serviceId)
     {
-        return array_key_exists($id, $this->services);
+        return array_key_exists($serviceId, $this->services);
+    }
+
+    /**
+     * @deprecated Use has()
+     * @param $serviceId
+     * @return bool
+     */
+    public function isDefined($serviceId)
+    {
+        return $this->has($serviceId);
     }
 
     /**

--- a/src/PhpSpec/Container/ServiceContainerConfigurer.php
+++ b/src/PhpSpec/Container/ServiceContainerConfigurer.php
@@ -27,6 +27,7 @@ use PhpSpec\Console\Formatter;
 use PhpSpec\Console\Prompter\Question;
 use PhpSpec\Console\ResultConverter;
 use PhpSpec\Factory\ReflectionFactory;
+use PhpSpec\Process\Context\JsonExecutionContext;
 use PhpSpec\Process\Prerequisites\SuitePrerequisites;
 use PhpSpec\Util\ClassFileAnalyser;
 use PhpSpec\Util\Filesystem;
@@ -55,6 +56,7 @@ class ServiceContainerConfigurer
     {
         $this->setupConfigManager($container);
         $this->setupConsoleManager($container);
+        $this->setupExecutionContext($container);
         $this->setupIO($container);
         $this->setupEventDispatcher($container);
         $this->setupConsoleEventDispatcher($container);
@@ -84,6 +86,13 @@ class ServiceContainerConfigurer
     {
         $container->setShared('phpspec.console-manager', function (ServiceContainer $container) {
             return new ConsoleManager();
+        });
+    }
+
+    private function setupExecutionContext(ServiceContainer $container)
+    {
+        $container->setShared('process.executioncontext', function () {
+            return JsonExecutionContext::fromEnv($_SERVER);
         });
     }
 

--- a/src/PhpSpec/Container/ServiceContainerConfigurer.php
+++ b/src/PhpSpec/Container/ServiceContainerConfigurer.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Console;
+namespace PhpSpec\Container;
 
 use PhpSpec\CodeAnalysis\MagicAwareAccessInspector;
 use PhpSpec\CodeAnalysis\StaticRejectingNamespaceResolver;
@@ -19,7 +19,11 @@ use PhpSpec\CodeAnalysis\TokenizedNamespaceResolver;
 use PhpSpec\CodeAnalysis\TokenizedTypeHintRewriter;
 use PhpSpec\CodeAnalysis\VisibilityAccessInspector;
 use PhpSpec\Console\Assembler\PresenterAssembler;
+use PhpSpec\Console\Command;
+use PhpSpec\Console\ConsoleIO;
+use PhpSpec\Console\Formatter;
 use PhpSpec\Console\Prompter\Question;
+use PhpSpec\Console\ResultConverter;
 use PhpSpec\Factory\ReflectionFactory;
 use PhpSpec\Process\Prerequisites\SuitePrerequisites;
 use PhpSpec\Util\ClassFileAnalyser;
@@ -28,7 +32,6 @@ use PhpSpec\Util\ReservedWordsMethodNameChecker;
 use PhpSpec\Process\ReRunner;
 use PhpSpec\Util\MethodAnalyser;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use PhpSpec\ServiceContainer;
 use PhpSpec\CodeGenerator;
 use PhpSpec\Formatter as SpecFormatter;
 use PhpSpec\Listener;
@@ -42,7 +45,7 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use PhpSpec\Message\CurrentExampleTracker;
 use PhpSpec\Process\Shutdown\Shutdown;
 
-class ContainerAssembler
+class ServiceContainerConfigurer
 {
     /**
      * @param ServiceContainer $container
@@ -69,7 +72,7 @@ class ContainerAssembler
 
     private function setupIO(ServiceContainer $container)
     {
-        if (!$container->isDefined('console.prompter')) {
+        if (!$container->has('console.prompter')) {
             $container->setShared('console.prompter', function ($c) {
                 return new Question(
                     $c->get('console.input'),
@@ -426,16 +429,16 @@ class ContainerAssembler
                 return new Loader\Transformer\TypeHintRewriter($c->get('analysis.typehintrewriter'));
             });
         }
-        $container->setShared('analysis.typehintrewriter', function($c) {
+        $container->setShared('analysis.typehintrewriter', function ($c) {
             return new TokenizedTypeHintRewriter(
                 $c->get('loader.transformer.typehintindex'),
                 $c->get('analysis.namespaceresolver')
             );
         });
-        $container->setShared('loader.transformer.typehintindex', function() {
+        $container->setShared('loader.transformer.typehintindex', function () {
             return new Loader\Transformer\InMemoryTypeHintIndex();
         });
-        $container->setShared('analysis.namespaceresolver.tokenized', function() {
+        $container->setShared('analysis.namespaceresolver.tokenized', function () {
             return new TokenizedNamespaceResolver();
         });
         $container->setShared('analysis.namespaceresolver', function ($c) {
@@ -611,15 +614,15 @@ class ContainerAssembler
             return new Wrapper\Unwrapper();
         });
 
-        $container->setShared('access_inspector', function($c) {
+        $container->setShared('access_inspector', function ($c) {
             return $c->get('access_inspector.magic');
         });
 
-        $container->setShared('access_inspector.magic', function($c) {
+        $container->setShared('access_inspector.magic', function ($c) {
             return new MagicAwareAccessInspector($c->get('access_inspector.visibility'));
         });
 
-        $container->setShared('access_inspector.visibility', function() {
+        $container->setShared('access_inspector.visibility', function () {
             return new VisibilityAccessInspector();
         });
     }
@@ -685,7 +688,7 @@ class ContainerAssembler
             );
         });
 
-        if ($container->isDefined('process.rerunner.platformspecific')) {
+        if ($container->has('process.rerunner.platformspecific')) {
             return;
         }
 
@@ -745,7 +748,7 @@ class ContainerAssembler
    */
     private function setupShutdown(ServiceContainer $container)
     {
-        $container->setShared('process.shutdown', function() {
+        $container->setShared('process.shutdown', function () {
             return new Shutdown();
         });
     }

--- a/src/PhpSpec/Container/ServiceNotFound.php
+++ b/src/PhpSpec/Container/ServiceNotFound.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Container;
+
+use Interop\Container\Exception\NotFoundException;
+
+class ServiceNotFound extends \InvalidArgumentException implements NotFoundException
+{
+    /**
+     * @param string $serviceId
+     * @return ServiceNotFound
+     */
+    public static function constructFromServiceId($serviceId)
+    {
+        return new ServiceNotFound('Service "' . $serviceId . '" not found in container');
+    }
+}


### PR DESCRIPTION
Depends on: https://github.com/phpspec/phpspec/pull/935
Depends on: https://github.com/phpspec/phpspec/pull/938

Creates a new Console Manager object.  Using this, removes all usages of `ServiceContainer::set()` from the `Application` class.

Though (possibly) valuable on its own, this is also a prerequisite for other changes to the dependency injection situation, to be proposed shortly.

This PR is based on previous ones, still open at time of writing. The proposed changes which are unique to this PR can be viewed in the [branch diff](https://github.com/Sam-Burns/phpspec/compare/di-option-2-phase-2...Sam-Burns:di-option-2-phase-3)