### PR TITLE
Add missing magic matcher methods

### DIFF
--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -31,9 +31,25 @@ use ArrayAccess;
  * @method void beConstructedWith(...$arguments)
  * @method void beConstructedThrough($factoryMethod, array $constructorArguments = array())
  * @method void beAnInstanceOf($class)
+ *
  * @method void shouldHaveType($type)
+ * @method void shouldNotHaveType($type)
+ * @method void shouldBeAnInstanceOf($type)
+ * @method void shouldNotBeAnInstanceOf($type)
  * @method void shouldImplement($interface)
+ * @method void shouldNotImplement($interface)
+ *
  * @method Subject\Expectation\DuringCall shouldThrow($exception = null)
+ * @method Subject\Expectation\DuringCall shouldNotThrow($exception = null)
+ *
+ * @method void shouldHaveCount($count)
+ * @method void shouldNotHaveCount($count)
+ *
+ * @method void shouldHaveKeyWithValue($key, $value)
+ * @method void shouldNotHaveKeyWithValue($key, $value)
+ *
+ * @method void shouldHaveKey($key)
+ * @method void shouldNotHaveKey($key)
  */
 abstract class ObjectBehavior implements
     ArrayAccess,

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -20,6 +20,88 @@ use PhpSpec\Wrapper\Subject\ExpectationFactory;
 use PhpSpec\Util\Instantiator;
 use ArrayAccess;
 
+/**
+ * @method void shouldHaveType($type)
+ * @method void shouldNotHaveType($type)
+ * @method void shouldReturnAnInstanceOf($type)
+ * @method void shouldNotReturnAnInstanceOf($type)
+ * @method void shouldBeAnInstanceOf($type)
+ * @method void shouldNotBeAnInstanceOf($type)
+ * @method void shouldImplement($interface)
+ * @method void shouldNotImplement($interface)
+ *
+ * @method void shouldBe($value)
+ * @method void shouldNotBe($value)
+ * @method void shouldBeEqualTo($value)
+ * @method void shouldNotBeEqualTo($value)
+ * @method void shouldReturn($value)
+ * @method void shouldNotReturn($value)
+ * @method void shouldEqual($value)
+ * @method void shouldNotEqual($value)
+ *
+ * @method void shouldBeLike($value)
+ * @method void shouldNotBeLike($value)
+ *
+ * @method void shouldHaveCount($count)
+ * @method void shouldNotHaveCount($count)
+ *
+ * @method void shouldBeArray()
+ * @method void shouldNotBeArray()
+ * @method void shouldBeBool()
+ * @method void shouldNotBeBool()
+ * @method void shouldBeBoolean()
+ * @method void shouldNotBeBoolean()
+ * @method void shouldBeCallable()
+ * @method void shouldNotBeCallable()
+ * @method void shouldBeDouble()
+ * @method void shouldNotBeDouble()
+ * @method void shouldBeFloat()
+ * @method void shouldNotBeFloat()
+ * @method void shouldBeInt()
+ * @method void shouldNotBeInt()
+ * @method void shouldBeInteger()
+ * @method void shouldNotBeInteger()
+ * @method void shouldBeLong()
+ * @method void shouldNotBeLong()
+ * @method void shouldBeNull()
+ * @method void shouldNotBeNull()
+ * @method void shouldBeNumeric()
+ * @method void shouldNotBeNumeric()
+ * @method void shouldBeObject()
+ * @method void shouldNotBeObject()
+ * @method void shouldBeReal()
+ * @method void shouldNotBeReal()
+ * @method void shouldBeResource()
+ * @method void shouldNotBeResource()
+ * @method void shouldBeScalar()
+ * @method void shouldNotBeScalar()
+ * @method void shouldBeString()
+ * @method void shouldNotBeString()
+ * @method void shouldBeNan()
+ * @method void shouldNotBeNan()
+ * @method void shouldBeFinite()
+ * @method void shouldNotBeFinite()
+ * @method void shouldBeInfinite()
+ * @method void shouldNotBeInfinite()
+ *
+ * @method void shouldContain($value)
+ * @method void shouldNotContain($value)
+ *
+ * @method void shouldHaveKeyWithValue($key, $value)
+ * @method void shouldNotHaveKeyWithValue($key, $value)
+ *
+ * @method void shouldHaveKey($key)
+ * @method void shouldNotHaveKey($key)
+ *
+ * @method void shouldStartWith($string)
+ * @method void shouldNotStartWith($string)
+ *
+ * @method void shouldEndWith($string)
+ * @method void shouldNotEndWith($string)
+ *
+ * @method void shouldMatch($regex)
+ * @method void shouldNotMatch($regex)
+ */
 class Subject implements ArrayAccess, ObjectWrapper
 {
     /**


### PR DESCRIPTION
Adds all missing `@method` tags to `ObjectBehaviour` for "static" matcher methods to improve DX (IDE autocompletion).
I'm not sure if this addition is desired but as there are already some present in the class, it should be all or nothing IMO. As long as a [real PhpStorm plugin solution is not possible](https://youtrack.jetbrains.com/issue/WI-22881), this helps at least for most of the matchers. Let me know what you guys think about it ;)