### PR TITLE
Deprecate the Resource interface

### DIFF
--- a/docs/manual/upgrading-to-phpspec-4.rst
+++ b/docs/manual/upgrading-to-phpspec-4.rst
@@ -1,0 +1,10 @@
+Upgrading to phpspec 4
+======================
+
+Here is a guide to upgrading a test suite or an extension, based on BC-breaking
+changes made in phpspec 4.
+
+Upgrading for Extension Authors
+-------------------------------
+
+- ``PhpSpec\Locator\Resource`` is now ``PhpSpec\Locator\CompositeResource``

--- a/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
@@ -9,7 +9,7 @@ use Prophecy\Argument;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Util\Filesystem;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 class ClassGeneratorSpec extends ObjectBehavior
 {
@@ -23,12 +23,12 @@ class ClassGeneratorSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('PhpSpec\CodeGenerator\Generator\Generator');
     }
 
-    function it_supports_class_generation(Resource $resource)
+    function it_supports_class_generation(CompositeResource $resource)
     {
         $this->supports($resource, 'class', array())->shouldReturn(true);
     }
 
-    function it_does_not_support_anything_else(Resource $resource)
+    function it_does_not_support_anything_else(CompositeResource $resource)
     {
         $this->supports($resource, 'anything_else', array())->shouldReturn(false);
     }
@@ -39,7 +39,7 @@ class ClassGeneratorSpec extends ObjectBehavior
     }
 
     function it_generates_class_from_resource_and_puts_it_into_appropriate_folder(
-        $io, $tpl, $fs, Resource $resource
+        $io, $tpl, $fs, CompositeResource $resource
     ) {
         $resource->getName()->willReturn('App');
         $resource->getSrcFilename()->willReturn('/project/src/Acme/App.php');
@@ -64,7 +64,7 @@ class ClassGeneratorSpec extends ObjectBehavior
     }
 
     function it_uses_template_provided_by_templating_system_if_there_is_one(
-        $io, $tpl, $fs, Resource $resource
+        $io, $tpl, $fs, CompositeResource $resource
     ) {
         $resource->getName()->willReturn('App');
         $resource->getSrcFilename()->willReturn('/project/src/Acme/App.php');
@@ -88,7 +88,7 @@ class ClassGeneratorSpec extends ObjectBehavior
         $this->generate($resource);
     }
 
-    function it_creates_folder_for_class_if_needed($io, $tpl, $fs, Resource $resource)
+    function it_creates_folder_for_class_if_needed($io, $tpl, $fs, CompositeResource $resource)
     {
         $resource->getName()->willReturn('App');
         $resource->getSrcFilename()->willReturn('/project/src/Acme/App.php');
@@ -104,7 +104,7 @@ class ClassGeneratorSpec extends ObjectBehavior
     }
 
     function it_asks_confirmation_if_class_already_exists(
-        $io, $tpl, $fs, Resource $resource
+        $io, $tpl, $fs, CompositeResource $resource
     ) {
         $resource->getName()->willReturn('App');
         $resource->getSrcFilename()->willReturn('/project/src/Acme/App.php');
@@ -119,7 +119,7 @@ class ClassGeneratorSpec extends ObjectBehavior
         $this->generate($resource);
     }
 
-    function it_records_that_class_was_created_in_executioncontext(Resource $resource, ExecutionContext $executionContext)
+    function it_records_that_class_was_created_in_executioncontext(CompositeResource $resource, ExecutionContext $executionContext)
     {
         $resource->getName()->willReturn('App');
         $resource->getSrcFilename()->willReturn('/project/src/Acme/App.php');

--- a/spec/PhpSpec/CodeGenerator/Generator/MethodGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/MethodGeneratorSpec.php
@@ -9,7 +9,7 @@ use Prophecy\Argument;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Util\Filesystem;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 class MethodGeneratorSpec extends ObjectBehavior
 {
@@ -23,12 +23,12 @@ class MethodGeneratorSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('PhpSpec\CodeGenerator\Generator\Generator');
     }
 
-    function it_supports_method_generation(Resource $resource)
+    function it_supports_method_generation(CompositeResource $resource)
     {
         $this->supports($resource, 'method', array())->shouldReturn(true);
     }
 
-    function it_does_not_support_anything_else(Resource $resource)
+    function it_does_not_support_anything_else(CompositeResource $resource)
     {
         $this->supports($resource, 'anything_else', array())->shouldReturn(false);
     }
@@ -38,7 +38,7 @@ class MethodGeneratorSpec extends ObjectBehavior
         $this->getPriority()->shouldReturn(0);
     }
 
-    function it_generates_class_method_from_resource($io, $tpl, $fs, Resource $resource, CodeWriter $codeWriter)
+    function it_generates_class_method_from_resource($io, $tpl, $fs, CompositeResource $resource, CodeWriter $codeWriter)
     {
         $codeWithoutMethod = <<<CODE
 <?php

--- a/spec/PhpSpec/CodeGenerator/Generator/NamedConstructorGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/NamedConstructorGeneratorSpec.php
@@ -5,7 +5,7 @@ namespace spec\PhpSpec\CodeGenerator\Generator;
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\CodeGenerator\Writer\CodeWriter;
 use PhpSpec\Console\ConsoleIO;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\Filesystem;
 use Prophecy\Argument;
@@ -22,12 +22,12 @@ class NamedConstructorGeneratorSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('PhpSpec\CodeGenerator\Generator\Generator');
     }
 
