### PR TITLE
Use more compact formatters on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ install:
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
 script:
-   - bin/phpspec run --format=pretty
-   - ./vendor/bin/phpunit --testdox
-   - ./vendor/bin/behat --format=pretty
+   - bin/phpspec run --format=dot
+   - ./vendor/bin/phpunit
+   - ./vendor/bin/behat --format=progress
 
 before_deploy:
   - curl -LSs https://box-project.github.io/box2/installer.php | php

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,6 @@ install:
 
 test_script:
     - cd c:\projects\phpspec
-    - php bin\phpspec run --format=pretty
-    - php vendor\phpunit\phpunit\phpunit --testdox
-    - php vendor\behat\behat\bin\behat --format=pretty --tags="~@php-version,@php5.4&&~@hhvm"
+    - php bin\phpspec run --format=dot
+    - php vendor\phpunit\phpunit\phpunit
+    - php vendor\behat\behat\bin\behat --format=progress --tags="~@php-version,@php5.4&&~@hhvm"


### PR DESCRIPTION
The pretty formatter actually make it really hard to see why the CI build failed, because the failure is somewhere in the middle of a very long scroll.
The progress formatter of Behat and PHPunit (and its dot equivalent in PhpSpec) is actually better for CI, as it gives room to failures rather than to successful cases, and these are the one we want to see on CI (going to see details for a green build is not the common usage for the CI server)