### PR TITLE
Removed ConsoleIO dependency from *most* Generators

### DIFF
--- a/spec/PhpSpec/CodeGenerator/Generator/MethodGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/MethodGeneratorSpec.php
@@ -13,9 +13,9 @@ use PhpSpec\Locator\Resource;
 
 class MethodGeneratorSpec extends ObjectBehavior
 {
-    function let(ConsoleIO $io, TemplateRenderer $tpl, Filesystem $fs, CodeWriter $codeWriter)
+    function let(TemplateRenderer $tpl, Filesystem $fs, CodeWriter $codeWriter)
     {
-        $this->beConstructedWith($io, $tpl, $fs, $codeWriter);
+        $this->beConstructedWith($tpl, $fs, $codeWriter);
     }
 
     function it_is_a_generator()
@@ -38,7 +38,7 @@ class MethodGeneratorSpec extends ObjectBehavior
         $this->getPriority()->shouldReturn(0);
     }
 
-    function it_generates_class_method_from_resource($io, $tpl, $fs, Resource $resource, CodeWriter $codeWriter)
+    function it_generates_class_method_from_resource($tpl, $fs, Resource $resource, CodeWriter $codeWriter)
     {
         $codeWithoutMethod = <<<CODE
 <?php

--- a/spec/PhpSpec/CodeGenerator/Generator/NamedConstructorGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/NamedConstructorGeneratorSpec.php
@@ -12,9 +12,9 @@ use Prophecy\Argument;
 
 class NamedConstructorGeneratorSpec extends ObjectBehavior
 {
-    function let(ConsoleIO $io, TemplateRenderer $tpl, Filesystem $fs, CodeWriter $codeWriter)
+    function let(TemplateRenderer $tpl, Filesystem $fs, CodeWriter $codeWriter)
     {
-        $this->beConstructedWith($io, $tpl, $fs, $codeWriter);
+        $this->beConstructedWith($tpl, $fs, $codeWriter);
     }
 
     function it_is_a_generator()
@@ -37,7 +37,7 @@ class NamedConstructorGeneratorSpec extends ObjectBehavior
         $this->getPriority()->shouldReturn(0);
     }
 
-    function it_generates_static_constructor_method_from_resource($io, $tpl, $fs, Resource $resource, CodeWriter $codeWriter)
+    function it_generates_static_constructor_method_from_resource($tpl, $fs, Resource $resource, CodeWriter $codeWriter)
     {
         $codeWithoutMethod = <<<CODE
 <?php

--- a/spec/PhpSpec/CodeGenerator/Generator/ReturnConstantGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ReturnConstantGeneratorSpec.php
@@ -11,9 +11,9 @@ use PhpSpec\Locator\Resource;
 
 class ReturnConstantGeneratorSpec extends ObjectBehavior
 {
-    function let(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
+    function let(TemplateRenderer $templates, Filesystem $filesystem)
     {
-        $this->beConstructedWith($io, $templates, $filesystem);
+        $this->beConstructedWith($templates, $filesystem);
     }
 
     function it_is_a_generator()

--- a/spec/PhpSpec/Listener/ClassNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/ClassNotFoundListenerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Listener;
 
+use PhpSpec\Locator\Resource;
 use PhpSpec\Locator\ResourceManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -17,10 +18,11 @@ use Prophecy\Exception\Doubler\ClassNotFoundException as ProphecyClassException;
 class ClassNotFoundListenerSpec extends ObjectBehavior
 {
     function let(ConsoleIO $io, ResourceManager $resourceManager, GeneratorManager $generatorManager,
-                 SuiteEvent $suiteEvent, ExampleEvent $exampleEvent)
+                 SuiteEvent $suiteEvent, ExampleEvent $exampleEvent, Resource $resource)
     {
-        $io->writeln(Argument::any())->willReturn();
+        $io->writeln(Argument::cetera())->willReturn();
         $io->askConfirmation(Argument::any())->willReturn();
+        $resourceManager->createResource(Argument::any())->willReturn($resource);
 
         $this->beConstructedWith($io, $resourceManager, $generatorManager);
     }
@@ -77,5 +79,44 @@ class ClassNotFoundListenerSpec extends ObjectBehavior
         $this->afterSuite($suiteEvent);
 
         $io->askConfirmation(Argument::any())->shouldNotBeenCalled();
+    }
+    
+    function it_generates_class_and_notifies_when_prophecy_classnotfoundexception_was_thrown_and_input_is_interactive($exampleEvent, $suiteEvent, $io, $generatorManager, ProphecyClassException $exception)
+    {
+        $exampleEvent->getException()->willReturn($exception);
+        $io->isCodeGenerationEnabled()->willReturn(true);
+        $io->askConfirmation(Argument::any())->willReturn(true);
+        $generatorManager->generate(Argument::any(), "class")->willReturn($message = 'Non-empty string');
+        
+        $this->afterExample($exampleEvent);
+        $this->afterSuite($suiteEvent);
+
+        $io->writeln($message, Argument::any())->shouldHaveBeenCalled();
+    }
+    
+    function it_generates_class_and_notifies_when_phpspec_classnotfoundexception_was_thrown_and_input_is_interactive($exampleEvent, $suiteEvent, $io, $generatorManager, PhpspecClassException $exception)
+    {
+        $exampleEvent->getException()->willReturn($exception);
+        $io->isCodeGenerationEnabled()->willReturn(true);
+        $io->askConfirmation(Argument::any())->willReturn(true);
+        $generatorManager->generate(Argument::any(), "class")->willReturn($message = 'Non-empty string');
+        
+        $this->afterExample($exampleEvent);
+        $this->afterSuite($suiteEvent);
+        
+        $io->writeln($message, Argument::any())->shouldHaveBeenCalled();
+    }
+    
+    function it_does_not_output_an_empty_string_if_generator_has_no_output($exampleEvent, $suiteEvent, $io, $generatorManager, PhpspecClassException $exception)
+    {
+        $exampleEvent->getException()->willReturn($exception);
+        $io->isCodeGenerationEnabled()->willReturn(true);
+        $io->askConfirmation(Argument::any())->willReturn(true);
+        $generatorManager->generate(Argument::any(), "class")->willReturn('');
+    
+        $this->afterExample($exampleEvent);
+        $this->afterSuite($suiteEvent);
+    
+        $io->writeln('', Argument::any())->shouldNotHaveBeenCalled();
     }
 }

--- a/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
@@ -187,6 +187,42 @@ class CollaboratorMethodNotFoundListenerSpec extends ObjectBehavior
 
         $this->afterSuite($suiteEvent);
     }
+    
+    function it_notifies_the_user_when_it_generated_the_method_signature(
+        ConsoleIO $io, ExampleEvent $event, SuiteEvent $suiteEvent, MethodNotFoundException $exception,
+        Resource $resource, GeneratorManager $generator
+    )
+    {
+        $io->writeln(Argument::cetera())->willReturn();
+        $io->askConfirmation(Argument::any())->willReturn(true);
+        $generator->generate($resource, 'method-signature', Argument::any())->willReturn($message = 'Non-empty string');
+        
+        $exception->getClassname()->willReturn('spec\PhpSpec\Listener\DoubleOfInterface');
+        $exception->getMethodName()->willReturn('aMethod');
+        
+        $this->afterExample($event);
+        $this->afterSuite($suiteEvent);
+        
+        $io->writeln($message, Argument::any())->shouldHaveBeenCalled();
+    }
+    
+    function it_doesnt_output_an_empty_line_when_the_generator_has_no_output(
+        ConsoleIO $io, ExampleEvent $event, SuiteEvent $suiteEvent, MethodNotFoundException $exception,
+        Resource $resource, GeneratorManager $generator
+    )
+    {
+        $io->writeln(Argument::cetera())->willReturn();
+        $io->askConfirmation(Argument::any())->willReturn(true);
+        $generator->generate($resource, 'method-signature', Argument::any())->willReturn($message = '');
+        
+        $exception->getClassname()->willReturn('spec\PhpSpec\Listener\DoubleOfInterface');
+        $exception->getMethodName()->willReturn('aMethod');
+        
+        $this->afterExample($event);
+        $this->afterSuite($suiteEvent);
+        
+        $io->writeln($message, Argument::any())->shouldNotHaveBeenCalled();
+    }
 
     private function callAfterExample($event, $nameChecker, $method, $isNameValid = true)
     {

--- a/spec/PhpSpec/Listener/CollaboratorNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorNotFoundListenerSpec.php
@@ -29,7 +29,7 @@ class CollaboratorNotFoundListenerSpec extends ObjectBehavior
 
         $io->isCodeGenerationEnabled()->willReturn(true);
         $io->askConfirmation(Argument::any())->willReturn(false);
-        $io->writeln(Argument::any())->willReturn(null);
+        $io->writeln(Argument::cetera())->willReturn(null);
     }
 
     function it_listens_to_afterexample_and_aftersuite_events()
@@ -114,6 +114,38 @@ class CollaboratorNotFoundListenerSpec extends ObjectBehavior
 
         $generator->generate($resource, 'interface')->shouldHaveBeenCalled();
         $suiteEvent->markAsWorthRerunning()->shouldHaveBeenCalled();
+    }
+    
+    function it_notifies_user_when_it_generated_interface(
+        ConsoleIO $io, ExampleEvent $exampleEvent, SuiteEvent $suiteEvent,
+        GeneratorManager $generator, Resource $resource
+    )
+    {
+        $io->askConfirmation(
+            'Would you like me to generate an interface `Example\ExampleClass` for you?'
+        )->willReturn(true);
+        $generator->generate($resource, 'interface')->willReturn($message = 'Non-empty string');
+
+        $this->afterExample($exampleEvent);
+        $this->afterSuite($suiteEvent);
+
+        $io->writeln($message, Argument::any())->shouldHaveBeenCalled();
+    }
+    
+    function it_doesnt_output_empty_line_when_generator_has_no_output(
+        ConsoleIO $io, ExampleEvent $exampleEvent, SuiteEvent $suiteEvent,
+        GeneratorManager $generator, Resource $resource
+    )
+    {
+        $io->askConfirmation(
+            'Would you like me to generate an interface `Example\ExampleClass` for you?'
+        )->willReturn(true);
+        $generator->generate($resource, 'interface')->willReturn($message = '');
+
+        $this->afterExample($exampleEvent);
+        $this->afterSuite($suiteEvent);
+
+        $io->writeln($message, Argument::any())->shouldNotHaveBeenCalled();
     }
 
     function it_does_not_generate_interface_when_prompt_is_answered_with_no(

--- a/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
@@ -206,4 +206,44 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         $generatorManager->generate($resource, 'returnConstant', array('method' => 'myMethod', 'expected' => 100))
             ->shouldHaveBeenCalled();
     }