-    function it_supports_static_constructor_generation(Resource $resource)
+    function it_supports_static_constructor_generation(CompositeResource $resource)
     {
         $this->supports($resource, 'named_constructor', array())->shouldReturn(true);
     }
 
-    function it_does_not_support_anything_else(Resource $resource)
+    function it_does_not_support_anything_else(CompositeResource $resource)
     {
         $this->supports($resource, 'anything_else', array())->shouldReturn(false);
     }
@@ -37,7 +37,7 @@ class NamedConstructorGeneratorSpec extends ObjectBehavior
         $this->getPriority()->shouldReturn(0);
     }
 
-    function it_generates_static_constructor_method_from_resource($io, $tpl, $fs, Resource $resource, CodeWriter $codeWriter)
+    function it_generates_static_constructor_method_from_resource($io, $tpl, $fs, CompositeResource $resource, CodeWriter $codeWriter)
     {
         $codeWithoutMethod = <<<CODE
 <?php

--- a/spec/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGeneratorSpec.php
@@ -4,7 +4,7 @@ namespace spec\PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\CodeGenerator\Generator\Generator;
 use PhpSpec\Event\FileCreationEvent;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\Filesystem;
 use Prophecy\Argument;
@@ -24,7 +24,7 @@ class NewFileNotifyingGeneratorSpec extends ObjectBehavior
         $this->shouldImplement('PhpSpec\CodeGenerator\Generator\Generator');
     }
 
-    function it_should_proxy_the_support_call_to_the_decorated_object($generator, Resource $resource)
+    function it_should_proxy_the_support_call_to_the_decorated_object($generator, CompositeResource $resource)
     {
         $generator->supports($resource, 'foo', array('bar'))->willReturn(true);
         $this->supports($resource, 'foo', array('bar'))->shouldReturn(true);
@@ -36,13 +36,13 @@ class NewFileNotifyingGeneratorSpec extends ObjectBehavior
         $this->getPriority()->shouldReturn(5);
     }
 
-    function it_should_proxy_the_generate_call_to_the_decorated_object($generator, Resource $resource)
+    function it_should_proxy_the_generate_call_to_the_decorated_object($generator, CompositeResource $resource)
     {
         $this->generate($resource, array());
         $generator->generate($resource, array())->shouldHaveBeenCalled();
     }
 
-    function it_should_dispatch_an_event_when_a_file_is_created($dispatcher, $filesystem, Resource $resource)
+    function it_should_dispatch_an_event_when_a_file_is_created($dispatcher, $filesystem, CompositeResource $resource)
     {
         $path = '/foo';
         $resource->getSrcFilename()->willReturn($path);
@@ -54,7 +54,7 @@ class NewFileNotifyingGeneratorSpec extends ObjectBehavior
         $dispatcher->dispatch('afterFileCreation', $event)->shouldHaveBeenCalled();
     }
 
-    function it_should_dispatch_an_event_with_the_spec_path_when_a_spec_is_created($generator, $dispatcher, $filesystem, Resource $resource)
+    function it_should_dispatch_an_event_with_the_spec_path_when_a_spec_is_created($generator, $dispatcher, $filesystem, CompositeResource $resource)
     {
         $path = '/foo';
         $generator->supports($resource, 'specification', array())->willReturn(true);
@@ -68,7 +68,7 @@ class NewFileNotifyingGeneratorSpec extends ObjectBehavior
         $dispatcher->dispatch('afterFileCreation', $event)->shouldHaveBeenCalled();
     }
 
-    function it_should_check_that_the_file_was_created($generator, $filesystem, Resource $resource)
+    function it_should_check_that_the_file_was_created($generator, $filesystem, CompositeResource $resource)
     {
         $path = '/foo';
         $resource->getSrcFilename()->willReturn($path);
@@ -83,7 +83,7 @@ class NewFileNotifyingGeneratorSpec extends ObjectBehavior
         $this->generate($resource, array());
     }
 
-    function it_should_not_dispatch_an_event_if_the_file_was_not_created($dispatcher, $filesystem, Resource $resource)
+    function it_should_not_dispatch_an_event_if_the_file_was_not_created($dispatcher, $filesystem, CompositeResource $resource)
     {
         $path = '/foo';
         $resource->getSrcFilename()->willReturn($path);
@@ -95,7 +95,7 @@ class NewFileNotifyingGeneratorSpec extends ObjectBehavior
         $dispatcher->dispatch('afterFileCreation', Argument::any())->shouldNotHaveBeenCalled();
     }
 
