### PR TITLE
Implements Best Match Locator

### DIFF
--- a/docs/cookbook/configuration.rst
+++ b/docs/cookbook/configuration.rst
@@ -68,8 +68,8 @@ describing. In phpspec, you can group specification files by a certain namespace
   specifications. The complete namespace for specifications is
   ``%spec_prefix%\%namespace%``;
 * ``src_path`` [**default**: ``src``] - The path to store the generated
-  classes. By default paths are relative to the location where **phpspec** was 
-  invoked. **phpspec** creates the directories if they do not exist. This does 
+  classes. By default paths are relative to the location where **phpspec** was
+  invoked. **phpspec** creates the directories if they do not exist. This does
   not include the namespace directories;
 * ``spec_path`` [**default**: ``.``] - The path of the specifications. This
   does not include the spec prefix or namespace.
@@ -148,6 +148,31 @@ running:
     $ bin/phpspec describe Acme/Text/Markdown
 
 will create the spec in the file ``acme_spec/spec/Acme/Text/MarkdownSpec.php``
+
+Namespace in Multiple Directories
+---------------------------------
+
+**phpspec** supports classes with namespace in multiple directories. Simply
+specify multiple suites in your configuration:
+
+.. code-block:: yaml
+    suites:
+        acme_one:
+            src_path:  %paths.config%/src-one
+            spec_path: %paths.config%/spec-one
+
+        acme_two:
+          src_path:    %paths.config%/src-two
+          spec_path:   %paths.config%/spec-two
+
+Given the configuration above, running:
+
+.. code-block:: bash
+
+    $ bin/phpspec describe Acme/Text/Markdown --suite=acme_one
+
+will create the spec in the file ``spec-one/spec/Acme/Text/MarkdownSpec.php`` and the class will be created
+in ``src-one/Markdown.php``.
 
 Formatter
 ---------

--- a/docs/cookbook/configuration.rst
+++ b/docs/cookbook/configuration.rst
@@ -172,7 +172,7 @@ Given the configuration above, running:
     $ bin/phpspec describe Acme/Text/Markdown --suite=acme_one
 
 will create the spec in the file ``spec-one/spec/Acme/Text/MarkdownSpec.php`` and the class will be created
-in ``src-one/Markdown.php``.
+in ``src-one/Acme/Text/MarkdownSpec.php``.
 
 Formatter
 ---------

--- a/docs/cookbook/console.rst
+++ b/docs/cookbook/console.rst
@@ -57,9 +57,16 @@ Note that ``/`` is used as the separator. To use ``\`` it must be quoted:
 
     $ bin/phpspec describe "Namespace\ClassName"
 
