### PR TITLE
Optimise autoloader when building Phar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build-phar:
 	@echo "--> Cleaning vendor directory"
 	rm -Rfv vendor
 	@echo "--> Installing dependencies without dev"
-	composer install --no-dev
+	composer install --no-dev -o
 	@echo "--> Building Phar"
 	box build
 	@echo "--> Success"


### PR DESCRIPTION
This takes extra time during the build phase but speeds up every execution for Phar users