### PR TITLE
Avoid using the Application::getTerminalWidth() method

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
 use Symfony\Component\Yaml\Yaml;
 use PhpSpec\ServiceContainer\IndexedServiceContainer;
 use PhpSpec\Extension;
@@ -84,7 +85,9 @@ final class Application extends BaseApplication
 
         $this->setDispatcher($this->container->get('console_event_dispatcher'));
 
-        $this->container->get('console.io')->setConsoleWidth($this->getTerminalWidth());
+        $this->container->get('console.io')->setConsoleWidth(
+            class_exists(Terminal::class) ? (new Terminal())->getWidth() : $this->getTerminalWidth()
+        );
 
         StreamWrapper::reset();
         foreach ($this->container->getByTag('loader.resource_loader.spec_transformer') as $transformer) {


### PR DESCRIPTION
Since the release of Symfony/console 3.2 yesterday, the Application::getTerminalWidth() method is throwing a deprecated warning.

More info: https://github.com/symfony/console/blob/master/Application.php#L703
This is causing Travis to fail on one of the projects I maintain.