### PR TITLE
Registered configured custom matchers

### DIFF
--- a/features/matchers/developer_uses_custom_matcher.feature
+++ b/features/matchers/developer_uses_custom_matcher.feature
@@ -1,0 +1,90 @@
+Feature: Developer uses custom matcher
+  As a Developer
+  I want a custom matcher
+  In order to confirm any custom assertion I need
+
+  Scenario: Succesfully register a custom matcher
+    Given the spec file "spec/Matchers/Custom/MovieSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Matchers\Custom;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function it_should_have_some_specific_options_by_default()
+        {
+            $this->getEntries()->shouldTotalize(130);
+        }
+    }
+    """
+
+    And the class file "src/Matchers/Custom/TotalizeMatcher.php" contains:
+    """
+    <?php
+
+    namespace Matchers\Custom;
+
+    use PhpSpec\Matcher\BasicMatcher;
+    use PhpSpec\Exception\Example\FailureException;
+
+    class TotalizeMatcher extends BasicMatcher
+    {
+        public function supports($name, $subject, array $arguments)
+        {
+            return 'totalize' === $name &&
+                is_array($subject) &&
+                isset($arguments[0]) &&
+                is_int($arguments[0])
+            ;
+        }
+
+        protected function matches($subject, array $arguments)
+        {
+            return array_sum($subject) === $arguments[0];
+        }
+
+        protected function getFailureException($name, $subject, array $arguments)
+        {
+            return new FailureException(sprintf(
+                'Expected to totalize %d, but got %d.',
+                $arguments[0],
+                array_sum($subject)
+            ));
+        }
+
+        protected function getNegativeFailureException($name, $subject, array $arguments)
+        {
+            return new FailureException(sprintf(
+                'Expected to not totalize %d, but it does.',
+                $arguments[0]
+            ));
+        }
+    }
+    """
+
+    And the class file "src/Matchers/Custom/Movie.php" contains:
+    """
+    <?php
+
+    namespace Matchers\Custom;
+
+    class Movie
+    {
+        public function getEntries()
+        {
+            return [100, 10, 20];
+        }
+    }
+    """
+
+    And the config file contains:
+    """
+    matchers:
+        - Matchers\Custom\TotalizeMatcher
+    """
+    When I run phpspec
+    Then the suite should pass

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -147,6 +147,13 @@ class Application extends BaseApplication
 
                     $extension->load($container);
                 }
+            } elseif ('matchers' === $key && is_array($val)) {
+                foreach ($val as $class) {
+                    $id = strtolower(str_replace('Matcher', '', substr($class, strrpos($class, '\\') + 1)));
+                    $container->set(sprintf('matchers.%s', $id), function (ServiceContainer $c) use ($class) {
+                        return new $class();
+                    });
+                }
             } else {
                 $container->setParam($key, $val);
             }


### PR DESCRIPTION
Hello everyone,

I'm starting a piece of contribution related to https://github.com/phpspec/phpspec/issues/870, if that's ok for you.

I like the idea of registering custom matchers that can be reused across specs, which is already possible to achieve with inline matcher and inheritance by the way, but a bit painfull.

The solution provided in this PR is to register the custom matchers in the container using the `matchers` prefix which is then used by the assembler to populate the `MatcherManager`.

I have a few questions:

  - What about overriding PhpSpec core matchers? Is it wishable? I don't really think so as it can lead to confusion.
  - A presenter is injected in all of the core matchers. Is it wishable to do the same with the custom matchers (see below)? 
  - Should it be a 3.0 feature or should it also be implemented in 2.5?

## Custom Matcher Dependencies
### Reflection
We could infer the ctor parameter and auto-inject the presenter.
```php
$id = strtolower(str_replace('Matcher', '', substr($class, strrpos($class, '\\') + 1)));
$container->set(sprintf('matchers.%s', $id), function (ServiceContainer $c) use ($class) {
    $reflClass = new \ReflectionClass($class);
    $args = [];
    foreach ($reflClass->getConstructor()->getParameters() as $parameter) {
        $class = $parameter->getClass();

        if ($class->implementsInterface(Presenter::class)) {
            $args[] = $c->get('formatter.presenter');
        }
    }

    return $reflClass->newInstanceArgs($args);
});
```

### Be Specific
 Another solution is to be specific in the configuration and define for each custom matcher which service to inject into it like so:
``` yaml
matchers:
    - App\Matcher\FooMatcher:
        formatter.presenter
``` 

Any toughts welcome, of course :wink: 