### PR TITLE
Add basic support for array objects in ArrayContainMatcher

### DIFF
--- a/spec/PhpSpec/Matcher/ArrayContainMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ArrayContainMatcherSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Matcher;
 
+use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -22,9 +23,14 @@ class ArrayContainMatcherSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('PhpSpec\Matcher\Matcher');
     }
 
-    function it_responds_to_contain()
+    function it_supports_arrays()
     {
         $this->supports('contain', array(), array(''))->shouldReturn(true);
+    }
+
+    function it_supports_array_objects()
+    {
+        $this->supports('contain', new \ArrayObject(), [''])->shouldReturn(true);
     }
 
     function it_matches_array_with_specified_value()
@@ -42,5 +48,17 @@ class ArrayContainMatcherSpec extends ObjectBehavior
     function it_matches_array_without_specified_value()
     {
         $this->shouldNotThrow()->duringNegativeMatch('contain', array(1,2,3), array('abc'));
+    }
+
+    function it_matches_array_object_with_specified_value()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('contain', new \ArrayObject([1, 2, 3]), array(1));
+    }
+
+    function it_does_not_match_array_object_without_specified_value()
+    {
+        $this->shouldThrow()->duringPositiveMatch('contain', new \ArrayObject([1, 2, 3]), ['abc']);
+        $this->shouldThrow(FailureException::class)
+            ->duringPositiveMatch('contain', new \ArrayObject([1, 2, 3]), [new \stdClass()]);
     }
 }

--- a/src/PhpSpec/Matcher/ArrayContainMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayContainMatcher.php
@@ -42,7 +42,7 @@ final class ArrayContainMatcher extends BasicMatcher
     {
         return 'contain' === $name
             && 1 == count($arguments)
-            && is_array($subject)
+            && (is_array($subject) || $subject instanceof \ArrayObject)
         ;
     }
 
@@ -54,6 +54,10 @@ final class ArrayContainMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments)
     {
+        if ($subject instanceof \ArrayObject) {
+            $subject = $subject->getArrayCopy();
+        }
+
         return in_array($arguments[0], $subject, true);
     }
 


### PR DESCRIPTION
Fixes issue raised in https://github.com/phpspec/prophecy/issues/206.

This allows the `ArrayContainMatcher` to work with `ArrayObject` instances as well as arrays, by basically using an array copy.

There may also be an argument for supporting `SplFixedArray`

EDIT: If this is of value then I will add the same support to the other Array matchers