### PR TITLE
phpspec 3 upgrade doc: added note about getByPrefix

### DIFF
--- a/docs/manual/upgrading-to-phpspec-3.rst
+++ b/docs/manual/upgrading-to-phpspec-3.rst
@@ -87,3 +87,4 @@ Other things to bear in mind:
 
 - ``PhpSpec\ServiceContainer`` is now an interface (available implementation:
   ``PhpSpec\ServiceContainer\IndexedServiceContainer``)
+- ``PhpSpec\ServiceContainer\ServiceContainer#getByPrefix`` has been replaced by ``PhpSpec\ServiceContainer\ServiceContainer#getByTag``. Tags can be set via ``PhpSpec\ServiceContainer\ServiceContainer#define``'s third argument


### PR DESCRIPTION
I've found another thing to take into account while upgrading to phpspec 3: spec-gen registers new Containers, which is done by prefixing the services. But since 3.0.0-beta2, getting services by prefix a have been replaced by tags.