### PR TITLE
fix printing the last row when remainder is zero

### DIFF
--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -62,15 +62,16 @@ final class DotFormatter extends ConsoleFormatter
         }
 
         $remainder = $eventsCount % 50;
+        $endOfRow = 0 === $remainder;
         $lastRow = $eventsCount === $this->examplesCount;
 
-        if ($remainder === 0 || $lastRow) {
+        if ($lastRow && !$endOfRow) {
+            $io->write(str_repeat(' ', 50 - $remainder));
+        }
+
+        if ($lastRow || $endOfRow) {
             $length = strlen((string) $this->examplesCount);
             $format = sprintf(' %%%dd / %%%dd', $length, $length);
-
-            if ($lastRow) {
-                $io->write(str_repeat(' ', 50 - $remainder));
-            }
 
             $io->write(sprintf($format, $eventsCount, $this->examplesCount));
 


### PR DESCRIPTION
Before:
![screen shot 2016-05-31 at 11 43 32](https://cloud.githubusercontent.com/assets/625392/15671849/f94190b0-2724-11e6-8cb0-67d9cd66db7a.png)

After:
![screen shot 2016-05-31 at 11 42 35](https://cloud.githubusercontent.com/assets/625392/15671853/00732b50-2725-11e6-8757-43596c39ea74.png)
