### PR TITLE
Use an easier to maintain way of disabling xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   fast_finish: true
 
 before_install:
-  - if [ ${TRAVIS_PHP_VERSION:0:4} != "hhvm" ] && [ ${TRAVIS_PHP_VERSION:0:3} != "7.1" ] && [ ${TRAVIS_PHP_VERSION:0:7} != "nightly" ]; then phpenv config-rm xdebug.ini; fi
+  - phpenv config-rm xdebug.ini || true
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master


### PR DESCRIPTION
Originally had it as `phpenv config-rm xdebug.ini 2>/dev/null || :` but Travis didn't like the colon (null command that returns `0`) and `true` is probably more obvious.