### PR TITLE
[3.0 migration guide] Fixed `PhpSpec\Extension`

### DIFF
--- a/docs/manual/upgrading-to-phpspec-3.rst
+++ b/docs/manual/upgrading-to-phpspec-3.rst
@@ -45,8 +45,7 @@ changes you will need to make in your code.
   *PhpSpec\Formatter\Presenter\Presenter*
 - *PhpSpec\CodeGenerator\Generator\GeneratorInterface* is now
   *PhpSpec\CodeGenerator\Generator\Generator*
-- *PhpSpec\Extension\ExtensionInterface* is now *PhpSpec\Extension\Extension*
-- *PhpSpec\Extension\ExtensionInterface* is now *PhpSpec\Extension\Extension*
+- *PhpSpec\Extension\ExtensionInterface* is now *PhpSpec\Extension*
 - *Phpspec\CodeAnalysis\AccessInspectorInterface* is now *Phpspec\CodeAnalysis\AccessInspector*
 - *Phpspec\Event\EventInterface* is now *Phpspec\Event\PhpSpecEvent*
 - *PhpSpec\Formatter\Presenter\Differ\EngineInterface* is now *PhpSpec\Formatter\Presenter\Differ\DifferEngine*

--- a/docs/manual/upgrading-to-phpspec-3.rst
+++ b/docs/manual/upgrading-to-phpspec-3.rst
@@ -36,24 +36,24 @@ Upgrading for Extension Authors
 Several interfaces have been renamed in **phpspec** 3.0.  Here is a quick guide to
 changes you will need to make in your code.
 
