### PR TITLE
Refactor/simplify container

### DIFF
--- a/features/extensions/developer_uses_extension.feature
+++ b/features/extensions/developer_uses_extension.feature
@@ -24,7 +24,7 @@ Feature: Developer uses extension
          */
         public function load(ServiceContainer $container)
         {
-            $container->set('matchers.seven', function (ServiceContainer $c) {
+            $container->define('matchers.seven', function (ServiceContainer $c) {
                 return new BeSevenMatcher($c->get('formatter.presenter'));
             }, ['matchers']);
         }

--- a/features/extensions/developer_uses_extension.feature
+++ b/features/extensions/developer_uses_extension.feature
@@ -26,7 +26,7 @@ Feature: Developer uses extension
         {
             $container->set('matchers.seven', function (ServiceContainer $c) {
                 return new BeSevenMatcher($c->get('formatter.presenter'));
-            });
+            }, ['matchers']);
         }
     }
 

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -179,7 +179,7 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
         $this->supportsQuery(
-            realpath($this->srcPath.'/PhpSpec/ServiceContainer.php')
+            realpath($this->srcPath.'/PhpSpec/Locator/PSR0/PSR0Locator.php')
         )->shouldReturn(true);
     }
 
@@ -202,7 +202,7 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
         $this->supportsQuery(
-            realpath($this->specPath.'/spec/PhpSpec/ServiceContainerSpec.php')
+            realpath($this->specPath.'/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php')
         )->shouldReturn(true);
     }
 
@@ -281,30 +281,30 @@ class PSR0LocatorSpec extends ObjectBehavior
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/ServiceContainerSpec.php');
+        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php');
 
-        $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/ServiceContainerSpec.php'))->willReturn(true);
-        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec; class ServiceContainer {} ?>');
+        $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php'))->willReturn(true);
+        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec\\Locator\\PSR0; class PSR0LocatorSpec {} ?>');
         $file->getRealPath()->willReturn($filePath);
 
-        $resources = $this->findResources($this->srcPath.$this->convert_to_path('/PhpSpec/ServiceContainer.php'));
+        $resources = $this->findResources($this->srcPath.$this->convert_to_path('/PhpSpec/Locator/PSR0/PSR0Locator.php'));
         $resources->shouldHaveCount(1);
-        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\ServiceContainer');
+        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\Locator\PSR0\PSR0Locator');
     }
 
     function it_finds_single_spec_via_specPath(Filesystem $fs, SplFileInfo $file)
     {
         $this->beConstructedWith($fs, 'PhpSpec', 'spec', $this->srcPath, $this->specPath);
 
-        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/ServiceContainerSpec.php');
+        $filePath = $this->specPath.$this->convert_to_path('/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php');
 
-        $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/ServiceContainerSpec.php'))->willReturn(true);
-        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec; class ServiceContainer {} ?>');
+        $fs->pathExists($this->specPath.$this->convert_to_path('/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php'))->willReturn(true);
+        $fs->getFileContents($filePath)->willReturn('<?php namespace spec\\PhpSpec\\Locator\\PSR0; class PSR0Locator {} ?>');
         $file->getRealPath()->willReturn($filePath);
 
         $resources = $this->findResources($filePath);
         $resources->shouldHaveCount(1);
-        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\ServiceContainer');
+        $resources[0]->getSrcClassname()->shouldReturn('PhpSpec\Locator\PSR0\PSR0Locator');
     }
 
     function it_returns_empty_array_if_nothing_found(Filesystem $fs)

--- a/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
+++ b/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
@@ -39,6 +39,25 @@ class IndexedServiceContainerSpec extends ObjectBehavior
         $this->has('some_service')->shouldReturn(true);
     }
 
+    function it_returns_nothing_when_no_services_are_tagged()
+    {
+        $this->getByTag('some_tag')->shouldReturn([]);
+    }
+
+    function it_returns_services_which_are_set_using_tags($service)
+    {
+        $obj = new \StdClass();
+        $this->set('some_service', $obj, ['some_tag']);
+        $this->getByTag('some_tag')->shouldReturn([$obj]);
+    }
+
+    function it_returns_services_which_are_defined_using_tags()
+    {
+        $obj = new \StdClass();
+        $this->define('some_service', function () use ($obj) { return $obj; }, ['some_tag']);
+        $this->getByTag('some_tag')->shouldReturn([$obj]);
+    }
+
     function it_throws_exception_when_trying_to_get_unexisting_service()
     {
         $this->shouldThrow('InvalidArgumentException')->duringGet('unexisting');
@@ -53,22 +72,12 @@ class IndexedServiceContainerSpec extends ObjectBehavior
         $number2->shouldBe($number1);
     }
 
-    function it_provides_a_way_to_retrieve_services_by_prefix($service1, $service2, $service3)
-    {
-        $this->set('collection1.serv1', $service1);
-        $this->set('collection1.serv2', $service2);
-        $this->set('collection2.serv3', $service3);
-
-        $this->getByPrefix('collection1')->shouldReturn(array($service1, $service2));
-    }
-
     function it_provides_a_way_to_remove_service_by_key($service)
     {
         $this->set('collection1.some_service', $service);
         $this->remove('collection1.some_service');
 
         $this->shouldThrow()->duringGet('collection1.some_service');
-        $this->getByPrefix('collection1')->shouldHaveCount(0);
     }
 
     function it_supports_custom_service_configurators()

--- a/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
+++ b/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace spec\PhpSpec;
+namespace spec\PhpSpec\ServiceContainer;
 
 use PhpSpec\ObjectBehavior;
 