-    function it_should_not_dispatch_an_event_if_the_file_already_existed($dispatcher, $filesystem, Resource $resource)
+    function it_should_not_dispatch_an_event_if_the_file_already_existed($dispatcher, $filesystem, CompositeResource $resource)
     {
         $path = '/foo';
         $resource->getSrcFilename()->willReturn($path);

--- a/spec/PhpSpec/CodeGenerator/Generator/ReturnConstantGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ReturnConstantGeneratorSpec.php
@@ -7,7 +7,7 @@ use PhpSpec\Console\ConsoleIO;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\Filesystem;
 use Prophecy\Argument;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 class ReturnConstantGeneratorSpec extends ObjectBehavior
 {
@@ -21,12 +21,12 @@ class ReturnConstantGeneratorSpec extends ObjectBehavior
         $this->shouldHaveType('PhpSpec\CodeGenerator\Generator\Generator');
     }
 
-    function it_supports_returnConstant_generation(Resource $resource)
+    function it_supports_returnConstant_generation(CompositeResource $resource)
     {
         $this->supports($resource, 'returnConstant', array())->shouldReturn(true);
     }
 
-    function it_does_not_support_anything_else(Resource $resource)
+    function it_does_not_support_anything_else(CompositeResource $resource)
     {
         $this->supports($resource, 'anything_else', array())->shouldReturn(false);
     }

--- a/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
@@ -9,7 +9,7 @@ use Prophecy\Argument;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Util\Filesystem;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 class SpecificationGeneratorSpec extends ObjectBehavior
 {
@@ -23,12 +23,12 @@ class SpecificationGeneratorSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('PhpSpec\CodeGenerator\Generator\Generator');
     }
 
-    function it_supports_specification_generations(Resource $resource)
+    function it_supports_specification_generations(CompositeResource $resource)
     {
         $this->supports($resource, 'specification', array())->shouldReturn(true);
     }
 
-    function it_does_not_support_anything_else(Resource $resource)
+    function it_does_not_support_anything_else(CompositeResource $resource)
     {
         $this->supports($resource, 'anything_else', array())->shouldReturn(false);
     }
@@ -39,7 +39,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
     }
 
     function it_generates_spec_class_from_resource_and_puts_it_into_appropriate_folder(
-        $io, $tpl, $fs, Resource $resource
+        $io, $tpl, $fs, CompositeResource $resource
     ) {
         $resource->getSpecName()->willReturn('AppSpec');
         $resource->getSpecFilename()->willReturn('/project/spec/Acme/AppSpec.php');
@@ -66,7 +66,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
     }
 
     function it_uses_template_provided_by_templating_system_if_there_is_one(
-        $io, $tpl, $fs, Resource $resource
+        $io, $tpl, $fs, CompositeResource $resource
     ) {
         $resource->getSpecName()->willReturn('AppSpec');
         $resource->getSpecFilename()->willReturn('/project/spec/Acme/AppSpec.php');
@@ -92,7 +92,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
         $this->generate($resource);
     }
 
