### PR TITLE
Use extension to detect PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,7 @@ install:
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
-before_script:
-  - echo "<?php if (defined('HHVM_VERSION')) { echo ',@hhvm'; } else { if (PHP_VERSION_ID >= 50400) echo ',@php5.4'; if (PHP_VERSION_ID >= 70000) echo ',@php7'; }" > php_version_tags.php
-
 script:
    - bin/phpspec run --format=pretty
    - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty --tags '~@php-version'`php php_version_tags.php`
+   - ./vendor/bin/behat --format=pretty

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -9,6 +9,8 @@ default:
     smoke:
       contexts: [ IsolatedProcessContext, FilesystemContext ]
       filters: { tags: "@smoke && ~@isolated" }
+  extensions:
+    Cjm\Behat\VersionBasedTestSkipperExtension: ~
 
 no-smoke:
   suites:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "bossa/phpspec2-expect": "~1.0",
         "symfony/filesystem":    "~2.1|~3.0",
         "phpunit/phpunit":       "~4.4",
-        "ciaranmcnulty/versionbasedtestskipper": "0.2.*"
+        "ciaranmcnulty/versionbasedtestskipper": "^0.2.1"
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "behat/behat":           "^3.0.11",
         "bossa/phpspec2-expect": "~1.0",
         "symfony/filesystem":    "~2.1|~3.0",
-        "phpunit/phpunit":       "~4.4"
+        "phpunit/phpunit":       "~4.4",
+        "ciaranmcnulty/versionbasedtestskipper": "0.2.*"
     },
 
     "suggest": {

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -102,20 +102,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             $this->buildPhpSpecCmd() . " --format=$formatter run"
         );
         $process->run();
-        $this->lastOutput = $process->getErrorOutput();
-
-    }
-
-    /**
-     * @When I run phpspec on HHVM with the :formatter formatter
-     */
-    public function iRunPhpspecOnHhvmWithThe($formatter)
-    {
-        $process = new Process(
-            $this->buildPhpSpecCmd() . " --format=$formatter run"
-        );
-        $process->run();
-        $this->lastOutput = $process->getOutput();
+        $this->lastOutput = $process->getErrorOutput().$process->getOutput();
 
     }
 

--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -3,7 +3,7 @@ Feature: Developer generates a class
   I want to automate creating classes
   In order to avoid repetitive tasks and interruptions in development flow
 
-  @smoke @php-version @php5.4
+  @smoke @php:~5.4||~7.0
   Scenario: Generating a class
     Given I have started describing the "CodeGeneration/ClassExample1/Markdown" class
     When I run phpspec and answer "y" when asked if I want to generate the code
@@ -132,7 +132,7 @@ Feature: Developer generates a class
 
     """
 
-  @isolated @php-version @php5.4
+  @isolated @php:~5.4||~7.0
   Scenario: Generating a class outside of autoloadable paths gives a warning
     Given I have started describing the "CodeGeneration/ClassExample2/Markdown" class
     But I have not configured an autoloader

--- a/features/code_generation/developer_generates_collaborator_from_use_group.feature
+++ b/features/code_generation/developer_generates_collaborator_from_use_group.feature
@@ -1,4 +1,4 @@
-@php-version @php7
+@php:~7.0
 Feature: Developer generates a collaborator
   As a Developer
   I want to automate creating collaborators

--- a/features/code_generation/developer_generates_return_constant.feature
+++ b/features/code_generation/developer_generates_return_constant.feature
@@ -260,7 +260,7 @@ Feature: Developer generates a method returning a constant
     When I run phpspec interactively
     Then I should be prompted for code generation
 
-  @php-version @php5.4
+  @php:~5.4||~7.0
   Scenario: Generating a scalar return type when method is in trait
     Given the spec file "spec/CodeGeneration/ConstantExample7/MarkdownSpec.php" contains:
       """

--- a/features/code_generation/developer_reruns_features.feature
+++ b/features/code_generation/developer_reruns_features.feature
@@ -3,7 +3,7 @@ Feature: Developer generates a class
   I want the tests to automatically rerun after code generation events
   In order to avoid repetitive tasks and interruptions in development flow
 
-  @smoke @php-version @php5.4
+  @smoke @php:~5.4||~7.0
   Scenario: Rerun after class generation
     Given I have started describing the "CodeGeneration/RerunExample1/Markdown" class
     When I run phpspec and answer "y" when asked if I want to generate the code

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -45,7 +45,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     And  I should see "it fatals when calling an undeclared function"
 
   @isolated @php:~5.4||~7.0
-  Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
+  Scenario: Fatal error writer message not shown, when formatter does not support it.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """
       <?php
@@ -82,45 +82,4 @@ Feature: Developer is notified of which scenario caused a fatal error
 
       """
     When I run phpspec with the "junit" formatter
