### PR TITLE
Making get_class() work in PHP 7.2

### DIFF
--- a/spec/PhpSpec/Listener/MethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodNotFoundListenerSpec.php
@@ -68,6 +68,9 @@ class MethodNotFoundListenerSpec extends ObjectBehavior
     function it_does_not_prompt_for_method_generation_if_input_is_not_interactive($exampleEvent, $suiteEvent, $io, MethodNotFoundException $exception)
     {
         $exampleEvent->getException()->willReturn($exception);
+        $exception->getSubject()->willReturn(new \stdClass());
+        $exception->getMethodName()->willReturn('');
+        $exception->getArguments()->willReturn([]);
         $io->isCodeGenerationEnabled()->willReturn(false);
 
         $this->afterExample($exampleEvent);

--- a/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
@@ -108,6 +108,8 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io, ResourceManager $resourceManager, SuiteEvent $event
     ) {
         $resourceManager->createResource(Argument::any())->willThrow(new \RuntimeException());
+        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getMethod()->willReturn('');
 
         $this->afterMethodCall($methodCallEvent);
         $this->afterExample($exampleEvent);
@@ -120,6 +122,8 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io, SuiteEvent $event
     ) {
         $io->isCodeGenerationEnabled()->willReturn(false);
+        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getMethod()->willReturn('');
 
         $this->afterMethodCall($methodCallEvent);
         $this->afterExample($exampleEvent);
@@ -156,6 +160,9 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         $notEqualException->getExpected()->willReturn('foo');
         $notEqualException2->getExpected()->willReturn('bar');
 
+        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getMethod()->willReturn('');
+
         $this->afterMethodCall($methodCallEvent);
         $this->afterExample($exampleEvent);
 
@@ -171,6 +178,8 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io, SuiteEvent $event
     ) {
         $io->isFakingEnabled()->willReturn(false);
+        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getMethod()->willReturn('');
 
         $this->afterMethodCall($methodCallEvent);
         $this->afterExample($exampleEvent);
@@ -182,6 +191,9 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
     function it_prompts_when_correct_type_of_exception_is_thrown(
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io, SuiteEvent $event
     ) {
+        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getMethod()->willReturn('');
+
         $this->afterMethodCall($methodCallEvent);
         $this->afterExample($exampleEvent);
         $this->afterSuite($event);

--- a/spec/PhpSpec/Listener/NamedConstructorNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/NamedConstructorNotFoundListenerSpec.php
@@ -48,6 +48,10 @@ class NamedConstructorNotFoundListenerSpec extends ObjectBehavior
         $exampleEvent->getException()->willReturn($exception);
         $io->isCodeGenerationEnabled()->willReturn(true);
 
+        $exception->getSubject()->willReturn(new \stdClass());
+        $exception->getMethodName()->willReturn('');
+        $exception->getArguments()->willReturn([]);
+
         $this->afterExample($exampleEvent);
         $this->afterSuite($suiteEvent);
 
@@ -58,6 +62,10 @@ class NamedConstructorNotFoundListenerSpec extends ObjectBehavior
     {
         $exampleEvent->getException()->willReturn($exception);
         $io->isCodeGenerationEnabled()->willReturn(false);
+
+        $exception->getSubject()->willReturn(new \stdClass());
+        $exception->getMethodName()->willReturn('');
+        $exception->getArguments()->willReturn([]);
 
         $this->afterExample($exampleEvent);
         $this->afterSuite($suiteEvent);


### PR DESCRIPTION
Follows discussion on https://github.com/phpspec/phpspec/pull/1104.  Alternative to https://github.com/phpspec/phpspec/pull/1012.  Changes specs to avoid `get_class(null)` issue in PHP 7.2.