### PR TITLE
PHP7 typehints

### DIFF
--- a/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
@@ -90,13 +90,18 @@ class CallerSpec extends ObjectBehavior
             ->duringGetWrappedObject();
     }
 
-    function it_delegates_throwing_method_not_found_exception(WrappedObject $wrappedObject, ExceptionFactory $exceptions)
-    {
+    function it_delegates_throwing_method_not_found_exception(
+        WrappedObject $wrappedObject,
+        ExceptionFactory $exceptions,
+        AccessInspector $accessInspector
+    ) {
         $obj = new \ArrayObject();
 
         $wrappedObject->isInstantiated()->willReturn(true);
         $wrappedObject->getInstance()->willReturn($obj);
         $wrappedObject->getClassName()->willReturn('ArrayObject');
+
+        $accessInspector->isMethodCallable($obj,'foo')->willReturn(false);
 
         $exceptions->methodNotFound('ArrayObject', 'foo', array())
             ->willReturn(new \PhpSpec\Exception\Fracture\MethodNotFoundException(
@@ -158,13 +163,18 @@ class CallerSpec extends ObjectBehavior
             ->duringCall('foo');
     }
 
-    function it_delegates_throwing_method_not_visible_exception(WrappedObject $wrappedObject, ExceptionFactory $exceptions)
-    {
+    function it_delegates_throwing_method_not_visible_exception(
+        WrappedObject $wrappedObject,
+        ExceptionFactory $exceptions,
+        AccessInspector $accessInspector
+    ) {
         $obj = new ExampleClass();
 
         $wrappedObject->isInstantiated()->willReturn(true);
         $wrappedObject->getInstance()->willReturn($obj);
         $wrappedObject->getClassName()->willReturn('spec\PhpSpec\Wrapper\Subject\ExampleClass');
+
+        $accessInspector->isMethodCallable($obj,'privateMethod')->willReturn(false);
 
         $exceptions->methodNotVisible('spec\PhpSpec\Wrapper\Subject\ExampleClass', 'privateMethod', array())
             ->willReturn(new \PhpSpec\Exception\Fracture\MethodNotVisibleException(
@@ -179,12 +189,17 @@ class CallerSpec extends ObjectBehavior
             ->duringCall('privateMethod');
     }
 
-    function it_delegates_throwing_property_not_found_exception(WrappedObject $wrappedObject, ExceptionFactory $exceptions)
-    {
+    function it_delegates_throwing_property_not_found_exception(
+        WrappedObject $wrappedObject,
+        ExceptionFactory $exceptions,
+        AccessInspector $accessInspector
+    ) {
         $obj = new ExampleClass();
 
         $wrappedObject->isInstantiated()->willReturn(true);
         $wrappedObject->getInstance()->willReturn($obj);
+
+        $accessInspector->isPropertyWritable($obj,'nonExistentProperty')->willReturn(false);
 
         $exceptions->propertyNotFound($obj, 'nonExistentProperty')
             ->willReturn(new \PhpSpec\Exception\Fracture\PropertyNotFoundException(

--- a/src/PhpSpec/CodeAnalysis/AccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/AccessInspector.php
@@ -17,25 +17,16 @@ interface AccessInspector
 {
     /**
      * @param object $object
-     * @param string $property
-     *
-     * @return bool
      */
-    public function isPropertyReadable($object, $property);
+    public function isPropertyReadable($object, string $property) : bool;
 
     /**
      * @param object $object
-     * @param string $property
-     *
-     * @return bool
      */
-    public function isPropertyWritable($object, $property);
+    public function isPropertyWritable($object, string $property) : bool;
 
     /**
      * @param object $object
-     * @param string $method
-     *
-     * @return bool
      */
-    public function isMethodCallable($object, $method);
+    public function isMethodCallable($object, string $method) : bool;
 }

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -30,33 +30,24 @@ final class MagicAwareAccessInspector implements AccessInspector
 
     /**
      * @param object $object
-     * @param string $property
-     *
-     * @return bool
      */
-    public function isPropertyReadable($object, $property)
+    public function isPropertyReadable($object, string $property) : bool
     {
         return method_exists($object, '__get') || $this->accessInspector->isPropertyReadable($object, $property);
     }
 
     /**
      * @param object $object
-     * @param string $property
-     *
-     * @return bool
      */
-    public function isPropertyWritable($object, $property)
+    public function isPropertyWritable($object, string $property) : bool
     {
         return method_exists($object, '__set') || $this->accessInspector->isPropertyWritable($object, $property);
     }
 
     /**
      * @param object $object
-     * @param string $method
-     *
-     * @return bool
      */
-    public function isMethodCallable($object, $method)
+    public function isMethodCallable($object, string $method) : bool
     {
         return method_exists($object, '__call') || $this->accessInspector->isMethodCallable($object, $method);
     }

--- a/src/PhpSpec/CodeAnalysis/NamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/NamespaceResolver.php
@@ -15,7 +15,7 @@ namespace PhpSpec\CodeAnalysis;
 
 interface NamespaceResolver
 {
-    public function analyse($code);
+    public function analyse(string $code);
 
-    public function resolve($typeAlias);
+    public function resolve(string $typeAlias);
 }

--- a/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
@@ -25,12 +25,12 @@ final class StaticRejectingNamespaceResolver implements NamespaceResolver
         $this->namespaceResolver = $namespaceResolver;
     }
 
-    public function analyse($code)
+    public function analyse(string $code)
     {
         $this->namespaceResolver->analyse($code);
     }
 
-    public function resolve($typeAlias)
+    public function resolve(string $typeAlias)
     {
         $this->guardNonObjectTypeHints($typeAlias);
 
@@ -38,10 +38,9 @@ final class StaticRejectingNamespaceResolver implements NamespaceResolver
     }
 
     /**
-     * @param $typeAlias
      * @throws \Exception
      */
-    private function guardNonObjectTypeHints($typeAlias)
+    private function guardNonObjectTypeHints(string $typeAlias)
     {
         $nonObjectTypes = [
             'int',

--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -30,7 +30,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
     /**
      * @param string $code
      */
-    public function analyse($code)
+    public function analyse(string $code)
     {
         $this->state = self::STATE_DEFAULT;
         $this->currentUse = null;
@@ -95,12 +95,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
         }
     }
 
-    /**
-     * @param string $typeAlias
-     *
-     * @return string
-     */
-    public function resolve($typeAlias)
+    public function resolve(string $typeAlias) : string
     {
         if (strpos($typeAlias, '\\') === 0) {
             return substr($typeAlias, 1);

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -52,12 +52,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         $this->namespaceResolver = $namespaceResolver;
     }
 
-    /**
-     * @param string $classDefinition
-     *
-     * @return string
-     */
-    public function rewrite($classDefinition)
+    public function rewrite(string $classDefinition) : string
     {
         $this->namespaceResolver->analyse($classDefinition);
 
@@ -75,11 +70,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         $this->currentFunction = '';
     }
 
-    /**
-     * @param array $tokens
-     * @return array $tokens
-     */
-    private function stripTypeHints($tokens)
+    private function stripTypeHints(array $tokens) : array
     {
         foreach ($tokens as $index => $token) {
             if ($this->isToken($token, '{')) {
@@ -143,19 +134,14 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
      * @param array $tokens
      * @return string
      */
-    private function tokensToString($tokens)
+    private function tokensToString(array $tokens) : string
     {
         return join('', array_map(function ($token) {
             return is_array($token) ? $token[1] : $token;
         }, $tokens));
     }
 
-    /**
-     * @param array $tokens
-     * @param integer $index
-     * @param array $token
-     */
-    private function extractTypehints(&$tokens, $index, $token)
+    private function extractTypehints(array &$tokens, int $index, array $token)
     {
         $typehint = '';
         for ($i = $index - 1; in_array($tokens[$i][0], $this->typehintTokens); $i--) {
@@ -189,32 +175,21 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
 
     /**
      * @param array|string $token
-     * @param string $type
-     *
-     * @return bool
      */
-    private function tokenHasType($token, $type)
+    private function tokenHasType($token, string $type) : bool
     {
         return is_array($token) && $type == $token[0];
     }
 
-    /**
-     * @param string $className
-     *
-     * @return bool
-     */
-    private function shouldExtractTokensOfClass($className)
+    private function shouldExtractTokensOfClass(string $className) : bool
     {
         return substr($className, -4) == 'Spec';
     }
 
     /**
      * @param array|string $token
-     * @param string $string
-     *
-     * @return bool
      */
-    private function isToken($token, $string)
+    private function isToken($token, string $string) : bool
     {
         return $token == $string || (is_array($token) && $token[1] == $string);
     }

--- a/src/PhpSpec/CodeAnalysis/TypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TypeHintRewriter.php
@@ -20,5 +20,5 @@ interface TypeHintRewriter
      *
      * @return string
      */
-    public function rewrite($classDefinition);
+    public function rewrite(string $classDefinition) : string;
 }

--- a/src/PhpSpec/CodeAnalysis/VisibilityAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/VisibilityAccessInspector.php
@@ -20,33 +20,24 @@ final class VisibilityAccessInspector implements AccessInspector
 {
     /**
      * @param object $object
-     * @param string $property
-     *
-     * @return bool
      */
-    public function isPropertyReadable($object, $property)
+    public function isPropertyReadable($object, string $property) : bool
     {
         return $this->isExistingPublicProperty($object, $property);
     }
 
     /**
      * @param object $object
-     * @param string $property
-     *
-     * @return bool
      */
-    public function isPropertyWritable($object, $property)
+    public function isPropertyWritable($object, string $property) : bool
     {
         return $this->isExistingPublicProperty($object, $property);
     }
 
     /**
      * @param object $object
-     * @param string $property
-     *
-     * @return bool
      */
-    private function isExistingPublicProperty($object, $property)
+    private function isExistingPublicProperty($object, string $property) : bool
     {
         if (!property_exists($object, $property)) {
             return false;
@@ -59,22 +50,16 @@ final class VisibilityAccessInspector implements AccessInspector
 
     /**
      * @param object $object
-     * @param string $method
-     *
-     * @return bool
      */
-    public function isMethodCallable($object, $method)
+    public function isMethodCallable($object, string $method) : bool
     {
         return $this->isExistingPublicMethod($object, $method);
     }
 
     /**
      * @param object $object
-     * @param string $method
-     *
-     * @return bool
      */
-    private function isExistingPublicMethod($object, $method)
+    private function isExistingPublicMethod($object, string $method) : bool
     {
         if (!method_exists($object, $method)) {
             return false;


### PR DESCRIPTION
- Adding PHP7 typehints to part of the codebase.
- Removing redundant docblocks.
- Bumping min version of Prophecy to one which is less panicky about scalar typehints.
- Stubbing behaviour of doubles where necessary, to keep tests passing in the presence of return typehinting.