-    Then I should see "Call to undefined function"
-
-
-  @isolated @hhvm
-  Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stdout.
-    Given the spec file "spec/Message/Fatal/FatalHhvmSpec.php" contains:
-      """
-      <?php
-
-      namespace spec\Message\Fatal;
-
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
-
-      class FatalHhvmSpec extends ObjectBehavior
-      {
-          function it_fatals_when_calling_an_undeclared_function()
-          {
-              anything();
-          }
-      }
-
-      """
-    And the class file "src/Message/Fatal/FatalHhvm.php" contains:
-      """
-      <?php
-
-      namespace Message\Fatal;
-
-      class FatalHhvm
-      {
-          public function __construct($param)
-          {
-              if ($param == 'throw') {
-                  throw new \Exception();
-              }
-          }
-      }
-
-      """
-    When I run phpspec on HHVM with the "junit" formatter
     Then I should see "Call to undefined function"

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -44,7 +44,7 @@ Feature: Developer is notified of which scenario caused a fatal error
     Then I should see "Fatal error happened while executing the following"
     And  I should see "it fatals when calling an undeclared function"
 
-  @isolated @php-version @php5.4 @php7
+  @isolated @php:~5.4||~7.0
   Scenario: Fatal error writer message not shown, when formatter does not support it, outputs to stderr.
     Given the spec file "spec/Message/Fatal/Fatal2Spec.php" contains:
       """

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -4,7 +4,7 @@ Feature: Developer is shown a parse error
   So that I can know that I can handle pass errors
 
   @isolated @php:~5.4||~7.0
-  Scenario: Spec attempts to call an undeclared function and outputs to stderr
+  Scenario: Spec attempts to call an undeclared function
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """
       <?php
@@ -40,43 +40,4 @@ Feature: Developer is shown a parse error
 
       """
     When I run phpspec with the "junit" formatter
-    Then I should see "syntax error"
-
-  @isolated @hhvm
-  Scenario: Spec attempts to call an undeclared function and outputs to stdout
-    Given the spec file "spec/Message/Fatal/ParseHhvmSpec.php" contains:
-      """
-      <?php
-
-      namespace spec\Message\Fatal;
-
-      use Parse;
-      use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
-
-      class ParseHhvmSpec extends ObjectBehavior
-      {
-          function it_thro ws_a_syntax_error()
-          {
-              $this->cool();
-          }
-      }
-
-      """
-    And the spec file "src/Message/Fatal/ParseHhvm.php" contains:
-      """
-      <?php
-
-      namespace Message\Parse;
-
-      class ParseHhvm
-      {
-          public function cool()
-          {
-              return true;
-          }
-      }
-
-      """
-    When I run phpspec on HHVM with the "junit" formatter
     Then I should see "syntax error"

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -3,7 +3,7 @@ Feature: Developer is shown a parse error
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
-  @isolated @php-version @php5.4 @php7
+  @isolated @php:~5.4||~7.0
   Scenario: Spec attempts to call an undeclared function and outputs to stderr
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """

--- a/features/invalid_usage/developer_uses_unsupported_collaborator_type_hinting.feature
+++ b/features/invalid_usage/developer_uses_unsupported_collaborator_type_hinting.feature
@@ -43,7 +43,7 @@ Feature: Developer uses unsupported collaborator type hinting
             spec\InvalidUsage\InvalidUsageExample1\StorageSpec::it_can_store_data.
       """
 
-  @php-version @php5.4
+  @php:~5.4||~7.0
   Scenario: Callable collaborator type hinting
     Given the spec file "spec/InvalidUsage/InvalidUsageExample2/InvokerSpec.php" contains:
       """
@@ -86,7 +86,7 @@ Feature: Developer uses unsupported collaborator type hinting
       """
 
 
-  @php-version @php7
+  @php:~7.0
   Scenario: Integer collaborator type hinting
     Given the spec file "spec/InvalidUsage/InvalidUsageExample3/StorageSpec.php" contains:
       """

--- a/features/runner/developer_is_told_about_pending_specs.feature
+++ b/features/runner/developer_is_told_about_pending_specs.feature
@@ -89,7 +89,7 @@ Feature: Developer is told about pending specs
       1 examples (1 passed)
       """
 
-  @php-version @php5.4
+  @php:~5.4||~7.0
   Scenario: Spec defined in trait does not cause pending
     Given the trait file "spec/Runner/PendingExample4/PartialSpecTrait.php" contains:
       """


### PR DESCRIPTION
I wrote an extension with this sort of testing in mind; replaces the existing mechanism for skipping tests based on PHP version