### PR TITLE
Add namespace provider

### DIFF
--- a/spec/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProviderSpec.php
+++ b/spec/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProviderSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\PhpSpec\NamespaceProvider;
+
+use PhpSpec\NamespaceProvider\ComposerPsrNamespaceProvider;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ComposerPsrNamespaceProviderSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(__DIR__ . '/../../..', 'spec');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ComposerPsrNamespaceProvider::class);
+    }
+
+    public function it_should_return_a_map_of_locations()
+    {
+        $this->getNamespaces()->shouldReturn(array('PhpSpec' => 'src'));
+    }
+}

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace PhpSpec\NamespaceProvider;
+
+use Composer\Autoload\ClassLoader;
+
+/**
+ * Provides project namespaces and where to find them.
+ */
+class ComposerPsrNamespaceProvider
+{
+    /**
+     * @var string path to the root directory of the project, without a trailing slash
+     */
+    private $rootDirectory;
+
+    /**
+     * @var string prefix of the specifications namespace
+     */
+    private $specPrefix;
+
+    public function __construct($rootDirectory, $specPrefix)
+    {
+        $this->rootDirectory = $rootDirectory;
+        $this->specPrefix = $specPrefix;
+    }
+
+    /**
+     * @return string[] a map associating a namespace to a location, e.g
+     *                  [
+     *                      'My\PSR4Namespace' => 'my/PSR4Namespace',
+     *                      'My\PSR0Namespace' => '',
+     *                  ]
+     */
+    public function getNamespaces()
+    {
+        $vendors = array();
+        foreach (get_declared_classes() as $class) {
+            if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
+                $r = new \ReflectionClass($class);
+                $v = dirname(dirname($r->getFileName()));
+                if (file_exists($v.'/composer/installed.json')) {
+                    $vendors[] = $v;
+                }
+            }
+        }
+        $classLoader = require $this->rootDirectory . '/vendor/autoload.php';
+        return
+            $this->getNamespacesFromPrefixes($classLoader->getPrefixes(), $vendors)
+            +
+            $this->getNamespacesFromPrefixes($classLoader->getPrefixesPsr4(), $vendors);
+    }
+
+    private function getNamespacesFromPrefixes(array $prefixes, array $vendors)
+    {
+        $namespaces = array();
+        foreach ($prefixes as $namespace => $psrPrefix) {
+            foreach ($psrPrefix as $location) {
+                foreach ($vendors as $vendor) {
+                    if (strpos(realpath($location), $vendor) === 0) {
+                        break 2;
+                    }
+                }
+                if (strpos($namespace, $this->specPrefix) !== 0) {
+                    $namespaces[$namespace] = substr(
+                        realpath($location),
+                        strlen(realpath($this->rootDirectory)) + 1 // trailing slash
+                    );
+                }
+            }
+        }
+
+        return $namespaces;
+    }
+}

--- a/src/PhpSpec/NamespaceProvider/NamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/NamespaceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PhpSpec\NamespaceProvider;
+
+/**
+ * Provides project namespaces and where to find them.
+ */
+interface NamespaceProvider
+{
+    /**
+     * @return string[] a map associating a namespace to a location, e.g
+     *                  ['My\Namespace' => 'my/location/relative/to/spec/or/src/directory']
+     */
+    public function getNamespaces();
+}


### PR DESCRIPTION
This should be useful for automating things like prefix/namespace
configuration, or auto-complete.

This is not well-tested because I need to add a fixture "project" and do not know where I should put it, but seems to do the job.