### PR TITLE
[Do not merge] Traversable Throw matcher

### DIFF
--- a/features/matchers/developer_uses_traversable_throw_matcher.feature
+++ b/features/matchers/developer_uses_traversable_throw_matcher.feature
@@ -1,0 +1,41 @@
+Feature: Developer uses traversable-throw matcher
+  As a Developer
+  I want a traversable-throw matcher
+  In order to confirm that an exception can be thrown when iterating on a Traversable object
+
+  Scenario: "ThrowWhenIterating" alias matches using the traversable-throw matcher
+    Given the spec file "spec/Matchers/TraversableThrowExample1/TraversableObjectSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Matchers\TraversableThrowExample1;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class TraversableObjectSpec extends ObjectBehavior
+    {
+        function it_should_throw_an_exception()
+        {
+            $this->shouldThrowWhenIterating('\RuntimeException');
+        }
+    }
+    """
+    And the class file "src/Matchers/TraversableThrowExample1/TraversableObject.php" contains:
+    """
+    <?php
+
+    namespace Matchers\TraversableThrowExample1;
+
+    class TraversableObject implements \IteratorAggregate
+    {
+        public function getIterator()
+        {
+            yield 1;
+            yield 2;
+            throw new \RuntimeException();
+        }
+    }
+    """
+    When I run phpspec
+    Then the suite should pass

--- a/spec/PhpSpec/Matcher/TraversableThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/TraversableThrowMatcherSpec.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace spec\PhpSpec\Matcher;
+
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Matcher\Matcher;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+final class TraversableThrowMatcherSpec extends ObjectBehavior
+{
+    function let(Presenter $presenter)
+    {
+        $presenter->presentValue(Argument::any())->willReturn('traversable');
+
+        $this->beConstructedWith($presenter);
+    }
+
+    function it_is_a_matcher()
+    {
+        $this->shouldBeAnInstanceOf(Matcher::class);
+    }
+
+    function it_responds_to_contain()
+    {
+        $this->supports('throwWhenIterating', $this->createGeneratorThrowing(null), [''])->shouldReturn(true);
+    }
+
+    function it_positive_match_something_thrown_when_any_exception_is_expected()
+    {
+        $this
+            ->shouldNotThrow(FailureException::class)
+            ->during('positiveMatch', ['throwWhenIterating', $this->createGeneratorThrowing(new \Exception()), []])
+            ;
+    }
+
+    function it_does_not_positive_match_nothing_thrown_when_any_exception_is_expected()
+    {
+        $this
+            ->shouldThrow(FailureException::class)
+            ->during('positiveMatch', ['throwWhenIterating', $this->createGeneratorThrowing(null), []])
+        ;
+    }
+
+    function it_positive_match_when_exception_thrown_is_same_as_expected()
+    {
+        $this
+            ->shouldNotThrow(FailureException::class)
+            ->during('positiveMatch', ['throwWhenIterating', $this->createGeneratorThrowing(new \RuntimeException()), ['\\RuntimeException']])
+        ;
+    }
+
+    function it_does_not_positive_match_exception_thrown_is_not_same_as_expected()
+    {
+        $this
+            ->shouldThrow(FailureException::class)
+            ->during('positiveMatch', ['throwWhenIterating', $this->createGeneratorThrowing(new \RuntimeException()), ['\\LogicException']])
+        ;
+    }
+
+    function it_negative_match_nothing_thrown_when_nothing_should_be_thrown()
+    {
+        $this
+            ->shouldNotThrow(FailureException::class)
+            ->during('negativeMatch', ['throwWhenIterating', $this->createGeneratorThrowing(null), []])
+        ;
+    }
+
+    function it_does_not_negative_match_something_thrown_when_nothing_should_be_thrown()
+    {
+        $this
+            ->shouldThrow(FailureException::class)
+            ->during('negativeMatch', ['throwWhenIterating', $this->createGeneratorThrowing(new \Exception()), []])
+        ;
+    }
+
+    function it_negative_match_something_thrown_different_than_expected()
+    {
+        $this
+            ->shouldNotThrow(FailureException::class)
+            ->during('negativeMatch', ['throwWhenIterating', $this->createGeneratorThrowing(new \RuntimeException()), ['\\LogicException']])
+        ;
+    }
+
+    function it_does_not_negative_match_something_thrown_same_as_expected()
+    {
+        $this
+            ->shouldThrow(FailureException::class)
+            ->during('negativeMatch', ['throwWhenIterating', $this->createGeneratorThrowing(new \RuntimeException()), ['\\RuntimeException']])
+        ;
+    }
+    
+    /**
+     * @param array $values
+     *
+     * @return \Generator
+     */
+    private function createGeneratorThrowing(\Exception $exception = null) {
+        yield 1;
+        yield 2;
+        if (null !== $exception) {
+            throw $exception;
+        }
+        yield 3;
+    }
+}

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -705,6 +705,9 @@ final class ContainerAssembler
         $container->define('matchers.traversable_contain', function (IndexedServiceContainer $c) {
             return new Matcher\TraversableContainMatcher($c->get('formatter.presenter'));
         }, ['matchers']);
+        $container->define('matchers.traversable_throw', function (IndexedServiceContainer $c) {
+            return new Matcher\TraversableThrowMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
         $container->define('matchers.iterate', function (IndexedServiceContainer $c) {
             return new Matcher\IterateAsMatcher($c->get('formatter.presenter'));
         }, ['matchers']);

--- a/src/PhpSpec/Matcher/TraversableThrowMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableThrowMatcher.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Matcher;
+
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\Presenter;
+
+final class TraversableThrowMatcher implements Matcher
+{
+    /**
+     * @var Presenter
+     */
+    private $presenter;
+
+    /**
+     * @param Presenter $presenter
+     */
+    public function __construct(Presenter $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($name, $subject, array $arguments)
+    {
+        return 'throwWhenIterating' === $name
+            && $subject instanceof \Traversable
+            ;
+    }
+
+    private function loop($subject)
+    {
+        $exceptionThrown = null;
+        try {
+            foreach ($subject as $item) {
+                continue;
+            }
+        } catch (\Exception $e) {
+            $exceptionThrown = $e;
+        } catch (\Throwable $e) {
+            $exceptionThrown = $e;
+        }
+        return $exceptionThrown;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function positiveMatch($name, $subject, array $arguments)
+    {
+        if (empty($arguments)) {
+            $arguments = [
+                '\\Exception',
+                '\\Throwable',
+            ];
+        }
+        $exceptionThrown = $this->loop($subject);
+        if (null === $exceptionThrown) {
+            throw new FailureException(sprintf('Expected to get %s thrown, none got.', implode(' / ', array_map(function ($class) {
+                return ltrim($class, '\\');
+            }, $arguments))));
+        } else {
+            foreach ($arguments as $exceptionClass) {
+                if (is_a($exceptionThrown, $exceptionClass)) {
+                    return;
+                }
+            }
+            throw new FailureException(sprintf('Expected to get %s thrown, got %s.', implode(' / ', array_map(function ($class) {
+                return ltrim($class, '\\');
+            }, $arguments)), get_class($exceptionThrown)));
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function negativeMatch($name, $subject, array $arguments)
+    {
+
+        $exceptionThrown = $this->loop($subject);
+        if (null !== $exceptionThrown) {
+            if (empty($arguments)) {
+                throw new FailureException(sprintf('Expected nothing to be thrown, got %s.', get_class($exceptionThrown)));
+            } else {
+                foreach ($arguments as $exceptionClass) {
+                    if (is_a($exceptionThrown, $exceptionClass)) {
+                        throw new FailureException(sprintf('Expected %s to be not thrown, and it was.', implode(' / ', array_map(function ($class) {
+                            return ltrim($class, '\\');
+                        }, $arguments))));
+                    }
+                }
+            }
+        }
+    }
+
+    public function getPriority()
+    {
+        return 100;
+    }
+}

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -38,6 +38,8 @@ use ArrayAccess;
  * @method void shouldNotBeAnInstanceOf($type)
  * @method void shouldImplement($interface)
  * @method void shouldNotImplement($interface)
+ * @method void shouldThrowWhenIterating($exception = null)
+ * @method void shouldNotThrowWhenIterating($exception = null)
  *
  * @method Subject\Expectation\DuringCall shouldThrow($exception = null)
  * @method Subject\Expectation\DuringCall shouldNotThrow($exception = null)


### PR DESCRIPTION
To engage discussion about #1057, here is a proof of concept. 

Todo:

- [x] Match that an exception should be / shouldn't be thrown when looping on a generator / an instanciated object implementing `Traversable`
- [ ] Match that an exception should be / shouldn't be thrown when looping on an `iterable` returned by a method of the object being tested
- [ ] Match that an error should be / shouldn't be triggered when looping on a generator / an instanciated object implementing `Traversable`
- [ ] Match that an error should be / shouldn't be triggered when looping on an `iterable` returned by a method of the object being tested

What are your thoughts?