### PR TITLE
Possibility to test if a php error is triggered

### DIFF
--- a/docs/cookbook/matchers.rst
+++ b/docs/cookbook/matchers.rst
@@ -173,6 +173,72 @@ You can also use the Throw matcher with named constructors.
     }
 
 
+Trigger Matcher
+---------------
+
+Let's say you have the following class and method which is deprecated
+
+.. code-block:: php
+
+    <?php
+
+    class Movie
+    {
+        function setStars($value)
+        {
+            trigger_error('The method setStars is deprecated. Use setRating instead', E_USER_DEPRECATED);
+
+            $this->rating = $value * 4;
+        }
+    }
+
+
+You can describe an object triggering an error using the Trigger matcher.
+You use the Trigger matcher by calling it straight from ``$this``, making
+the example easier to read.
+
+.. code-block:: php
+
+    <?php
+
+    namespace spec;
+
+    use PhpSpec\ObjectBehavior;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function set_stars_should_be_deprecated()
+        {
+            $this->shouldTrigger(E_USER_DEPRECATED)->duringSetStars(4);
+        }
+    }
+
+You may want to specify against the message of the error. You can do this by
+adding a string parameter to the `shouldTrigger` method :
+
+.. code-block:: php
+
+    <?php
+
+    namespace spec;
+
+    use PhpSpec\ObjectBehavior;
+
+    class MovieSpec extends ObjectBehavior
+    {
+        function set_stars_should_be_deprecated()
+        {
+            $this->shouldTrigger(E_USER_DEPRECATED, 'The method setStars is deprecated. Use setRating instead')->duringSetRating(4);
+        }
+    }
+
+.. note::
+   
+    As with the Throw matcher, you can also use the `during` syntax described
+    in the Throw section, or use the instanciation mecanisms (such as
+    duringInstanciation, ... etc)
+
+
 Type Matcher
 ------------
 

--- a/docs/cookbook/matchers.rst
+++ b/docs/cookbook/matchers.rst
@@ -176,7 +176,7 @@ You can also use the Throw matcher with named constructors.
 Trigger Matcher
 ---------------
 
-Let's say you have the following class and method which is deprecated
+Let's say you have the following class and a method which is deprecated
 
 .. code-block:: php
 
@@ -213,7 +213,7 @@ the example easier to read.
         }
     }
 
-You may want to specify against the message of the error. You can do this by
+You may want to specify the message of the error. You can do this by
 adding a string parameter to the `shouldTrigger` method :
 
 .. code-block:: php
@@ -235,8 +235,8 @@ adding a string parameter to the `shouldTrigger` method :
 .. note::
    
     As with the Throw matcher, you can also use the `during` syntax described
-    in the Throw section, or use the instanciation mecanisms (such as
-    duringInstanciation, ... etc)
+    in the Throw section, or use the instantiation mechanisms (such as
+    duringInstantiation, ... etc)
 
 
 Type Matcher

