### PR TITLE
Allow PHP5 keywords methods generation on PHP7

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -359,6 +359,7 @@ class ApplicationContext implements Context
     {
         $string = preg_replace('/\([0-9]+ms\)/', '', $string);
         $string = str_replace("\r", '', $string);
+        $string = preg_replace('#(Double\\\\.+?\\\\P)\d+#u', '$1', $string);
 
         return $string;
     }

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -120,4 +120,16 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
         }
     }
 
+    /**
+     * @Then the suite should pass
+     */
+    public function theSuiteShouldPass()
+    {
+        $exitCode = $this->process->getExitCode();
+        if ($exitCode !== 0) {
+            throw new \Exception(sprintf('Expected that tests will pass, but exit code was %s.', $exitCode));
+        }
+    }
+
+
 }

--- a/features/code_generation/developer_generates_collaborator_method.feature
+++ b/features/code_generation/developer_generates_collaborator_method.feature
@@ -212,6 +212,7 @@ Feature: Developer generates a collaborator's method
     When I run phpspec and answer "n" when asked if I want to generate the code
     Then I should not be prompted for code generation
 
+  @php:5.6
   Scenario: Being warned when a collaborator method is a restricted word
     Given the spec file "spec/CodeGeneration/CollaboratorMethodExample6/MarkdownSpec.php" contains:
       """

--- a/features/code_generation/developer_generates_method.feature
+++ b/features/code_generation/developer_generates_method.feature
@@ -372,7 +372,8 @@ Feature: Developer generates a method
 
       """
 
-  Scenario: Generating a method named with a restricted keyword
+  @php:~5.6
+  Scenario: Restricted generation of a method named with a reserved keyword
     Given the spec file "spec/MyNamespace/RestrictedSpec.php" contains:
       """
       <?php
@@ -415,3 +416,53 @@ Feature: Developer generates a method
       }
 
       """
+
+  @php:~7 @isolated
+  Scenario: Successful generation of a method named with a reserved keyword in previous PHP versions
+    Given the spec file "spec/MyNamespace/KeywordMethodSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\MyNamespace;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class KeywordMethodSpec extends ObjectBehavior
+      {
+          function it_tries_to_call_wrong_method()
+          {
+              $this->throw()->shouldReturn(null);
+          }
+      }
+
+      """
+    And the class file "src/MyNamespace/KeywordMethod.php" contains:
+      """
+      <?php
+
+      namespace MyNamespace;
+
+      class KeywordMethod
+      {
+      }
+
+      """
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then the class in "src/MyNamespace/KeywordMethod.php" should contain:
+      """
+      <?php
+
+      namespace MyNamespace;
+
+      class KeywordMethod
+      {
+          public function throw()
+          {
+              // TODO: write logic here
+          }
+      }
+
+      """
+    Then the tests should be rerun
+    Then the suite should pass

--- a/features/code_generation/developer_generates_method.feature
+++ b/features/code_generation/developer_generates_method.feature
@@ -464,5 +464,4 @@ Feature: Developer generates a method
       }
 
       """
-    Then the tests should be rerun
-    Then the suite should pass
+    And the suite should pass

--- a/spec/PhpSpec/Util/ReservedWordsMethodNameCheckerSpec.php
+++ b/spec/PhpSpec/Util/ReservedWordsMethodNameCheckerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Util;
 
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -19,17 +20,33 @@ class ReservedWordsMethodNameCheckerSpec extends ObjectBehavior
 
     function it_returns_false_for_php_restricted_name()
     {
+        $this->skipIfPhp7();
         $this->isNameValid('function')->shouldReturn(false);
     }
 
     function it_returns_false_for_php_predefined_constant()
     {
+        $this->skipIfPhp7();
         $this->isNameValid('__CLASS__')->shouldReturn(false);
     }
 
     function it_returns_false_for_php_restricted_name_case_insensitive()
     {
+        $this->skipIfPhp7();
         $this->isNameValid('instanceof')->shouldReturn(false);
         $this->isNameValid('instanceOf')->shouldReturn(false);
     }
+
+    function it_returns_false_for___halt_compiler_function()
+    {
+        $this->isNameValid('__halt_compiler')->shouldReturn(false);
+    }
+
+    private function skipIfPhp7()
+    {
+        if (\PHP_VERSION_ID >= 70000) {
+            throw new SkippingException('Reserved keywords list in PHP 7 does not include most of PHP 5.6 keywords');
+        }
+    }
+
 }

--- a/src/PhpSpec/Util/ReservedWordsMethodNameChecker.php
+++ b/src/PhpSpec/Util/ReservedWordsMethodNameChecker.php
@@ -91,6 +91,13 @@ final class ReservedWordsMethodNameChecker implements NameChecker
         '__trait__',
     );
 
+    public function __construct()
+    {
+        if (\PHP_VERSION_ID >= 70000) {
+            $this->reservedWords = ['__halt_compiler'];
+        }
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Based and depends on the phpspec/prophecy#309
While that PR is not merged tests may fail, so marked as WIP.
