### PR TITLE
Allow \Error instances in ThrowMatcher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Upcoming 2.5
 ============
 
 * [fixed] Accidental linebreaks in spec name are not allowed (@randompixel)
+* [fixed] Throwable can be passed as instance to shouldThrow (@jameshalsall)
 * [performance] Phar version now has an optimised autoloader
 
 2.5.2 / 2017-09-04

--- a/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
@@ -42,6 +42,10 @@ class ThrowMatcherSpec extends ObjectBehavior
         $arr->ksort()->willThrow('\Error');
 
         $this->positiveMatch('throw', $arr, array('\Error'))->during('ksort', array());
+
+        $arr->ksort()->willThrow(new \Error());
+
+        $this->positiveMatch('throw', $arr, array('\Error'))->during('ksort', array());
     }
 
     function it_accepts_a_method_during_which_an_exception_should_not_be_thrown(ArrayObject $arr)

--- a/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
@@ -33,7 +33,7 @@ class ThrowMatcherSpec extends ObjectBehavior
         $this->positiveMatch('throw', $arr, array('\Exception'))->during('ksort', array());
     }
 
-    function it_accepts_a_method_during_which_an_error_should_be_thrown(ArrayObject $arr)
+    function it_accepts_a_method_during_which_an_error_specified_by_class_name_should_be_thrown(ArrayObject $arr)
     {
         if (!class_exists('\Error')) {
             throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
@@ -42,10 +42,17 @@ class ThrowMatcherSpec extends ObjectBehavior
         $arr->ksort()->willThrow('\Error');
 
         $this->positiveMatch('throw', $arr, array('\Error'))->during('ksort', array());
+    }
+
+    function it_accepts_a_method_during_which_an_error_specified_by_instance_should_be_thrown(ArrayObject $arr)
+    {
+        if (!class_exists('\Error')) {
+            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
+        }
 
         $arr->ksort()->willThrow(new \Error());
 
-        $this->positiveMatch('throw', $arr, array('\Error'))->during('ksort', array());
+        $this->positiveMatch('throw', $arr, array(new \Error()))->during('ksort', array());
     }
 
     function it_accepts_a_method_during_which_an_exception_should_not_be_thrown(ArrayObject $arr)

--- a/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
@@ -50,7 +50,7 @@ class ThrowMatcherSpec extends ObjectBehavior
             throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
         }
 
-        $arr->ksort()->willThrow(new \Error());
+        $arr->ksort()->will(function(){ throw new \Error(); });
 
         $this->positiveMatch('throw', $arr, array(new \Error()))->during('ksort', array());
     }

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -284,7 +284,7 @@ class ThrowMatcher implements MatcherInterface
         }
 
         if (is_object($arguments[0])) {
-            if (interface_exists('\Throwable') && $arguments[0] instanceof \Throwable) {
+            if ($arguments[0] instanceof \Throwable) {
                 return $arguments[0];
             } elseif ($arguments[0] instanceof \Exception) {
                 return $arguments[0];

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -284,7 +284,7 @@ class ThrowMatcher implements MatcherInterface
         }
 
         if (is_object($arguments[0])) {
-            if (class_exists('\Throwable') && $arguments[0] instanceof \Throwable) {
+            if (interface_exists('\Throwable') && $arguments[0] instanceof \Throwable) {
                 return $arguments[0];
             } elseif ($arguments[0] instanceof \Exception) {
                 return $arguments[0];


### PR DESCRIPTION
Helps to fix https://github.com/phpspec/prophecy/issues/281.

`ThrowMatcher` was checking for a class `\Throwable` instead of an interface.

I've opened this against 2.5 as it is a bug that should probably be backported (prophecy is still using PHPSpec 2.x).

The build will fail until https://github.com/phpspec/prophecy/pull/288 is merged into a stable release.