-The ``describe`` command has no additional options. It will create a spec class in the `spec`
-directory. To configure a different path to the specs you can use :ref:`suites <configuration-suites>`
-in the configuration file.
+By default, the ``describe`` will create a spec class in the `spec` directory. To configure a different path to the
+specs you can use :ref:`suites <configuration-suites>` in the configuration file. If multiple suites are defined,
+**phpspec** will attempt to match a give ClassName to its appropriate suite. On cases where a ClassName matches
+multiple suites, a suite must be specified:
+
+.. code-block:: bash
+
+    $ bin/phpspec describe "Namespace\ClassName" --suite=<suite_name>
+
+.. attention:: Describing a ClassName that matches multiple suite and not specifying the suite will result to an error.
 
 Run Command
 -----------

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -82,9 +82,22 @@ class ApplicationContext implements Context
      */
     public function iDescribeTheClass($class)
     {
-        $arguments = array(
-            'command' => 'describe',
-            'class' => $class
+        $arguments = $this->getCommonDescribeCommandArguments($class);
+
+        if ($this->tester->run($arguments, array('interactive' => false)) !== 0) {
+            throw new \Exception('Test runner exited with an error');
+        }
+    }
+
+    /**
+     * @Given I have started describing the :class class and specified :suite suite
+     * @Given I start describing the :class class and specified :suite suite
+     */
+    public function iDescribeTheClassAndSpecifiedSuite($class, $suite)
+    {
+        $arguments = array_merge(
+            $this->getCommonDescribeCommandArguments($class),
+            ['--suite' => $suite]
         );
 
         if ($this->tester->run($arguments, array('interactive' => false)) !== 0) {
@@ -397,4 +410,30 @@ class ApplicationContext implements Context
         $this->checkApplicationOutput('name contains reserved keyword');
     }
 
+    /**
+     * @When I describe the :class class, I should see a :exception error
+     */
+    public function iDescribeTheClassThenIShouldSeeAError($class, $exception)
+    {
+        $arguments = $this->getCommonDescribeCommandArguments($class);
+
+        if ($this->tester->run($arguments, array('interactive' => false)) === 0) {
+            throw new \Exception('Test runner was expecting an error but none was thrown');
+        }
+
+        $this->checkApplicationOutput((string)$exception);
+    }
+
+    /**
+     * @param  string $class
+     *
+     * @return array
+     */
+    private function getCommonDescribeCommandArguments($class)
+    {
+        return array(
+            'command' => 'describe',
+            'class' => $class
+        );
+    }
 }

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -33,6 +33,28 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Given I have started describing the :class class and specified :suite suite
+     * @Given I start describing the :class class and specified :suite suite
+     */
+    public function iHaveStartedDescribingTheClassAndSpecifiedSuite($class, $suite)
+    {
+        $command = sprintf(
+            '%s %s %s %s',
+            $this->buildPhpSpecCmd(),
+            'describe', escapeshellarg($class),
+            "--suite={$suite}"
+        );
+
+        $process = new Process($command);
+
+        $process->run();
+
+        if ($process->getExitCode() !== 0) {
+            throw new \Exception('The describe process ended with an error');
+        }
+    }
+
+    /**
      * @When I run phpspec and answer :answer when asked if I want to generate the code
      */
     public function iRunPhpspecAndAnswerWhenAskedIfIWantToGenerateTheCode($answer)

--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -172,12 +172,12 @@ Feature: Developer generates a class
     """
     suites:
       spec_a:
-        src_path:    %paths.config%/src-a
-        spec_path:   %paths.config%/spec-a
+        src_path:    '%paths.config%/src-a'
+        spec_path:   '%paths.config%/spec-a'
 
       spec_b:
-        src_path:    %paths.config%/src-b
-        spec_path:   %paths.config%/spec-b
+        src_path:    '%paths.config%/src-b'
+        spec_path:   '%paths.config%/spec-b'
     """
     And I have started describing the "Behat\Tests\MyNamespace\Markdown" class and specified "spec_a" suite
     When I run phpspec and answer "y" when asked if I want to generate the code

--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -165,3 +165,30 @@ Feature: Developer generates a class
     But I have not configured an autoloader
     When I run phpspec and answer "y" when asked if I want to generate the code
     Then I should see an error about the missing autoloader
+
+  @isolated
+  Scenario: Generating a class from spec described using suite option
+    Given the config file contains:
+    """
+    suites:
+      spec_a:
+        src_path:    %paths.config%/src-a
+        spec_path:   %paths.config%/spec-a
+
+      spec_b:
+        src_path:    %paths.config%/src-b
+        spec_path:   %paths.config%/spec-b
+    """
+    And I have started describing the "Behat\Tests\MyNamespace\Markdown" class and specified "spec_a" suite
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then a new class should be generated in the "src-a/Behat/Tests/MyNamespace/Markdown.php":
+    """
+    <?php
+
+    namespace Behat\Tests\MyNamespace;
+
+    class Markdown
+    {
+    }
+
+    """

--- a/features/code_generation/developer_generates_spec.feature
+++ b/features/code_generation/developer_generates_spec.feature
@@ -170,3 +170,125 @@ Feature: Developer generates a spec
     Given I have started describing the "Namespace/ClassExample1/Markdown" class
     Then I should an error about invalid class name "Namespace\ClassExample1\Markdown" to generate spec for
     And there should be no file "spec/Namespace/ClassExample1/MarkdownSpec.php"
+
+  Scenario: Error is thrown when generating a spec for a class that matches multiple suites
+    Given the config file contains:
+      """
+      suites:
+        spec_a:
+          src_path:    %paths.config%/src-a
+          spec_path:   %paths.config%/spec-a
+
+        spec_b:
+          src_path:    %paths.config%/src-b
+          spec_path:   %paths.config%/spec-b
+
+        spec_match:
+          namespace:   Behat\CodeGeneration
+
+      """
+    When I describe the "ClassThatMatchMultipleSuite" class, I should see a "Can not find appropriate suite scope" error
+
+  Scenario: Generating a spec for a class matching a namespace
+    Given the config file contains:
+      """
+      suites:
+        spec_a:
+          src_path:    %paths.config%/src-a
+          spec_path:   %paths.config%/spec-a
+
+        spec_b:
+          src_path:    %paths.config%/src-b
+          spec_path:   %paths.config%/spec-b
+
+        spec_match:
+          namespace:   Behat\CodeGeneration
+
+      """
+    When I start describing the "Behat\CodeGeneration\MarkDown" class
+    Then a new spec should be generated in the "spec/Behat/CodeGeneration/MarkDownSpec.php":
+      """
+      <?php
+
+      namespace spec\Behat\CodeGeneration;
+
+      use Behat\CodeGeneration\MarkDown;
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class MarkDownSpec extends ObjectBehavior
+      {
+          function it_is_initializable()
+          {
+              $this->shouldHaveType(MarkDown::class);
+          }
+      }
+
+      """
+
+  Scenario: Generating a spec for a class matching a deeper namespace
+    Given the config file contains:
+      """
+      suites:
+        spec_shallow:
+          namespace: Behat
+          spec_path: spec-shallow
+        spec_deep:
+          namespace: Behat\CodeGeneration
+          spec_path: spec-deep
+
+      """
+    When I start describing the "Behat\CodeGeneration\MarkDown" class
+    Then a new spec should be generated in the "spec-deep/spec/Behat/CodeGeneration/MarkDownSpec.php":
+      """
+      <?php
+
+      namespace spec\Behat\CodeGeneration;
+
+      use Behat\CodeGeneration\MarkDown;
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class MarkDownSpec extends ObjectBehavior
+      {
+          function it_is_initializable()
+          {
+              $this->shouldHaveType(MarkDown::class);
+          }
+      }
+
+      """
+
+  Scenario: Generating a spec for a class with specified suite
+    Given the config file contains:
+      """
+      suites:
+        spec_a:
+          src_path:    %paths.config%/src-a
+          spec_path:   %paths.config%/spec-a
+
+        spec_b:
+          src_path:    %paths.config%/src-b
+          spec_path:   %paths.config%/spec-b
+
+      """
+    When I start describing the "Behat\CodeGeneration\MarkDown" class and specified "spec_b" suite
+    Then a new spec should be generated in the "spec-b/spec/Behat/CodeGeneration/MarkDownSpec.php":
+      """
+      <?php
+
+      namespace spec\Behat\CodeGeneration;
+
+      use Behat\CodeGeneration\MarkDown;
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class MarkDownSpec extends ObjectBehavior
+      {
+          function it_is_initializable()
+          {
+              $this->shouldHaveType(MarkDown::class);
+          }
+      }
+
+      """

--- a/features/code_generation/developer_generates_spec.feature
+++ b/features/code_generation/developer_generates_spec.feature
@@ -176,12 +176,12 @@ Feature: Developer generates a spec
       """
       suites:
         spec_a:
-          src_path:    %paths.config%/src-a
-          spec_path:   %paths.config%/spec-a
+          src_path:    '%paths.config%/src-a'
+          spec_path:   '%paths.config%/spec-a'
 
         spec_b:
-          src_path:    %paths.config%/src-b
-          spec_path:   %paths.config%/spec-b
+          src_path:    '%paths.config%/src-b'
+          spec_path:   '%paths.config%/spec-b'
 
         spec_match:
           namespace:   Behat\CodeGeneration
@@ -194,12 +194,12 @@ Feature: Developer generates a spec
       """
       suites:
         spec_a:
-          src_path:    %paths.config%/src-a
-          spec_path:   %paths.config%/spec-a
+          src_path:    '%paths.config%/src-a'
+          spec_path:   '%paths.config%/spec-a'
 
         spec_b:
-          src_path:    %paths.config%/src-b
-          spec_path:   %paths.config%/spec-b
+          src_path:    '%paths.config%/src-b'
+          spec_path:   '%paths.config%/spec-b'
 
         spec_match:
           namespace:   Behat\CodeGeneration
@@ -264,12 +264,12 @@ Feature: Developer generates a spec
       """
       suites:
         spec_a:
-          src_path:    %paths.config%/src-a
-          spec_path:   %paths.config%/spec-a
+          src_path:    '%paths.config%/src-a'
+          spec_path:   '%paths.config%/spec-a'
 
         spec_b:
-          src_path:    %paths.config%/src-b
-          spec_path:   %paths.config%/spec-b
+          src_path:    '%paths.config%/src-b'
+          spec_path:   '%paths.config%/spec-b'
 
       """
     When I start describing the "Behat\CodeGeneration\MarkDown" class and specified "spec_b" suite

--- a/spec/PhpSpec/Locator/BestMatchResourceManagerSpec.php
+++ b/spec/PhpSpec/Locator/BestMatchResourceManagerSpec.php
@@ -15,8 +15,8 @@ class BestMatchResourceManagerSpec extends ObjectBehavior
         $locator2->getPriority()->willReturn(10);
     }
 
