### PR TITLE
Compatibility with PHP7.2 strict method signatures

### DIFF
--- a/src/PhpSpec/Formatter/Html/HtmlIO.php
+++ b/src/PhpSpec/Formatter/Html/HtmlIO.php
@@ -18,9 +18,11 @@ use PhpSpec\IO\IO;
 final class HtmlIO implements IO
 {
     /**
-     * @param $message
+     * @param string       $message
+     * @param integer|null $indent
+     * @param bool         $newline
      */
-    public function write($message)
+    public function write($message, $indent = null, $newline = false)
     {
         echo $message;
     }

--- a/src/PhpSpec/IO/IO.php
+++ b/src/PhpSpec/IO/IO.php
@@ -16,9 +16,11 @@ namespace PhpSpec\IO;
 interface IO
 {
     /**
-     * @param string $message
+     * @param string       $message
+     * @param integer|null $indent
+     * @param bool         $newline
      */
-    public function write($message);
+    public function write($message, $indent = null, $newline = false);
 
     /**
      * @return bool


### PR DESCRIPTION
Follows discussion on https://github.com/phpspec/phpspec/pull/1104.  Makes `IO::write()`, `HtmlIO::write()` and `ConsoleIO::write()` all have the same method signature.  This is to fix build breaks like https://travis-ci.org/phpspec/phpspec/jobs/238440400#L211-L213.