### PR TITLE
Compare diff output using system line endings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
     ],
 
     "require": {
-        "php":                      "^5.6|^7.0",
-        "phpspec/prophecy":         "~1.5",
+        "php":                      "^5.6 || ^7.0",
+        "phpspec/prophecy":         "^1.5",
         "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "~1.0",
-        "symfony/console":          "~2.7|~3.0",
-        "symfony/event-dispatcher": "~2.7|~3.0",
-        "symfony/process":          "^2.7|~3.0",
-        "symfony/finder":           "~2.7|~3.0",
-        "symfony/yaml":             "~2.7|~3.0",
+        "sebastian/exporter":       "^1.0",
+        "symfony/console":          "^2.7 || ^3.0",
+        "symfony/event-dispatcher": "^2.7 || ^3.0",
+        "symfony/process":          "^2.7 || ^3.0",
+        "symfony/finder":           "^2.7 || ^3.0",
+        "symfony/yaml":             "^2.7 || ^3.0",
         "doctrine/instantiator":    "^1.0.1",
         "ext-tokenizer":            "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php":                      "^5.6|^7.0",
         "phpspec/prophecy":         "~1.5",
-        "phpspec/php-diff":         "~1.0.0",
+        "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "~1.0",
         "symfony/console":          "~2.7|~3.0",
         "symfony/event-dispatcher": "~2.7|~3.0",

--- a/spec/PhpSpec/Formatter/Presenter/Differ/StringEngineSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Differ/StringEngineSpec.php
@@ -18,14 +18,15 @@ class StringEngineSpec extends ObjectBehavior
 
     function it_calculates_strings_diff()
     {
-        $expected = <<<DIFF
+        $expected = str_replace("\n", PHP_EOL, <<<DIFF
 <code>
 @@ -1,1 +1,1 @@
 <diff-del>-string1</diff-del>
 <diff-add>+string2</diff-add>
 </code>
-DIFF;
+DIFF
+);
 
-        $this->compare('string1', 'string2')->shouldReturn($expected);
+        $this->compare('string1', 'string2')->shouldBe($expected);
     }
 }


### PR DESCRIPTION
This test fails on windows when php-diff is upgraded (see #963)