### PR TITLE
Bump PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "require-dev": {
         "behat/behat":           "^3.3",
         "symfony/filesystem":    "^3.2",
-        "phpunit/phpunit":       "^5.7|^6.0"
+        "phpunit/phpunit":       "^6.2",
+        "sebastian/exporter":    "^3.1"
     },
 
     "suggest": {


### PR DESCRIPTION
Increases PHPUnit version to 6.1, now PHP5 no longer required