-class ServiceContainerSpec extends ObjectBehavior
+class IndexedServiceContainerSpec extends ObjectBehavior
 {
     function it_stores_parameters()
     {

--- a/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
+++ b/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
@@ -72,6 +72,18 @@ class IndexedServiceContainerSpec extends ObjectBehavior
         $number2->shouldBe($number1);
     }
 
+    function it_uses_new_definition_when_a_service_is_redefined()
+    {
+        $this->define('some_service', function () { return 1; });
+        $this->get('some_service');
+
+
+        $this->define('some_service', function () { return 2; });
+
+        $this->get('some_service')->shouldBe(2);
+    }
+
+
     function it_does_not_evaluate_callables_that_are_set()
     {
         $this->set('some_service', function(){ return 100; });

--- a/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
+++ b/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
@@ -72,6 +72,12 @@ class IndexedServiceContainerSpec extends ObjectBehavior
         $number2->shouldBe($number1);
     }
 
+    function it_does_not_evaluate_callables_that_are_set()
+    {
+        $this->set('some_service', function(){ return 100; });
+        $this->get('some_service')->shouldNotBe(100);
+    }
+
     function it_provides_a_way_to_remove_service_by_key($service)
     {
         $this->set('collection1.some_service', $service);

--- a/spec/PhpSpec/ServiceContainerSpec.php
+++ b/spec/PhpSpec/ServiceContainerSpec.php
@@ -44,18 +44,6 @@ class ServiceContainerSpec extends ObjectBehavior
         $this->shouldThrow('InvalidArgumentException')->duringGet('unexisting');
     }
 
-    function it_evaluates_factory_function_set_as_service()
-    {
-        $this->set('random_number', function () { return rand(); });
-        $number1 = $this->get('random_number');
-        $number2 = $this->get('random_number');
-
-        $number1->shouldBeInteger();
-        $number2->shouldBeInteger();
-
-        $number2->shouldNotBe($number1);
-    }
-
     function it_evaluates_factory_function_only_once_for_shared_services()
     {
         $this->define('random_number', function () { return rand(); });

--- a/spec/PhpSpec/ServiceContainerSpec.php
+++ b/spec/PhpSpec/ServiceContainerSpec.php
@@ -28,6 +28,17 @@ class ServiceContainerSpec extends ObjectBehavior
         $this->get('some_service')->shouldReturn($service);
     }
 
+    function it_knows_when_services_are_not_defined()
+    {
+        $this->has('some_service')->shouldReturn(false);
+    }
+
+    function it_knows_when_services_are_defined($service)
+    {
+        $this->set('some_service', $service);
+        $this->has('some_service')->shouldReturn(true);
+    }
+
     function it_throws_exception_when_trying_to_get_unexisting_service()
     {
         $this->shouldThrow('InvalidArgumentException')->duringGet('unexisting');
@@ -47,7 +58,7 @@ class ServiceContainerSpec extends ObjectBehavior
 
     function it_evaluates_factory_function_only_once_for_shared_services()
     {
-        $this->setShared('random_number', function () { return rand(); });
+        $this->define('random_number', function () { return rand(); });
         $number1 = $this->get('random_number');
         $number2 = $this->get('random_number');
 

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -26,8 +26,10 @@ use RuntimeException;
 
 /**
  * The command line application entry point
+ *
+ * @Internal
  */
-class Application extends BaseApplication
+final class Application extends BaseApplication
 {
     /**
      * @var ServiceContainer

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
-use PhpSpec\ServiceContainer;
+use PhpSpec\ServiceContainer\IndexedServiceContainer;
 use PhpSpec\Extension;
 use RuntimeException;
 
@@ -32,7 +32,7 @@ use RuntimeException;
 final class Application extends BaseApplication
 {
     /**
-     * @var ServiceContainer
+     * @var IndexedServiceContainer
      */
     private $container;
 
@@ -41,12 +41,12 @@ final class Application extends BaseApplication
      */
     public function __construct($version)
     {
-        $this->container = new ServiceContainer();
+        $this->container = new IndexedServiceContainer();
         parent::__construct('phpspec', $version);
     }
 
     /**
-     * @return ServiceContainer
+     * @return IndexedServiceContainer
      */
     public function getContainer()
     {
@@ -127,11 +127,11 @@ final class Application extends BaseApplication
 
     /**
      * @param InputInterface   $input
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      *
      * @throws \RuntimeException
      */
-    protected function loadConfigurationFile(InputInterface $input, ServiceContainer $container)
+    protected function loadConfigurationFile(InputInterface $input, IndexedServiceContainer $container)
     {
         $config = $this->parseConfigurationFile($input);
 

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -15,6 +15,7 @@ namespace PhpSpec\Console;
 
 use PhpSpec\Loader\StreamWrapper;
 use PhpSpec\Process\Context\JsonExecutionContext;
+use PhpSpec\ServiceContainer;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -27,7 +28,7 @@ use RuntimeException;
 /**
  * The command line application entry point
  *
- * @Internal
+ * @internal
  */
 final class Application extends BaseApplication
 {
@@ -46,7 +47,7 @@ final class Application extends BaseApplication
     }
 
     /**
-     * @return IndexedServiceContainer
+     * @return ServiceContainer
      */
     public function getContainer()
     {

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -75,7 +75,7 @@ final class Application extends BaseApplication
 
         $this->loadConfigurationFile($input, $this->container);
 
-        foreach ($this->container->getByPrefix('console.commands') as $command) {
+        foreach ($this->container->getByTag('console.commands') as $command) {
             $this->add($command);
         }
 
@@ -84,7 +84,7 @@ final class Application extends BaseApplication
         $this->container->get('console.io')->setConsoleWidth($this->getTerminalWidth());
 
         StreamWrapper::reset();
-        foreach ($this->container->getByPrefix('loader.resource_loader.spec_transformer') as $transformer) {
+        foreach ($this->container->getByTag('loader.resource_loader.spec_transformer') as $transformer) {
             StreamWrapper::addTransformer($transformer);
         }
         StreamWrapper::register();

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -66,7 +66,7 @@ final class Application extends BaseApplication
         $this->container->set('console.output', $output);
         $this->container->set('console.helper_set', $helperSet);
 
-        $this->container->setShared('process.executioncontext', function () {
+        $this->container->define('process.executioncontext', function () {
             return JsonExecutionContext::fromEnv($_SERVER);
         });
 

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -59,7 +59,7 @@ final class PresenterAssembler
      */
     private function assembleDiffer(ServiceContainer $container)
     {
-        $container->setShared('formatter.presenter.differ', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.differ', function (ServiceContainer $c) {
             $differ = new Differ();
 
             array_map(
@@ -97,31 +97,31 @@ final class PresenterAssembler
      */
     private function assembleTypePresenters(ServiceContainer $container)
     {
-        $container->setShared('formatter.presenter.value.array_type_presenter', function () {
+        $container->define('formatter.presenter.value.array_type_presenter', function () {
             return new ArrayTypePresenter();
         });
 
-        $container->setShared('formatter.presenter.value.boolean_type_presenter', function () {
+        $container->define('formatter.presenter.value.boolean_type_presenter', function () {
             return new BooleanTypePresenter();
         });
 
-        $container->setShared('formatter.presenter.value.callable_type_presenter', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.value.callable_type_presenter', function (ServiceContainer $c) {
             return new CallableTypePresenter($c->get('formatter.presenter'));
         });
 
-        $container->setShared('formatter.presenter.value.exception_type_presenter', function () {
+        $container->define('formatter.presenter.value.exception_type_presenter', function () {
             return new BaseExceptionTypePresenter();
         });
 
-        $container->setShared('formatter.presenter.value.null_type_presenter', function () {
+        $container->define('formatter.presenter.value.null_type_presenter', function () {
             return new NullTypePresenter();
         });
 
-        $container->setShared('formatter.presenter.value.object_type_presenter', function () {
+        $container->define('formatter.presenter.value.object_type_presenter', function () {
             return new ObjectTypePresenter();
         });
 
-        $container->setShared('formatter.presenter.value.string_type_presenter', function () {
+        $container->define('formatter.presenter.value.string_type_presenter', function () {
             return new TruncatingStringTypePresenter(new QuotingStringTypePresenter());
         });
 
@@ -138,7 +138,7 @@ final class PresenterAssembler
      */
     private function assemblePresenter(ServiceContainer $container)
     {
-        $container->setShared('formatter.presenter', function (ServiceContainer $c) {
+        $container->define('formatter.presenter', function (ServiceContainer $c) {
             return new TaggingPresenter(
                 new SimplePresenter(
                     $c->get('formatter.presenter.value_presenter'),
@@ -152,18 +152,18 @@ final class PresenterAssembler
             );
         });
 
-        $container->setShared('formatter.presenter.value_presenter', function () {
+        $container->define('formatter.presenter.value_presenter', function () {
             return new ComposedValuePresenter();
         });
 
-        $container->setShared('formatter.presenter.exception_element_presenter', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.exception_element_presenter', function (ServiceContainer $c) {
             return new TaggingExceptionElementPresenter(
                 $c->get('formatter.presenter.value.exception_type_presenter'),
                 $c->get('formatter.presenter.value_presenter')
             );
         });
 
-        $container->setShared('formatter.presenter.exception.phpspec', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.exception.phpspec', function (ServiceContainer $c) {
             return new GenericPhpSpecExceptionPresenter(
                 $c->get('formatter.presenter.exception_element_presenter')
             );
@@ -175,7 +175,7 @@ final class PresenterAssembler
      */
     private function assembleHtmlPresenter(ServiceContainer $container)
     {
-        $container->setShared('formatter.presenter.html', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.html', function (ServiceContainer $c) {
             return new SimplePresenter(
                 $c->get('formatter.presenter.value_presenter'),
                 new SimpleExceptionPresenter(
@@ -187,14 +187,14 @@ final class PresenterAssembler
             );
         });
 
-        $container->setShared('formatter.presenter.html.exception_element_presenter', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.html.exception_element_presenter', function (ServiceContainer $c) {
             return new SimpleExceptionElementPresenter(
                 $c->get('formatter.presenter.value.exception_type_presenter'),
                 $c->get('formatter.presenter.value_presenter')
             );
         });
 
-        $container->setShared('formatter.presenter.html.exception.phpspec', function () {
+        $container->define('formatter.presenter.html.exception.phpspec', function () {
             return new HtmlPhpSpecExceptionPresenter();
         });
     }

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -37,7 +37,10 @@ use PhpSpec\Formatter\Presenter\Value\TruncatingStringTypePresenter;
 use PhpSpec\ServiceContainer;
 use SebastianBergmann\Exporter\Exporter;
 
-class PresenterAssembler
+/**
+ * @Internal
+ */
+final class PresenterAssembler
 {
     /**
      * @param ServiceContainer $container

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -38,7 +38,7 @@ use PhpSpec\ServiceContainer\IndexedServiceContainer;
 use SebastianBergmann\Exporter\Exporter;
 
 /**
- * @Internal
+ * @internal
  */
 final class PresenterAssembler
 {

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -64,7 +64,7 @@ final class PresenterAssembler
 
             array_map(
                 array($differ, 'addEngine'),
-                $c->getByPrefix('formatter.presenter.differ.engines')
+                $c->getByTag('formatter.presenter.differ.engines')
             );
 
             return $differ;
@@ -78,18 +78,18 @@ final class PresenterAssembler
     {
         $container->define('formatter.presenter.differ.engines.string', function () {
             return new StringEngine();
-        });
+        }, ['formatter.presenter.differ.engines']);
 
         $container->define('formatter.presenter.differ.engines.array', function () {
             return new ArrayEngine();
-        });
+        }, ['formatter.presenter.differ.engines']);
 
         $container->define('formatter.presenter.differ.engines.object', function (IndexedServiceContainer $c) {
             return new ObjectEngine(
                 new Exporter(),
                 $c->get('formatter.presenter.differ.engines.string')
             );
-        });
+        }, ['formatter.presenter.differ.engines']);
     }
 
     /**
@@ -99,36 +99,36 @@ final class PresenterAssembler
     {
         $container->define('formatter.presenter.value.array_type_presenter', function () {
             return new ArrayTypePresenter();
-        });
+        }, ['formatter.presenter.value']);
 
         $container->define('formatter.presenter.value.boolean_type_presenter', function () {
             return new BooleanTypePresenter();
-        });
+        }, ['formatter.presenter.value']);
 
         $container->define('formatter.presenter.value.callable_type_presenter', function (IndexedServiceContainer $c) {
             return new CallableTypePresenter($c->get('formatter.presenter'));
-        });
+        }, ['formatter.presenter.value']);
 
         $container->define('formatter.presenter.value.exception_type_presenter', function () {
             return new BaseExceptionTypePresenter();
-        });
+        }, ['formatter.presenter.value']);
 
         $container->define('formatter.presenter.value.null_type_presenter', function () {
             return new NullTypePresenter();
-        });
+        }, ['formatter.presenter.value']);
 
         $container->define('formatter.presenter.value.object_type_presenter', function () {
             return new ObjectTypePresenter();
-        });
+        }, ['formatter.presenter.value']);
 
         $container->define('formatter.presenter.value.string_type_presenter', function () {
             return new TruncatingStringTypePresenter(new QuotingStringTypePresenter());
-        });
+        }, ['formatter.presenter.value']);
 
         $container->addConfigurator(function (IndexedServiceContainer $c) {
             array_map(
                 array($c->get('formatter.presenter.value_presenter'), 'addTypePresenter'),
-                $c->getByPrefix('formatter.presenter.value')
+                $c->getByTag('formatter.presenter.value')
             );
         });
     }

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -76,15 +76,15 @@ final class PresenterAssembler
      */
     private function assembleDifferEngines(ServiceContainer $container)
     {
-        $container->set('formatter.presenter.differ.engines.string', function () {
+        $container->define('formatter.presenter.differ.engines.string', function () {
             return new StringEngine();
         });
 
-        $container->set('formatter.presenter.differ.engines.array', function () {
+        $container->define('formatter.presenter.differ.engines.array', function () {
             return new ArrayEngine();
         });
 
-        $container->set('formatter.presenter.differ.engines.object', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.differ.engines.object', function (ServiceContainer $c) {
             return new ObjectEngine(
                 new Exporter(),
                 $c->get('formatter.presenter.differ.engines.string')

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -34,7 +34,7 @@ use PhpSpec\Formatter\Presenter\Value\NullTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\ObjectTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\QuotingStringTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\TruncatingStringTypePresenter;
-use PhpSpec\ServiceContainer;
+use PhpSpec\ServiceContainer\IndexedServiceContainer;
 use SebastianBergmann\Exporter\Exporter;
 
 /**
@@ -43,9 +43,9 @@ use SebastianBergmann\Exporter\Exporter;
 final class PresenterAssembler
 {
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    public function assemble(ServiceContainer $container)
+    public function assemble(IndexedServiceContainer $container)
     {
         $this->assembleDiffer($container);
         $this->assembleDifferEngines($container);
@@ -55,11 +55,11 @@ final class PresenterAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function assembleDiffer(ServiceContainer $container)
+    private function assembleDiffer(IndexedServiceContainer $container)
     {
-        $container->define('formatter.presenter.differ', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.differ', function (IndexedServiceContainer $c) {
             $differ = new Differ();
 
             array_map(
@@ -72,9 +72,9 @@ final class PresenterAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function assembleDifferEngines(ServiceContainer $container)
+    private function assembleDifferEngines(IndexedServiceContainer $container)
     {
         $container->define('formatter.presenter.differ.engines.string', function () {
             return new StringEngine();
@@ -84,7 +84,7 @@ final class PresenterAssembler
             return new ArrayEngine();
         });
 
-        $container->define('formatter.presenter.differ.engines.object', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.differ.engines.object', function (IndexedServiceContainer $c) {
             return new ObjectEngine(
                 new Exporter(),
                 $c->get('formatter.presenter.differ.engines.string')
@@ -93,9 +93,9 @@ final class PresenterAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function assembleTypePresenters(ServiceContainer $container)
+    private function assembleTypePresenters(IndexedServiceContainer $container)
     {
         $container->define('formatter.presenter.value.array_type_presenter', function () {
             return new ArrayTypePresenter();
@@ -105,7 +105,7 @@ final class PresenterAssembler
             return new BooleanTypePresenter();
         });
 
-        $container->define('formatter.presenter.value.callable_type_presenter', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.value.callable_type_presenter', function (IndexedServiceContainer $c) {
             return new CallableTypePresenter($c->get('formatter.presenter'));
         });
 
@@ -125,7 +125,7 @@ final class PresenterAssembler
             return new TruncatingStringTypePresenter(new QuotingStringTypePresenter());
         });
 
-        $container->addConfigurator(function (ServiceContainer $c) {
+        $container->addConfigurator(function (IndexedServiceContainer $c) {
             array_map(
                 array($c->get('formatter.presenter.value_presenter'), 'addTypePresenter'),
                 $c->getByPrefix('formatter.presenter.value')
@@ -134,11 +134,11 @@ final class PresenterAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function assemblePresenter(ServiceContainer $container)
+    private function assemblePresenter(IndexedServiceContainer $container)
     {
-        $container->define('formatter.presenter', function (ServiceContainer $c) {
+        $container->define('formatter.presenter', function (IndexedServiceContainer $c) {
             return new TaggingPresenter(
                 new SimplePresenter(
                     $c->get('formatter.presenter.value_presenter'),
@@ -156,14 +156,14 @@ final class PresenterAssembler
             return new ComposedValuePresenter();
         });
 
-        $container->define('formatter.presenter.exception_element_presenter', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.exception_element_presenter', function (IndexedServiceContainer $c) {
             return new TaggingExceptionElementPresenter(
                 $c->get('formatter.presenter.value.exception_type_presenter'),
                 $c->get('formatter.presenter.value_presenter')
             );
         });
 
-        $container->define('formatter.presenter.exception.phpspec', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.exception.phpspec', function (IndexedServiceContainer $c) {
             return new GenericPhpSpecExceptionPresenter(
                 $c->get('formatter.presenter.exception_element_presenter')
             );
@@ -171,11 +171,11 @@ final class PresenterAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function assembleHtmlPresenter(ServiceContainer $container)
+    private function assembleHtmlPresenter(IndexedServiceContainer $container)
     {
-        $container->define('formatter.presenter.html', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.html', function (IndexedServiceContainer $c) {
             return new SimplePresenter(
                 $c->get('formatter.presenter.value_presenter'),
                 new SimpleExceptionPresenter(
@@ -187,7 +187,7 @@ final class PresenterAssembler
             );
         });
 
-        $container->define('formatter.presenter.html.exception_element_presenter', function (ServiceContainer $c) {
+        $container->define('formatter.presenter.html.exception_element_presenter', function (IndexedServiceContainer $c) {
             return new SimpleExceptionElementPresenter(
                 $c->get('formatter.presenter.value.exception_type_presenter'),
                 $c->get('formatter.presenter.value_presenter')

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -21,8 +21,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Command line command responsible to signal to generators we will need to
  * generate a new spec
+ *
+ * @Internal
  */
-class DescribeCommand extends Command
+final class DescribeCommand extends Command
 {
     protected function configure()
     {

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Main command, responsible for running the specs
  *
- * @Internal
+ * @internal
  */
 final class RunCommand extends Command
 {

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -150,7 +150,7 @@ EOF
 
         if ($currentFormatter instanceof FatalPresenter) {
 
-            $container->setShared('process.shutdown.update_console_action', function(ServiceContainer $c) use ($currentFormatter) {
+            $container->define('process.shutdown.update_console_action', function(ServiceContainer $c) use ($currentFormatter) {
                 return new UpdateConsoleAction(
                     $c->get('current_example'),
                     $currentFormatter

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -25,8 +25,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Main command, responsible for running the specs
+ *
+ * @Internal
  */
-class RunCommand extends Command
+final class RunCommand extends Command
 {
     protected function configure()
     {

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -150,7 +150,7 @@ EOF
 
         if ($currentFormatter instanceof FatalPresenter) {
 
-            $container->define('process.shutdown.update_console_action', function(IndexedServiceContainer $c) use ($currentFormatter) {
+            $container->define('process.shutdown.update_console_action', function (IndexedServiceContainer $c) use ($currentFormatter) {
                 return new UpdateConsoleAction(
                     $c->get('current_example'),
                     $currentFormatter

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -15,7 +15,7 @@ namespace PhpSpec\Console\Command;
 
 use PhpSpec\Formatter\FatalPresenter;
 use PhpSpec\Process\Shutdown\UpdateConsoleAction;
-use PhpSpec\ServiceContainer;
+use PhpSpec\ServiceContainer\IndexedServiceContainer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -150,7 +150,7 @@ EOF
 
         if ($currentFormatter instanceof FatalPresenter) {
 
-            $container->define('process.shutdown.update_console_action', function(ServiceContainer $c) use ($currentFormatter) {
+            $container->define('process.shutdown.update_console_action', function(IndexedServiceContainer $c) use ($currentFormatter) {
                 return new UpdateConsoleAction(
                     $c->get('current_example'),
                     $currentFormatter

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -429,16 +429,16 @@ final class ContainerAssembler
                 return new Loader\Transformer\TypeHintRewriter($c->get('analysis.typehintrewriter'));
             });
         }
-        $container->define('analysis.typehintrewriter', function($c) {
+        $container->define('analysis.typehintrewriter', function ($c) {
             return new TokenizedTypeHintRewriter(
                 $c->get('loader.transformer.typehintindex'),
                 $c->get('analysis.namespaceresolver')
             );
         });
-        $container->define('loader.transformer.typehintindex', function() {
+        $container->define('loader.transformer.typehintindex', function () {
             return new Loader\Transformer\InMemoryTypeHintIndex();
         });
-        $container->define('analysis.namespaceresolver.tokenized', function() {
+        $container->define('analysis.namespaceresolver.tokenized', function () {
             return new TokenizedNamespaceResolver();
         });
         $container->define('analysis.namespaceresolver', function ($c) {
@@ -614,15 +614,15 @@ final class ContainerAssembler
             return new Wrapper\Unwrapper();
         });
 
-        $container->define('access_inspector', function($c) {
+        $container->define('access_inspector', function ($c) {
             return $c->get('access_inspector.magic');
         });
 
-        $container->define('access_inspector.magic', function($c) {
+        $container->define('access_inspector.magic', function ($c) {
             return new MagicAwareAccessInspector($c->get('access_inspector.visibility'));
         });
 
-        $container->define('access_inspector.visibility', function() {
+        $container->define('access_inspector.visibility', function () {
             return new VisibilityAccessInspector();
         });
     }
@@ -748,7 +748,7 @@ final class ContainerAssembler
    */
     private function setupShutdown(IndexedServiceContainer $container)
     {
-        $container->define('process.shutdown', function() {
+        $container->define('process.shutdown', function () {
             return new Shutdown();
         });
     }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -28,7 +28,7 @@ use PhpSpec\Util\ReservedWordsMethodNameChecker;
 use PhpSpec\Process\ReRunner;
 use PhpSpec\Util\MethodAnalyser;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use PhpSpec\ServiceContainer;
+use PhpSpec\ServiceContainer\IndexedServiceContainer;
 use PhpSpec\CodeGenerator;
 use PhpSpec\Formatter as SpecFormatter;
 use PhpSpec\Listener;
@@ -48,9 +48,9 @@ use PhpSpec\Process\Shutdown\Shutdown;
 final class ContainerAssembler
 {
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    public function build(ServiceContainer $container)
+    public function build(IndexedServiceContainer $container)
     {
         $this->setupIO($container);
         $this->setupEventDispatcher($container);
@@ -70,7 +70,7 @@ final class ContainerAssembler
         $this->setupShutdown($container);
     }
 
-    private function setupIO(ServiceContainer $container)
+    private function setupIO(IndexedServiceContainer $container)
     {
         if (!$container->has('console.prompter')) {
             $container->define('console.prompter', function ($c) {
@@ -81,7 +81,7 @@ final class ContainerAssembler
                 );
             });
         }
-        $container->define('console.io', function (ServiceContainer $c) {
+        $container->define('console.io', function (IndexedServiceContainer $c) {
             return new ConsoleIO(
                 $c->get('console.input'),
                 $c->get('console.output'),
@@ -100,14 +100,14 @@ final class ContainerAssembler
         });
     }
 
-    private function setupResultConverter(ServiceContainer $container)
+    private function setupResultConverter(IndexedServiceContainer $container)
     {
         $container->define('console.result_converter', function () {
             return new ResultConverter();
         });
     }
 
-    private function setupCommands(ServiceContainer $container)
+    private function setupCommands(IndexedServiceContainer $container)
     {
         $container->define('console.commands.run', function () {
             return new Command\RunCommand();
@@ -119,11 +119,11 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupConsoleEventDispatcher(ServiceContainer $container)
+    private function setupConsoleEventDispatcher(IndexedServiceContainer $container)
     {
-        $container->define('console_event_dispatcher', function (ServiceContainer $c) {
+        $container->define('console_event_dispatcher', function (IndexedServiceContainer $c) {
             $dispatcher = new EventDispatcher();
 
             array_map(
@@ -136,9 +136,9 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupEventDispatcher(ServiceContainer $container)
+    private function setupEventDispatcher(IndexedServiceContainer $container)
     {
         $container->define('event_dispatcher', function () {
             return new EventDispatcher();
@@ -147,21 +147,21 @@ final class ContainerAssembler
         $container->define('event_dispatcher.listeners.stats', function () {
             return new Listener\StatisticsCollector();
         });
-        $container->define('event_dispatcher.listeners.class_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.class_not_found', function (IndexedServiceContainer $c) {
             return new Listener\ClassNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
         });
-        $container->define('event_dispatcher.listeners.collaborator_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.collaborator_not_found', function (IndexedServiceContainer $c) {
             return new Listener\CollaboratorNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
         });
-        $container->define('event_dispatcher.listeners.collaborator_method_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.collaborator_method_not_found', function (IndexedServiceContainer $c) {
             return new Listener\CollaboratorMethodNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
@@ -169,14 +169,14 @@ final class ContainerAssembler
                 $c->get('util.reserved_words_checker')
             );
         });
-        $container->define('event_dispatcher.listeners.named_constructor_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.named_constructor_not_found', function (IndexedServiceContainer $c) {
             return new Listener\NamedConstructorNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
         });
-        $container->define('event_dispatcher.listeners.method_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.method_not_found', function (IndexedServiceContainer $c) {
             return new Listener\MethodNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
@@ -184,23 +184,23 @@ final class ContainerAssembler
                 $c->get('util.reserved_words_checker')
             );
         });
-        $container->define('event_dispatcher.listeners.stop_on_failure', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.stop_on_failure', function (IndexedServiceContainer $c) {
             return new Listener\StopOnFailureListener(
                 $c->get('console.io')
             );
         });
-        $container->define('event_dispatcher.listeners.rerun', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.rerun', function (IndexedServiceContainer $c) {
             return new Listener\RerunListener(
                 $c->get('process.rerunner'),
                 $c->get('process.prerequisites')
             );
         });
-        $container->define('process.prerequisites', function (ServiceContainer $c) {
+        $container->define('process.prerequisites', function (IndexedServiceContainer $c) {
             return new SuitePrerequisites(
                 $c->get('process.executioncontext')
             );
         });
-        $container->define('event_dispatcher.listeners.method_returned_null', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.method_returned_null', function (IndexedServiceContainer $c) {
             return new Listener\MethodReturnedNullListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
@@ -214,12 +214,12 @@ final class ContainerAssembler
         $container->define('util.reserved_words_checker', function () {
             return new ReservedWordsMethodNameChecker();
         });
-        $container->define('event_dispatcher.listeners.bootstrap', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.bootstrap', function (IndexedServiceContainer $c) {
             return new Listener\BootstrapListener(
                 $c->get('console.io')
             );
         });
-        $container->define('event_dispatcher.listeners.current_example_listener', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.current_example_listener', function (IndexedServiceContainer $c) {
             return new Listener\CurrentExampleListener(
                 $c->get('current_example')
             );
@@ -227,11 +227,11 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupGenerators(ServiceContainer $container)
+    private function setupGenerators(IndexedServiceContainer $container)
     {
-        $container->define('code_generator', function (ServiceContainer $c) {
+        $container->define('code_generator', function (IndexedServiceContainer $c) {
             $generator = new CodeGenerator\GeneratorManager();
 
             array_map(
@@ -242,7 +242,7 @@ final class ContainerAssembler
             return $generator;
         });
 
-        $container->define('code_generator.generators.specification', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.specification', function (IndexedServiceContainer $c) {
             $specificationGenerator =  new CodeGenerator\Generator\SpecificationGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -256,7 +256,7 @@ final class ContainerAssembler
                 $c->get('util.filesystem')
             );
         });
-        $container->define('code_generator.generators.class', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.class', function (IndexedServiceContainer $c) {
             $classGenerator = new CodeGenerator\Generator\ClassGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -270,7 +270,7 @@ final class ContainerAssembler
                 $c->get('util.filesystem')
             );
         });
-        $container->define('code_generator.generators.interface', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.interface', function (IndexedServiceContainer $c) {
             $interfaceGenerator = new CodeGenerator\Generator\InterfaceGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -287,7 +287,7 @@ final class ContainerAssembler
         $container->define('code_generator.writers.tokenized', function () {
             return new CodeGenerator\Writer\TokenizedCodeWriter(new ClassFileAnalyser());
         });
-        $container->define('code_generator.generators.method', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.method', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\MethodGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -295,14 +295,14 @@ final class ContainerAssembler
                 $c->get('code_generator.writers.tokenized')
             );
         });
-        $container->define('code_generator.generators.methodSignature', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.methodSignature', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\MethodSignatureGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem')
             );
         });
-        $container->define('code_generator.generators.returnConstant', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.returnConstant', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\ReturnConstantGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -310,7 +310,7 @@ final class ContainerAssembler
             );
         });
 
-        $container->define('code_generator.generators.named_constructor', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.named_constructor', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\NamedConstructorGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -319,7 +319,7 @@ final class ContainerAssembler
             );
         });
 
-        $container->define('code_generator.generators.private_constructor', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.private_constructor', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\PrivateConstructorGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -328,7 +328,7 @@ final class ContainerAssembler
             );
         });
 
-        $container->define('code_generator.templates', function (ServiceContainer $c) {
+        $container->define('code_generator.templates', function (IndexedServiceContainer $c) {
             $renderer = new CodeGenerator\TemplateRenderer(
                 $c->get('util.filesystem')
             );
@@ -350,20 +350,20 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupPresenter(ServiceContainer $container)
+    private function setupPresenter(IndexedServiceContainer $container)
     {
         $presenterAssembler = new PresenterAssembler();
         $presenterAssembler->assemble($container);
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupLocator(ServiceContainer $container)
+    private function setupLocator(IndexedServiceContainer $container)
     {
-        $container->define('locator.resource_manager', function (ServiceContainer $c) {
+        $container->define('locator.resource_manager', function (IndexedServiceContainer $c) {
             $manager = new Locator\PrioritizedResourceManager();
 
             array_map(
@@ -374,7 +374,7 @@ final class ContainerAssembler
             return $manager;
         });
 
-        $container->addConfigurator(function (ServiceContainer $c) {
+        $container->addConfigurator(function (IndexedServiceContainer $c) {
             $suites = $c->getParam('suites', array('main' => ''));
 
             foreach ($suites as $name => $suite) {
@@ -398,7 +398,7 @@ final class ContainerAssembler
 
                 $c->set(
                     sprintf('locator.locators.%s_suite', $name),
-                    function (ServiceContainer $c) use ($config) {
+                    function (IndexedServiceContainer $c) use ($config) {
                         return new Locator\PSR0\PSR0Locator(
                             $c->get('util.filesystem'),
                             $config['namespace'],
@@ -414,18 +414,18 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupLoader(ServiceContainer $container)
+    private function setupLoader(IndexedServiceContainer $container)
     {
-        $container->define('loader.resource_loader', function (ServiceContainer $c) {
+        $container->define('loader.resource_loader', function (IndexedServiceContainer $c) {
             return new Loader\ResourceLoader(
                 $c->get('locator.resource_manager'),
                 $c->get('util.method_analyser')
             );
         });
         if (PHP_VERSION >= 7) {
-            $container->define('loader.resource_loader.spec_transformer.typehint_rewriter', function (ServiceContainer $c) {
+            $container->define('loader.resource_loader.spec_transformer.typehint_rewriter', function (IndexedServiceContainer $c) {
                 return new Loader\Transformer\TypeHintRewriter($c->get('analysis.typehintrewriter'));
             });
         }
@@ -450,15 +450,15 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      *
      * @throws \RuntimeException
      */
-    protected function setupFormatter(ServiceContainer $container)
+    protected function setupFormatter(IndexedServiceContainer $container)
     {
         $container->set(
             'formatter.formatters.progress',
-            function (ServiceContainer $c) {
+            function (IndexedServiceContainer $c) {
                 return new SpecFormatter\ProgressFormatter(
                     $c->get('formatter.presenter'),
                     $c->get('console.io'),
@@ -468,7 +468,7 @@ final class ContainerAssembler
         );
         $container->set(
             'formatter.formatters.pretty',
-            function (ServiceContainer $c) {
+            function (IndexedServiceContainer $c) {
                 return new SpecFormatter\PrettyFormatter(
                     $c->get('formatter.presenter'),
                     $c->get('console.io'),
@@ -478,7 +478,7 @@ final class ContainerAssembler
         );
         $container->set(
             'formatter.formatters.junit',
-            function (ServiceContainer $c) {
+            function (IndexedServiceContainer $c) {
                 return new SpecFormatter\JUnitFormatter(
                     $c->get('formatter.presenter'),
                     $c->get('console.io'),
@@ -488,7 +488,7 @@ final class ContainerAssembler
         );
         $container->set(
             'formatter.formatters.dot',
-            function (ServiceContainer $c) {
+            function (IndexedServiceContainer $c) {
                 return new SpecFormatter\DotFormatter(
                     $c->get('formatter.presenter'),
                     $c->get('console.io'),
@@ -498,7 +498,7 @@ final class ContainerAssembler
         );
         $container->set(
             'formatter.formatters.tap',
-            function (ServiceContainer $c) {
+            function (IndexedServiceContainer $c) {
                 return new SpecFormatter\TapFormatter(
                     $c->get('formatter.presenter'),
                     $c->get('console.io'),
@@ -508,7 +508,7 @@ final class ContainerAssembler
         );
         $container->set(
             'formatter.formatters.html',
-            function (ServiceContainer $c) {
+            function (IndexedServiceContainer $c) {
                 $io = new SpecFormatter\Html\HtmlIO();
                 $template = new SpecFormatter\Html\Template($io);
                 $factory = new SpecFormatter\Html\ReportItemFactory($template);
@@ -524,12 +524,12 @@ final class ContainerAssembler
         );
         $container->set(
             'formatter.formatters.h',
-            function (ServiceContainer $c) {
+            function (IndexedServiceContainer $c) {
                 return $c->get('formatter.formatters.html');
             }
         );
 
-        $container->addConfigurator(function (ServiceContainer $c) {
+        $container->addConfigurator(function (IndexedServiceContainer $c) {
             $formatterName = $c->getParam('formatter.name', 'progress');
 
             $c->get('console.output')->setFormatter(new Formatter(
@@ -546,25 +546,25 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupRunner(ServiceContainer $container)
+    private function setupRunner(IndexedServiceContainer $container)
     {
-        $container->define('runner.suite', function (ServiceContainer $c) {
+        $container->define('runner.suite', function (IndexedServiceContainer $c) {
             return new Runner\SuiteRunner(
                 $c->get('event_dispatcher'),
                 $c->get('runner.specification')
             );
         });
 
-        $container->define('runner.specification', function (ServiceContainer $c) {
+        $container->define('runner.specification', function (IndexedServiceContainer $c) {
             return new Runner\SpecificationRunner(
                 $c->get('event_dispatcher'),
                 $c->get('runner.example')
             );
         });
 
-        $container->define('runner.example', function (ServiceContainer $c) {
+        $container->define('runner.example', function (IndexedServiceContainer $c) {
             $runner = new Runner\ExampleRunner(
                 $c->get('event_dispatcher'),
                 $c->get('formatter.presenter')
@@ -578,12 +578,12 @@ final class ContainerAssembler
             return $runner;
         });
 
-        $container->define('runner.maintainers.errors', function (ServiceContainer $c) {
+        $container->define('runner.maintainers.errors', function (IndexedServiceContainer $c) {
             return new Runner\Maintainer\ErrorMaintainer(
                 $c->getParam('runner.maintainers.errors.level', E_ALL ^ E_STRICT)
             );
         });
-        $container->define('runner.maintainers.collaborators', function (ServiceContainer $c) {
+        $container->define('runner.maintainers.collaborators', function (IndexedServiceContainer $c) {
             return new Runner\Maintainer\CollaboratorsMaintainer(
                 $c->get('unwrapper'),
                 $c->get('loader.transformer.typehintindex')
@@ -593,7 +593,7 @@ final class ContainerAssembler
             return new Runner\Maintainer\LetAndLetgoMaintainer();
         });
 
-        $container->define('runner.maintainers.matchers', function (ServiceContainer $c) {
+        $container->define('runner.maintainers.matchers', function (IndexedServiceContainer $c) {
             $matchers = $c->getByPrefix('matchers');
             return new Runner\Maintainer\MatchersMaintainer(
                 $c->get('formatter.presenter'),
@@ -601,7 +601,7 @@ final class ContainerAssembler
             );
         });
 
-        $container->define('runner.maintainers.subject', function (ServiceContainer $c) {
+        $container->define('runner.maintainers.subject', function (IndexedServiceContainer $c) {
             return new Runner\Maintainer\SubjectMaintainer(
                 $c->get('formatter.presenter'),
                 $c->get('unwrapper'),
@@ -628,60 +628,60 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupMatchers(ServiceContainer $container)
+    private function setupMatchers(IndexedServiceContainer $container)
     {
-        $container->define('matchers.identity', function (ServiceContainer $c) {
+        $container->define('matchers.identity', function (IndexedServiceContainer $c) {
             return new Matcher\IdentityMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.comparison', function (ServiceContainer $c) {
+        $container->define('matchers.comparison', function (IndexedServiceContainer $c) {
             return new Matcher\ComparisonMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.throwm', function (ServiceContainer $c) {
+        $container->define('matchers.throwm', function (IndexedServiceContainer $c) {
             return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
         });
-        $container->define('matchers.type', function (ServiceContainer $c) {
+        $container->define('matchers.type', function (IndexedServiceContainer $c) {
             return new Matcher\TypeMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.object_state', function (ServiceContainer $c) {
+        $container->define('matchers.object_state', function (IndexedServiceContainer $c) {
             return new Matcher\ObjectStateMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.scalar', function (ServiceContainer $c) {
+        $container->define('matchers.scalar', function (IndexedServiceContainer $c) {
             return new Matcher\ScalarMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.array_count', function (ServiceContainer $c) {
+        $container->define('matchers.array_count', function (IndexedServiceContainer $c) {
             return new Matcher\ArrayCountMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.array_key', function (ServiceContainer $c) {
+        $container->define('matchers.array_key', function (IndexedServiceContainer $c) {
             return new Matcher\ArrayKeyMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.array_key_with_value', function (ServiceContainer $c) {
+        $container->define('matchers.array_key_with_value', function (IndexedServiceContainer $c) {
             return new Matcher\ArrayKeyValueMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.array_contain', function (ServiceContainer $c) {
+        $container->define('matchers.array_contain', function (IndexedServiceContainer $c) {
             return new Matcher\ArrayContainMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.string_start', function (ServiceContainer $c) {
+        $container->define('matchers.string_start', function (IndexedServiceContainer $c) {
             return new Matcher\StringStartMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.string_end', function (ServiceContainer $c) {
+        $container->define('matchers.string_end', function (IndexedServiceContainer $c) {
             return new Matcher\StringEndMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.string_regex', function (ServiceContainer $c) {
+        $container->define('matchers.string_regex', function (IndexedServiceContainer $c) {
             return new Matcher\StringRegexMatcher($c->get('formatter.presenter'));
         });
-        $container->define('matchers.string_contain', function (ServiceContainer $c) {
+        $container->define('matchers.string_contain', function (IndexedServiceContainer $c) {
             return new Matcher\StringContainMatcher($c->get('formatter.presenter'));
         });
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupRerunner(ServiceContainer $container)
+    private function setupRerunner(IndexedServiceContainer $container)
     {
-        $container->define('process.rerunner', function (ServiceContainer $c) {
+        $container->define('process.rerunner', function (IndexedServiceContainer $c) {
             return new ReRunner\OptionalReRunner(
                 $c->get('process.rerunner.platformspecific'),
                 $c->get('console.io')
@@ -692,24 +692,24 @@ final class ContainerAssembler
             return;
         }
 
-        $container->define('process.rerunner.platformspecific', function (ServiceContainer $c) {
+        $container->define('process.rerunner.platformspecific', function (IndexedServiceContainer $c) {
             return new ReRunner\CompositeReRunner(
                 $c->getByPrefix('process.rerunner.platformspecific')
             );
         });
-        $container->define('process.rerunner.platformspecific.pcntl', function (ServiceContainer $c) {
+        $container->define('process.rerunner.platformspecific.pcntl', function (IndexedServiceContainer $c) {
             return ReRunner\PcntlReRunner::withExecutionContext(
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
             );
         });
-        $container->define('process.rerunner.platformspecific.passthru', function (ServiceContainer $c) {
+        $container->define('process.rerunner.platformspecific.passthru', function (IndexedServiceContainer $c) {
             return ReRunner\ProcOpenReRunner::withExecutionContext(
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
             );
         });
-        $container->define('process.rerunner.platformspecific.windowspassthru', function (ServiceContainer $c) {
+        $container->define('process.rerunner.platformspecific.windowspassthru', function (IndexedServiceContainer $c) {
             return ReRunner\WindowsPassthruReRunner::withExecutionContext(
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
@@ -721,11 +721,11 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupSubscribers(ServiceContainer $container)
+    private function setupSubscribers(IndexedServiceContainer $container)
     {
-        $container->addConfigurator(function (ServiceContainer $c) {
+        $container->addConfigurator(function (IndexedServiceContainer $c) {
             array_map(
                 array($c->get('event_dispatcher'), 'addSubscriber'),
                 $c->getByPrefix('event_dispatcher.listeners')
@@ -734,9 +734,9 @@ final class ContainerAssembler
     }
 
     /**
-     * @param ServiceContainer $container
+     * @param IndexedServiceContainer $container
      */
-    private function setupCurrentExample(ServiceContainer $container)
+    private function setupCurrentExample(IndexedServiceContainer $container)
     {
         $container->define('current_example', function () {
             return new CurrentExampleTracker();
@@ -744,9 +744,9 @@ final class ContainerAssembler
     }
 
   /**
-   * @param ServiceContainer $container
+   * @param IndexedServiceContainer $container
    */
-    private function setupShutdown(ServiceContainer $container)
+    private function setupShutdown(IndexedServiceContainer $container)
     {
         $container->define('process.shutdown', function() {
             return new Shutdown();

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -396,7 +396,7 @@ final class ContainerAssembler
                     mkdir($config['spec_path'], 0777, true);
                 }
 
-                $c->set(
+                $c->define(
                     sprintf('locator.locators.%s_suite', $name),
                     function (IndexedServiceContainer $c) use ($config) {
                         return new Locator\PSR0\PSR0Locator(
@@ -457,7 +457,7 @@ final class ContainerAssembler
      */
     protected function setupFormatter(IndexedServiceContainer $container)
     {
-        $container->set(
+        $container->define(
             'formatter.formatters.progress',
             function (IndexedServiceContainer $c) {
                 return new SpecFormatter\ProgressFormatter(
@@ -467,7 +467,7 @@ final class ContainerAssembler
                 );
             }
         );
-        $container->set(
+        $container->define(
             'formatter.formatters.pretty',
             function (IndexedServiceContainer $c) {
                 return new SpecFormatter\PrettyFormatter(
@@ -477,7 +477,7 @@ final class ContainerAssembler
                 );
             }
         );
-        $container->set(
+        $container->define(
             'formatter.formatters.junit',
             function (IndexedServiceContainer $c) {
                 return new SpecFormatter\JUnitFormatter(
@@ -487,7 +487,7 @@ final class ContainerAssembler
                 );
             }
         );
-        $container->set(
+        $container->define(
             'formatter.formatters.dot',
             function (IndexedServiceContainer $c) {
                 return new SpecFormatter\DotFormatter(
@@ -497,7 +497,7 @@ final class ContainerAssembler
                 );
             }
         );
-        $container->set(
+        $container->define(
             'formatter.formatters.tap',
             function (IndexedServiceContainer $c) {
                 return new SpecFormatter\TapFormatter(
@@ -507,7 +507,7 @@ final class ContainerAssembler
                 );
             }
         );
-        $container->set(
+        $container->define(
             'formatter.formatters.html',
             function (IndexedServiceContainer $c) {
                 $io = new SpecFormatter\Html\HtmlIO();
@@ -523,7 +523,7 @@ final class ContainerAssembler
                 );
             }
         );
-        $container->set(
+        $container->define(
             'formatter.formatters.h',
             function (IndexedServiceContainer $c) {
                 return $c->get('formatter.formatters.html');

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -72,8 +72,8 @@ final class ContainerAssembler
 
     private function setupIO(ServiceContainer $container)
     {
-        if (!$container->isDefined('console.prompter')) {
-            $container->setShared('console.prompter', function ($c) {
+        if (!$container->has('console.prompter')) {
+            $container->define('console.prompter', function ($c) {
                 return new Question(
                     $c->get('console.input'),
                     $c->get('console.output'),
@@ -81,7 +81,7 @@ final class ContainerAssembler
                 );
             });
         }
-        $container->setShared('console.io', function (ServiceContainer $c) {
+        $container->define('console.io', function (ServiceContainer $c) {
             return new ConsoleIO(
                 $c->get('console.input'),
                 $c->get('console.output'),
@@ -95,25 +95,25 @@ final class ContainerAssembler
                 $c->get('console.prompter')
             );
         });
-        $container->setShared('util.filesystem', function () {
+        $container->define('util.filesystem', function () {
             return new Filesystem();
         });
     }
 
     private function setupResultConverter(ServiceContainer $container)
     {
-        $container->setShared('console.result_converter', function () {
+        $container->define('console.result_converter', function () {
             return new ResultConverter();
         });
     }
 
     private function setupCommands(ServiceContainer $container)
     {
-        $container->setShared('console.commands.run', function () {
+        $container->define('console.commands.run', function () {
             return new Command\RunCommand();
         });
 
-        $container->setShared('console.commands.describe', function () {
+        $container->define('console.commands.describe', function () {
             return new Command\DescribeCommand();
         });
     }
@@ -123,7 +123,7 @@ final class ContainerAssembler
      */
     private function setupConsoleEventDispatcher(ServiceContainer $container)
     {
-        $container->setShared('console_event_dispatcher', function (ServiceContainer $c) {
+        $container->define('console_event_dispatcher', function (ServiceContainer $c) {
             $dispatcher = new EventDispatcher();
 
             array_map(
@@ -140,28 +140,28 @@ final class ContainerAssembler
      */
     private function setupEventDispatcher(ServiceContainer $container)
     {
-        $container->setShared('event_dispatcher', function () {
+        $container->define('event_dispatcher', function () {
             return new EventDispatcher();
         });
 
-        $container->setShared('event_dispatcher.listeners.stats', function () {
+        $container->define('event_dispatcher.listeners.stats', function () {
             return new Listener\StatisticsCollector();
         });
-        $container->setShared('event_dispatcher.listeners.class_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.class_not_found', function (ServiceContainer $c) {
             return new Listener\ClassNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
         });
-        $container->setShared('event_dispatcher.listeners.collaborator_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.collaborator_not_found', function (ServiceContainer $c) {
             return new Listener\CollaboratorNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
         });
-        $container->setShared('event_dispatcher.listeners.collaborator_method_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.collaborator_method_not_found', function (ServiceContainer $c) {
             return new Listener\CollaboratorMethodNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
@@ -169,14 +169,14 @@ final class ContainerAssembler
                 $c->get('util.reserved_words_checker')
             );
         });
-        $container->setShared('event_dispatcher.listeners.named_constructor_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.named_constructor_not_found', function (ServiceContainer $c) {
             return new Listener\NamedConstructorNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
         });
-        $container->setShared('event_dispatcher.listeners.method_not_found', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.method_not_found', function (ServiceContainer $c) {
             return new Listener\MethodNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
@@ -184,23 +184,23 @@ final class ContainerAssembler
                 $c->get('util.reserved_words_checker')
             );
         });
-        $container->setShared('event_dispatcher.listeners.stop_on_failure', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.stop_on_failure', function (ServiceContainer $c) {
             return new Listener\StopOnFailureListener(
                 $c->get('console.io')
             );
         });
-        $container->setShared('event_dispatcher.listeners.rerun', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.rerun', function (ServiceContainer $c) {
             return new Listener\RerunListener(
                 $c->get('process.rerunner'),
                 $c->get('process.prerequisites')
             );
         });
-        $container->setShared('process.prerequisites', function (ServiceContainer $c) {
+        $container->define('process.prerequisites', function (ServiceContainer $c) {
             return new SuitePrerequisites(
                 $c->get('process.executioncontext')
             );
         });
-        $container->setShared('event_dispatcher.listeners.method_returned_null', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.method_returned_null', function (ServiceContainer $c) {
             return new Listener\MethodReturnedNullListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
@@ -208,18 +208,18 @@ final class ContainerAssembler
                 $c->get('util.method_analyser')
             );
         });
-        $container->setShared('util.method_analyser', function () {
+        $container->define('util.method_analyser', function () {
             return new MethodAnalyser();
         });
-        $container->setShared('util.reserved_words_checker', function () {
+        $container->define('util.reserved_words_checker', function () {
             return new ReservedWordsMethodNameChecker();
         });
-        $container->setShared('event_dispatcher.listeners.bootstrap', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.bootstrap', function (ServiceContainer $c) {
             return new Listener\BootstrapListener(
                 $c->get('console.io')
             );
         });
-        $container->setShared('event_dispatcher.listeners.current_example_listener', function (ServiceContainer $c) {
+        $container->define('event_dispatcher.listeners.current_example_listener', function (ServiceContainer $c) {
             return new Listener\CurrentExampleListener(
                 $c->get('current_example')
             );
@@ -231,7 +231,7 @@ final class ContainerAssembler
      */
     private function setupGenerators(ServiceContainer $container)
     {
-        $container->setShared('code_generator', function (ServiceContainer $c) {
+        $container->define('code_generator', function (ServiceContainer $c) {
             $generator = new CodeGenerator\GeneratorManager();
 
             array_map(
@@ -328,7 +328,7 @@ final class ContainerAssembler
             );
         });
 
-        $container->setShared('code_generator.templates', function (ServiceContainer $c) {
+        $container->define('code_generator.templates', function (ServiceContainer $c) {
             $renderer = new CodeGenerator\TemplateRenderer(
                 $c->get('util.filesystem')
             );
@@ -363,7 +363,7 @@ final class ContainerAssembler
      */
     private function setupLocator(ServiceContainer $container)
     {
-        $container->setShared('locator.resource_manager', function (ServiceContainer $c) {
+        $container->define('locator.resource_manager', function (ServiceContainer $c) {
             $manager = new Locator\PrioritizedResourceManager();
 
             array_map(
@@ -418,30 +418,30 @@ final class ContainerAssembler
      */
     private function setupLoader(ServiceContainer $container)
     {
-        $container->setShared('loader.resource_loader', function (ServiceContainer $c) {
+        $container->define('loader.resource_loader', function (ServiceContainer $c) {
             return new Loader\ResourceLoader(
                 $c->get('locator.resource_manager'),
                 $c->get('util.method_analyser')
             );
         });
         if (PHP_VERSION >= 7) {
-            $container->setShared('loader.resource_loader.spec_transformer.typehint_rewriter', function (ServiceContainer $c) {
+            $container->define('loader.resource_loader.spec_transformer.typehint_rewriter', function (ServiceContainer $c) {
                 return new Loader\Transformer\TypeHintRewriter($c->get('analysis.typehintrewriter'));
             });
         }
-        $container->setShared('analysis.typehintrewriter', function($c) {
+        $container->define('analysis.typehintrewriter', function($c) {
             return new TokenizedTypeHintRewriter(
                 $c->get('loader.transformer.typehintindex'),
                 $c->get('analysis.namespaceresolver')
             );
         });
-        $container->setShared('loader.transformer.typehintindex', function() {
+        $container->define('loader.transformer.typehintindex', function() {
             return new Loader\Transformer\InMemoryTypeHintIndex();
         });
-        $container->setShared('analysis.namespaceresolver.tokenized', function() {
+        $container->define('analysis.namespaceresolver.tokenized', function() {
             return new TokenizedNamespaceResolver();
         });
-        $container->setShared('analysis.namespaceresolver', function ($c) {
+        $container->define('analysis.namespaceresolver', function ($c) {
             if (PHP_VERSION >= 7) {
                 return new StaticRejectingNamespaceResolver($c->get('analysis.namespaceresolver.tokenized'));
             }
@@ -550,21 +550,21 @@ final class ContainerAssembler
      */
     private function setupRunner(ServiceContainer $container)
     {
-        $container->setShared('runner.suite', function (ServiceContainer $c) {
+        $container->define('runner.suite', function (ServiceContainer $c) {
             return new Runner\SuiteRunner(
                 $c->get('event_dispatcher'),
                 $c->get('runner.specification')
             );
         });
 
-        $container->setShared('runner.specification', function (ServiceContainer $c) {
+        $container->define('runner.specification', function (ServiceContainer $c) {
             return new Runner\SpecificationRunner(
                 $c->get('event_dispatcher'),
                 $c->get('runner.example')
             );
         });
 
-        $container->setShared('runner.example', function (ServiceContainer $c) {
+        $container->define('runner.example', function (ServiceContainer $c) {
             $runner = new Runner\ExampleRunner(
                 $c->get('event_dispatcher'),
                 $c->get('formatter.presenter')
@@ -610,19 +610,19 @@ final class ContainerAssembler
             );
         });
 
-        $container->setShared('unwrapper', function () {
+        $container->define('unwrapper', function () {
             return new Wrapper\Unwrapper();
         });
 
-        $container->setShared('access_inspector', function($c) {
+        $container->define('access_inspector', function($c) {
             return $c->get('access_inspector.magic');
         });
 
-        $container->setShared('access_inspector.magic', function($c) {
+        $container->define('access_inspector.magic', function($c) {
             return new MagicAwareAccessInspector($c->get('access_inspector.visibility'));
         });
 
-        $container->setShared('access_inspector.visibility', function() {
+        $container->define('access_inspector.visibility', function() {
             return new VisibilityAccessInspector();
         });
     }
@@ -681,41 +681,41 @@ final class ContainerAssembler
      */
     private function setupRerunner(ServiceContainer $container)
     {
-        $container->setShared('process.rerunner', function (ServiceContainer $c) {
+        $container->define('process.rerunner', function (ServiceContainer $c) {
             return new ReRunner\OptionalReRunner(
                 $c->get('process.rerunner.platformspecific'),
                 $c->get('console.io')
             );
         });
 
-        if ($container->isDefined('process.rerunner.platformspecific')) {
+        if ($container->has('process.rerunner.platformspecific')) {
             return;
         }
 
-        $container->setShared('process.rerunner.platformspecific', function (ServiceContainer $c) {
+        $container->define('process.rerunner.platformspecific', function (ServiceContainer $c) {
             return new ReRunner\CompositeReRunner(
                 $c->getByPrefix('process.rerunner.platformspecific')
             );
         });
-        $container->setShared('process.rerunner.platformspecific.pcntl', function (ServiceContainer $c) {
+        $container->define('process.rerunner.platformspecific.pcntl', function (ServiceContainer $c) {
             return ReRunner\PcntlReRunner::withExecutionContext(
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
             );
         });
-        $container->setShared('process.rerunner.platformspecific.passthru', function (ServiceContainer $c) {
+        $container->define('process.rerunner.platformspecific.passthru', function (ServiceContainer $c) {
             return ReRunner\ProcOpenReRunner::withExecutionContext(
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
             );
         });
-        $container->setShared('process.rerunner.platformspecific.windowspassthru', function (ServiceContainer $c) {
+        $container->define('process.rerunner.platformspecific.windowspassthru', function (ServiceContainer $c) {
             return ReRunner\WindowsPassthruReRunner::withExecutionContext(
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
             );
         });
-        $container->setShared('process.phpexecutablefinder', function () {
+        $container->define('process.phpexecutablefinder', function () {
             return new PhpExecutableFinder();
         });
     }
@@ -738,7 +738,7 @@ final class ContainerAssembler
      */
     private function setupCurrentExample(ServiceContainer $container)
     {
-        $container->setShared('current_example', function () {
+        $container->define('current_example', function () {
             return new CurrentExampleTracker();
         });
     }
@@ -748,7 +748,7 @@ final class ContainerAssembler
    */
     private function setupShutdown(ServiceContainer $container)
     {
-        $container->setShared('process.shutdown', function() {
+        $container->define('process.shutdown', function() {
             return new Shutdown();
         });
     }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -242,7 +242,7 @@ final class ContainerAssembler
             return $generator;
         });
 
-        $container->set('code_generator.generators.specification', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.specification', function (ServiceContainer $c) {
             $specificationGenerator =  new CodeGenerator\Generator\SpecificationGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -256,7 +256,7 @@ final class ContainerAssembler
                 $c->get('util.filesystem')
             );
         });
-        $container->set('code_generator.generators.class', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.class', function (ServiceContainer $c) {
             $classGenerator = new CodeGenerator\Generator\ClassGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -270,7 +270,7 @@ final class ContainerAssembler
                 $c->get('util.filesystem')
             );
         });
-        $container->set('code_generator.generators.interface', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.interface', function (ServiceContainer $c) {
             $interfaceGenerator = new CodeGenerator\Generator\InterfaceGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -284,10 +284,10 @@ final class ContainerAssembler
                 $c->get('util.filesystem')
             );
         });
-        $container->set('code_generator.writers.tokenized', function () {
+        $container->define('code_generator.writers.tokenized', function () {
             return new CodeGenerator\Writer\TokenizedCodeWriter(new ClassFileAnalyser());
         });
-        $container->set('code_generator.generators.method', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.method', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\MethodGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -295,14 +295,14 @@ final class ContainerAssembler
                 $c->get('code_generator.writers.tokenized')
             );
         });
-        $container->set('code_generator.generators.methodSignature', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.methodSignature', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\MethodSignatureGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem')
             );
         });
-        $container->set('code_generator.generators.returnConstant', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.returnConstant', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\ReturnConstantGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -310,7 +310,7 @@ final class ContainerAssembler
             );
         });
 
-        $container->set('code_generator.generators.named_constructor', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.named_constructor', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\NamedConstructorGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -319,7 +319,7 @@ final class ContainerAssembler
             );
         });
 
-        $container->set('code_generator.generators.private_constructor', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.private_constructor', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\PrivateConstructorGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
@@ -578,22 +578,22 @@ final class ContainerAssembler
             return $runner;
         });
 
-        $container->set('runner.maintainers.errors', function (ServiceContainer $c) {
+        $container->define('runner.maintainers.errors', function (ServiceContainer $c) {
             return new Runner\Maintainer\ErrorMaintainer(
                 $c->getParam('runner.maintainers.errors.level', E_ALL ^ E_STRICT)
             );
         });
-        $container->set('runner.maintainers.collaborators', function (ServiceContainer $c) {
+        $container->define('runner.maintainers.collaborators', function (ServiceContainer $c) {
             return new Runner\Maintainer\CollaboratorsMaintainer(
                 $c->get('unwrapper'),
                 $c->get('loader.transformer.typehintindex')
             );
         });
-        $container->set('runner.maintainers.let_letgo', function () {
+        $container->define('runner.maintainers.let_letgo', function () {
             return new Runner\Maintainer\LetAndLetgoMaintainer();
         });
 
-        $container->set('runner.maintainers.matchers', function (ServiceContainer $c) {
+        $container->define('runner.maintainers.matchers', function (ServiceContainer $c) {
             $matchers = $c->getByPrefix('matchers');
             return new Runner\Maintainer\MatchersMaintainer(
                 $c->get('formatter.presenter'),
@@ -601,7 +601,7 @@ final class ContainerAssembler
             );
         });
 
-        $container->set('runner.maintainers.subject', function (ServiceContainer $c) {
+        $container->define('runner.maintainers.subject', function (ServiceContainer $c) {
             return new Runner\Maintainer\SubjectMaintainer(
                 $c->get('formatter.presenter'),
                 $c->get('unwrapper'),
@@ -632,46 +632,46 @@ final class ContainerAssembler
      */
     private function setupMatchers(ServiceContainer $container)
     {
-        $container->set('matchers.identity', function (ServiceContainer $c) {
+        $container->define('matchers.identity', function (ServiceContainer $c) {
             return new Matcher\IdentityMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.comparison', function (ServiceContainer $c) {
+        $container->define('matchers.comparison', function (ServiceContainer $c) {
             return new Matcher\ComparisonMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.throwm', function (ServiceContainer $c) {
+        $container->define('matchers.throwm', function (ServiceContainer $c) {
             return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
         });
-        $container->set('matchers.type', function (ServiceContainer $c) {
+        $container->define('matchers.type', function (ServiceContainer $c) {
             return new Matcher\TypeMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.object_state', function (ServiceContainer $c) {
+        $container->define('matchers.object_state', function (ServiceContainer $c) {
             return new Matcher\ObjectStateMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.scalar', function (ServiceContainer $c) {
+        $container->define('matchers.scalar', function (ServiceContainer $c) {
             return new Matcher\ScalarMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.array_count', function (ServiceContainer $c) {
+        $container->define('matchers.array_count', function (ServiceContainer $c) {
             return new Matcher\ArrayCountMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.array_key', function (ServiceContainer $c) {
+        $container->define('matchers.array_key', function (ServiceContainer $c) {
             return new Matcher\ArrayKeyMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.array_key_with_value', function (ServiceContainer $c) {
+        $container->define('matchers.array_key_with_value', function (ServiceContainer $c) {
             return new Matcher\ArrayKeyValueMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.array_contain', function (ServiceContainer $c) {
+        $container->define('matchers.array_contain', function (ServiceContainer $c) {
             return new Matcher\ArrayContainMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.string_start', function (ServiceContainer $c) {
+        $container->define('matchers.string_start', function (ServiceContainer $c) {
             return new Matcher\StringStartMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.string_end', function (ServiceContainer $c) {
+        $container->define('matchers.string_end', function (ServiceContainer $c) {
             return new Matcher\StringEndMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.string_regex', function (ServiceContainer $c) {
+        $container->define('matchers.string_regex', function (ServiceContainer $c) {
             return new Matcher\StringRegexMatcher($c->get('formatter.presenter'));
         });
-        $container->set('matchers.string_contain', function (ServiceContainer $c) {
+        $container->define('matchers.string_contain', function (ServiceContainer $c) {
             return new Matcher\StringContainMatcher($c->get('formatter.presenter'));
         });
     }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -111,11 +111,11 @@ final class ContainerAssembler
     {
         $container->define('console.commands.run', function () {
             return new Command\RunCommand();
-        });
+        }, ['console.commands']);
 
         $container->define('console.commands.describe', function () {
             return new Command\DescribeCommand();
-        });
+        }, ['console.commands']);
     }
 
     /**
@@ -128,7 +128,7 @@ final class ContainerAssembler
 
             array_map(
                 array($dispatcher, 'addSubscriber'),
-                $c->getByPrefix('console_event_dispatcher.listeners')
+                $c->getByTag('console_event_dispatcher.listeners')
             );
 
             return $dispatcher;
@@ -146,21 +146,21 @@ final class ContainerAssembler
 
         $container->define('event_dispatcher.listeners.stats', function () {
             return new Listener\StatisticsCollector();
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('event_dispatcher.listeners.class_not_found', function (IndexedServiceContainer $c) {
             return new Listener\ClassNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('event_dispatcher.listeners.collaborator_not_found', function (IndexedServiceContainer $c) {
             return new Listener\CollaboratorNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('event_dispatcher.listeners.collaborator_method_not_found', function (IndexedServiceContainer $c) {
             return new Listener\CollaboratorMethodNotFoundListener(
                 $c->get('console.io'),
@@ -168,14 +168,14 @@ final class ContainerAssembler
                 $c->get('code_generator'),
                 $c->get('util.reserved_words_checker')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('event_dispatcher.listeners.named_constructor_not_found', function (IndexedServiceContainer $c) {
             return new Listener\NamedConstructorNotFoundListener(
                 $c->get('console.io'),
                 $c->get('locator.resource_manager'),
                 $c->get('code_generator')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('event_dispatcher.listeners.method_not_found', function (IndexedServiceContainer $c) {
             return new Listener\MethodNotFoundListener(
                 $c->get('console.io'),
@@ -183,18 +183,18 @@ final class ContainerAssembler
                 $c->get('code_generator'),
                 $c->get('util.reserved_words_checker')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('event_dispatcher.listeners.stop_on_failure', function (IndexedServiceContainer $c) {
             return new Listener\StopOnFailureListener(
                 $c->get('console.io')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('event_dispatcher.listeners.rerun', function (IndexedServiceContainer $c) {
             return new Listener\RerunListener(
                 $c->get('process.rerunner'),
                 $c->get('process.prerequisites')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('process.prerequisites', function (IndexedServiceContainer $c) {
             return new SuitePrerequisites(
                 $c->get('process.executioncontext')
@@ -207,7 +207,7 @@ final class ContainerAssembler
                 $c->get('code_generator'),
                 $c->get('util.method_analyser')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('util.method_analyser', function () {
             return new MethodAnalyser();
         });
@@ -218,12 +218,12 @@ final class ContainerAssembler
             return new Listener\BootstrapListener(
                 $c->get('console.io')
             );
-        });
+        }, ['event_dispatcher.listeners']);
         $container->define('event_dispatcher.listeners.current_example_listener', function (IndexedServiceContainer $c) {
             return new Listener\CurrentExampleListener(
                 $c->get('current_example')
             );
-        });
+        }, ['event_dispatcher.listeners']);
     }
 
     /**
@@ -236,7 +236,7 @@ final class ContainerAssembler
 
             array_map(
                 array($generator, 'registerGenerator'),
-                $c->getByPrefix('code_generator.generators')
+                $c->getByTag('code_generator.generators')
             );
 
             return $generator;
@@ -255,7 +255,7 @@ final class ContainerAssembler
                 $c->get('event_dispatcher'),
                 $c->get('util.filesystem')
             );
-        });
+        }, ['code_generator.generators']);
         $container->define('code_generator.generators.class', function (IndexedServiceContainer $c) {
             $classGenerator = new CodeGenerator\Generator\ClassGenerator(
                 $c->get('console.io'),
@@ -269,7 +269,7 @@ final class ContainerAssembler
                 $c->get('event_dispatcher'),
                 $c->get('util.filesystem')
             );
-        });
+        }, ['code_generator.generators']);
         $container->define('code_generator.generators.interface', function (IndexedServiceContainer $c) {
             $interfaceGenerator = new CodeGenerator\Generator\InterfaceGenerator(
                 $c->get('console.io'),
@@ -283,7 +283,7 @@ final class ContainerAssembler
                 $c->get('event_dispatcher'),
                 $c->get('util.filesystem')
             );
-        });
+        }, ['code_generator.generators']);
         $container->define('code_generator.writers.tokenized', function () {
             return new CodeGenerator\Writer\TokenizedCodeWriter(new ClassFileAnalyser());
         });
@@ -294,21 +294,21 @@ final class ContainerAssembler
                 $c->get('util.filesystem'),
                 $c->get('code_generator.writers.tokenized')
             );
-        });
+        }, ['code_generator.generators']);
         $container->define('code_generator.generators.methodSignature', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\MethodSignatureGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem')
             );
-        });
+        }, ['code_generator.generators']);
         $container->define('code_generator.generators.returnConstant', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\ReturnConstantGenerator(
                 $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem')
             );
-        });
+        }, ['code_generator.generators']);
 
         $container->define('code_generator.generators.named_constructor', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\NamedConstructorGenerator(
@@ -317,7 +317,7 @@ final class ContainerAssembler
                 $c->get('util.filesystem'),
                 $c->get('code_generator.writers.tokenized')
             );
-        });
+        }, ['code_generator.generators']);
 
         $container->define('code_generator.generators.private_constructor', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\PrivateConstructorGenerator(
@@ -326,7 +326,7 @@ final class ContainerAssembler
                 $c->get('util.filesystem'),
                 $c->get('code_generator.writers.tokenized')
             );
-        });
+        }, ['code_generator.generators']);
 
         $container->define('code_generator.templates', function (IndexedServiceContainer $c) {
             $renderer = new CodeGenerator\TemplateRenderer(
@@ -368,7 +368,7 @@ final class ContainerAssembler
 
             array_map(
                 array($manager, 'registerLocator'),
-                $c->getByPrefix('locator.locators')
+                $c->getByTag('locator.locators')
             );
 
             return $manager;
@@ -407,7 +407,8 @@ final class ContainerAssembler
                             $config['spec_path'],
                             $config['psr4_prefix']
                         );
-                    }
+                    },
+                    ['locator.locators']
                 );
             }
         });
@@ -427,7 +428,7 @@ final class ContainerAssembler
         if (PHP_VERSION >= 7) {
             $container->define('loader.resource_loader.spec_transformer.typehint_rewriter', function (IndexedServiceContainer $c) {
                 return new Loader\Transformer\TypeHintRewriter($c->get('analysis.typehintrewriter'));
-            });
+            }, ['loader.resource_loader.spec_transformer']);
         }
         $container->define('analysis.typehintrewriter', function ($c) {
             return new TokenizedTypeHintRewriter(
@@ -541,7 +542,7 @@ final class ContainerAssembler
             } catch (\InvalidArgumentException $e) {
                 throw new \RuntimeException(sprintf('Formatter not recognised: "%s"', $formatterName));
             }
-            $c->set('event_dispatcher.listeners.formatter', $formatter);
+            $c->set('event_dispatcher.listeners.formatter', $formatter, ['event_dispatcher.listeners']);
         });
     }
 
@@ -572,7 +573,7 @@ final class ContainerAssembler
 
             array_map(
                 array($runner, 'registerMaintainer'),
-                $c->getByPrefix('runner.maintainers')
+                $c->getByTag('runner.maintainers')
             );
 
             return $runner;
@@ -582,24 +583,24 @@ final class ContainerAssembler
             return new Runner\Maintainer\ErrorMaintainer(
                 $c->getParam('runner.maintainers.errors.level', E_ALL ^ E_STRICT)
             );
-        });
+        }, ['runner.maintainers']);
         $container->define('runner.maintainers.collaborators', function (IndexedServiceContainer $c) {
             return new Runner\Maintainer\CollaboratorsMaintainer(
                 $c->get('unwrapper'),
                 $c->get('loader.transformer.typehintindex')
             );
-        });
+        }, ['runner.maintainers']);
         $container->define('runner.maintainers.let_letgo', function () {
             return new Runner\Maintainer\LetAndLetgoMaintainer();
-        });
+        }, ['runner.maintainers']);
 
         $container->define('runner.maintainers.matchers', function (IndexedServiceContainer $c) {
-            $matchers = $c->getByPrefix('matchers');
+            $matchers = $c->getByTag('matchers');
             return new Runner\Maintainer\MatchersMaintainer(
                 $c->get('formatter.presenter'),
                 $matchers
             );
-        });
+        }, ['runner.maintainers']);
 
         $container->define('runner.maintainers.subject', function (IndexedServiceContainer $c) {
             return new Runner\Maintainer\SubjectMaintainer(
@@ -608,7 +609,7 @@ final class ContainerAssembler
                 $c->get('event_dispatcher'),
                 $c->get('access_inspector')
             );
-        });
+        }, ['runner.maintainers']);
 
         $container->define('unwrapper', function () {
             return new Wrapper\Unwrapper();
@@ -634,46 +635,46 @@ final class ContainerAssembler
     {
         $container->define('matchers.identity', function (IndexedServiceContainer $c) {
             return new Matcher\IdentityMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.comparison', function (IndexedServiceContainer $c) {
             return new Matcher\ComparisonMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.throwm', function (IndexedServiceContainer $c) {
             return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
-        });
+        }, ['matchers']);
         $container->define('matchers.type', function (IndexedServiceContainer $c) {
             return new Matcher\TypeMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.object_state', function (IndexedServiceContainer $c) {
             return new Matcher\ObjectStateMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.scalar', function (IndexedServiceContainer $c) {
             return new Matcher\ScalarMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.array_count', function (IndexedServiceContainer $c) {
             return new Matcher\ArrayCountMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.array_key', function (IndexedServiceContainer $c) {
             return new Matcher\ArrayKeyMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.array_key_with_value', function (IndexedServiceContainer $c) {
             return new Matcher\ArrayKeyValueMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.array_contain', function (IndexedServiceContainer $c) {
             return new Matcher\ArrayContainMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.string_start', function (IndexedServiceContainer $c) {
             return new Matcher\StringStartMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.string_end', function (IndexedServiceContainer $c) {
             return new Matcher\StringEndMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.string_regex', function (IndexedServiceContainer $c) {
             return new Matcher\StringRegexMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
         $container->define('matchers.string_contain', function (IndexedServiceContainer $c) {
             return new Matcher\StringContainMatcher($c->get('formatter.presenter'));
-        });
+        }, ['matchers']);
     }
 
     /**
@@ -694,7 +695,7 @@ final class ContainerAssembler
 
         $container->define('process.rerunner.platformspecific', function (IndexedServiceContainer $c) {
             return new ReRunner\CompositeReRunner(
-                $c->getByPrefix('process.rerunner.platformspecific')
+                $c->getByTag('process.rerunner.platformspecific')
             );
         });
         $container->define('process.rerunner.platformspecific.pcntl', function (IndexedServiceContainer $c) {
@@ -702,19 +703,19 @@ final class ContainerAssembler
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
             );
-        });
+        }, ['process.rerunner.platformspecific']);
         $container->define('process.rerunner.platformspecific.passthru', function (IndexedServiceContainer $c) {
             return ReRunner\ProcOpenReRunner::withExecutionContext(
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
             );
-        });
+        }, ['process.rerunner.platformspecific']);
         $container->define('process.rerunner.platformspecific.windowspassthru', function (IndexedServiceContainer $c) {
             return ReRunner\WindowsPassthruReRunner::withExecutionContext(
                 $c->get('process.phpexecutablefinder'),
                 $c->get('process.executioncontext')
             );
-        });
+        }, ['process.rerunner.platformspecific']);
         $container->define('process.phpexecutablefinder', function () {
             return new PhpExecutableFinder();
         });
@@ -728,7 +729,7 @@ final class ContainerAssembler
         $container->addConfigurator(function (IndexedServiceContainer $c) {
             array_map(
                 array($c->get('event_dispatcher'), 'addSubscriber'),
-                $c->getByPrefix('event_dispatcher.listeners')
+                $c->getByTag('event_dispatcher.listeners')
             );
         });
     }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -42,7 +42,10 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use PhpSpec\Message\CurrentExampleTracker;
 use PhpSpec\Process\Shutdown\Shutdown;
 
-class ContainerAssembler
+/**
+ * @Internal
+ */
+final class ContainerAssembler
 {
     /**
      * @param ServiceContainer $container

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -43,7 +43,7 @@ use PhpSpec\Message\CurrentExampleTracker;
 use PhpSpec\Process\Shutdown\Shutdown;
 
 /**
- * @Internal
+ * @internal
  */
 final class ContainerAssembler
 {

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -66,37 +66,27 @@ class ServiceContainer
     }
 
     /**
-     * Sets a object or a callable for the object creation. A callable will be invoked
-     * every time get is called.
+     * Sets a object to be used as a service
      *
-     * @param string          $id
-     * @param object|callable $value
+     * @param string $id
+     * @param object $value
      *
      * @throws \InvalidArgumentException if service is not an object or callable
      */
     public function set($id, $value)
     {
-        if (!is_object($value) && !is_callable($value)) {
+        if (!is_object($value)) {
             throw new InvalidArgumentException(sprintf(
-                'Service should be callable or object, but %s given.',
+                'Service should be an object, but %s given.',
                 gettype($value)
             ));
         }
 
-        list($prefix, $sid) = $this->getPrefixAndSid($id);
-        if ($prefix) {
-            if (!isset($this->prefixed[$prefix])) {
-                $this->prefixed[$prefix] = array();
-            }
-
-            $this->prefixed[$prefix][$sid] = $id;
-        }
-
-        $this->services[$id] = $value;
+        $this->addToIndex($id, $value);
     }
 
     /**
-     * Sets a callable for the object creation. The same object will
+     * Sets a callable for the service creation. The same service will
      * be returned every time
      *
      * @param string   $id
@@ -113,7 +103,7 @@ class ServiceContainer
             ));
         }
 
-        $this->set($id, function ($container) use ($callable) {
+        $this->addToIndex($id, function ($container) use ($callable) {
             static $instance;
 
             if (null === $instance) {
@@ -250,5 +240,25 @@ class ServiceContainer
         $prefix = implode('.', $parts);
 
         return array($prefix, $sid);
+    }
+
+    /**
+     * Adds a service or service definition to the index
+     *
+     * @param string $id
+     * @param mixed  $value
+     */
+    private function addToIndex($id, $value)
+    {
+        list($prefix, $sid) = $this->getPrefixAndSid($id);
+        if ($prefix) {
+            if (!isset($this->prefixed[$prefix])) {
+                $this->prefixed[$prefix] = array();
+            }
+
+            $this->prefixed[$prefix][$sid] = $id;
+        }
+
+        $this->services[$id] = $value;
     }
 }

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -30,22 +30,24 @@ interface ServiceContainer
      * Sets a object to be used as a service
      *
      * @param string $id
-     * @param object $value
+     * @param object $service
+     * @param array  $tags
      *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set($id, $value);
+    public function set($id, $service, $tags = []);
 
     /**
      * Sets a factory for the service creation. The same service will
      * be returned every time
      *
-     * @param string $id
-     * @param value $value
+     * @param string   $id
+     * @param callable $definition
+     * @param array    $tags
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
-    public function define($id, $value);
+    public function define($id, callable $definition, $tags = []);
 
     /**
      * Retrieves a service from the container

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -32,20 +32,20 @@ interface ServiceContainer
      * @param string $id
      * @param object $value
      *
-     * @throws \InvalidArgumentException if service is not an object or callable
+     * @throws \InvalidArgumentException if service is not an object
      */
     public function set($id, $value);
 
     /**
-     * Sets a callable for the service creation. The same service will
+     * Sets a factory for the service creation. The same service will
      * be returned every time
      *
      * @param string $id
-     * @param callable $callable
+     * @param value $value
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
-    public function define($id, $callable);
+    public function define($id, $value);
 
     /**
      * Retrieves a service from the container

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -1,69 +1,30 @@
 <?php
 
-/*
- * This file is part of PhpSpec, A php toolset to drive emergent
- * design by specification.
- *
- * (c) Marcello Duarte <marcello.duarte@gmail.com>
- * (c) Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace PhpSpec;
-
-use InvalidArgumentException;
 
 /**
  * The Service Container is a lightweight container based on Pimple to handle
  * object creation of PhpSpec services.
  */
-class ServiceContainer
+interface ServiceContainer
 {
-    /**
-     * @var array
-     */
-    private $parameters = array();
-
-    /**
-     * @var array
-     */
-    private $services = array();
-
-    /**
-     * @var array
-     */
-    private $prefixed = array();
-
-    /**
-     * @var array
-     */
-    private $configurators = array();
-
     /**
      * Sets a param in the container
      *
      * @param string $id
-     * @param mixed  $value
+     * @param mixed $value
      */
-    public function setParam($id, $value)
-    {
-        $this->parameters[$id] = $value;
-    }
+    public function setParam($id, $value);
 
     /**
      * Gets a param from the container or a default value.
      *
      * @param string $id
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return mixed
      */
-    public function getParam($id, $default = null)
-    {
-        return isset($this->parameters[$id]) ? $this->parameters[$id] : $default;
-    }
+    public function getParam($id, $default = null);
 
     /**
      * Sets a object to be used as a service
@@ -73,46 +34,18 @@ class ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not an object or callable
      */
-    public function set($id, $value)
-    {
-        if (!is_object($value)) {
-            throw new InvalidArgumentException(sprintf(
-                'Service should be an object, but %s given.',
-                gettype($value)
-            ));
-        }
-
-        $this->addToIndex($id, $value);
-    }
+    public function set($id, $value);
 
     /**
      * Sets a callable for the service creation. The same service will
      * be returned every time
      *
-     * @param string   $id
+     * @param string $id
      * @param callable $callable
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
-    public function define($id, $callable)
-    {
-        if (!is_callable($callable)) {
-            throw new InvalidArgumentException(sprintf(
-                'Service should be callable, "%s" given.',
-                gettype($callable)
-            ));
-        }
-
-        $this->addToIndex($id, function ($container) use ($callable) {
-            static $instance;
-
-            if (null === $instance) {
-                $instance = call_user_func($callable, $container);
-            }
-
-            return $instance;
-        });
-    }
+    public function define($id, $callable);
 
     /**
      * Retrieves a service from the container
@@ -123,19 +56,7 @@ class ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function get($id)
-    {
-        if (!array_key_exists($id, $this->services)) {
-            throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
-        }
-
-        $value = $this->services[$id];
-        if (is_callable($value)) {
-            return call_user_func($value, $this);
-        }
-
-        return $value;
-    }
+    public function get($id);
 
     /**
      * Determines whether a service is defined
@@ -143,10 +64,7 @@ class ServiceContainer
      * @param $id
      * @return bool
      */
-    public function has($id)
-    {
-        return array_key_exists($id, $this->services);
-    }
+    public function has($id);
 
     /**
      * Retrieves a list of services of a given prefix
@@ -155,19 +73,7 @@ class ServiceContainer
      *
      * @return array
      */
-    public function getByPrefix($prefix)
-    {
-        if (!array_key_exists($prefix, $this->prefixed)) {
-            return array();
-        }
-
-        $services = array();
-        foreach ($this->prefixed[$prefix] as $id) {
-            $services[] = $this->get($id);
-        }
-
-        return $services;
-    }
+    public function getByPrefix($prefix);
 
     /**
      * Removes a service from the container
@@ -176,89 +82,5 @@ class ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function remove($id)
-    {
-        if (!array_key_exists($id, $this->services)) {
-            throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
-        }
-
-        list($prefix, $sid) = $this->getPrefixAndSid($id);
-        if ($prefix) {
-            unset($this->prefixed[$prefix][$sid]);
-        }
-
-        unset($this->services[$id]);
-    }
-
-    /**
-     * Adds a configurator, that can configure many services in one callable
-     *
-     * @internal
-     *
-     * @param callable $configurator
-     *
-     * @throws \InvalidArgumentException if configurator is not a callable
-     */
-    public function addConfigurator($configurator)
-    {
-        if (!is_callable($configurator)) {
-            throw new InvalidArgumentException(sprintf(
-                'Configurator should be callable, but %s given.',
-                gettype($configurator)
-            ));
-        }
-
-        $this->configurators[] = $configurator;
-    }
-
-    /**
-     * Loop through all configurators and invoke them
-     *
-     * @internal
-     */
-    public function configure()
-    {
-        foreach ($this->configurators as $configurator) {
-            call_user_func($configurator, $this);
-        }
-    }
-
-    /**
-     * Retrieves the prefix and sid of a given service
-     *
-     * @param string $id
-     *
-     * @return array
-     */
-    private function getPrefixAndSid($id)
-    {
-        if (count($parts = explode('.', $id)) < 2) {
-            return array(null, $id);
-        }
-
-        $sid    = array_pop($parts);
-        $prefix = implode('.', $parts);
-
-        return array($prefix, $sid);
-    }
-
-    /**
-     * Adds a service or service definition to the index
-     *
-     * @param string $id
-     * @param mixed  $value
-     */
-    private function addToIndex($id, $value)
-    {
-        list($prefix, $sid) = $this->getPrefixAndSid($id);
-        if ($prefix) {
-            if (!isset($this->prefixed[$prefix])) {
-                $this->prefixed[$prefix] = array();
-            }
-
-            $this->prefixed[$prefix][$sid] = $id;
-        }
-
-        $this->services[$id] = $value;
-    }
+    public function remove($id);
 }

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -67,15 +67,6 @@ interface ServiceContainer
     public function has($id);
 
     /**
-     * Retrieves a list of services of a given prefix
-     *
-     * @param string $prefix
-     *
-     * @return array
-     */
-    public function getByPrefix($prefix);
-
-    /**
      * Removes a service from the container
      *
      * @param string $id
@@ -83,4 +74,13 @@ interface ServiceContainer
      * @throws \InvalidArgumentException if service is not defined
      */
     public function remove($id);
+
+    /**
+     * Finds all services tagged with a particular string
+     *
+     * @param string $tag
+     *
+     * @return array
+     */
+    public function getByTag($tag);
 }

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -201,6 +201,8 @@ class ServiceContainer
     /**
      * Adds a configurator, that can configure many services in one callable
      *
+     * @internal
+     *
      * @param callable $configurator
      *
      * @throws \InvalidArgumentException if configurator is not a callable
@@ -219,6 +221,8 @@ class ServiceContainer
 
     /**
      * Loop through all configurators and invoke them
+     *
+     * @internal
      */
     public function configure()
     {

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -104,7 +104,7 @@ class ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
-    public function setShared($id, $callable)
+    public function define($id, $callable)
     {
         if (!is_callable($callable)) {
             throw new InvalidArgumentException(sprintf(
@@ -148,10 +148,12 @@ class ServiceContainer
     }
 
     /**
+     * Determines whether a service is defined
+     *
      * @param $id
      * @return bool
      */
-    public function isDefined($id)
+    public function has($id)
     {
         return array_key_exists($id, $this->services);
     }

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -75,21 +75,21 @@ final class IndexedServiceContainer implements ServiceContainer
      * Sets a object to be used as a service
      *
      * @param string $id
-     * @param object $object
+     * @param object $service
      * @param array  $tags
      *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set($id, $object, $tags=[])
+    public function set($id, $service, $tags = [])
     {
-        if (!is_object($object)) {
+        if (!is_object($service)) {
             throw new InvalidArgumentException(sprintf(
                 'Service should be an object, but %s given.',
-                gettype($object)
+                gettype($service)
             ));
         }
 
-        $this->services[$id] = $object;
+        $this->services[$id] = $service;
         unset($this->definitions[$id]);
 
         $this->indexTags($id, $tags);
@@ -100,14 +100,14 @@ final class IndexedServiceContainer implements ServiceContainer
      * be returned every time
      *
      * @param string   $id
-     * @param callable $value
+     * @param callable $definition
      * @param array    $tags
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
-    public function define($id, $value, $tags = [])
+    public function define($id, callable $definition, $tags = [])
     {
-        $this->definitions[$id] = $value;
+        $this->definitions[$id] = $definition;
         unset($this->services[$id]);
 
         $this->indexTags($id, $tags);

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -1,0 +1,265 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\ServiceContainer;
+
+use InvalidArgumentException;
+use PhpSpec\ServiceContainer;
+
+/**
+ * The Service Container is a lightweight container based on Pimple to handle
+ * object creation of PhpSpec services.
+ */
+final class IndexedServiceContainer implements ServiceContainer
+{
+    /**
+     * @var array
+     */
+    private $parameters = array();
+
+    /**
+     * @var array
+     */
+    private $services = array();
+
+    /**
+     * @var array
+     */
+    private $prefixed = array();
+
+    /**
+     * @var array
+     */
+    private $configurators = array();
+
+    /**
+     * Sets a param in the container
+     *
+     * @param string $id
+     * @param mixed  $value
+     */
+    public function setParam($id, $value)
+    {
+        $this->parameters[$id] = $value;
+    }
+
+    /**
+     * Gets a param from the container or a default value.
+     *
+     * @param string $id
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function getParam($id, $default = null)
+    {
+        return isset($this->parameters[$id]) ? $this->parameters[$id] : $default;
+    }
+
+    /**
+     * Sets a object to be used as a service
+     *
+     * @param string $id
+     * @param object $value
+     *
+     * @throws \InvalidArgumentException if service is not an object or callable
+     */
+    public function set($id, $value)
+    {
+        if (!is_object($value)) {
+            throw new InvalidArgumentException(sprintf(
+                'Service should be an object, but %s given.',
+                gettype($value)
+            ));
+        }
+
+        $this->addToIndex($id, $value);
+    }
+
+    /**
+     * Sets a callable for the service creation. The same service will
+     * be returned every time
+     *
+     * @param string   $id
+     * @param callable $callable
+     *
+     * @throws \InvalidArgumentException if service is not a callable
+     */
+    public function define($id, $callable)
+    {
+        if (!is_callable($callable)) {
+            throw new InvalidArgumentException(sprintf(
+                'Service should be callable, "%s" given.',
+                gettype($callable)
+            ));
+        }
+
+        $this->addToIndex($id, function ($container) use ($callable) {
+            static $instance;
+
+            if (null === $instance) {
+                $instance = call_user_func($callable, $container);
+            }
+
+            return $instance;
+        });
+    }
+
+    /**
+     * Retrieves a service from the container
+     *
+     * @param string $id
+     *
+     * @return object
+     *
+     * @throws \InvalidArgumentException if service is not defined
+     */
+    public function get($id)
+    {
+        if (!array_key_exists($id, $this->services)) {
+            throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
+        }
+
+        $value = $this->services[$id];
+        if (is_callable($value)) {
+            return call_user_func($value, $this);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Determines whether a service is defined
+     *
+     * @param $id
+     * @return bool
+     */
+    public function has($id)
+    {
+        return array_key_exists($id, $this->services);
+    }
+
+    /**
+     * Retrieves a list of services of a given prefix
+     *
+     * @param string $prefix
+     *
+     * @return array
+     */
+    public function getByPrefix($prefix)
+    {
+        if (!array_key_exists($prefix, $this->prefixed)) {
+            return array();
+        }
+
+        $services = array();
+        foreach ($this->prefixed[$prefix] as $id) {
+            $services[] = $this->get($id);
+        }
+
+        return $services;
+    }
+
+    /**
+     * Removes a service from the container
+     *
+     * @param string $id
+     *
+     * @throws \InvalidArgumentException if service is not defined
+     */
+    public function remove($id)
+    {
+        if (!array_key_exists($id, $this->services)) {
+            throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
+        }
+
+        list($prefix, $sid) = $this->getPrefixAndSid($id);
+        if ($prefix) {
+            unset($this->prefixed[$prefix][$sid]);
+        }
+
+        unset($this->services[$id]);
+    }
+
+    /**
+     * Adds a configurator, that can configure many services in one callable
+     *
+     * @internal
+     *
+     * @param callable $configurator
+     *
+     * @throws \InvalidArgumentException if configurator is not a callable
+     */
+    public function addConfigurator($configurator)
+    {
+        if (!is_callable($configurator)) {
+            throw new InvalidArgumentException(sprintf(
+                'Configurator should be callable, but %s given.',
+                gettype($configurator)
+            ));
+        }
+
+        $this->configurators[] = $configurator;
+    }
+
+    /**
+     * Loop through all configurators and invoke them
+     *
+     * @internal
+     */
+    public function configure()
+    {
+        foreach ($this->configurators as $configurator) {
+            call_user_func($configurator, $this);
+        }
+    }
+
+    /**
+     * Retrieves the prefix and sid of a given service
+     *
+     * @param string $id
+     *
+     * @return array
+     */
+    private function getPrefixAndSid($id)
+    {
+        if (count($parts = explode('.', $id)) < 2) {
+            return array(null, $id);
+        }
+
+        $sid    = array_pop($parts);
+        $prefix = implode('.', $parts);
+
+        return array($prefix, $sid);
+    }
+
+    /**
+     * Adds a service or service definition to the index
+     *
+     * @param string $id
+     * @param mixed  $value
+     */
+    private function addToIndex($id, $value)
+    {
+        list($prefix, $sid) = $this->getPrefixAndSid($id);
+        if ($prefix) {
+            if (!isset($this->prefixed[$prefix])) {
+                $this->prefixed[$prefix] = array();
+            }
+
+            $this->prefixed[$prefix][$sid] = $id;
+        }
+
+        $this->services[$id] = $value;
+    }
+}

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -102,8 +102,6 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param string   $id
      * @param callable $definition
      * @param array    $tags
-     *
-     * @throws \InvalidArgumentException if service is not a callable
      */
     public function define($id, callable $definition, $tags = [])
     {

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -171,9 +171,6 @@ final class IndexedServiceContainer implements ServiceContainer
     private function indexTags($id, array $tags)
     {
         foreach ($tags as $tag) {
-            if (!isset($this->tags[$tag])) {
-                $this->tags[$tag] = [];
-            }
             $this->tags[$tag][] = $id;
         }
     }

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -84,7 +84,13 @@ final class IndexedServiceContainer implements ServiceContainer
             ));
         }
 
-        $this->addToIndex($id, $value, $tags);
+        $this->addToIndex(
+            $id,
+            function() use ($value) {
+                return $value;
+            },
+            $tags
+        );
     }
 
     /**
@@ -136,12 +142,7 @@ final class IndexedServiceContainer implements ServiceContainer
             throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
         }
 
-        $value = $this->services[$id];
-        if (is_callable($value)) {
-            return call_user_func($value, $this);
-        }
-
-        return $value;
+        return call_user_func($this->services[$id], $this);
     }
 
     /**


### PR DESCRIPTION
Bearing in mind there's likely to be some changes in how extensions operate, I've taken the opportunity to simplify the container usage, chiefly to introduce an interface but also to mark areas likely to be volatile as `@internal`.

Having the interface should enable us to change the internally-used container, as well as support more container types in extensions in future via adapters.

The only part of the interface I particularly dislike is the `getByPrefix` which always felt hacky, but it's behaviour should be simple enough to emulate in other containers.