+    
+    function it_notifies_user_when_it_generated_the_method(
+        MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io,
+        GeneratorManager $generatorManager, ResourceManager $resourceManager, Resource $resource, SuiteEvent $event
+    ) {
+        $io->askConfirmation(Argument::any())->willReturn(true);
+        $io->writeln(Argument::cetera())->willReturn();
+        $resourceManager->createResource(Argument::any())->willReturn($resource);
+        $generatorManager->generate($resource, 'returnConstant', array('method' => 'myMethod', 'expected' => 100))
+            ->willReturn($message = 'Non-empty string');
+
+        $methodCallEvent->getSubject()->willReturn(new \StdClass());
+        $methodCallEvent->getMethod()->willReturn('myMethod');
+
+        $this->afterMethodCall($methodCallEvent);
+        $this->afterExample($exampleEvent);
+        $this->afterSuite($event);
+
+        $io->writeln($message, Argument::any())->shouldHaveBeenCalled();
+    }
+    
+    function it_doesnt_output_empty_line_when_generator_has_no_output(
+        MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io,
+        GeneratorManager $generatorManager, ResourceManager $resourceManager, Resource $resource, SuiteEvent $event
+    ) {
+        $io->askConfirmation(Argument::any())->willReturn(true);
+        $io->writeln(Argument::cetera())->willReturn();
+        $resourceManager->createResource(Argument::any())->willReturn($resource);
+        $generatorManager->generate($resource, 'returnConstant', array('method' => 'myMethod', 'expected' => 100))
+            ->willReturn($message = '');
+
+        $methodCallEvent->getSubject()->willReturn(new \StdClass());
+        $methodCallEvent->getMethod()->willReturn('myMethod');
+
+        $this->afterMethodCall($methodCallEvent);
+        $this->afterExample($exampleEvent);
+        $this->afterSuite($event);
+
+        $io->writeln($message, Argument::any())->shouldNotHaveBeenCalled();
+    }
 }

