### PR TITLE
Backport the support of sebastian/exporter 2 to 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php":                      ">=5.3.3",
         "phpspec/prophecy":         "~1.4",
         "phpspec/php-diff":         "~1.0.0",
-        "sebastian/exporter":       "~1.0",
+        "sebastian/exporter":       "~1.0|~2.0",
         "symfony/console":          "~2.3|~3.0",
         "symfony/event-dispatcher": "~2.1|~3.0",
         "symfony/process":          "^2.6|~3.0",


### PR DESCRIPTION
There was no change needed to support it (the main reason to bump the major version was dropping support for older PHP versions).
This is the same than https://github.com/phpspec/phpspec/pull/1038 in PhpSpec 3.

Some projects are stuck to phpspec 2.5 due to PHP version support (I'm talking about Prophecy here). And enforcing usage of ``sebastian/exporter`` forces to install PHPUnit 4.8 when using both phpspec and phpunit through composer (which we do). This is bad news, as PHPUnit 4.8 has only partial support for PHP 7.