### PR TITLE
Normalized end of line

### DIFF
--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -83,9 +83,9 @@ final class TokenizedCodeWriter implements CodeWriter
      */
     private function insertStringAfterLine($target, $toInsert, $line, $leadingNewline = true)
     {
-        $lines = explode("\n", $target);
+        $lines = explode(PHP_EOL, $target);
         $lastLines = array_slice($lines, $line);
-        $toInsert = trim($toInsert, "\n\r");
+        $toInsert = trim($toInsert, PHP_EOL);
         if ($leadingNewline) {
             $toInsert = "\n" . $toInsert;
         }
@@ -104,9 +104,9 @@ final class TokenizedCodeWriter implements CodeWriter
     private function insertStringBeforeLine($target, $toInsert, $line)
     {
         $line--;
-        $lines = explode("\n", $target);
+        $lines = explode(PHP_EOL, $target);
         $lastLines = array_slice($lines, $line);
-        array_unshift($lastLines, trim($toInsert, "\n\r") . "\n");
+        array_unshift($lastLines, trim($toInsert, PHP_EOL) . "\n");
         array_splice($lines, $line, count($lines), $lastLines);
 
         return implode("\n", $lines);

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -271,7 +271,7 @@ class ConsoleIO implements IO
     {
         $lines   = array();
         $lines[] = '<question>'.str_repeat(' ', $this->getBlockWidth())."</question>";
-        foreach (explode("\n", wordwrap($question, $this->getBlockWidth() - 4, "\n", true)) as $line) {
+        foreach (explode(PHP_EOL, wordwrap($question, $this->getBlockWidth() - 4, "\n", true)) as $line) {
             $lines[] = '<question>  '.str_pad($line, $this->getBlockWidth() - 2).'</question>';
         }
         $lines[] = '<question>'.str_repeat(' ', $this->getBlockWidth() - 8).'</question> <value>'.
@@ -294,7 +294,7 @@ class ConsoleIO implements IO
             function ($line) use ($indent) {
                 return str_repeat(' ', $indent).$line;
             },
-            explode("\n", $text)
+            explode(PHP_EOL, $text)
         ));
     }
 
@@ -357,7 +357,7 @@ class ConsoleIO implements IO
 
         $this->output->writeln("<broken-bg>".str_repeat(" ", $this->getBlockWidth())."</broken-bg>");
 
-        foreach (explode("\n", $message) as $line) {
+        foreach (explode(PHP_EOL, $message) as $line) {
             $this->output->writeln("<broken-bg>".str_pad($line, $this->getBlockWidth(), ' ')."</broken-bg>");
         }
 

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -78,7 +78,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
         $title = str_replace('\\', DIRECTORY_SEPARATOR, $event->getSpecification()->getTitle());
         $message = $this->getPresenter()->presentException($event->getException(), $this->io->isVerbose());
 
-        foreach (explode("\n", wordwrap($title, $this->io->getBlockWidth(), "\n", true)) as $line) {
+        foreach (explode(PHP_EOL, wordwrap($title, $this->io->getBlockWidth(), "\n", true)) as $line) {
             $this->io->writeln(sprintf('<%s-bg>%s</%s-bg>', $type, str_pad($line, $this->io->getBlockWidth()), $type));
         }
 

--- a/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
@@ -22,8 +22,8 @@ class StringEngine implements DifferEngine
 
     public function compare($expected, $actual)
     {
-        $expected = explode("\n", (string) $expected);
-        $actual   = explode("\n", (string) $actual);
+        $expected = explode(PHP_EOL, (string) $expected);
+        $actual   = explode(PHP_EOL, (string) $actual);
 
         $diff = new \Diff($expected, $actual, array());
 
@@ -31,7 +31,7 @@ class StringEngine implements DifferEngine
         $text = $diff->render($renderer);
 
         $lines = array();
-        foreach (explode("\n", $text) as $line) {
+        foreach (explode(PHP_EOL, $text) as $line) {
             if (0 === strpos($line, '-')) {
                 $lines[] = sprintf('<diff-del>%s</diff-del>', $line);
             } elseif (0 === strpos($line, '+')) {

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -44,7 +44,7 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
             return $this->stringTypePresenter->present($value);
         }
 
-        $lines = explode("\n", $value);
+        $lines = explode(PHP_EOL, $value);
         return $this->stringTypePresenter->present(sprintf('%s...', substr($lines[0], 0, 25)));
     }
 


### PR DESCRIPTION
Using `\n` should be safe to used for display purpose on any environment, however for read / comparison purpose we'll need to rely on `PHP_EOL`.

> **Note**: Tests pass on GNU/Linux. Unfortunately I don't have any Windows environment to test it so I'll rely on appveyor.