--- a/src/PhpSpec/CodeGenerator/Generator/Generator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/Generator.php
@@ -31,7 +31,9 @@ interface Generator
 
     /**
      * @param Resource $resource
-     * @param array             $data
+     * @param array    $data
+     *
+     * @return string
      */
     public function generate(Resource $resource, array $data);
 

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -25,11 +25,6 @@ use PhpSpec\Locator\Resource;
 final class MethodGenerator implements Generator
 {
     /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
      * @var TemplateRenderer
      */
     private $templates;
@@ -45,14 +40,12 @@ final class MethodGenerator implements Generator
     private $codeWriter;
 
     /**
-     * @param ConsoleIO $io
      * @param TemplateRenderer $templates
      * @param Filesystem $filesystem
      * @param CodeWriter $codeWriter
      */
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
     {
-        $this->io         = $io;
         $this->templates  = $templates;
         $this->filesystem = $filesystem;
         $this->codeWriter = $codeWriter;
@@ -72,7 +65,9 @@ final class MethodGenerator implements Generator
 
     /**
      * @param Resource $resource
-     * @param array             $data
+     * @param array    $data
+     *
+     * @return string
      */
     public function generate(Resource $resource, array $data = array())
     {
@@ -95,12 +90,12 @@ final class MethodGenerator implements Generator
 
         $code = $this->filesystem->getFileContents($filepath);
         $this->filesystem->putFileContents($filepath, $this->getUpdatedCode($name, $content, $code));
-
-        $this->io->writeln(sprintf(
+        
+        return sprintf(
             "<info>Method <value>%s::%s()</value> has been created.</info>\n",
             $resource->getSrcClassname(),
             $name
-        ), 2);
+        );
     }
 
     /**

--- a/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
@@ -24,11 +24,6 @@ use PhpSpec\Locator\Resource;
 final class MethodSignatureGenerator implements Generator
 {
     /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
      * @var TemplateRenderer
      */
     private $templates;
@@ -39,13 +34,11 @@ final class MethodSignatureGenerator implements Generator
     private $filesystem;
 
     /**
-     * @param ConsoleIO               $io
      * @param TemplateRenderer $templates
      * @param Filesystem       $filesystem
      */
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
+    public function __construct(TemplateRenderer $templates, Filesystem $filesystem)
     {
-        $this->io         = $io;
         $this->templates  = $templates;
         $this->filesystem = $filesystem;
     }
@@ -64,7 +57,9 @@ final class MethodSignatureGenerator implements Generator
 
     /**
      * @param Resource $resource
-     * @param array             $data
+     * @param array    $data
+     *
+     * @return string
      */
     public function generate(Resource $resource, array $data = array())
     {
@@ -83,10 +78,11 @@ final class MethodSignatureGenerator implements Generator
 
         $this->insertMethodSignature($filepath, $content);
 
-        $this->io->writeln(sprintf(
+        return sprintf(
             "<info>Method signature <value>%s::%s()</value> has been created.</info>\n",
-            $resource->getSrcClassname(), $name
-        ), 2);
+            $resource->getSrcClassname(),
+            $name
+        );
     }
 
     /**

--- a/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
@@ -23,11 +23,6 @@ use PhpSpec\Util\Filesystem;
 final class NamedConstructorGenerator implements Generator
 {
     /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
      * @var TemplateRenderer
      */
     private $templates;
@@ -42,14 +37,12 @@ final class NamedConstructorGenerator implements Generator
     private $codeWriter;
 
     /**
-     * @param ConsoleIO $io
      * @param TemplateRenderer $templates
      * @param Filesystem $filesystem
      * @param CodeWriter $codeWriter
      */
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
     {
-        $this->io         = $io;
         $this->templates  = $templates;
         $this->filesystem = $filesystem;
         $this->codeWriter = $codeWriter;
@@ -86,11 +79,11 @@ final class NamedConstructorGenerator implements Generator
         );
         $this->filesystem->putFileContents($filepath, $code);
 
-        $this->io->writeln(sprintf(
+        return sprintf(
             "<info>Method <value>%s::%s()</value> has been created.</info>\n",
             $resource->getSrcClassname(),
             $methodName
-        ), 2);
+        );
     }
 
     /**

--- a/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
@@ -50,7 +50,9 @@ final class NewFileNotifyingGenerator implements Generator
 
     /**
      * @param Resource $resource
-     * @param array $data
+     * @param array    $data
+     *
+     * @return string
      */
     public function generate(Resource $resource, array $data)
     {
@@ -58,9 +60,11 @@ final class NewFileNotifyingGenerator implements Generator
 
         $fileExisted = $this->fileExists($filePath);
 
-        $this->generator->generate($resource, $data);
+        $output = $this->generator->generate($resource, $data);
 
         $this->dispatchEventIfFileWasCreated($fileExisted, $filePath);
+        
+        return $output;
     }
 
     /**

--- a/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
@@ -23,11 +23,6 @@ use PhpSpec\Util\Filesystem;
 final class PrivateConstructorGenerator implements Generator
 {
     /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
      * @var TemplateRenderer
      */
     private $templates;
@@ -43,14 +38,12 @@ final class PrivateConstructorGenerator implements Generator
     private $codeWriter;
 
     /**
-     * @param ConsoleIO $io
      * @param TemplateRenderer $templates
      * @param Filesystem $filesystem
      * @param CodeWriter $codeWriter
      */
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
     {
-        $this->io         = $io;
         $this->templates  = $templates;
         $this->filesystem = $filesystem;
         $this->codeWriter = $codeWriter;
@@ -70,7 +63,9 @@ final class PrivateConstructorGenerator implements Generator
 
     /**
      * @param Resource $resource
-     * @param array $data
+     * @param array    $data
+     *
+     * @return string
      */
     public function generate(Resource $resource, array $data)
     {
@@ -87,7 +82,7 @@ final class PrivateConstructorGenerator implements Generator
         $code = $this->codeWriter->insertMethodFirstInClass($code, $content);
         $this->filesystem->putFileContents($filepath, $code);
 
-        $this->io->writeln("<info>Private constructor has been created.</info>\n", 2);
+        return "<info>Private constructor has been created.</info>\n";
     }
 
     /**

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -60,7 +60,9 @@ abstract class PromptingGenerator implements Generator
 
     /**
      * @param Resource $resource
-     * @param array             $data
+     * @param array    $data
+     *
+     * @return string
      */
     public function generate(Resource $resource, array $data = array())
     {
@@ -75,8 +77,10 @@ abstract class PromptingGenerator implements Generator
         }
 
         $this->createDirectoryIfItDoesExist($filepath);
-        $this->generateFileAndRenderTemplate($resource, $filepath);
+        $output = $this->generateFileAndRenderTemplate($resource, $filepath);
         $this->executionContext->addGeneratedType($resource->getSrcClassname());
+        
+        return $output;
     }
 
     /**
@@ -145,13 +149,16 @@ abstract class PromptingGenerator implements Generator
 
     /**
      * @param Resource $resource
-     * @param string            $filepath
+     * @param string   $filepath
+     *
+     * @return string
      */
     private function generateFileAndRenderTemplate(Resource $resource, $filepath)
     {
         $content = $this->renderTemplate($resource, $filepath);
 
         $this->filesystem->putFileContents($filepath, $content);
-        $this->io->writeln($this->getGeneratedMessage($resource, $filepath));
+        
+        return $this->getGeneratedMessage($resource, $filepath);
     }
 }

