### PR TITLE
Fix PHP Warning when src_path is empty

### DIFF
--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -357,7 +357,7 @@ class ContainerAssembler
 
                 $config = array_merge($defaults, $suite);
 
-                if (!is_dir($config['src_path']) && !empty($config['src_path'])) {
+                if (!empty($config['src_path']) && !is_dir($config['src_path'])) {
                     mkdir($config['src_path'], 0777, true);
                 }
                 if (!is_dir($config['spec_path'])) {

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -357,7 +357,7 @@ class ContainerAssembler
 
                 $config = array_merge($defaults, $suite);
 
-                if (!is_dir($config['src_path'])) {
+                if (!is_dir($config['src_path']) && !empty($config['src_path'])) {
                     mkdir($config['src_path'], 0777, true);
                 }
                 if (!is_dir($config['spec_path'])) {


### PR DESCRIPTION
Added the check to see if the user has set src_path to an empty string like found in this issue:

[Issue 1065](https://github.com/phpspec/phpspec/issues/1065)

This was causing the a PHP warning when creating the Spec class since it would pass the check:

```php
if (!is_dir($config['src_path'])) {
    mkdir($config['src_path'], 0777, true);
}
```

But then the ```mkdir``` command would not be able to execute since it is passed an empty string. So I added the check to make sure it is also not empty the ```src_path``` and after testing it locally it works fine. I added only to src_path because I can image people might want to have their classes in the root of the folder but did not do the same for spec_path because that would not make sense to be in the root as those should definitely be in a separate folder.