### PR TITLE
Support non-standard vendor and bin dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ behat.yml
 vendor
 composer.lock
 phpspec.phar
+bin/*
+!bin/phpspec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ install:
 
 script:
    - bin/phpspec run --format=pretty
-   - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty
+   - bin/phpunit --testdox
+   - bin/behat --format=pretty

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -3,12 +3,12 @@
 
 call_user_func(function ($version) {
 
-    $COMPOSER_AUTOLOAD='';
+    // modified by post-install hook, do not change manually
+    $COMPOSER_AUTOLOAD = '../vendor/autoload.php';
 
-    // Load composer autoloader
-    if (!@include($COMPOSER_AUTOLOAD)) {
+    if (!@include(__DIR__ . '/' . $COMPOSER_AUTOLOAD)) {
         fwrite(STDERR,
-            'You must set up the PhpSpec project dependencies, using composer (http://getcomposer.org)'
+            "You must set up the PhpSpec project dependencies, using composer (http://getcomposer.org)\n"
         );
         exit(1);
     }

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -3,26 +3,19 @@
 
 call_user_func(function ($version) {
 
-    if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
-        require $autoload;
-    } elseif (is_file($autoload = getcwd() . '/../../autoload.php')) {
-        require $autoload;
-    }
+    $COMPOSER_AUTOLOAD='';
 
-    if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
-        require($autoload);
-    } elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
-        require($autoload);
-    } else {
+    // Load composer autoloader
+    if (!@include($COMPOSER_AUTOLOAD)) {
         fwrite(STDERR,
-            'You must set up the project dependencies, run the following commands:' . PHP_EOL .
-            'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
-            'php composer.phar install' . PHP_EOL
+            'You must set up the PhpSpec project dependencies, using composer (http://getcomposer.org)'
         );
         exit(1);
     }
 
-    $app = new PhpSpec\Console\Application($version);
-    $app->run();
+    // Guess location of project autoloader (if composer is not project composer dep)
+    @include(getcwd() . '/vendor/autoload.php');
+
+    (new PhpSpec\Console\Application($version))->run();
 
 }, '3.1.0-beta');

--- a/composer.json
+++ b/composer.json
@@ -64,5 +64,11 @@
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         }
+    },
+    "scripts" : {
+        "post-autoload-dump" : "PhpSpec\\Composer\\AutoloaderFixer::postUpdate"
+    },
+    "config" : {
+        "bin-dir" : "bin"
     }
 }

--- a/src/PhpSpec/Composer/AutoloaderFixer.php
+++ b/src/PhpSpec/Composer/AutoloaderFixer.php
@@ -12,14 +12,23 @@ class AutoloaderFixer
         $autoloaderPath = $event->getComposer()->getConfig()->get('vendor-dir') . '/autoload.php';
         $binPath = $event->getComposer()->getConfig()->get('bin-dir') . '/phpspec';
 
-        $binary = file_get_contents($binPath );
+        $relPath = self::getRelativePath($autoloaderPath, $binPath);
 
-        $newBinary = preg_replace(
-            "/(COMPOSER_AUTOLOAD=')[^']*(')/",
-            '\1' . $autoloaderPath .'\2',
-            $binary
-        );
+        file_put_contents($binPath, preg_replace(
+            "/(COMPOSER_AUTOLOAD = ')[^']*(')/",
+            '\1' . $relPath .'\2',
+            file_get_contents($binPath)
+        ));
+    }
 
-        file_put_contents($binPath, $newBinary);
+    private static function getRelativePath($to, $from)
+    {
+        for ($i=0; isset($to{$i}); $i++) {
+            if (!isset($from{$i}) || $to{$i} != $from{$i}) {
+                break;
+            }
+        }
+
+        return '..' . substr($to, strrpos(substr($to, 0, $i), '/'));
     }
 }

--- a/src/PhpSpec/Composer/AutoloaderFixer.php
+++ b/src/PhpSpec/Composer/AutoloaderFixer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpSpec\Composer;
+
+use Composer\Script\Event;
+use Composer\Installer\PackageEvent;
+
+class AutoloaderFixer
+{
+    public static function postUpdate(Event $event)
+    {
+        $autoloaderPath = $event->getComposer()->getConfig()->get('vendor-dir') . '/autoload.php';
+        $binPath = $event->getComposer()->getConfig()->get('bin-dir') . '/phpspec';
+
+        $binary = file_get_contents($binPath );
+
+        $newBinary = preg_replace(
+            "/(COMPOSER_AUTOLOAD=')[^']*(')/",
+            '\1' . $autoloaderPath .'\2',
+            $binary
+        );
+
+        file_put_contents($binPath, $newBinary);
+    }
+}


### PR DESCRIPTION
Current binary searches well-known paths for the composer autoloader - unfortunately these are configurable by users.

It breaks in the case of the user configuring `vendor-dir` or a deep `bin-dir`

This change introduces a post-update hook to composer that modifies the path in the binary file to point to the actual autoloader location.