### PR TITLE
Fix dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - php: 5.6
     - php: hhvm
     - php: 7.0
+    - php: 7.1
+      env: DEPENDENCIES='low'
   allow_failures:
     - env: DEPENDENCIES='dev'
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/process":          "^2.6|~3.0",
         "symfony/finder":           "~2.1|~3.0",
         "symfony/yaml":             "~2.1|~3.0",
-        "doctrine/instantiator":    "^1.0.1",
+        "doctrine/instantiator":    "^1.0.5",
         "ext-tokenizer":            "*"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpspec/prophecy":         "~1.4",
         "phpspec/php-diff":         "~1.0.0",
         "sebastian/exporter":       "~1.0|~2.0",
-        "symfony/console":          "~2.3|~3.0",
+        "symfony/console":          "~2.7|~3.0",
         "symfony/event-dispatcher": "~2.1|~3.0",
         "symfony/process":          "^2.6|~3.0",
         "symfony/finder":           "~2.1|~3.0",

--- a/features/formatter/use_the_junit_formatter.feature
+++ b/features/formatter/use_the_junit_formatter.feature
@@ -41,7 +41,7 @@ Feature: Use the JUnit formatter
           // skipped
           function it_does_some_incompatible_things()
           {
-              throw new \PhpSpec\Exception\Example\SkippingException();
+              throw new \PhpSpec\Exception\Example\SkippingException('Reason for skipping');
           }
       }
 


### PR DESCRIPTION
Tests previously failed in PHP 7 after `composer update --prefer-lowest`.  Problem related to instantiation of final classes with `doctrine/instantiator` `<1.0.5`.