### PR TITLE
Prepare for a stable release of PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,10 @@ matrix:
     - php: 5.6
     - php: hhvm
     - php: 7.0
-      env: DEPENDENCIES='dev'
     - php: 7.1
+      env: DEPENDENCIES='dev'
     - php: nightly
   allow_failures:
-    - php: 7.1
     - php: nightly
   fast_finish: true
 


### PR DESCRIPTION
Removes 7.1 from the allowed failures and tests the latest development dependencies against 7.1.