### PR TITLE
Handle fatal errors in SUS and Spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 Upcoming 3.x
 ============
 
+* Fatal errors are now caught and reported (@ciaranmcnulty)
 * Validates that matchers specified in config are valid matchers (@avant1)
 * Shows Error message even when Exception was expected (@harrisonbro)
 * Disallows doubling of PHP 7.1's `iterable` type (@avant1)

--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -1,3 +1,4 @@
+@php:~5.6
 Feature: Developer is notified of which scenario caused a fatal error
   As a Developer
   I want to know in which scenario or example my script was running

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -119,3 +119,4 @@ Feature: Developer is shown a parse error
       """
     When I run phpspec
     Then I should see "1 broken"
+    And I should see "syntax error"

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -80,3 +80,42 @@ Feature: Developer is shown a parse error
       """
     When I run phpspec
     Then I should see "1 broken"
+
+  @php:~7.0
+  Scenario: Parse error in spec
+    Given the spec file "spec/Message/Fatal2/ParseSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Message\Fatal2;
+
+      use Parse;
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class ParseSpec extends ObjectBehavior
+      {
+          function it_thro ws_a_syntax_error()
+          {
+              $this->cool();
+          }
+      }
+
+      """
+    And the spec file "src/Message/Fatal2/Parse.php" contains:
+      """
+      <?php
+
+      namespace Message\Parse2;
+
+      class Parse
+      {
+          public function cool()
+          {
+              return true;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see "1 broken"

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -3,8 +3,8 @@ Feature: Developer is shown a parse error
   I want to know if a parse error was thrown
   So that I can know that I can handle pass errors
 
-  @isolated
-  Scenario: Spec attempts to call an undeclared function
+  @php:~5.6 @isolated
+  Scenario: Parse error in spec
     Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
       """
       <?php
@@ -41,3 +41,42 @@ Feature: Developer is shown a parse error
       """
     When I run phpspec with the "junit" formatter
     Then I should see "syntax error"
+
+  @php:~7.0
+  Scenario: Parse error in class
+    Given the spec file "spec/Message/Fatal/ParseSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Message\Fatal;
+
+      use Parse;
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class ParseSpec extends ObjectBehavior
+      {
+          function it_throws_a_syntax_error()
+          {
+              $this->cool();
+          }
+      }
+
+      """
+    And the spec file "src/Message/Fatal/Parse.php" contains:
+      """
+      <?php
+
+      namespace Message\Parse;
+
+      class Par se
+      {
+          public function cool()
+          {
+              return true;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see "1 broken"

--- a/features/exception_handling/developer_is_shown_runtime_errors.feature
+++ b/features/exception_handling/developer_is_shown_runtime_errors.feature
@@ -1,0 +1,88 @@
+@php:~7.0
+Feature: Developer is shown runtime errors
+  As a developer
+  To debug fatal errors better
+  I should be shown errors but the rest of the suite should run
+
+  Scenario: Runtime error in class being specified
+    Given the spec file "spec/Message/Fatal/RuntimeSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Message\Fatal;
+
+      use PhpSpec\ObjectBehavior;
+
+      class RuntimeSpec extends ObjectBehavior
+      {
+          function it_breaks()
+          {
+              $this->broken();
+          }
+
+          function it_passes()
+          {
+              $this->passing();
+          }
+      }
+      """
+    And the class file "src/Message/Fatal/Runtime.php" contains:
+      """
+      <?php
+
+      namespace Message\Fatal;
+
+      class Runtime
+      {
+          public function broken()
+          {
+              foo();
+          }
+
+          public function passing()
+          {
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see "1 passed, 1 broken"
+
+  Scenario: Runtime error in spec
+    Given the spec file "spec/Message/Fatal2/RuntimeSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Message\Fatal2;
+
+      use PhpSpec\ObjectBehavior;
+
+      class RuntimeSpec extends ObjectBehavior
+      {
+          function it_breaks()
+          {
+              foo();
+          }
+
+          function it_passes()
+          {
+              $this->passing();
+          }
+      }
+      """
+    And the class file "src/Message/Fatal2/Runtime.php" contains:
+      """
+      <?php
+
+      namespace Message\Fatal2;
+
+      class Runtime
+      {
+          public function passing()
+          {
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see "1 passed, 1 broken"

--- a/spec/PhpSpec/Exception/ErrorExceptionSpec.php
+++ b/spec/PhpSpec/Exception/ErrorExceptionSpec.php
@@ -9,13 +9,15 @@ use Prophecy\Argument;
 
 class ErrorExceptionSpec extends ObjectBehavior
 {
+    private $error;
+
     function let()
     {
         if (!class_exists('\Error')) {
             throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
         }
 
-        $this->beConstructedWith(new \Error('This is an error'));
+        $this->beConstructedWith($this->error = new \Error('This is an error', 42));
     }
 
     function it_is_an_exception()
@@ -23,8 +25,23 @@ class ErrorExceptionSpec extends ObjectBehavior
         $this->shouldHaveType(\Exception::class);
     }
 
-    function its_message_comes_from_the_error()
+    function its_message_is_the_same_as_the_errors()
     {
         $this->getMessage()->shouldEqual('This is an error');
+    }
+
+    function its_code_is_the_same_as_the_errors()
+    {
+        $this->getCode()->shouldEqual(42);
+    }
+
+    function its_previous_is_the_error()
+    {
+        $this->getPrevious()->shouldEqual($this->error);
+    }
+
+    function its_line_is_the_same_as_the_errors()
+    {
+        $this->getLine()->shouldEqual($this->error->getLine());
     }
 }

--- a/spec/PhpSpec/Exception/ErrorExceptionSpec.php
+++ b/spec/PhpSpec/Exception/ErrorExceptionSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace spec\PhpSpec\Exception;
+
+use PhpSpec\Exception\ErrorException;
+use PhpSpec\Exception\Example\SkippingException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ErrorExceptionSpec extends ObjectBehavior
+{
+    function let()
+    {
+        if (!class_exists('\Error')) {
+            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
+        }
+
+        $this->beConstructedWith(new \Error('This is an error'));
+    }
+
+    function it_is_an_exception()
+    {
+        $this->shouldHaveType(\Exception::class);
+    }
+
+    function its_message_comes_from_the_error()
+    {
+        $this->getMessage()->shouldEqual('This is an error');
+    }
+}

--- a/spec/PhpSpec/Formatter/DotFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/DotFormatterSpec.php
@@ -108,8 +108,7 @@ class DotFormatterSpec extends ObjectBehavior
         ConsoleIO $io,
         StatisticsCollector $stats,
         SpecificationNode $specification,
-        ExampleNode $example,
-        ReflectionFunctionAbstract $reflectionFunction
+        ExampleNode $example
     ) {
         $example->getLineNumber()->willReturn(37);
         $example->getTitle()->willReturn('it tests something');

--- a/spec/PhpSpec/Formatter/DotFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/DotFormatterSpec.php
@@ -111,8 +111,7 @@ class DotFormatterSpec extends ObjectBehavior
         ExampleNode $example,
         ReflectionFunctionAbstract $reflectionFunction
     ) {
-        $reflectionFunction->getStartLine()->willReturn(37);
-        $example->getFunctionReflection()->willReturn($reflectionFunction);
+        $example->getLineNumber()->willReturn(37);
         $example->getTitle()->willReturn('it tests something');
         $pendingEvent->getException()->willReturn(new PendingException());
         $pendingEvent->getSpecification()->willReturn($specification);

--- a/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\PhpSpec\Formatter\Presenter\Value;
 
+use PhpSpec\Exception\ErrorException;
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -21,5 +23,15 @@ class BaseExceptionTypePresenterSpec extends ObjectBehavior
     {
         $this->present(new \Exception('foo'))
             ->shouldReturn('[exc:Exception("foo")]');
+    }
+
+    function it_should_present_an_error_as_a_string()
+    {
+        if (!class_exists('\Error')) {
+            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
+        }
+
+        $this->present(new ErrorException(new \Error('foo')))
+            ->shouldReturn('[err:Error("foo")]');
     }
 }

--- a/spec/PhpSpec/Loader/Node/ExampleNodeSpec.php
+++ b/spec/PhpSpec/Loader/Node/ExampleNodeSpec.php
@@ -13,6 +13,7 @@ class ExampleNodeSpec extends ObjectBehavior
 {
     function let(ReflectionFunctionAbstract $function)
     {
+        $function->isClosure()->willReturn(false);
         $this->beConstructedWith('example node', $function);
     }
 
@@ -53,5 +54,21 @@ class ExampleNodeSpec extends ObjectBehavior
     {
         $this->markAsPending(false);
         $this->isPending()->shouldReturn(false);
+    }
+
+    function it_returns_its_line_number(\ReflectionFunctionAbstract $function)
+    {
+        $function->getStartLine()->willReturn(100);
+
+        $this->getLineNumber()->shouldReturn(100);
+    }
+
+    function it_returns_its_line_number_as_zero_if_constructed_with_closure(
+        \ReflectionFunctionAbstract $function
+    )
+    {
+        $function->isClosure()->willReturn(true);
+
+        $this->getLineNumber()->shouldReturn(0);
     }
 }

--- a/spec/PhpSpec/Specification/ErrorSpecificationSpec.php
+++ b/spec/PhpSpec/Specification/ErrorSpecificationSpec.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace spec\PhpSpec\Specification;
+
+use PhpSpec\Specification;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ErrorSpecificationSpec extends ObjectBehavior
+{
+    function it_is_a_specification()
+    {
+        $this->shouldHaveType(Specification::class);
+    }
+}

--- a/src/PhpSpec/Exception/ErrorException.php
+++ b/src/PhpSpec/Exception/ErrorException.php
@@ -17,6 +17,9 @@ final class ErrorException extends \Exception
 {
     public function __construct(\Error $error)
     {
-        parent::__construct($error->getMessage());
+        parent::__construct($error->getMessage(), $error->getCode(), $error);
+
+        $this->line = $error->getLine();
+        $this->file = $error->getFile();
     }
 }

--- a/src/PhpSpec/Exception/ErrorException.php
+++ b/src/PhpSpec/Exception/ErrorException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Exception;
+
+final class ErrorException extends \Exception
+{
+    public function __construct(\Error $error)
+    {
+        parent::__construct($error->getMessage());
+    }
+}

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -84,7 +84,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
 
         $this->io->writeln(sprintf(
             '<lineno>%4d</lineno>  <%s>- %s</%s>',
-            $event->getExample()->getFunctionReflection()->getStartLine(),
+            $event->getExample()->getLineNumber(),
             $type,
             $event->getExample()->getTitle(),
             $type

--- a/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
@@ -13,6 +13,8 @@
 
 namespace PhpSpec\Formatter\Presenter\Value;
 
+use PhpSpec\Exception\ErrorException;
+
 final class BaseExceptionTypePresenter implements ExceptionTypePresenter
 {
     /**
@@ -30,8 +32,16 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
      */
     public function present($value)
     {
+        $label = 'exc';
+
+        if ($value instanceof ErrorException) {
+            $value = $value->getPrevious();
+            $label = 'err';
+        }
+
         return sprintf(
-            '[exc:%s("%s")]',
+            '[%s:%s("%s")]',
+            $label,
             get_class($value),
             $value->getMessage()
         );

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -91,4 +91,12 @@ class ExampleNode
     {
         return $this->specification;
     }
+
+    /**
+     * @return int
+     */
+    public function getLineNumber()
+    {
+        return $this->function->isClosure() ? 0 : $this->function->getStartLine();
+    }
 }

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Loader;
 
+use PhpSpec\Specification\ErrorSpecification;
 use PhpSpec\Util\MethodAnalyser;
 use PhpSpec\Locator\ResourceManager;
 use ReflectionClass;
@@ -50,7 +51,21 @@ class ResourceLoader
         $suite = new Suite();
         foreach ($this->manager->locateResources($locator) as $resource) {
             if (!class_exists($resource->getSpecClassname(), false) && is_file($resource->getSpecFilename())) {
-                require_once StreamWrapper::wrapPath($resource->getSpecFilename());
+                try {
+                    require_once StreamWrapper::wrapPath($resource->getSpecFilename());
+                }
+                catch (\Error $e) {
+                    $reflection = new ReflectionClass(ErrorSpecification::class);
+                    $spec = new Node\SpecificationNode($resource->getSrcClassname(),$reflection, $resource);
+
+                    $errorFunction = new \ReflectionFunction(function () use ($e) { throw $e; });
+                    $example = new Node\ExampleNode('Loading specification', $errorFunction);
+
+                    $spec->addExample($example);
+                    $suite->addSpecification($spec);
+
+                    continue;
+                }
             }
             if (!class_exists($resource->getSpecClassname(), false)) {
                 continue;

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -146,7 +146,12 @@ class ExampleRunner
         $reflection = $example->getFunctionReflection();
 
         try {
-            $reflection->invokeArgs($context, $collaborators->getArgumentsFor($reflection));
+            if ($reflection instanceof \ReflectionMethod) {
+                $reflection->invokeArgs($context, $collaborators->getArgumentsFor($reflection));
+            }
+            else {
+                $reflection->invokeArgs($collaborators->getArgumentsFor($reflection));
+            }
         } catch (\Exception $e) {
             $this->runMaintainersTeardown(
                 $this->searchExceptionMaintainers($maintainers),

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -13,6 +13,8 @@
 
 namespace PhpSpec\Runner;
 
+use Error;
+use PhpSpec\Exception\ErrorException;
 use PhpSpec\Runner\Maintainer\Maintainer;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use PhpSpec\Runner\Maintainer\LetAndLetgoMaintainer;
@@ -98,6 +100,9 @@ class ExampleRunner
         } catch (Exception $e) {
             $status    = ExampleEvent::BROKEN;
             $exception = $e;
+        } catch (Error $e) {
+            $status    = ExampleEvent::BROKEN;
+            $exception = new ErrorException($e);
         }
 
         if ($exception instanceof PhpSpecException) {

--- a/src/PhpSpec/Specification/ErrorSpecification.php
+++ b/src/PhpSpec/Specification/ErrorSpecification.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Specification;
+
+use PhpSpec\Specification;
+
+final class ErrorSpecification implements Specification
+{
+}


### PR DESCRIPTION
Rather than try and handle Errors directly, this wraps any Errors that occur in an Exception.

This allows PhpSpec to continue in the case of runtime Errors