### PR TITLE
Reduce verbosity of the deploy logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
 before_deploy:
   - curl -LSs https://box-project.github.io/box2/installer.php | php
   - export PATH=.:$PATH
-  - rm -Rfv ./vendor
+  - rm -Rf ./vendor
   - composer install --no-dev -o
   - box.phar build
 


### PR DESCRIPTION
Listing all files from the vendor folder when removing them makes the log too big for the travis UI for something which is not relevant