### PR TITLE
Tweak badges and links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,14 +4,14 @@ phpspec
 The main website with documentation is at `http://www.phpspec.net <http://www.phpspec.net>`_.
 
 .. image:: https://travis-ci.org/phpspec/phpspec.svg?branch=master
-   :target: http://travis-ci.org/phpspec/phpspec
+   :target: https://travis-ci.org/phpspec/phpspec
    :alt: Master Travis Build Status
 
-.. image:: https://scrutinizer-ci.com/g/phpspec/phpspec/badges/quality-score.png?b=master
+.. image:: https://img.shields.io/scrutinizer/g/phpspec/phpspec.svg
    :target: https://scrutinizer-ci.com/g/phpspec/phpspec/build-status/master
    :alt: Master Scrutinizer Quality Score
 
-.. image:: https://ci.appveyor.com/api/projects/status/wce4nun9re76ocp6/branch/master?svg=true
+.. image:: https://img.shields.io/appveyor/ci/ciaranmcnulty/phpspec.svg
    :target: https://ci.appveyor.com/project/ciaranmcnulty/phpspec/branch/master
    :alt: AppVeyor build status
 
@@ -34,9 +34,9 @@ The main website with documentation is at `http://www.phpspec.net <http://www.ph
 Installing Dependencies
 -----------------------
 
-Dependencies are handled via `composer <http://getcomposer.org>`_::
+Dependencies are handled via `composer <https://getcomposer.org>`_::
 
-   wget -nc http://getcomposer.org/composer.phar
+   wget -nc https://getcomposer.org/composer.phar
    php composer.phar install
 
 Developer's mailing list

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The main website with documentation is at `http://www.phpspec.net <http://www.ph
    :target: https://scrutinizer-ci.com/g/phpspec/phpspec/build-status/master
    :alt: Master Scrutinizer Quality Score
 
-.. image:: https://img.shields.io/appveyor/ci/ciaranmcnulty/phpspec.svg
+.. image:: https://img.shields.io/appveyor/ci/ciaranmcnulty/phpspec/master.svg
    :target: https://ci.appveyor.com/project/ciaranmcnulty/phpspec/branch/master
    :alt: AppVeyor build status
 


### PR DESCRIPTION
- Github has a nasty habit of caching the Scrutinizer score badge for several days, something shields.io overcomes
- Travis CI is now exclusively HTTPS, as is getcomposer.org