--- a/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
@@ -21,10 +21,6 @@ use PhpSpec\Util\Filesystem;
 final class ReturnConstantGenerator implements Generator
 {
     /**
-     * @var ConsoleIO
-     */
-    private $io;
-    /**
      * @var TemplateRenderer
      */
     private $templates;
@@ -34,13 +30,11 @@ final class ReturnConstantGenerator implements Generator
     private $filesystem;
 
     /**
-     * @param ConsoleIO        $io
      * @param TemplateRenderer $templates
      * @param Filesystem       $filesystem
      */
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
+    public function __construct(TemplateRenderer $templates, Filesystem $filesystem)
     {
-        $this->io = $io;
         $this->templates = $templates;
         $this->filesystem = $filesystem;
     }
@@ -59,7 +53,9 @@ final class ReturnConstantGenerator implements Generator
 
     /**
      * @param Resource $resource
-     * @param array             $data
+     * @param array    $data
+     *
+     * @return string
      */
     public function generate(Resource $resource, array $data)
     {
@@ -83,11 +79,11 @@ final class ReturnConstantGenerator implements Generator
 
         $this->filesystem->putFileContents($resource->getSrcFilename(), $modifiedCode);
 
-        $this->io->writeln(sprintf(
+        return sprintf(
             "<info>Method <value>%s::%s()</value> has been modified.</info>\n",
             $resource->getSrcClassname(),
             $method
-        ), 2);
+        );
     }
 
     /**

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -289,7 +289,6 @@ final class ContainerAssembler
         });
         $container->define('code_generator.generators.method', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\MethodGenerator(
-                $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem'),
                 $c->get('code_generator.writers.tokenized')
@@ -297,14 +296,12 @@ final class ContainerAssembler
         }, ['code_generator.generators']);
         $container->define('code_generator.generators.methodSignature', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\MethodSignatureGenerator(
-                $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem')
             );
         }, ['code_generator.generators']);
         $container->define('code_generator.generators.returnConstant', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\ReturnConstantGenerator(
-                $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem')
             );
@@ -312,7 +309,6 @@ final class ContainerAssembler
 
         $container->define('code_generator.generators.named_constructor', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\NamedConstructorGenerator(
-                $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem'),
                 $c->get('code_generator.writers.tokenized')
@@ -321,7 +317,6 @@ final class ContainerAssembler
 
         $container->define('code_generator.generators.private_constructor', function (IndexedServiceContainer $c) {
             return new CodeGenerator\Generator\PrivateConstructorGenerator(
-                $c->get('console.io'),
                 $c->get('code_generator.templates'),
                 $c->get('util.filesystem'),
                 $c->get('code_generator.writers.tokenized')

--- a/src/PhpSpec/Listener/ClassNotFoundListener.php
+++ b/src/PhpSpec/Listener/ClassNotFoundListener.php
@@ -88,7 +88,12 @@ final class ClassNotFoundListener implements EventSubscriberInterface
             }
 
             if ($this->io->askConfirmation($message)) {
-                $this->generator->generate($resource, 'class');
+                $output = $this->generator->generate($resource, 'class');
+                
+                if (!empty($output)) {
+                    $this->io->writeln($output, 2);
+                }
+                
                 $event->markAsWorthRerunning();
             }
         }

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -150,7 +150,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
                 }
 
                 if ($this->io->askConfirmation(sprintf(self::PROMPT, $interface, $method))) {
-                    $this->generator->generate(
+                    $output = $this->generator->generate(
                         $resource,
                         'method-signature',
                         array(
@@ -158,6 +158,11 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
                             'arguments' => $this->getRealArguments($arguments)
                         )
                     );
+    
+                    if (!empty($output)) {
+                        $this->io->writeln($output, 2);
+                    }
+                    
                     $event->markAsWorthRerunning();
                 }
             }

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -96,7 +96,12 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
             if ($this->io->askConfirmation(
                 sprintf('Would you like me to generate an interface `%s` for you?', $exception->getCollaboratorName())
             )) {
-                $this->generator->generate($resource, 'interface');
+                $output = $this->generator->generate($resource, 'interface');
+    
+                if (!empty($output)) {
+                    $this->io->writeln($output, 2);
+                }
+                
                 $event->markAsWorthRerunning();
             }
         }

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -98,10 +98,15 @@ final class MethodNotFoundListener implements EventSubscriberInterface
             }
 
             if ($this->io->askConfirmation($message)) {
-                $this->generator->generate($resource, 'method', array(
+                $output = $this->generator->generate($resource, 'method', array(
                     'name'      => $method,
                     'arguments' => $arguments
                 ));
+                
+                if (!empty($output)) {
+                    $this->io->writeln($output, 2);
+                }
+                
                 $event->markAsWorthRerunning();
             }
         }

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -163,11 +163,16 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
             }
 
             if ($this->io->askConfirmation($message)) {
-                $this->generator->generate(
+                $output = $this->generator->generate(
                     $resource,
                     'returnConstant',
                     array('method' => $failedCall['method'], 'expected' => $expected)
                 );
+                
+                if (!empty($output)) {
+                    $this->io->writeln($output, 2);
+                }
+                
                 $event->markAsWorthRerunning();
             }
         }

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -74,20 +74,29 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
             }
 
             if ($this->io->askConfirmation($message)) {
-                $this->generator->generate($resource, 'named_constructor', array(
+                $output = $this->generator->generate($resource, 'named_constructor', array(
                     'name'      => $method,
                     'arguments' => $arguments
                 ));
+    
+                if (!empty($output)) {
+                    $this->io->writeln($output, 2);
+                }
+                
                 $event->markAsWorthRerunning();
 
                 if (!method_exists($classname, '__construct')) {
                     $message = sprintf('Do you want me to make the constructor of %s private for you?', $classname);
 
                     if ($this->io->askConfirmation($message)) {
-                        $this->generator->generate($resource, 'private-constructor', array(
+                        $output = $this->generator->generate($resource, 'private-constructor', array(
                             'name' => $method,
                             'arguments' => $arguments
                         ));
+    
+                        if (!empty($output)) {
+                            $this->io->writeln($output, 2);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Generators could report back to the caller instead of writing directly to output, so now the `generate` method returns the string that used to be written directly.

Output used to be void, so there shouldn't be any risk of BC.
I think I've been thorough with usage lookup, but let me know if there's any other case I can cover.

The PromptingGenerators are pretty much impossible to decouple. I would consider switching out `ConsoleIO` for `IO` instead, that way those classes can be used with a simple `NullIO` object in non-console scenarios.