### PR TITLE
Update the nyan-formatters suggestion to ~2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
 
     "suggest": {
-        "phpspec/nyan-formatters": "~2.0 – Adds Nyan formatters"
+        "phpspec/nyan-formatters": "Adds Nyan formatters"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
 
     "suggest": {
-        "phpspec/nyan-formatters": "~1.0 – Adds Nyan formatters"
+        "phpspec/nyan-formatters": "~2.0 – Adds Nyan formatters"
     },
 
     "autoload": {


### PR DESCRIPTION
The suggestion of `phpspec/nyan-formatters:~1.0` when installing phpspec >=3.0 is not satisfiable so I have bumped the suggested version number.