### PR TITLE
Updating dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
     ],
 
     "require": {
-        "php":                      "^5.6|^7.0",
-        "phpspec/prophecy":         "~1.5",
+        "php":                      "^5.6 || ^7.0",
+        "phpspec/prophecy":         "^1.5",
         "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "~1.0",
-        "symfony/console":          "~2.7|~3.0",
-        "symfony/event-dispatcher": "~2.7|~3.0",
-        "symfony/process":          "^2.7|~3.0",
-        "symfony/finder":           "~2.7|~3.0",
-        "symfony/yaml":             "~2.7|~3.0",
+        "sebastian/exporter":       "^1.0",
+        "symfony/console":          "^2.7 || ^3.0",
+        "symfony/event-dispatcher": "^2.7 || ^3.0",
+        "symfony/process":          "^2.7 || ^3.0",
+        "symfony/finder":           "^2.7 || ^3.0",
+        "symfony/yaml":             "^2.7 || ^3.0",
         "doctrine/instantiator":    "^1.0.1",
         "ext-tokenizer":            "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php":                      "^5.6|^7.0",
         "phpspec/prophecy":         "~1.5",
-        "phpspec/php-diff":         "~1.0.0",
+        "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "~1.0",
         "symfony/console":          "~2.7|~3.0",
         "symfony/event-dispatcher": "~2.7|~3.0",

--- a/spec/PhpSpec/Formatter/Presenter/Differ/StringEngineSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Differ/StringEngineSpec.php
@@ -25,7 +25,8 @@ class StringEngineSpec extends ObjectBehavior
 <diff-add>+string2</diff-add>
 </code>
 DIFF;
+        $normalizedExpected = preg_replace('/['.PHP_EOL.']/', "\n", $expected);
 
-        $this->compare('string1', 'string2')->shouldReturn($expected);
+        $this->compare('string1', 'string2')->shouldReturn($normalizedExpected);
     }
 }


### PR DESCRIPTION
Hi there!

By running `composer outdated` on some projects with phpspec, I've realised `phpspec/php-diff` was outdated (installed version 1.0, when 1.1 was available). This PR fixes it (I've run phpspec, phpunit and behat tests and all went well).

I've also taken the opportunity to make composer configuration more consistent (using `^` instead of `~`) and update it (using `||` instead of `|`).