--- a/features/matchers/developer_uses_trigger_matcher.feature
+++ b/features/matchers/developer_uses_trigger_matcher.feature
@@ -1,0 +1,119 @@
+Feature: Developer uses trigger matcher
+  As a Developer
+  I want a trigger matcher
+  In order to validate triggered exceptions against my expectations
+
+  Scenario: Checking if a deprecated error has been triggered
+    Given the spec file "spec/Matchers/TriggerExample1/FooSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Matchers\TriggerExample1;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class FooSpec extends ObjectBehavior
+    {
+        function it_triggers_an_error_when_calling_something_deprecated()
+        {
+            $this->shouldTrigger(E_USER_DEPRECATED)->duringDoDeprecatedStuff();
+        }
+    }
+    """
+    And the class file "src/Matchers/TriggerExample1/Foo.php" contains:
+    """
+    <?php
+
+    namespace Matchers\TriggerExample1;
+
+    class Foo
+    {
+        public function doDeprecatedStuff()
+        {
+            trigger_error('Foo', E_USER_DEPRECATED);
+        }
+    }
+    """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: Checking that a deprecated error has the right message
+    Given the spec file "spec/Matchers/TriggerExample2/FooSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Matchers\TriggerExample3;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class FooSpec extends ObjectBehavior
+    {
+        function it_triggers_a_specific_deprecated_error_when_calling_deprecated_method()
+        {
+            $this->shouldTrigger(E_USER_DEPRECATED, 'This is deprecated')->duringDoDeprecatedStuff();
+        }
+    }
+    """
+    And the class file "src/Matchers/TriggerExample2/Foo.php" contains:
+    """
+    <?php
+
+    namespace Matchers\TriggerExample2;
+
+    class Foo
+    {
+        public function doDeprecatedStuff()
+        {
+            trigger_error('This is deprecated', E_USER_DEPRECATED);
+        }
+    }
+    """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Trigger" alias matches using the trigger matcher and let the code continue afterwards
+    Given the spec file "spec/Matchers/TriggerExample3/FooSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Matchers\TriggerExample3;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class FooSpec extends ObjectBehavior
+    {
+        function it_triggers_a_deprecated_error_when_calling_deprecated_method_but_do_not_interrupt()
+        {
+            $this->shouldTrigger(E_USER_DEPRECATED, 'This is deprecated')->duringDoDeprecatedStuff(0);
+            $this->getDeprecated()->shouldBe(0);
+        }
+    }
+    """
+    And the class file "src/Matchers/TriggerExample3/Foo.php" contains:
+    """
+    <?php
+
+    namespace Matchers\TriggerExample3;
+
+    class Foo
+    {
+        private $deprecated;
+
+        public function getDeprecated()
+        {
+            return $this->deprecated;
+        }
+
+        public function doDeprecatedStuff($value)
+        {
+            trigger_error('This is deprecated', E_USER_DEPRECATED);
+            $this->deprecated = $value;
+        }
+    }
+    """
+    When I run phpspec
+    Then the suite should pass
+

--- a/spec/PhpSpec/Matcher/TriggerMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/TriggerMatcherSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace spec\PhpSpec\Matcher;
+
+use PhpSpec\Factory\ReflectionFactory;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Unwrapper;
+use Prophecy\Argument;
+use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Exception\Example\SkippingException;
+use ArrayObject;
+
+class TriggerMatcherSpec extends ObjectBehavior
+{
+    function let(Unwrapper $unwrapper)
+    {
+        $unwrapper->unwrapAll(Argument::any())->willReturnArgument();
+
+        $this->beConstructedWith($unwrapper);
+    }
+
+    function it_supports_the_trigger_alias_for_object_and_exception_name()
+    {
+        $this->supports('trigger', '', array())->shouldReturn(true);
+    }
+
+    function it_accepts_a_method_during_which_an_error_should_be_triggered(ArrayObject $arr)
+    {
+        $arr->ksort()->will(function () { trigger_error('An error', E_USER_NOTICE); });
+
+        $this->positiveMatch('trigger', $arr, array(E_USER_NOTICE, 'An error'))->during('ksort', array());
+    }
+
+    function it_accepts_a_method_during_which_any_error_should_be_triggered(ArrayObject $arr)
+    {
+        $arr->ksort()->will(function () { trigger_error('An error', E_USER_NOTICE); });
+
+        $this->positiveMatch('trigger', $arr, array(null, null))->during('ksort', array());
+    }
+
+    function it_accepts_a_method_during_which_an_error_should_not_be_triggered(ArrayObject $arr)
+    {
+        $this->negativeMatch('trigger', $arr, array(E_USER_NOTICE, 'An error'))->during('ksort', array());
+    }
+
+    function it_accepts_a_method_during_which_any_error_should_not_be_triggered(ArrayObject $arr)
+    {
+        $this->negativeMatch('trigger', $arr, array(null, null))->during('ksort', array());
+    }
+}

--- a/spec/PhpSpec/Wrapper/Subject/ExpectationFactorySpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/ExpectationFactorySpec.php
@@ -59,4 +59,24 @@ class ExpectationFactorySpec extends ObjectBehavior
 
         $expectation->shouldHaveType('PhpSpec\Wrapper\Subject\Expectation\NegativeThrow');
     }
+
+    function it_creates_positive_trigger_expectations(MatcherManager $matchers, Matcher $matcher, Subject $subject)
+    {
+        $matchers->find(Argument::cetera())->willReturn($matcher);
+
+        $subject->__call('getWrappedObject', array())->willReturn(new \stdClass());
+        $expectation = $this->create('shouldTrigger', $subject);
+
+        $expectation->shouldHaveType('PhpSpec\Wrapper\Subject\Expectation\PositiveTrigger');
+    }
+
+    function it_creates_negative_trigger_expectations(MatcherManager $matchers, Matcher $matcher, Subject $subject)
+    {
+        $matchers->find(Argument::cetera())->willReturn($matcher);
+
+        $subject->__call('getWrappedObject', array())->willReturn(new \stdClass());
+        $expectation = $this->create('shouldNotTrigger', $subject);
+
+        $expectation->shouldHaveType('PhpSpec\Wrapper\Subject\Expectation\NegativeTrigger');
+    }
 }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -642,6 +642,9 @@ final class ContainerAssembler
         $container->define('matchers.throwm', function (IndexedServiceContainer $c) {
             return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
         }, ['matchers']);
+        $container->define('matchers.trigger', function (IndexedServiceContainer $c) {
+            return new Matcher\TriggerMatcher($c->get('unwrapper'));
+        }, ['matchers']);
         $container->define('matchers.type', function (IndexedServiceContainer $c) {
             return new Matcher\TypeMatcher($c->get('formatter.presenter'));
         }, ['matchers']);

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -77,7 +77,7 @@ final class TriggerMatcher implements Matcher
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function verifyPositive($callable, array $arguments, $level = null, $message = null)
+    public function verifyPositive(callable $callable, array $arguments, $level = null, $message = null)
     {
         $triggered = 0;
 
@@ -110,7 +110,7 @@ final class TriggerMatcher implements Matcher
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function verifyNegative($callable, array $arguments, $level = null, $message = null)
+    public function verifyNegative(callable $callable, array $arguments, $level = null, $message = null)
     {
         $triggered = 0;
 

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -158,7 +158,7 @@ final class TriggerMatcher implements Matcher
     private function getDelayedCall($check, $subject, array $arguments)
     {
         $unwrapper = $this->unwrapper;
-        list($level, $message) = $arguments;
+        list($level, $message) = $this->unpackArguments($arguments);
 
         return new DelayedCall(
             function ($method, $arguments) use ($check, $subject, $level, $message, $unwrapper) {
@@ -181,5 +181,34 @@ final class TriggerMatcher implements Matcher
                 return call_user_func($check, $callable, $arguments, $level, $message);
             }
         );
+    }
+
+    /**
+     * @return array
+     */
+    private function unpackArguments(array $arguments)
+    {
+        $count = count($arguments);
+
+        if (0 === $count) {
+            return array(null, null);
+        }
+
+        if (1 === $count) {
+            return array($arguments[0], null);
+        }
+
+        if (2 !== $count) {
+            throw new MatcherException(
+                sprintf(
+                    "Wrong argument count provided in trigger matcher.\n".
+                    "Up to two arguments expected,\n".
+                    "Got %d.",
+                    $count
+                )
+            );
+        }
+
+        return array($arguments[0], $arguments[1]);
     }
 }

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Matcher;
+
+use PhpSpec\Wrapper\Unwrapper;
+use PhpSpec\Wrapper\DelayedCall;
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Exception\Fracture\MethodNotFoundException;
+
+final class TriggerMatcher implements Matcher
+{
+    /**
+     * @var Unwrapper
+     */
+    private $unwrapper;
+
+    /**
+     * @param Unwrapper $unwrapper
+     */
+    public function __construct(Unwrapper $unwrapper)
+    {
+        $this->unwrapper = $unwrapper;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return bool
+     */
+    public function supports($name, $subject, array $arguments)
+    {
+        return 'trigger' === $name;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return DelayedCall
+     */
+    public function positiveMatch($name, $subject, array $arguments)
+    {
+        return $this->getDelayedCall(array($this, 'verifyPositive'), $subject, $arguments);
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return DelayedCall
+     */
+    public function negativeMatch($name, $subject, array $arguments)
+    {
+        return $this->getDelayedCall(array($this, 'verifyNegative'), $subject, $arguments);
+    }
+
+    /**
+     * @param callable    $callable
+     * @param array       $arguments
+     * @param int|null    $level
+     * @param string|null $message
+     *
+     * @throws \PhpSpec\Exception\Example\FailureException
+     */
+    public function verifyPositive($callable, array $arguments, $level = null, $message = null)
+    {
+        $triggered = 0;
+
+        $prevHandler = set_error_handler(function ($type, $str, $file, $line, $context) use (&$prevHandler, $level, $message, &$triggered) {
+            if (null !== $level && $level !== $type) {
+                return null !== $prevHandler && call_user_func($prevHandler, $type, $str, $file, $line, $context);
+            }
+
+            if (null !== $message && false === strpos($str, $message)) {
+                return null !== $prevHandler && call_user_func($prevHandler, $type, $str, $file, $line, $context);
+            }
+
+            ++$triggered;
+        });
+
+        call_user_func_array($callable, $arguments);
+
+        restore_error_handler();
+
+        if ($triggered === 0) {
+            throw new FailureException('Expected to trigger errors, but got none.');
+        }
+    }
+
+    /**
+     * @param callable    $callable
+     * @param array       $arguments
+     * @param int|null    $level
+     * @param string|null $message
+     *
+     * @throws \PhpSpec\Exception\Example\FailureException
+     */
+    public function verifyNegative($callable, array $arguments, $level = null, $message = null)
+    {
+        $triggered = 0;
+
+        $prevHandler = set_error_handler(function ($type, $str, $file, $line, $context) use (&$prevHandler, $level, $message, &$triggered) {
+            if (null !== $level && $level !== $type) {
+                return null !== $prevHandler && call_user_func($prevHandler, $type, $str, $file, $line, $context);
+            }
+
+            if (null !== $message && false === strpos($str, $message)) {
+                return null !== $prevHandler && call_user_func($prevHandler, $type, $str, $file, $line, $context);
+            }
+
+            ++$triggered;
+        });
+
+        call_user_func_array($callable, $arguments);
+
+        restore_error_handler();
+
+        if ($triggered > 0) {
+            throw new FailureException(
+                sprintf(
+                    'Expected to not trigger errors, but got %d.',
+                    $triggered
+                )
+            );
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 1;
+    }
+
+    /**
+     * @param callable $check
+     * @param mixed    $subject
+     * @param array    $arguments
+     *
+     * @return DelayedCall
+     */
+    private function getDelayedCall($check, $subject, array $arguments)
+    {
+        $unwrapper = $this->unwrapper;
+        list($level, $message) = $arguments;
+
+        return new DelayedCall(
+            function ($method, $arguments) use ($check, $subject, $level, $message, $unwrapper) {
+                $arguments = $unwrapper->unwrapAll($arguments);
+
+                $methodName = $arguments[0];
+                $arguments = isset($arguments[1]) ? $arguments[1] : array();
+                $callable = array($subject, $methodName);
+
+                list($class, $methodName) = array($subject, $methodName);
+                if (!method_exists($class, $methodName) && !method_exists($class, '__call')) {
+                    throw new MethodNotFoundException(
+                        sprintf('Method %s::%s not found.', get_class($class), $methodName),
+                        $class,
+                        $methodName,
+                        $arguments
+                    );
+                }
+
+                return call_user_func($check, $callable, $arguments, $level, $message);
+            }
+        );
+    }
+}

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -41,6 +41,7 @@ use ArrayAccess;
  *
  * @method Subject\Expectation\DuringCall shouldThrow($exception = null)
  * @method Subject\Expectation\DuringCall shouldNotThrow($exception = null)
+ * @method Subject\Expectation\DuringCall shouldTrigger($level = null, $message = null)
  *
  * @method void shouldHaveCount($count)
  * @method void shouldNotHaveCount($count)

--- a/src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Wrapper\Subject\Expectation;
+
+final class NegativeTrigger extends DuringCall implements ThrowExpectation
+{
+    /**
+     * @param object $object
+     * @param string $method
+     * @param array  $arguments
+     *
+     * @return mixed
+     */
+    protected function runDuring($object, $method, array $arguments = array())
+    {
+        return $this->getMatcher()->negativeMatch('trigger', $object, $this->getArguments())
+            ->during($method, $arguments);
+    }
+}

--- a/src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Wrapper\Subject\Expectation;
+
+final class PositiveTrigger extends DuringCall implements ThrowExpectation
+{
+    /**
+     * @param object $object
+     * @param string $method
+     * @param array  $arguments
+     *
+     * @return mixed
+     */
+    protected function runDuring($object, $method, array $arguments = array())
+    {
+        return $this->getMatcher()->positiveMatch('trigger', $object, $this->getArguments())
+            ->during($method, $arguments);
+    }
+}

--- a/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
+++ b/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
@@ -82,6 +82,10 @@ class ExpectationFactory
             return $this->createDecoratedExpectation("PositiveThrow", $name, $subject, $arguments);
         }
 
+        if (strtolower($name) === 'trigger') {
+            return $this->createDecoratedExpectation("PositiveTrigger", $name, $subject, $arguments);
+        }
+
         return $this->createDecoratedExpectation("Positive", $name, $subject, $arguments);
     }
 
@@ -96,6 +100,10 @@ class ExpectationFactory
     {
         if (strtolower($name) === 'throw') {
             return $this->createDecoratedExpectation("NegativeThrow", $name, $subject, $arguments);
+        }
+
+        if (strtolower($name) === 'trigger') {
+            return $this->createDecoratedExpectation("NegativeTrigger", $name, $subject, $arguments);
         }
 
         return $this->createDecoratedExpectation("Negative", $name, $subject, $arguments);


### PR DESCRIPTION
Should fix #957, and add helpers such as `$this->shouldTrigger()`.

If nothing is provided as arguments, it validates if any error at all is triggered (or none at all, if `shouldNotTrigger` is used). If a `$level` and / or `$message` is provided, it should filter them and check that the triggered error tested against these parameters matches before validating or not the match.

- [x] Add TriggerMatcher
- [x] Add support for `trigger` methods in `ExpectationFactory`
- [x] Add `PositiveTrigger` and `NegativeTrigger`... even though it looks a lot like the `throw` counterpart.
- [x] Add some specs (I can think of some more to add, such as testing the filters parts or going against the predictions, making them fail ?)
- [x] Add some behat tests ?
- [x] Add some documentation

I was first going for the handling of phpspec's `ErrorException` and use the `ThrowMatcher` (so just creating a `ErrorException` exception, and then feed it to `PositiveThrow` and `NegativeThrow`), but as the `ErrorException` is currently made (only creating a string, with filename and line number), it looked difficult to do so and build a correct exception.

So I went with the long way, with more or less duplicating a lot of stuff from the `Throw` counterparts, registering a temporary error handler to do the job.

As this is a kind of a new feature, I targetted the master branch. Open for discussion :}