### PR TITLE
Stop newline characters from accidentally being added when describing…

### DIFF
--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -503,6 +503,18 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->shouldThrow($exception)->duringCreateResource('Namespace/');
     }
 
+    function it_throws_an_exception_on_PSR0_resource_with_line_breaks_at_end(Filesystem $fs)
+    {
+        $this->beConstructedWith($fs, '', 'spec', $this->srcPath, $this->specPath);
+
+        $exception = new \InvalidArgumentException(
+            'String "Namespace\Classname'.PHP_EOL.'" is not a valid class name.'.PHP_EOL.
+            'Please see reference document: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md'
+        );
+
+        $this->shouldThrow($exception)->duringCreateResource('Namespace\Classname'.PHP_EOL);
+    }
+
     function it_throws_an_exception_on_PSR4_prefix_not_matching_namespace(Filesystem $fs)
     {
         $exception = new \InvalidArgumentException(

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -357,7 +357,7 @@ class PSR0Locator implements ResourceLocator
      */
     private function validatePsr0Classname($classname)
     {
-        $pattern = '/^([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*[\/\\\\]?)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/';
+        $pattern = '/\A([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*[\/\\\\]?)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\z/';
 
         if (!preg_match($pattern, $classname)) {
             throw new InvalidArgumentException(


### PR DESCRIPTION
So one day when writing a description on my Macbook I accidentally hit Shift-Enter in the middle of the line (It's near " - what can I say?). 

I tried to fix it by carrying on....
<img width="178" alt="screen shot 2016-09-01 at 21 41 43" src="https://cloud.githubusercontent.com/assets/2316601/18183581/ee7d96b8-708c-11e6-946b-fe7c78acfe12.png">

However PHPSpec continues and you end up with something very magical and a bit broken:
<img width="243" alt="screen shot 2016-09-01 at 21 35 10" src="https://cloud.githubusercontent.com/assets/2316601/18183620/1db8b85e-708d-11e6-9b4d-b925fd7f4bac.png">

This patch is a simple one that will strip the OS default newline character out of the name. There should never be an instance when you'd want a new line in the middle of a describe string. This gives you:
<img width="314" alt="screen shot 2016-09-01 at 21 34 40" src="https://cloud.githubusercontent.com/assets/2316601/18183649/3d2c597a-708d-11e6-9283-e8ff72bccad5.png">

I did have a look around the tests to see if there was something to update but couldn't find anything. If you have any suggestions I'm happy to update this PR.
