### PR TITLE
Avoid Behat version with PHP5.4+ code in it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
 
     "require-dev": {
-        "behat/behat":           "^3.0.11",
+        "behat/behat":           "^3.0.11,!=3.3.1",
         "symfony/filesystem":    "~2.1|~3.0",
         "phpunit/phpunit":       "~4.4",
         "ciaranmcnulty/versionbasedtestskipper": "^0.2.1"


### PR DESCRIPTION
The build may break on `2.5` branch the next time it runs, because a [Behat file we're using](https://github.com/Behat/Behat/blob/v3.3.1/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php) has had more short array syntax added recently, and does not in fact work in PHP5.3.

This PR restricts the Behat version used to one where the tests will pass.

(Build break observed [on fork](https://travis-ci.org/Sam-Burns/phpspec/jobs/233561625), where the PhpSpec 2.5/PHP5.3 tests failed.)