### PR TITLE
Bump sebastian/exporter version to 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php":                      "^5.6 || ^7.0",
         "phpspec/prophecy":         "^1.5",
         "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "^2.0",
+        "sebastian/exporter":       "^1.0 || ^2.0",
         "symfony/console":          "^2.7 || ^3.0",
         "symfony/event-dispatcher": "^2.7 || ^3.0",
         "symfony/process":          "^2.7 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php":                      "^5.6 || ^7.0",
         "phpspec/prophecy":         "^1.5",
         "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "^1.0",
+        "sebastian/exporter":       "^2.0",
         "symfony/console":          "^2.7 || ^3.0",
         "symfony/event-dispatcher": "^2.7 || ^3.0",
         "symfony/process":          "^2.7 || ^3.0",


### PR DESCRIPTION
This prevents installation problems with current versions of PHPUnit.