### PR TITLE
Bugfix: Constructor is made private multiple times

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -119,15 +119,7 @@ class ApplicationContext implements Context
      */
     public function iRunPhpspecAndAnswerWhenAskedIfIWantToGenerateTheCode($answer, $option=null)
     {
-        $arguments = array (
-            'command' => 'run'
-        );
-
-        $this->addOptionToArguments($option, $arguments);
-
-        $this->prompter->setAnswer($answer=='y');
-
-        $this->lastExitCode = $this->tester->run($arguments, array('interactive' => true));
+        $this->runPhpSpecAndAnswerQuestions($answer, 1, $option);
     }
 
     /**
@@ -135,12 +127,34 @@ class ApplicationContext implements Context
      */
     public function iRunPhpspecAndAnswerToBothQuestions($answer)
     {
+        $this->runPhpSpecAndAnswerQuestions($answer, 2);
+    }
+
+    /**
+     * @When I run phpspec and answer :answer to the three questions
+     */
+    public function iRunPhpspecAndAnswerToTheThreeQuestions($answer)
+    {
+        $this->runPhpSpecAndAnswerQuestions($answer, 5);
+    }
+
+    /**
+     * @param string  $answer
+     * @param integer $times
+     * @param string  $option
+     */
+    private function runPhpSpecAndAnswerQuestions($answer, $times, $option = null)
+    {
         $arguments = array (
             'command' => 'run'
         );
 
-        $this->prompter->setAnswer($answer=='y');
-        $this->prompter->setAnswer($answer=='y');
+        $this->addOptionToArguments($option, $arguments);
+
+        $i = 0;
+        while ($i++ < $times) {
+            $this->prompter->setAnswer($answer=='y');
+        }
 
         $this->lastExitCode = $this->tester->run($arguments, array('interactive' => true));
     }

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -123,19 +123,11 @@ class ApplicationContext implements Context
     }
 
     /**
-     * @When I run phpspec and answer :answer to both questions
+     * @When I run phpspec and answer :answer to (the) :amount questions
      */
-    public function iRunPhpspecAndAnswerToBothQuestions($answer)
+    public function iRunPhpspecAndAnswerToBothQuestions($amount, $answer)
     {
-        $this->runPhpSpecAndAnswerQuestions($answer, 2);
-    }
-
-    /**
-     * @When I run phpspec and answer :answer to the three questions
-     */
-    public function iRunPhpspecAndAnswerToTheThreeQuestions($answer)
-    {
-        $this->runPhpSpecAndAnswerQuestions($answer, 3);
+        $this->runPhpSpecAndAnswerQuestions($answer, ($amount === 'both' ? 2 : 3));
     }
 
     /**

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -366,4 +366,16 @@ class ApplicationContext implements Context
 
         return $string;
     }
+    
+    /**
+     * @Then I should not be prompted for more questions
+     */
+    public function iShouldNotBePromptedForMoreQuestions()
+    {
+        if ($this->prompter->hasUnansweredQuestions()) {
+            throw new \Exception(
+                'Not all questions were answered. This might lead into further code generation not reflected in the scenario.'
+            );
+        }
+    }
 }

