### PR TITLE
Improve the default specification template

### DIFF
--- a/src/PhpSpec/CodeGenerator/Generator/templates/specification.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/specification.template
@@ -8,8 +8,8 @@ use Prophecy\Argument;
 
 class %name% extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_()
     {
-        $this->shouldHaveType(%subject_class%::class);
+        // $this->new%name%Method($arg1, $arg2)->shouldReturn($result);
     }
 }


### PR DESCRIPTION
Original `it_is_initializable` was used to address one particular
problem in the PhpSpec 2.0 design - only one generator was being
executed during a single `phpspec run`. So basically, if back then
you described a new spec and then immediately wrote an example for
it, you were forced to run `phpspec run` twice - once to generate
the object and once to generate the method itself. To avoid this
problem I added `it_is_initializable` example into the
specification template. So that when you `describe` and then
immediately execute ` run`, PhpSpec generates an object for you.
That limited situations when you needed to rerun specs just
because of code generation. That's it.

@ciaranmcnulty solved the real problem in 2.1 by introducing
automated specification rerun on code generation. This made this
functionality redundant.

Redundancy is a good enough reason to change template on its own,
but I have a bigger reason - I see way too many specs with
`it_is_initializable` still in them. This particular "example" is
not a real example and was never supposed to be used for anything
but the use case described above.

This change both removes meaningless example and provides a
better starting point for PhpSpec newcomers by giving them a
better example template to start.