### PR TITLE
Compatibility for PHP 7.2 get_class() changes

### DIFF
--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -70,7 +70,8 @@ final class MethodNotFoundListener implements EventSubscriberInterface
             return;
         }
 
-        $classname = get_class($exception->getSubject());
+        $subject = $exception->getSubject();
+        $classname = null === $subject ? get_class() : get_class($subject);
         $methodName = $exception->getMethodName();
         $this->methods[$classname .'::'.$methodName] = $exception->getArguments();
         $this->checkIfMethodNameAllowed($methodName);

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -110,7 +110,8 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
             return;
         }
 
-        $class = get_class($this->lastMethodCallEvent->getSubject());
+        $subject = $this->lastMethodCallEvent->getSubject();
+        $class = null === $subject ? get_class() : get_class($subject);
         $method = $this->lastMethodCallEvent->getMethod();
 
         if (!$this->methodAnalyser->methodIsEmpty($class, $method)) {

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -53,7 +53,8 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
             return;
         }
 
-        $className = get_class($exception->getSubject());
+        $subject = $exception->getSubject();
+        $className = null === $subject ? get_class() : get_class($subject);
         $this->methods[$className .'::'.$exception->getMethodName()] = $exception->getArguments();
     }
 


### PR DESCRIPTION
The RFC https://wiki.php.net/rfc/get_class_disallow_null_parameter has been implemented yesterday and phpSpec isn't compatible with it. The PR fixes the issue, while retaining backwards compatibility. 