--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -135,7 +135,7 @@ class ApplicationContext implements Context
      */
     public function iRunPhpspecAndAnswerToTheThreeQuestions($answer)
     {
-        $this->runPhpSpecAndAnswerQuestions($answer, 5);
+        $this->runPhpSpecAndAnswerQuestions($answer, 3);
     }
 
     /**

--- a/features/bootstrap/Fake/Prompter.php
+++ b/features/bootstrap/Fake/Prompter.php
@@ -9,6 +9,7 @@ class Prompter implements PrompterInterface
     private $answers = array();
     private $hasBeenAsked = false;
     private $question;
+    private $unansweredQuestions = false;
 
     public function setAnswer($answer)
     {
@@ -19,6 +20,8 @@ class Prompter implements PrompterInterface
     {
         $this->hasBeenAsked = true;
         $this->question = $question;
+
+        $this->unansweredQuestions = count($this->answers) > 1;
         return (bool)array_shift($this->answers);
     }
 
@@ -30,6 +33,11 @@ class Prompter implements PrompterInterface
 
         return $this->hasBeenAsked
             && $this->normalise($this->question) == $this->normalise($question);
+    }
+
+    public function hasUnansweredQuestions()
+    {
+        return $this->unansweredQuestions;
     }
 
     /**

--- a/features/code_generation/developer_generates_named_constructor.feature
+++ b/features/code_generation/developer_generates_named_constructor.feature
@@ -442,3 +442,74 @@ Feature: Developer generates a named constructor
       }
 
       """
+
+  Scenario: Generating multiple private constructors at once
+    Given the spec file "spec/CodeGeneration/PrivateConstructor/AgeSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\CodeGeneration\PrivateConstructor;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class AgeSpec extends ObjectBehavior
+      {
+          function it_is_constructed_from_string()
+          {
+              $this->beConstructedFromString('30');
+              $this->getAge()->shouldReturn(30);
+          }
+
+          function it_is_constructed_from_integer()
+          {
+              $this->beConstructedFromInteger(30);
+              $this->getAge()->shouldReturn(30);
+          }
+      }
+
+      """
+    And the class file "src/CodeGeneration/PrivateConstructor/Age.php" contains:
+      """
+      <?php
+
+      namespace CodeGeneration\PrivateConstructor;
+
+      class Age
+      {
+      }
+
+      """
+    When I run phpspec and answer "y" to the three questions
+    Then the class in "src/CodeGeneration/PrivateConstructor/Age.php" should contain:
+      """
+      <?php
+
+      namespace CodeGeneration\PrivateConstructor;
+
+      class Age
+      {
+          private function __construct()
+          {
+          }
+
+          public static function fromInteger($argument1)
+          {
+              $age = new Age();
+
+              // TODO: write logic here
+
+              return $age;
+          }
+
+          public static function fromString($argument1)
+          {
+              $age = new Age();
+
+              // TODO: write logic here
+
+              return $age;
+          }
+      }
+
+      """

--- a/features/code_generation/developer_generates_named_constructor.feature
+++ b/features/code_generation/developer_generates_named_constructor.feature
@@ -443,7 +443,7 @@ Feature: Developer generates a named constructor
 
       """
 
-  Scenario: Generating multiple private constructors at once
+  Scenario: Generating multiple named constructors at once
     Given the spec file "spec/CodeGeneration/PrivateConstructor/AgeSpec.php" contains:
       """
       <?php
@@ -481,7 +481,8 @@ Feature: Developer generates a named constructor
 
       """
     When I run phpspec and answer "y" to the three questions
-    Then the class in "src/CodeGeneration/PrivateConstructor/Age.php" should contain:
+    Then I should not be prompted for more questions
+    And the class in "src/CodeGeneration/PrivateConstructor/Age.php" should contain:
       """
       <?php
 

--- a/spec/PhpSpec/CodeGenerator/Generator/ConfirmingGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ConfirmingGeneratorSpec.php
@@ -2,56 +2,56 @@
 
 namespace spec\PhpSpec\CodeGenerator\Generator;
 
-use PhpSpec\CodeGenerator\Generator\Generator;
-use PhpSpec\Console\ConsoleIO;
+use PhpSpec\CodeGenerator\Generator\GeneratorInterface;
+use PhpSpec\Console\IO;
 use PhpSpec\ObjectBehavior;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\ResourceInterface;
 
 class ConfirmingGeneratorSpec extends ObjectBehavior
 {
-    function let(ConsoleIO $io, Generator $generator)
+    function let(IO $io, GeneratorInterface $generator)
     {
         $this->beConstructedWith($io, 'Question for {CLASSNAME}', $generator);
     }
 
     function it_is_a_Generator()
     {
-        $this->shouldHaveType(Generator::class);
+        $this->shouldHaveType('PhpSpec\CodeGenerator\Generator\GeneratorInterface');
     }
 
-    function it_supports_the_same_generator_as_its_parent(Generator $generator, Resource $resource)
+    function it_supports_the_same_generator_as_its_parent(GeneratorInterface $generator, ResourceInterface $resource)
     {
-        $generator->supports($resource, 'generation', [])->willReturn(true);
+        $generator->supports($resource, 'generation', array())->willReturn(true);
 
-        $this->supports($resource, 'generation', [])->shouldReturn(true);
+        $this->supports($resource, 'generation', array())->shouldReturn(true);
     }
 
-    function it_has_the_same_priority_as_its_parent(Generator $generator)
+    function it_has_the_same_priority_as_its_parent(GeneratorInterface $generator)
     {
         $generator->getPriority()->willReturn(1324);
 
         $this->getPriority()->shouldReturn(1324);
     }
 
-    function it_does_not_call_the_parent_generate_method_if_the_user_answers_no(Generator $generator, Resource $resource, ConsoleIO $io)
+    function it_does_not_call_the_parent_generate_method_if_the_user_answers_no(GeneratorInterface $generator, ResourceInterface $resource, IO $io)
     {
         $resource->getSrcClassname()->willReturn('Namespace/Classname');
 
         $io->askConfirmation('Question for Namespace/Classname')->willReturn(false);
 
-        $this->generate($resource, []);
+        $this->generate($resource, array());
 
-        $generator->generate($resource, [])->shouldNotHaveBeenCalled();
+        $generator->generate($resource, array())->shouldNotHaveBeenCalled();
     }
 
-    function it_calls_the_parent_generate_method_if_the_user_answers_yes(Generator $generator, Resource $resource, ConsoleIO $io)
+    function it_calls_the_parent_generate_method_if_the_user_answers_yes(GeneratorInterface $generator, ResourceInterface $resource, IO $io)
     {
         $resource->getSrcClassname()->willReturn('Namespace/Classname');
 
         $io->askConfirmation('Question for Namespace/Classname')->willReturn(true);
 
-        $this->generate($resource, []);
+        $this->generate($resource, array());
 
-        $generator->generate($resource, [])->shouldHaveBeenCalled();
+        $generator->generate($resource, array())->shouldHaveBeenCalled();
     }
 }

--- a/spec/PhpSpec/CodeGenerator/Generator/ConfirmingGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ConfirmingGeneratorSpec.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace spec\PhpSpec\CodeGenerator\Generator;
+
+use PhpSpec\CodeGenerator\Generator\Generator;
+use PhpSpec\Console\ConsoleIO;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Locator\Resource;
+
+class ConfirmingGeneratorSpec extends ObjectBehavior
+{
+    function let(ConsoleIO $io, Generator $generator)
+    {
+        $this->beConstructedWith($io, 'Question for {CLASSNAME}', $generator);
+    }
+
+    function it_is_a_Generator()
+    {
+        $this->shouldHaveType(Generator::class);
+    }
+
+    function it_supports_the_same_generator_as_its_parent(Generator $generator, Resource $resource)
+    {
+        $generator->supports($resource, 'generation', [])->willReturn(true);
+
+        $this->supports($resource, 'generation', [])->shouldReturn(true);
+    }
+
+    function it_has_the_same_priority_as_its_parent(Generator $generator)
+    {
+        $generator->getPriority()->willReturn(1324);
+
+        $this->getPriority()->shouldReturn(1324);
+    }
+
+    function it_does_not_call_the_parent_generate_method_if_the_user_answers_no(Generator $generator, Resource $resource, ConsoleIO $io)
+    {
+        $resource->getSrcClassname()->willReturn('Namespace/Classname');
+
+        $io->askConfirmation('Question for Namespace/Classname')->willReturn(false);
+
+        $this->generate($resource, []);
+
+        $generator->generate($resource, [])->shouldNotHaveBeenCalled();
+    }
+
+    function it_calls_the_parent_generate_method_if_the_user_answers_yes(Generator $generator, Resource $resource, ConsoleIO $io)
+    {
+        $resource->getSrcClassname()->willReturn('Namespace/Classname');
+
+        $io->askConfirmation('Question for Namespace/Classname')->willReturn(true);
+
+        $this->generate($resource, []);
+
+        $generator->generate($resource, [])->shouldHaveBeenCalled();
+    }
+}

--- a/spec/PhpSpec/CodeGenerator/Generator/OneTimeGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/OneTimeGeneratorSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\PhpSpec\CodeGenerator\Generator;
+
+use PhpSpec\CodeGenerator\Generator\Generator;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Locator\Resource;
+
+class OneTimeGeneratorSpec extends ObjectBehavior
+{
+    function let(Generator $generator)
+    {
+        $this->beConstructedWith($generator);
+    }
+
+    function it_is_a_Generator()
+    {
+        $this->shouldHaveType(Generator::class);
+    }
+
+    function it_supports_the_same_generator_as_its_parent(Generator $generator, Resource $resource)
+    {
+        $generator->supports($resource, 'generation', [])->willReturn(true);
+
+        $this->supports($resource, 'generation', [])->shouldReturn(true);
+    }
+
+    function it_has_the_same_priority_as_its_parent(Generator $generator)
+    {
+        $generator->getPriority()->willReturn(1324);
+
+        $this->getPriority()->shouldReturn(1324);
+    }
+
+    function it_calls_the_parent_generate_method_just_once_for_the_same_classname(Generator $generator, Resource $resource)
+    {
+        $resource->getSrcClassname()->willReturn('Namespace/Classname');
+
+        $this->generate($resource, []);
+        $this->generate($resource, []);
+
+        $generator->generate($resource, [])->shouldHaveBeenCalledTimes(1);
+    }
+
+    function it_calls_the_parent_generate_method_once_per_each_classname(Generator $generator, Resource $resource)
+    {
+        $resource->getSrcClassname()->willReturn('Namespace/Classname1', 'Namespace/Classname2');
+
+        $this->generate($resource, []);
+        $this->generate($resource, []);
+
+        $generator->generate($resource, [])->shouldHaveBeenCalledTimes(2);
+    }
+}

--- a/spec/PhpSpec/CodeGenerator/Generator/OneTimeGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/OneTimeGeneratorSpec.php
@@ -2,53 +2,53 @@
 
 namespace spec\PhpSpec\CodeGenerator\Generator;
 
-use PhpSpec\CodeGenerator\Generator\Generator;
+use PhpSpec\CodeGenerator\Generator\GeneratorInterface;
 use PhpSpec\ObjectBehavior;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\ResourceInterface;
 
 class OneTimeGeneratorSpec extends ObjectBehavior
 {
-    function let(Generator $generator)
+    function let(GeneratorInterface $generator)
     {
         $this->beConstructedWith($generator);
     }
 
     function it_is_a_Generator()
     {
-        $this->shouldHaveType(Generator::class);
+        $this->shouldHaveType('PhpSpec\CodeGenerator\Generator\GeneratorInterface');
     }
 
-    function it_supports_the_same_generator_as_its_parent(Generator $generator, Resource $resource)
+    function it_supports_the_same_generator_as_its_parent(GeneratorInterface $generator, ResourceInterface $resource)
     {
-        $generator->supports($resource, 'generation', [])->willReturn(true);
+        $generator->supports($resource, 'generation', array())->willReturn(true);
 
-        $this->supports($resource, 'generation', [])->shouldReturn(true);
+        $this->supports($resource, 'generation', array())->shouldReturn(true);
     }
 
-    function it_has_the_same_priority_as_its_parent(Generator $generator)
+    function it_has_the_same_priority_as_its_parent(GeneratorInterface $generator)
     {
         $generator->getPriority()->willReturn(1324);
 
         $this->getPriority()->shouldReturn(1324);
     }
 
-    function it_calls_the_parent_generate_method_just_once_for_the_same_classname(Generator $generator, Resource $resource)
+    function it_calls_the_parent_generate_method_just_once_for_the_same_classname(GeneratorInterface $generator, ResourceInterface $resource)
     {
         $resource->getSrcClassname()->willReturn('Namespace/Classname');
 
-        $this->generate($resource, []);
-        $this->generate($resource, []);
+        $this->generate($resource, array());
+        $this->generate($resource, array());
 
-        $generator->generate($resource, [])->shouldHaveBeenCalledTimes(1);
+        $generator->generate($resource, array())->shouldHaveBeenCalledTimes(1);
     }
 
-    function it_calls_the_parent_generate_method_once_per_each_classname(Generator $generator, Resource $resource)
+    function it_calls_the_parent_generate_method_once_per_each_classname(GeneratorInterface $generator, ResourceInterface $resource)
     {
         $resource->getSrcClassname()->willReturn('Namespace/Classname1', 'Namespace/Classname2');
 
-        $this->generate($resource, []);
-        $this->generate($resource, []);
+        $this->generate($resource, array());
+        $this->generate($resource, array());
 
-        $generator->generate($resource, [])->shouldHaveBeenCalledTimes(2);
+        $generator->generate($resource, array())->shouldHaveBeenCalledTimes(2);
     }
 }

--- a/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\CodeGenerator\Generator;
+
+use PhpSpec\Console\ConsoleIO;
+use PhpSpec\Locator\Resource;
+
+final class ConfirmingGenerator implements Generator
+{
+    /**
+     * @var ConsoleIO
+     */
+    private $io;
+
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @var Generator
+     */
+    private $generator;
+
+    /**
+     * @param ConsoleIO $io
+     * @param string    $message
+     * @param Generator $generator
+     */
+    public function __construct(ConsoleIO $io, $message, Generator $generator)
+    {
+        $this->io = $io;
+        $this->message = $message;
+        $this->generator = $generator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Resource $resource, $generation, array $data)
+    {
+        return $this->generator->supports($resource, $generation, $data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(Resource $resource, array $data)
+    {
+        if ($this->io->askConfirmation($this->composeMessage($resource))) {
+            $this->generator->generate($resource, $data);
+        }
+    }
+
+    /**
+     * @param Resource $resource
+     *
+     * @return string
+     */
+    private function composeMessage(Resource $resource)
+    {
+        return str_replace('{CLASSNAME}', $resource->getSrcClassname(), $this->message);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        return $this->generator->getPriority();
+    }
+}

--- a/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
@@ -13,13 +13,13 @@
 
 namespace PhpSpec\CodeGenerator\Generator;
 
-use PhpSpec\Console\ConsoleIO;
-use PhpSpec\Locator\Resource;
+use PhpSpec\Console\IO;
+use PhpSpec\Locator\ResourceInterface;
 
-final class ConfirmingGenerator implements Generator
+final class ConfirmingGenerator implements GeneratorInterface
 {
     /**
-     * @var ConsoleIO
+     * @var IO
      */
     private $io;
 
@@ -29,16 +29,16 @@ final class ConfirmingGenerator implements Generator
     private $message;
 
     /**
-     * @var Generator
+     * @var GeneratorInterface
      */
     private $generator;
 
     /**
-     * @param ConsoleIO $io
-     * @param string    $message
-     * @param Generator $generator
+     * @param IO                 $io
+     * @param string             $message
+     * @param GeneratorInterface $generator
      */
-    public function __construct(ConsoleIO $io, $message, Generator $generator)
+    public function __construct(IO $io, $message, GeneratorInterface $generator)
     {
         $this->io = $io;
         $this->message = $message;
@@ -48,7 +48,7 @@ final class ConfirmingGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(ResourceInterface $resource, $generation, array $data)
     {
         return $this->generator->supports($resource, $generation, $data);
     }
@@ -56,7 +56,7 @@ final class ConfirmingGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(ResourceInterface $resource, array $data)
     {
         if ($this->io->askConfirmation($this->composeMessage($resource))) {
             $this->generator->generate($resource, $data);
@@ -64,11 +64,11 @@ final class ConfirmingGenerator implements Generator
     }
 
     /**
-     * @param Resource $resource
+     * @param ResourceInterface $resource
      *
      * @return string
      */
-    private function composeMessage(Resource $resource)
+    private function composeMessage(ResourceInterface $resource)
     {
         return str_replace('{CLASSNAME}', $resource->getSrcClassname(), $this->message);
     }

--- a/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\CodeGenerator\Generator;
+
+use PhpSpec\Locator\Resource;
+
+final class OneTimeGenerator implements Generator
+{
+    /**
+     * @var Generator
+     */
+    private $generator;
+
+    /**
+     * @var array
+     */
+    private $alreadyGenerated = [];
+
+    /**
+     * @param Generator $generator
+     */
+    public function __construct(Generator $generator)
+    {
+        $this->generator = $generator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Resource $resource, $generation, array $data)
+    {
+        return $this->generator->supports($resource, $generation, $data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(Resource $resource, array $data)
+    {
+        $classname = $resource->getSrcClassname();
+        if (in_array($classname, $this->alreadyGenerated)) {
+            return;
+        }
+
+        $this->generator->generate($resource, $data);
+        $this->alreadyGenerated[] = $classname;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        return $this->generator->getPriority();
+    }
+}

--- a/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
@@ -13,24 +13,24 @@
 
 namespace PhpSpec\CodeGenerator\Generator;
 
-use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\ResourceInterface;
 
-final class OneTimeGenerator implements Generator
+final class OneTimeGenerator implements GeneratorInterface
 {
     /**
-     * @var Generator
+     * @var GeneratorInterface
      */
     private $generator;
 
     /**
      * @var array
      */
-    private $alreadyGenerated = [];
+    private $alreadyGenerated = array();
 
     /**
-     * @param Generator $generator
+     * @param GeneratorInterface $generator
      */
-    public function __construct(Generator $generator)
+    public function __construct(GeneratorInterface $generator)
     {
         $this->generator = $generator;
     }
@@ -38,7 +38,7 @@ final class OneTimeGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(ResourceInterface $resource, $generation, array $data)
     {
         return $this->generator->supports($resource, $generation, $data);
     }
@@ -46,7 +46,7 @@ final class OneTimeGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(ResourceInterface $resource, array $data)
     {
         $classname = $resource->getSrcClassname();
         if (in_array($classname, $this->alreadyGenerated)) {

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -45,6 +45,7 @@ class ContainerAssembler
      */
     public function build(ServiceContainer $container)
     {
+        $this->setupParameters($container);
         $this->setupIO($container);
         $this->setupEventDispatcher($container);
         $this->setupConsoleEventDispatcher($container);
@@ -61,6 +62,14 @@ class ContainerAssembler
         $this->setupSubscribers($container);
         $this->setupCurrentExample($container);
         $this->setupShutdown($container);
+    }
+
+    private function setupParameters(IndexedServiceContainer $container)
+    {
+        $container->setParam(
+            'generator.private-constructor.message',
+            'Do you want me to make the constructor of {CLASSNAME} private for you?'
+        );
     }
 
     private function setupIO(ServiceContainer $container)
@@ -292,11 +301,17 @@ class ContainerAssembler
         });
 
         $container->define('code_generator.generators.private_constructor', function (ServiceContainer $c) {
-            return new CodeGenerator\Generator\PrivateConstructorGenerator(
-                $c->get('console.io'),
-                $c->get('code_generator.templates'),
-                $c->get('util.filesystem'),
-                $c->get('code_generator.writers.tokenized')
+            return new CodeGenerator\Generator\OneTimeGenerator(
+                new CodeGenerator\Generator\ConfirmingGenerator(
+                    $c->get('console.io'),
+                    $c->getParam('generator.private-constructor.message'),
+                    new CodeGenerator\Generator\PrivateConstructorGenerator(
+                        $c->get('console.io'),
+                        $c->get('code_generator.templates'),
+                        $c->get('util.filesystem'),
+                        $c->get('code_generator.writers.tokenized')
+                    )
+                )
             );
         });
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -64,7 +64,7 @@ class ContainerAssembler
         $this->setupShutdown($container);
     }
 
-    private function setupParameters(IndexedServiceContainer $container)
+    private function setupParameters(ServiceContainer $container)
     {
         $container->setParam(
             'generator.private-constructor.message',
@@ -300,16 +300,14 @@ class ContainerAssembler
             );
         });
 
-        $container->define('code_generator.generators.private_constructor', function (ServiceContainer $c) {
+        $container->set('code_generator.generators.private_constructor', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\OneTimeGenerator(
                 new CodeGenerator\Generator\ConfirmingGenerator(
                     $c->get('console.io'),
                     $c->getParam('generator.private-constructor.message'),
                     new CodeGenerator\Generator\PrivateConstructorGenerator(
                         $c->get('console.io'),
-                        $c->get('code_generator.templates'),
-                        $c->get('util.filesystem'),
-                        $c->get('code_generator.writers.tokenized')
+                        $c->get('code_generator.templates')
                     )
                 )
             );

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -291,10 +291,12 @@ class ContainerAssembler
             );
         });
 
-        $container->set('code_generator.generators.private_constructor', function (ServiceContainer $c) {
+        $container->define('code_generator.generators.private_constructor', function (ServiceContainer $c) {
             return new CodeGenerator\Generator\PrivateConstructorGenerator(
                 $c->get('console.io'),
-                $c->get('code_generator.templates')
+                $c->get('code_generator.templates'),
+                $c->get('util.filesystem'),
+                $c->get('code_generator.writers.tokenized')
             );
         });
 

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -81,14 +81,10 @@ class NamedConstructorNotFoundListener implements EventSubscriberInterface
                 $event->markAsWorthRerunning();
 
                 if (!method_exists($classname, '__construct')) {
-                    $message = sprintf('Do you want me to make the constructor of %s private for you?', $classname);
-
-                    if ($this->io->askConfirmation($message)) {
-                        $this->generator->generate($resource, 'private-constructor', array(
-                            'name' => $method,
-                            'arguments' => $arguments
-                        ));
-                    }
+                    $this->generator->generate($resource, 'private-constructor', array(
+                        'name' => $method,
+                        'arguments' => $arguments
+                    ));
                 }
             }
         }


### PR DESCRIPTION
This PR fixes the issue raised in https://github.com/phpspec/phpspec/issues/1058.

===========================================================

The solution is to add a new Generator called `OneTimeGenerator` which decorates any other Generator so that it only calls the parent the first time it is called per classname.