-- `PhpSpec\Console\IO` is now `PhpSpec\Console\ConsoleIO`
-- `PhpSpec\IO\IOInterface` is now `PhpSpec\IO\IO`
-- `PhpSpec\Locator\ResourceInterface` is now `PhpSpec\Locator\Resource`
-- `PhpSpec\Locator\ResourceLocatorInterface` is now
-  `PhpSpec\Locator\ResourceLocator`
-- `PhpSpec\Formatter\Presenter\PresenterInterface` is now
-  `PhpSpec\Formatter\Presenter\Presenter`
-- `PhpSpec\CodeGenerator\Generator\GeneratorInterface` is now
-  `PhpSpec\CodeGenerator\Generator\Generator`
-- `PhpSpec\Extension\ExtensionInterface` is now `PhpSpec\Extension`
-- `Phpspec\CodeAnalysis\AccessInspectorInterface` is now `Phpspec\CodeAnalysis\AccessInspector`
-- `Phpspec\Event\EventInterface` is now `Phpspec\Event\PhpSpecEvent`
-- `PhpSpec\Formatter\Presenter\Differ\EngineInterface` is now `PhpSpec\Formatter\Presenter\Differ\DifferEngine`
-- `PhpSpec\Matcher\MatcherInterface` is now `PhpSpec\Matcher\Matcher`
+- ``PhpSpec\Console\IO`` is now ``PhpSpec\Console\ConsoleIO``
+- ``PhpSpec\IO\IOInterface`` is now ``PhpSpec\IO\IO``
+- ``PhpSpec\Locator\ResourceInterface`` is now ``PhpSpec\Locator\Resource``
+- ``PhpSpec\Locator\ResourceLocatorInterface`` is now
+  ``PhpSpec\Locator\ResourceLocator``
+- ``PhpSpec\Formatter\Presenter\PresenterInterface`` is now
+  ``PhpSpec\Formatter\Presenter\Presenter``
+- ``PhpSpec\CodeGenerator\Generator\GeneratorInterface`` is now
+  ``PhpSpec\CodeGenerator\Generator\Generator``
+- ``PhpSpec\Extension\ExtensionInterface`` is now ``PhpSpec\Extension``
+- ``Phpspec\CodeAnalysis\AccessInspectorInterface`` is now ``Phpspec\CodeAnalysis\AccessInspector``
+- ``Phpspec\Event\EventInterface`` is now ``Phpspec\Event\PhpSpecEvent``
+- ``PhpSpec\Formatter\Presenter\Differ\EngineInterface` is now ``PhpSpec\Formatter\Presenter\Differ\DifferEngine``
+- ``PhpSpec\Matcher\MatcherInterface`` is now ``PhpSpec\Matcher\Matcher``
 
 Other things to bear in mind:
 
-- `PhpSpec\CodeGenerator\Generator\PromptingGenerator` now has a different
+- ``PhpSpec\CodeGenerator\Generator\PromptingGenerator`` now has a different
   method signature for its constructor.
-- `PhpSpec\Matcher\ThrowMatcher` now has a different method signature for its
+- ``PhpSpec\Matcher\ThrowMatcher`` now has a different method signature for its
   constructor.

--- a/docs/manual/upgrading-to-phpspec-3.rst
+++ b/docs/manual/upgrading-to-phpspec-3.rst
@@ -36,24 +36,24 @@ Upgrading for Extension Authors
 Several interfaces have been renamed in **phpspec** 3.0.  Here is a quick guide to
 changes you will need to make in your code.
 
-- *PhpSpec\Console\IO* is now *PhpSpec\Console\ConsoleIO*
-- *PhpSpec\IO\IOInterface* is now *PhpSpec\IO\IO*
-- *PhpSpec\Locator\ResourceInterface* is now *PhpSpec\Locator\Resource*
-- *PhpSpec\Locator\ResourceLocatorInterface* is now
-  *PhpSpec\Locator\ResourceLocator*
-- *PhpSpec\Formatter\Presenter\PresenterInterface* is now
-  *PhpSpec\Formatter\Presenter\Presenter*
-- *PhpSpec\CodeGenerator\Generator\GeneratorInterface* is now
-  *PhpSpec\CodeGenerator\Generator\Generator*
-- *PhpSpec\Extension\ExtensionInterface* is now *PhpSpec\Extension*
-- *Phpspec\CodeAnalysis\AccessInspectorInterface* is now *Phpspec\CodeAnalysis\AccessInspector*
-- *Phpspec\Event\EventInterface* is now *Phpspec\Event\PhpSpecEvent*
-- *PhpSpec\Formatter\Presenter\Differ\EngineInterface* is now *PhpSpec\Formatter\Presenter\Differ\DifferEngine*
-- *PhpSpec\Matcher\MatcherInterface* is now *PhpSpec\Matcher\Matcher*
+- `PhpSpec\Console\IO` is now `PhpSpec\Console\ConsoleIO`
+- `PhpSpec\IO\IOInterface` is now `PhpSpec\IO\IO`
+- `PhpSpec\Locator\ResourceInterface` is now `PhpSpec\Locator\Resource`
+- `PhpSpec\Locator\ResourceLocatorInterface` is now
+  `PhpSpec\Locator\ResourceLocator`
+- `PhpSpec\Formatter\Presenter\PresenterInterface` is now
+  `PhpSpec\Formatter\Presenter\Presenter`
+- `PhpSpec\CodeGenerator\Generator\GeneratorInterface` is now
+  `PhpSpec\CodeGenerator\Generator\Generator`
+- `PhpSpec\Extension\ExtensionInterface` is now `PhpSpec\Extension`
+- `Phpspec\CodeAnalysis\AccessInspectorInterface` is now `Phpspec\CodeAnalysis\AccessInspector`
+- `Phpspec\Event\EventInterface` is now `Phpspec\Event\PhpSpecEvent`
+- `PhpSpec\Formatter\Presenter\Differ\EngineInterface` is now `PhpSpec\Formatter\Presenter\Differ\DifferEngine`
+- `PhpSpec\Matcher\MatcherInterface` is now `PhpSpec\Matcher\Matcher`
 
 Other things to bear in mind:
 
-- *PhpSpec\CodeGenerator\Generator\PromptingGenerator* now has a different
+- `PhpSpec\CodeGenerator\Generator\PromptingGenerator` now has a different
   method signature for its constructor.
-- *PhpSpec\Matcher\ThrowMatcher* now has a different method signature for its
+- `PhpSpec\Matcher\ThrowMatcher` now has a different method signature for its
   constructor.


### PR DESCRIPTION
removed duplicated line, and fixed the actual new FQCN.