### PR TITLE
Switch usage from getMock to createMock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "behat/behat":           "^3.1",
         "symfony/filesystem":    "^3.0",
-        "phpunit/phpunit":       "^5.3",
+        "phpunit/phpunit":       "^5.4",
         "ciaranmcnulty/versionbasedtestskipper": "^0.2.1"
     },
 

--- a/integration/PhpSpec/Console/Prompter/QuestionTest.php
+++ b/integration/PhpSpec/Console/Prompter/QuestionTest.php
@@ -32,9 +32,9 @@ class QuestionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $this->output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $this->questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $this->input = $this->createMock('Symfony\Component\Console\Input\InputInterface');
+        $this->output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+        $this->questionHelper = $this->createMock('Symfony\Component\Console\Helper\QuestionHelper');
 
         $this->prompter = new Question($this->input, $this->output, $this->questionHelper);
     }


### PR DESCRIPTION
We were tagging PHPUnit `~5.3`, `createMock` is introduced in `5.4` and `getMock` is deprecated in `5.5`. This meant builds were triggering deprecation warnings.

This PR switches usage to `createMock` and bumps the corresponding dev dependency in `composer.json`