### PR TITLE
Don't fail the build when building against pre-releases of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,15 @@ matrix:
     - php: 5.6
     - php: hhvm
     - php: 7.0
-    - php: 7.1
-    - php: 7.1
+    - php: nightly
+    - php: nightly
       env: DEPENDENCIES='dev'
   allow_failures:
-    - env: DEPENDENCIES='dev'
+    - php: nightly
   fast_finish: true
 
 before_install:
-  - if [ ${TRAVIS_PHP_VERSION:0:4} != "hhvm" ] && [ ${TRAVIS_PHP_VERSION:0:3} != "7.1" ]; then phpenv config-rm xdebug.ini; fi
+  - if [ ${TRAVIS_PHP_VERSION:0:4} != "hhvm" ] && [ ${TRAVIS_PHP_VERSION:0:7} != "nightly" ]; then phpenv config-rm xdebug.ini; fi
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,16 @@ matrix:
     - php: 5.6
     - php: hhvm
     - php: 7.0
-    - php: nightly
-    - php: nightly
       env: DEPENDENCIES='dev'
+    - php: 7.1
+    - php: nightly
   allow_failures:
+    - php: 7.1
     - php: nightly
   fast_finish: true
 
 before_install:
-  - if [ ${TRAVIS_PHP_VERSION:0:4} != "hhvm" ] && [ ${TRAVIS_PHP_VERSION:0:7} != "nightly" ]; then phpenv config-rm xdebug.ini; fi
+  - if [ ${TRAVIS_PHP_VERSION:0:4} != "hhvm" ] && [ ${TRAVIS_PHP_VERSION:0:3} != "7.1" ] && [ ${TRAVIS_PHP_VERSION:0:7} != "nightly" ]; then phpenv config-rm xdebug.ini; fi
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master


### PR DESCRIPTION
I'm not sure how I feel about this yet, my other open PR is failing
because RC2 is failing the integration tests, that is also the cause
of the failing test on #1000 which @jameshalsall is working on.

I think it makes sense to test against the nightly builds since it
reveals issues earlier (for example, the RFC for disallowing null
parameters into `get_class` that passed 15/3 on October 9th has
already revealed some changes that are required in PhpSpec, I
have configured Travis to not panic too much about failures in
nightly builds because it is also likely to cause some false
positives.) – I think versions should only be added once they're
ready for production.

If this is merged, the other two open PRs should start passing.