-    function it_locates_resources_using_all_registered_locators($locator1, $locator2,
-        Resource $resource1, Resource $resource2, Resource $resource3
+    function it_locates_resources_using_all_registered_locators(
+        $locator1, $locator2, Resource $resource1, Resource $resource2, Resource $resource3
     ) {
         $this->registerLocator($locator1);
         $this->registerLocator($locator2);
@@ -33,8 +33,8 @@ class BestMatchResourceManagerSpec extends ObjectBehavior
         $this->locateResources('s:query')->shouldReturn(array($resource1, $resource3, $resource2));
     }
 
-    function it_locates_all_locators_resources_if_query_string_is_empty($locator1, $locator2,
-                                                                        Resource $resource1, Resource $resource2, Resource $resource3
+    function it_locates_all_locators_resources_if_query_string_is_empty(
+        $locator1, $locator2, Resource $resource1, Resource $resource2, Resource $resource3
     ) {
         $this->registerLocator($locator1);
         $this->registerLocator($locator2);

--- a/spec/PhpSpec/Locator/BestMatchResourceManagerSpec.php
+++ b/spec/PhpSpec/Locator/BestMatchResourceManagerSpec.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace spec\PhpSpec\Locator;
+
+use PhpSpec\Exception\Locator\ResourceCreationException;
+use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\ResourceLocator;
+use PhpSpec\ObjectBehavior;
+
+class BestMatchResourceManagerSpec extends ObjectBehavior
+{
+    function let(ResourceLocator $locator1, ResourceLocator $locator2)
+    {
+        $locator1->getPriority()->willReturn(5);
+        $locator2->getPriority()->willReturn(10);
+    }
+
+    function it_locates_resources_using_all_registered_locators($locator1, $locator2,
+        Resource $resource1, Resource $resource2, Resource $resource3
+    ) {
+        $this->registerLocator($locator1);
+        $this->registerLocator($locator2);
+
+        $locator1->supportsQuery('s:query')->willReturn(true);
+        $locator1->findResources('s:query')->willReturn(array($resource3, $resource2));
+        $locator2->supportsQuery('s:query')->willReturn(true);
+        $locator2->findResources('s:query')->willReturn(array($resource1));
+
+        $resource1->getSpecClassname()->willReturn('Some\Spec1');
+        $resource2->getSpecClassname()->willReturn('Some\Spec2');
+        $resource3->getSpecClassname()->willReturn('Some\Spec3');
+
+        $this->locateResources('s:query')->shouldReturn(array($resource1, $resource3, $resource2));
+    }
+
+    function it_locates_all_locators_resources_if_query_string_is_empty($locator1, $locator2,
+                                                                        Resource $resource1, Resource $resource2, Resource $resource3
+    ) {
+        $this->registerLocator($locator1);
+        $this->registerLocator($locator2);
+
+        $locator1->getAllResources()->willReturn(array($resource3, $resource2));
+        $locator2->getAllResources()->willReturn(array($resource1));
+
+        $resource1->getSpecClassname()->willReturn('Some\Spec1');
+        $resource2->getSpecClassname()->willReturn('Some\Spec2');
+        $resource3->getSpecClassname()->willReturn('Some\Spec3');
+
+        $this->locateResources('')->shouldReturn(array($resource1, $resource3, $resource2));
+    }
+
+    function it_returns_empty_array_if_registered_locators_do_not_support_query($locator1)
+    {
+        $this->registerLocator($locator1);
+
+        $locator1->supportsQuery('s:query')->willReturn(false);
+        $locator1->findResources('s:query')->shouldNotBeCalled();
+
+        $this->locateResources('s:query')->shouldReturn(array());
+    }
+
+    function it_throws_an_exception_if_multiple_locators_best_matches_a_classname($locator1, $locator2)
+    {
+        $this->registerLocator($locator1);
+        $this->registerLocator($locator2);
+
+        $subjectClass = 'Some\Class';
+        $locator1->calculateMatchScore($subjectClass)->willReturn(2);
+        $locator2->calculateMatchScore($subjectClass)->willReturn(2);
+
+        $this->shouldThrow(ResourceCreationException::class)->duringCreateResource($subjectClass);
+    }
+
+    function it_throws_an_exception_if_locators_do_not_support_classname($locator1)
+    {
+        $this->registerLocator($locator1);
+
+        $locator1->supportsClass('Some\Class')->willReturn(false);
+
+        $this->shouldThrow('RuntimeException')->duringCreateResource('Some\Class');
+    }
+
+    function it_does_not_allow_two_resources_for_the_same_spec(
+        $locator1, $locator2, Resource $resource1, Resource $resource2
+    ) {
+        $this->registerLocator($locator1);
+        $this->registerLocator($locator2);
+
+        $resource1->getSpecClassname()->willReturn('Some\Spec');
+        $resource2->getSpecClassname()->willReturn('Some\Spec');
+
+        $locator1->getAllResources()->willReturn(array($resource1));
+        $locator2->getAllResources()->willReturn(array($resource2));
+
+        $this->locateResources('')->shouldReturn(array($resource2));
+    }
+
+    function it_uses_the_resource_from_the_highest_priority_locator_when_duplicates_occur(
+        $locator1, $locator2, Resource $resource1, Resource $resource2
+    ) {
+        $locator1->getPriority()->willReturn(2);
+        $locator2->getPriority()->willReturn(1);
+
+        $this->registerLocator($locator1);
+        $this->registerLocator($locator2);
+
+        $resource1->getSpecClassname()->willReturn('Some\Spec');
+        $resource2->getSpecClassname()->willReturn('Some\Spec');
+
+        $locator1->getAllResources()->willReturn(array($resource1));
+        $locator2->getAllResources()->willReturn(array($resource2));
+
+        $this->locateResources('')->shouldReturn(array($resource1));
+    }
+}

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -390,7 +390,7 @@ final class ContainerAssembler
     private function setupLocator(IndexedServiceContainer $container)
     {
         $container->define('locator.resource_manager', function (IndexedServiceContainer $c) {
-            $manager = new Locator\PrioritizedResourceManager();
+            $manager = new Locator\BestMatchResourceManager();
 
             array_map(
                 array($manager, 'registerLocator'),

--- a/src/PhpSpec/Locator/BestMatchResourceManager.php
+++ b/src/PhpSpec/Locator/BestMatchResourceManager.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Locator;
+
+use PhpSpec\Exception\Locator\ResourceCreationException;
+
+final class BestMatchResourceManager implements ResourceManager
+{
+    /**
+     * @var ResourceLocator[]
+     */
+    private $locators = array();
+
+    /**
+     * @param ResourceLocator $locator
+     */
+    public function registerLocator(ResourceLocator $locator)
+    {
+        $this->locators[] = $locator;
+
+        @usort($this->locators, function (ResourceLocator $locator1, ResourceLocator $locator2) {
+            return $locator2->getPriority() - $locator1->getPriority();
+        });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function locateResources(string $query)
+    {
+        $resources = array();
+        foreach ($this->locators as $locator) {
+            if (empty($query)) {
+                $resources = array_merge($resources, $locator->getAllResources());
+                continue;
+            }
+
+            if (!$locator->supportsQuery($query)) {
+                continue;
+            }
+
+            $resources = array_merge($resources, $locator->findResources($query));
+        }
+
+        return $this->removeDuplicateResources($resources);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createResource(string $classname): \PhpSpec\Locator\Resource
+    {
+        $matchedLocators = $this->sortAndGroupLocatorsByMatchScore($classname);
+        $bestMatchedLocators = $this->removeDuplicateLocators(reset($matchedLocators));
+        if (count($bestMatchedLocators) === 1) {
+            $locator = array_pop($bestMatchedLocators);
+            return $locator->createResource($classname);
+        }
+
+        throw new ResourceCreationException(
+            sprintf(
+                'Can not find appropriate suite scope for class `%s`.',
+                $classname
+            )
+        );
+    }
+
+    /**
+     * @param array $resources
+     *
+     * @return Resource[]
+     */
+    private function removeDuplicateResources(array $resources)
+    {
+        $filteredResources = array();
+
+        foreach ($resources as $resource) {
+            if (!array_key_exists($resource->getSpecClassname(), $filteredResources)) {
+                $filteredResources[$resource->getSpecClassname()] = $resource;
+            }
+        }
+
+        return array_values($filteredResources);
+    }
+
+    /**
+     * @param  string $classname
+     *
+     * @return array
+     */
+    private function sortAndGroupLocatorsByMatchScore($classname)
+    {
+        $matchedLocators = [];
+        foreach ($this->locators as $locator) {
+            if (($matchScore = $locator->calculateMatchScore($classname)) > 0) {
+                $matchedLocators[$matchScore][] = $locator;
+            }
+        }
+        krsort($matchedLocators);
+        return $matchedLocators;
+    }
+
+    /**
+     * @param  ResourceLocator[] $locators
+     *
+     * @return array
+     */
+    private function removeDuplicateLocators(array $locators)
+    {
+        return array_unique($locators, SORT_REGULAR);
+    }
+}

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -223,6 +223,19 @@ class PSR0Locator implements ResourceLocator
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function calculateMatchScore(string $classname): int
+    {
+        if ($this->supportsClass($classname)) {
+            $score = substr_count(str_replace(['\\', '/'], '\\', trim($this->srcNamespace, '\\')), '\\');
+            return $score + (($this->supportsQuery($classname)) ? 2 : 1);
+        }
+
+        return 0;
+    }
+
+    /**
      * @param string $classname
      *
      * @return null|PSR0Resource

--- a/src/PhpSpec/Locator/ResourceLocator.php
+++ b/src/PhpSpec/Locator/ResourceLocator.php
@@ -52,4 +52,11 @@ interface ResourceLocator
      * @return integer
      */
     public function getPriority(): int;
+
+    /**
+     * @param  string $classname
+     *
+     * @return int
+     */
+    public function calculateMatchScore(string $classname): int;
 }


### PR DESCRIPTION
* Replaces PrioritizedResourceManager
* Adds `suite` option to describe command
* Potentially renders ResourceLocator::getPriority() deprecated

============================================================
Composer allows for classes of the same namespace to be located on multiple paths. Phpspec makes the decision which locator to use based on `priority`. It would be better if the developer is informed that a class being described matches multiple suites and thus be allowed to specify a suite to use. This will make Phpspec easier to work with when used on projects using old frameworks (e.g., Code Igniter).