### PR TITLE
[WIP] Fix errors on PHP 7

### DIFF
--- a/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
+++ b/features/exception_handling/developer_is_notified_which_example_caused_a_fatal_error.feature
@@ -1,4 +1,3 @@
-@php:~5.6
 Feature: Developer is notified of which scenario caused a fatal error
   As a Developer
   I want to know in which scenario or example my script was running

--- a/spec/PhpSpec/Process/Shutdown/ShutdownSpec.php
+++ b/spec/PhpSpec/Process/Shutdown/ShutdownSpec.php
@@ -3,19 +3,21 @@
 namespace spec\PhpSpec\Process\Shutdown;
 
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Process\Shutdown\Shutdown;
 use PhpSpec\Process\Shutdown\ShutdownAction;
 use Prophecy\Argument;
 
 class ShutdownSpec extends ObjectBehavior
 {
-    function it_has_type_shutdown()
+    function it_is_initializable()
     {
-        $this->beAnInstanceOf('PhpSpec/Process/Shutdown/Shutdown');
+        $this->shouldHaveType(Shutdown::class);
     }
 
-    function it_runs_through_all_registered_actions(ShutdownAction $action)
+    function it_runs_no_shutdown_actions_when_there_is_no_error(ShutdownAction $action)
     {
-        $action->runAction(null)->shouldBeCalled();
+        $action->runAction(Argument::any())->shouldNotBeCalled();
+
         $this->registerAction($action);
         $this->runShutdown();
     }

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -96,10 +96,10 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
     public function displayFatal(CurrentExampleTracker $currentExample, $error)
     {
         if (
-            (null !== $error && ($currentExample->getCurrentExample() || $error['type'] == E_ERROR)) ||
+            (($currentExample->getCurrentExample() || $error['type'] == E_ERROR)) ||
             (is_null($currentExample->getCurrentExample()) && defined('HHVM_VERSION'))
         ) {
-            ini_set('display_errors', "stderr");
+            ini_set('display_errors', 'stderr');
             $failedOpen = ($this->io->isDecorated()) ? '<failed>' : '';
             $failedClosed = ($this->io->isDecorated()) ? '</failed>' : '';
             $failedCross = ($this->io->isDecorated()) ? '✘' : '';

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -106,9 +106,9 @@ final class ThrowMatcher implements Matcher
 
         try {
             call_user_func_array($callable, $arguments);
-        } catch (\Exception $e) {
-            $exceptionThrown = $e;
         } catch (\Throwable $e) {
+            $exceptionThrown = $e;
+        } catch (\Exception $e) {
             $exceptionThrown = $e;
         }
 

--- a/src/PhpSpec/Process/Shutdown/Shutdown.php
+++ b/src/PhpSpec/Process/Shutdown/Shutdown.php
@@ -19,13 +19,12 @@ final class Shutdown
 
     public function __construct()
     {
-        $this->actions = array();
+        $this->actions = [];
     }
 
     public function registerShutdown()
     {
-        error_reporting(error_reporting() & ~E_ERROR);
-        register_shutdown_function(array($this, 'runShutdown'));
+        register_shutdown_function([$this, 'runShutdown']);
     }
 
     public function registerAction(ShutdownAction $action)
@@ -35,10 +34,10 @@ final class Shutdown
 
     public function runShutdown()
     {
-        $error = $this->getFatalError();
-
-        foreach ($this->actions as $fatalErrorActions) {
-            $fatalErrorActions->runAction($error);
+        if ($error = $this->getFatalError()) {
+            foreach ($this->actions as $fatalErrorActions) {
+                $fatalErrorActions->runAction($error);
+            }
         }
     }
 
@@ -46,6 +45,6 @@ final class Shutdown
     {
         $error = error_get_last();
 
-        return (null !== $error) && (bool) (E_ERROR & $error['type']) ? $error : null;
+        return $error;
     }
 }

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -49,10 +49,10 @@ final class ErrorMaintainer implements Maintainer
     }
 
     /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
+     * @param ExampleNode         $example
+     * @param Specification       $context
+     * @param MatcherManager      $matchers
+     * @param CollaboratorManager $collaborators
      */
     public function prepare(
         ExampleNode $example,
@@ -60,14 +60,14 @@ final class ErrorMaintainer implements Maintainer
         MatcherManager $matchers,
         CollaboratorManager $collaborators
     ) {
-        $this->errorHandler = set_error_handler(array($this, 'errorHandler'), $this->errorLevel);
+        $this->errorHandler = set_error_handler([$this, 'errorHandler'], $this->errorLevel);
     }
 
     /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
+     * @param ExampleNode         $example
+     * @param Specification       $context
+     * @param MatcherManager      $matchers
+     * @param CollaboratorManager $collaborators
      */
     public function teardown(
         ExampleNode $example,
@@ -100,11 +100,11 @@ final class ErrorMaintainer implements Maintainer
      * @param string  $file
      * @param integer $line
      *
-     * @return Boolean
+     * @return bool
      *
      * @throws ExampleException\ErrorException
      */
-    final public function errorHandler($level, $message, $file, $line)
+    public function errorHandler($level, $message, $file, $line)
     {
         $regex = '/^Argument (\d)+ passed to (?:(?P<class>[\w\\\]+)::)?(\w+)\(\)' .
                  ' must (?:be an instance of|implement interface) ([\w\\\]+),(?: instance of)? ([\w\\\]+) given/';


### PR DESCRIPTION
Sort of resolves issue #999 – when removing the `@php:~5.6` annotation, errors are not being output in PHP 7 since most fatals are now an instance of `\Error` – this initial work fixes that but I kind of think the `Shutdown` and `ConsoleFormatter` (since `displayFatal` is always called even if no error has occurred) are in need of some refactoring, at the moment the `Shutdown` process is only used to handle fatals, but will there ever be use-cases for registering custom shutdown methods?

When I write _sort of_ resolves #999, this fixes the issue with fatal errors being shown (in a formatted way) in PHP 7+, but the issue in #999 would have looped infinitely unless Xdebug is enabled and has a `max_nesting_limit` set, and when Xdebug throws an `E_ERROR` the custom registered shutdown function doesn't get reached.