-    function it_creates_folder_for_spec_if_needed($io, $tpl, $fs, Resource $resource)
+    function it_creates_folder_for_spec_if_needed($io, $tpl, $fs, CompositeResource $resource)
     {
         $resource->getSpecName()->willReturn('AppAppSpec');
         $resource->getSpecFilename()->willReturn('/project/spec/Acme/AppSpec.php');
@@ -109,7 +109,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
     }
 
     function it_asks_confirmation_if_spec_already_exists(
-        $io, $tpl, $fs, Resource $resource
+        $io, $tpl, $fs, CompositeResource $resource
     ) {
         $resource->getSpecName()->willReturn('AppSpec');
         $resource->getSpecFilename()->willReturn('/project/spec/Acme/AppSpec.php');

--- a/spec/PhpSpec/CodeGenerator/GeneratorManagerSpec.php
+++ b/spec/PhpSpec/CodeGenerator/GeneratorManagerSpec.php
@@ -6,12 +6,12 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 use PhpSpec\CodeGenerator\Generator\Generator;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 class GeneratorManagerSpec extends ObjectBehavior
 {
     function it_uses_registered_generators_to_generate_code(
-        Generator $generator, Resource $resource
+        Generator $generator, CompositeResource $resource
     ) {
         $generator->getPriority()->willReturn(0);
         $generator->supports($resource, 'specification', array())->willReturn(true);
@@ -22,7 +22,7 @@ class GeneratorManagerSpec extends ObjectBehavior
     }
 
     function it_chooses_generator_by_priority(
-        Generator $generator1, Generator $generator2, Resource $resource
+        Generator $generator1, Generator $generator2, CompositeResource $resource
     ) {
         $generator1->supports($resource, 'class', array('class' => 'CustomLoader'))
             ->willReturn(true);
@@ -39,7 +39,7 @@ class GeneratorManagerSpec extends ObjectBehavior
         $this->generate($resource, 'class', array('class' => 'CustomLoader'));
     }
 
-    function it_throws_exception_if_no_generator_found(Resource $resource)
+    function it_throws_exception_if_no_generator_found(CompositeResource $resource)
     {
         $this->shouldThrow()->duringGenerate($resource, 'class', array('class' => 'CustomLoader'));
     }

--- a/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
@@ -7,7 +7,7 @@ use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Exception\Locator\ResourceCreationException;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Locator\ResourceManager;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\NameChecker;
@@ -19,7 +19,7 @@ class CollaboratorMethodNotFoundListenerSpec extends ObjectBehavior
 {
     function let(
         ConsoleIO $io, ResourceManager $resources, ExampleEvent $event,
-        MethodNotFoundException $exception, Resource $resource, GeneratorManager $generator,
+        MethodNotFoundException $exception, CompositeResource $resource, GeneratorManager $generator,
         NameChecker $nameChecker
     ) {
         $this->beConstructedWith($io, $resources, $generator, $nameChecker);
@@ -125,7 +125,7 @@ class CollaboratorMethodNotFoundListenerSpec extends ObjectBehavior
 
     function it_generates_the_method_signature_when_user_says_yes_at_prompt(
         ConsoleIO $io, ExampleEvent $event, SuiteEvent $suiteEvent, MethodNotFoundException $exception,
-        Resource $resource, GeneratorManager $generator
+        CompositeResource $resource, GeneratorManager $generator
     )
     {
         $io->askConfirmation(Argument::any())->willReturn(true);

--- a/spec/PhpSpec/Listener/CollaboratorNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorNotFoundListenerSpec.php
@@ -7,7 +7,7 @@ use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Exception\Fracture\CollaboratorNotFoundException;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Locator\ResourceManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -16,7 +16,7 @@ class CollaboratorNotFoundListenerSpec extends ObjectBehavior
 {
     function let(
         ConsoleIO $io, CollaboratorNotFoundException $exception, ExampleEvent $exampleEvent,
-        ResourceManager $resources, GeneratorManager $generator, Resource $resource
+        ResourceManager $resources, GeneratorManager $generator, CompositeResource $resource
     )
     {
         $this->beConstructedWith($io, $resources, $generator);
@@ -102,7 +102,7 @@ class CollaboratorNotFoundListenerSpec extends ObjectBehavior
 
     function it_generates_interface_when_prompt_is_answered_with_yes(
         ConsoleIO $io, ExampleEvent $exampleEvent, SuiteEvent $suiteEvent,
-        GeneratorManager $generator, Resource $resource
+        GeneratorManager $generator, CompositeResource $resource
     )
     {
         $io->askConfirmation(

--- a/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
@@ -8,7 +8,7 @@ use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\MethodCallEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Exception\Example\NotEqualException;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Locator\ResourceManager;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\MethodAnalyser;
@@ -191,7 +191,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
 
     function it_invokes_method_body_generation_when_prompt_is_answered_yes(
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io,
-        GeneratorManager $generatorManager, ResourceManager $resourceManager, Resource $resource, SuiteEvent $event
+        GeneratorManager $generatorManager, ResourceManager $resourceManager, CompositeResource $resource, SuiteEvent $event
     ) {
         $io->askConfirmation(Argument::any())->willReturn(true);
         $resourceManager->createResource(Argument::any())->willReturn($resource);

--- a/spec/PhpSpec/Loader/Node/SpecificationNodeSpec.php
+++ b/spec/PhpSpec/Loader/Node/SpecificationNodeSpec.php
@@ -5,7 +5,7 @@ namespace spec\PhpSpec\Loader\Node;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\Loader\Suite;
 
@@ -13,7 +13,7 @@ use ReflectionClass;
 
 class SpecificationNodeSpec extends ObjectBehavior
 {
-    public function let(ReflectionClass $class, Resource $resource)
+    public function let(ReflectionClass $class, CompositeResource $resource)
     {
         $this->beConstructedWith('specification node', $class, $resource);
     }

--- a/spec/PhpSpec/Locator/PSR0/PSR0ResourceSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0ResourceSpec.php
@@ -27,7 +27,7 @@ class PSR0ResourceSpec extends ObjectBehavior
 
     function it_is_a_resource()
     {
-        $this->shouldBeAnInstanceOf('PhpSpec\Locator\Resource');
+        $this->shouldBeAnInstanceOf('PhpSpec\Locator\CompositeResource');
     }
 
     function it_generates_src_filename_from_provided_parts_using_locator($locator)

--- a/spec/PhpSpec/Locator/PrioritizedResourceManagerSpec.php
+++ b/spec/PhpSpec/Locator/PrioritizedResourceManagerSpec.php
@@ -5,7 +5,7 @@ namespace spec\PhpSpec\Locator;
 use PhpSpec\ObjectBehavior;
 
 use PhpSpec\Locator\ResourceLocator;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 class PrioritizedResourceManagerSpec extends ObjectBehavior
 {
@@ -16,7 +16,7 @@ class PrioritizedResourceManagerSpec extends ObjectBehavior
     }
 
     function it_locates_resources_using_all_registered_locators($locator1, $locator2,
-        Resource $resource1, Resource $resource2, Resource $resource3
+        CompositeResource $resource1, CompositeResource $resource2, CompositeResource $resource3
     ) {
         $this->registerLocator($locator1);
         $this->registerLocator($locator2);
@@ -34,7 +34,7 @@ class PrioritizedResourceManagerSpec extends ObjectBehavior
     }
 
     function it_locates_all_locators_resources_if_query_string_is_empty($locator1, $locator2,
-        Resource $resource1, Resource $resource2, Resource $resource3
+        CompositeResource $resource1, CompositeResource $resource2, CompositeResource $resource3
     ) {
         $this->registerLocator($locator1);
         $this->registerLocator($locator2);
@@ -60,7 +60,7 @@ class PrioritizedResourceManagerSpec extends ObjectBehavior
     }
 
     function it_creates_resource_from_classname_using_locator_with_highest_priority(
-        $locator1, $locator2, Resource $resource1, Resource $resource2
+        $locator1, $locator2, CompositeResource $resource1, CompositeResource $resource2
     ) {
         $this->registerLocator($locator1);
         $this->registerLocator($locator2);
@@ -83,7 +83,7 @@ class PrioritizedResourceManagerSpec extends ObjectBehavior
     }
 
     function it_does_not_allow_two_resources_for_the_same_spec(
-        $locator1, $locator2, Resource $resource1, Resource $resource2
+        $locator1, $locator2, CompositeResource $resource1, CompositeResource $resource2
     ) {
         $this->registerLocator($locator1);
         $this->registerLocator($locator2);
@@ -98,7 +98,7 @@ class PrioritizedResourceManagerSpec extends ObjectBehavior
     }
 
     function it_uses_the_resource_from_the_highest_priority_locator_when_duplicates_occur(
-        $locator1, $locator2, Resource $resource1, Resource $resource2
+        $locator1, $locator2, CompositeResource $resource1, CompositeResource $resource2
     ) {
         $locator1->getPriority()->willReturn(2);
         $locator2->getPriority()->willReturn(1);

--- a/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\CodeGenerator\Generator;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 /**
  * The Class Generator is responsible for generating the classes from a resource
@@ -22,13 +22,13 @@ use PhpSpec\Locator\Resource;
 final class ClassGenerator extends PromptingGenerator
 {
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $generation
      * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return 'class' === $generation;
     }
@@ -42,12 +42,12 @@ final class ClassGenerator extends PromptingGenerator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      *
      * @return string
      */
-    protected function renderTemplate(Resource $resource, $filepath)
+    protected function renderTemplate(CompositeResource $resource, $filepath)
     {
         $values = array(
             '%filepath%'        => $filepath,
@@ -77,22 +77,22 @@ final class ClassGenerator extends PromptingGenerator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      *
      * @return string
      */
-    protected function getFilePath(Resource $resource)
+    protected function getFilePath(CompositeResource $resource)
     {
         return $resource->getSrcFilename();
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      *
      * @return string
      */
-    protected function getGeneratedMessage(Resource $resource, $filepath)
+    protected function getGeneratedMessage(CompositeResource $resource, $filepath)
     {
         return sprintf(
             "<info>Class <value>%s</value> created in <value>%s</value>.</info>\n",

--- a/src/PhpSpec/CodeGenerator/Generator/Generator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/Generator.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\CodeGenerator\Generator;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 /**
  * Interface that all Generators need to implement in PhpSpec
@@ -21,19 +21,19 @@ use PhpSpec\Locator\Resource;
 interface Generator
 {
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $generation
      * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data);
+    public function supports(CompositeResource $resource, $generation, array $data);
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data);
+    public function generate(CompositeResource $resource, array $data);
 
     /**
      * @return int

--- a/src/PhpSpec/CodeGenerator/Generator/InterfaceGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/InterfaceGenerator.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\CodeGenerator\Generator;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 /**
  * The Interface Generator is responsible for generating the interface from a resource
@@ -22,13 +22,13 @@ use PhpSpec\Locator\Resource;
 final class InterfaceGenerator extends PromptingGenerator
 {
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $generation
      * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return 'interface' === $generation;
     }
@@ -42,12 +42,12 @@ final class InterfaceGenerator extends PromptingGenerator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      *
      * @return string
      */
-    protected function renderTemplate(Resource $resource, $filepath)
+    protected function renderTemplate(CompositeResource $resource, $filepath)
     {
         $values = array(
             '%filepath%'        => $filepath,
@@ -76,22 +76,22 @@ final class InterfaceGenerator extends PromptingGenerator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      *
      * @return string
      */
-    protected function getFilePath(Resource $resource)
+    protected function getFilePath(CompositeResource $resource)
     {
         return $resource->getSrcFilename();
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      *
      * @return string
      */
-    protected function getGeneratedMessage(Resource $resource, $filepath)
+    protected function getGeneratedMessage(CompositeResource $resource, $filepath)
     {
         return sprintf(
             "<info>Interface <value>%s</value> created in <value>%s</value>.</info>\n",

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -17,7 +17,7 @@ use PhpSpec\Console\ConsoleIO;
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\CodeGenerator\Writer\CodeWriter;
 use PhpSpec\Util\Filesystem;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 /**
  * Generates class methods from a resource
@@ -59,22 +59,22 @@ final class MethodGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $generation
      * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return 'method' === $generation;
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array())
+    public function generate(CompositeResource $resource, array $data = array())
     {
         $filepath  = $resource->getSrcFilename();
         $name      = $data['name'];

--- a/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
@@ -16,7 +16,7 @@ namespace PhpSpec\CodeGenerator\Generator;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Util\Filesystem;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 /**
  * Generates interface method signatures from a resource
@@ -51,22 +51,22 @@ final class MethodSignatureGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $generation
      * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return 'method-signature' === $generation;
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array())
+    public function generate(CompositeResource $resource, array $data = array())
     {
         $filepath  = $resource->getSrcFilename();
         $name      = $data['name'];

--- a/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
@@ -16,7 +16,7 @@ namespace PhpSpec\CodeGenerator\Generator;
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Exception\Generator\NamedMethodNotFoundException;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\CodeGenerator\Writer\CodeWriter;
 use PhpSpec\Util\Filesystem;
 
@@ -56,22 +56,22 @@ final class NamedConstructorGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $generation
      * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return 'named_constructor' === $generation;
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array())
+    public function generate(CompositeResource $resource, array $data = array())
     {
         $filepath   = $resource->getSrcFilename();
         $methodName = $data['name'];
@@ -102,12 +102,12 @@ final class NamedConstructorGenerator implements Generator
     }
 
     /**
-     * @param  Resource $resource
+     * @param  CompositeResource $resource
      * @param  string            $methodName
      * @param  array             $arguments
      * @return string
      */
-    private function getContent(Resource $resource, $methodName, $arguments)
+    private function getContent(CompositeResource $resource, $methodName, $arguments)
     {
         $className = $resource->getName();
         $class = $resource->getSrcClassname();

--- a/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
@@ -3,7 +3,7 @@
 namespace PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\Event\FileCreationEvent;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Util\Filesystem;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -37,22 +37,22 @@ final class NewFileNotifyingGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
-     * @param string $generation
-     * @param array $data
+     * @param CompositeResource $resource
+     * @param string            $generation
+     * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return $this->generator->supports($resource, $generation, $data);
     }
 
     /**
-     * @param Resource $resource
-     * @param array $data
+     * @param CompositeResource $resource
+     * @param array             $data
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(CompositeResource $resource, array $data)
     {
         $filePath = $this->getFilePath($resource);
 
@@ -72,10 +72,10 @@ final class NewFileNotifyingGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @return string
      */
-    private function getFilePath(Resource $resource)
+    private function getFilePath(CompositeResource $resource)
     {
         if ($this->generator->supports($resource, 'specification', array())) {
             return $resource->getSpecFilename();

--- a/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
@@ -16,7 +16,7 @@ namespace PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Console\ConsoleIO;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\CodeGenerator\Writer\CodeWriter;
 use PhpSpec\Util\Filesystem;
 
@@ -57,22 +57,22 @@ final class PrivateConstructorGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
-     * @param string $generation
-     * @param array $data
+     * @param CompositeResource $resource
+     * @param string            $generation
+     * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return 'private-constructor' === $generation;
     }
 
     /**
-     * @param Resource $resource
-     * @param array $data
+     * @param CompositeResource $resource
+     * @param array             $data
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(CompositeResource $resource, array $data)
     {
         $filepath  = $resource->getSrcFilename();
 

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -15,9 +15,9 @@ namespace PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\CodeGenerator\TemplateRenderer;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Process\Context\ExecutionContext;
 use PhpSpec\Util\Filesystem;
-use PhpSpec\Locator\Resource;
 
 /**
  * Base class with common behaviour for generating class and spec class
@@ -59,10 +59,10 @@ abstract class PromptingGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array())
+    public function generate(CompositeResource $resource, array $data = array())
     {
         $filepath = $this->getFilePath($resource);
 
@@ -88,27 +88,27 @@ abstract class PromptingGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      *
      * @return string
      */
-    abstract protected function getFilePath(Resource $resource);
+    abstract protected function getFilePath(CompositeResource $resource);
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      *
      * @return string
      */
-    abstract protected function renderTemplate(Resource $resource, $filepath);
+    abstract protected function renderTemplate(CompositeResource $resource, $filepath);
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      *
      * @return string
      */
-    abstract protected function getGeneratedMessage(Resource $resource, $filepath);
+    abstract protected function getGeneratedMessage(CompositeResource $resource, $filepath);
 
     /**
      * @param string $filepath
@@ -144,10 +144,10 @@ abstract class PromptingGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      */
-    private function generateFileAndRenderTemplate(Resource $resource, $filepath)
+    private function generateFileAndRenderTemplate(CompositeResource $resource, $filepath)
     {
         $content = $this->renderTemplate($resource, $filepath);
 

--- a/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
@@ -15,7 +15,7 @@ namespace PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Console\ConsoleIO;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Util\Filesystem;
 
 final class ReturnConstantGenerator implements Generator
@@ -46,22 +46,22 @@ final class ReturnConstantGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $generation
      * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return 'returnConstant' == $generation;
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(CompositeResource $resource, array $data)
     {
         $method = $data['method'];
         $expected = $data['expected'];

--- a/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\CodeGenerator\Generator;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
 /**
  * Generates spec classes from resources and puts them into the appropriate
@@ -22,13 +22,13 @@ use PhpSpec\Locator\Resource;
 final class SpecificationGenerator extends PromptingGenerator
 {
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $generation
      * @param array             $data
      *
      * @return bool
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(CompositeResource $resource, $generation, array $data)
     {
         return 'specification' === $generation;
     }
@@ -42,12 +42,12 @@ final class SpecificationGenerator extends PromptingGenerator
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      *
      * @return string
      */
-    protected function renderTemplate(Resource $resource, $filepath)
+    protected function renderTemplate(CompositeResource $resource, $filepath)
     {
         $values = array(
             '%filepath%'      => $filepath,
@@ -73,21 +73,21 @@ final class SpecificationGenerator extends PromptingGenerator
     }
 
     /**
-     * @param  Resource $resource
+     * @param  CompositeResource $resource
      * @return mixed
      */
-    protected function getFilePath(Resource $resource)
+    protected function getFilePath(CompositeResource $resource)
     {
         return $resource->getSpecFilename();
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $filepath
      *
      * @return string
      */
-    protected function getGeneratedMessage(Resource $resource, $filepath)
+    protected function getGeneratedMessage(CompositeResource $resource, $filepath)
     {
         return sprintf(
             "<info>Specification for <value>%s</value> created in <value>%s</value>.</info>\n",

--- a/src/PhpSpec/CodeGenerator/GeneratorManager.php
+++ b/src/PhpSpec/CodeGenerator/GeneratorManager.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\CodeGenerator;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use InvalidArgumentException;
 use PhpSpec\CodeGenerator\Generator\Generator;
 
@@ -39,14 +39,14 @@ class GeneratorManager
     }
 
     /**
-     * @param Resource $resource
+     * @param CompositeResource $resource
      * @param string            $name
      * @param array             $data
      *
      * @return mixed
      * @throws \InvalidArgumentException
      */
-    public function generate(Resource $resource, $name, array $data = array())
+    public function generate(CompositeResource $resource, $name, array $data = array())
     {
         foreach ($this->generators as $generator) {
             if ($generator->supports($resource, $name, $data)) {

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -18,6 +18,7 @@ use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Exception\Fracture\CollaboratorNotFoundException;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Locator\ResourceManager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -104,7 +105,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
 
     /**
      * @param CollaboratorNotFoundException $exception
-     * @param Resource $resource
+     * @param CompositeResource             $resource
      * @return bool
      */
     private function resourceIsInSpecNamespace($exception, $resource)

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -14,7 +14,7 @@
 namespace PhpSpec\Loader\Node;
 
 use PhpSpec\Loader\Suite;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use ReflectionClass;
 
 class SpecificationNode implements \Countable
@@ -28,7 +28,7 @@ class SpecificationNode implements \Countable
      */
     private $class;
     /**
-     * @var Resource
+     * @var CompositeResource
      */
     private $resource;
     /**
@@ -43,9 +43,9 @@ class SpecificationNode implements \Countable
     /**
      * @param string            $title
      * @param ReflectionClass   $class
-     * @param Resource $resource
+     * @param CompositeResource $resource
      */
-    public function __construct($title, ReflectionClass $class, Resource $resource)
+    public function __construct($title, ReflectionClass $class, CompositeResource $resource)
     {
         $this->title    = $title;
         $this->class    = $class;
@@ -69,7 +69,7 @@ class SpecificationNode implements \Countable
     }
 
     /**
-     * @return Resource
+     * @return CompositeResource
      */
     public function getResource()
     {

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -13,7 +13,7 @@
 
 namespace PhpSpec\Loader;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Specification\ErrorSpecification;
 use PhpSpec\Util\MethodAnalyser;
 use PhpSpec\Locator\ResourceManager;
@@ -110,7 +110,7 @@ class ResourceLoader
         return $line >= $method->getStartLine() && $line <= $method->getEndLine();
     }
 
-    private function addErrorThrowingExampleToSuite(Resource $resource, Suite $suite, \Error $error)
+    private function addErrorThrowingExampleToSuite(CompositeResource $resource, Suite $suite, \Error $error)
     {
         $reflection = new ReflectionClass(ErrorSpecification::class);
         $spec = new Node\SpecificationNode($resource->getSrcClassname(), $reflection, $resource);

--- a/src/PhpSpec/Locator/CompositeResource.php
+++ b/src/PhpSpec/Locator/CompositeResource.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Locator;
+
+interface CompositeResource
+{
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @return string
+     */
+    public function getSpecName();
+
+    /**
+     * @return string
+     */
+    public function getSrcFilename();
+
+    /**
+     * @return string
+     */
+    public function getSrcNamespace();
+
+    /**
+     * @return string
+     */
+    public function getSrcClassname();
+
+    /**
+     * @return string
+     */
+    public function getSpecFilename();
+
+    /**
+     * @return string
+     */
+    public function getSpecNamespace();
+
+    /**
+     * @return string
+     */
+    public function getSpecClassname();
+}

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Locator\PSR0;
 
+use PhpSpec\Locator\CompositeResource;
 use PhpSpec\Locator\ResourceLocator;
 use PhpSpec\Util\Filesystem;
 use InvalidArgumentException;
@@ -140,7 +141,7 @@ class PSR0Locator implements ResourceLocator
     }
 
     /**
-     * @return Resource[]
+     * @return CompositeResource[]
      */
     public function getAllResources()
     {
@@ -176,7 +177,7 @@ class PSR0Locator implements ResourceLocator
     /**
      * @param string $query
      *
-     * @return Resource[]
+     * @return CompositeResource[]
      */
     public function findResources($query)
     {

--- a/src/PhpSpec/Locator/PSR0/PSR0Resource.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Resource.php
@@ -13,9 +13,9 @@
 
 namespace PhpSpec\Locator\PSR0;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\CompositeResource;
 
-final class PSR0Resource implements Resource
+final class PSR0Resource implements CompositeResource
 {
     /**
      * @var array

--- a/src/PhpSpec/Locator/PrioritizedResourceManager.php
+++ b/src/PhpSpec/Locator/PrioritizedResourceManager.php
@@ -37,7 +37,7 @@ final class PrioritizedResourceManager implements ResourceManager
     /**
      * @param string $query
      *
-     * @return Resource[]
+     * @return CompositeResource[]
      */
     public function locateResources($query)
     {
@@ -61,7 +61,7 @@ final class PrioritizedResourceManager implements ResourceManager
     /**
      * @param string $classname
      *
-     * @return Resource
+     * @return CompositeResource
      *
      * @throws \RuntimeException
      */
@@ -84,7 +84,7 @@ final class PrioritizedResourceManager implements ResourceManager
     /**
      * @param array $resources
      *
-     * @return Resource[]
+     * @return CompositeResource[]
      */
     private function removeDuplicateResources(array $resources)
     {

--- a/src/PhpSpec/Locator/Resource.php
+++ b/src/PhpSpec/Locator/Resource.php
@@ -13,45 +13,9 @@
 
 namespace PhpSpec\Locator;
 
-interface Resource
+/**
+ * @deprecated The Resource interface will be replaced with CompositeResource in PhpSpec 4.0
+ */
+interface Resource extends CompositeResource
 {
-    /**
-     * @return string
-     */
-    public function getName();
-
-    /**
-     * @return string
-     */
-    public function getSpecName();
-
-    /**
-     * @return string
-     */
-    public function getSrcFilename();
-
-    /**
-     * @return string
-     */
-    public function getSrcNamespace();
-
-    /**
-     * @return string
-     */
-    public function getSrcClassname();
-
-    /**
-     * @return string
-     */
-    public function getSpecFilename();
-
-    /**
-     * @return string
-     */
-    public function getSpecNamespace();
-
-    /**
-     * @return string
-     */
-    public function getSpecClassname();
 }

--- a/src/PhpSpec/Locator/ResourceLocator.php
+++ b/src/PhpSpec/Locator/ResourceLocator.php
@@ -16,40 +16,40 @@ namespace PhpSpec\Locator;
 interface ResourceLocator
 {
     /**
-     * @return Resource[]
+     * @return CompositeResource[]
      */
     public function getAllResources();
 
     /**
      * @param string $query
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsQuery($query);
 
     /**
      * @param string $query
      *
-     * @return Resource[]
+     * @return CompositeResource[]
      */
     public function findResources($query);
 
     /**
      * @param string $classname
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsClass($classname);
 
     /**
      * @param string $classname
      *
-     * @return Resource|null
+     * @return CompositeResource|null
      */
     public function createResource($classname);
 
     /**
-     * @return integer
+     * @return int
      */
     public function getPriority();
 }

--- a/src/PhpSpec/Locator/ResourceManager.php
+++ b/src/PhpSpec/Locator/ResourceManager.php
@@ -18,14 +18,14 @@ interface ResourceManager
     /**
      * @param string $query
      *
-     * @return \PhpSpec\Locator\Resource[]
+     * @return \PhpSpec\Locator\CompositeResource[]
      */
     public function locateResources($query);
 
     /**
      * @param string $classname
      *
-     * @return \PhpSpec\Locator\Resource
+     * @return \PhpSpec\Locator\CompositeResource
      */
     public function createResource($classname);
 }


### PR DESCRIPTION
This deprecates the `Resource` interface and replaces it with `CompositeResource`, the reason for this is that `resource` is soft reserved in PHP 7. I have created a new `CompositeResource` interface and the original `Resource` interface extends this, allowing for an easy removal in the next major.

I chose `CompositeResource` since the interface represents a composite between the specification and the subject, but I'm open to a different name if we can think of something better?