### PR TITLE
Remove black background of line numbers for 'pretty' format.

### DIFF
--- a/src/PhpSpec/Console/Formatter.php
+++ b/src/PhpSpec/Console/Formatter.php
@@ -47,7 +47,7 @@ class Formatter extends OutputFormatter
         $this->setStyle('passed-bg', new OutputFormatterStyle('black', 'green', array('bold')));
 
         $this->setStyle('value', new OutputFormatterStyle('yellow'));
-        $this->setStyle('lineno', new OutputFormatterStyle(null, 'black'));
+        $this->setStyle('lineno', new OutputFormatterStyle(null));
         $this->setStyle('code', new OutputFormatterStyle('white'));
         $this->setStyle('label', new OutputFormatterStyle('white', null, array('bold')));
         $this->setStyle('hl', new OutputFormatterStyle('black', 'yellow', array('bold')));


### PR DESCRIPTION
Problem
Phpspec displays line numbers if pretty format has been chosen for run command.
The background of line numbers is always black. It makes an output difficult to read on light console backgrounds.

**Before:**
![phpspec-pretty-format-before](https://cloud.githubusercontent.com/assets/6177375/24776953/8042ad72-1b23-11e7-8c36-d4576c485d64.png)

**After:**
![phpspec-pretty-format-after](https://cloud.githubusercontent.com/assets/6177375/24776952/80414d7e-1b23-11e7-9fd3-f5db437e79b0.png)

**After (on black background):**
![phpspec-pretty-format-after-black](https://cloud.githubusercontent.com/assets/6177375/24777151/58d78a0e-1b24-11e7-8587-b8ccf3342164.png)

**Also looks good on any other background:**
![phpspec-pretty-format-after-blue](https://cloud.githubusercontent.com/assets/6177375/24777231/af6d688e-1b24-11e7-9006-e17938c515f0.png)



