### PR TITLE
Fix broken typehint triggering PHP 7.2 issues

### DIFF
--- a/spec/PhpSpec/CodeGenerator/Generator/ConfirmingGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ConfirmingGeneratorSpec.php
@@ -4,13 +4,12 @@ namespace spec\PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\CodeGenerator\Generator\Generator;
 use PhpSpec\Console\ConsoleIO;
-use PhpSpec\IO\IO;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Locator\Resource;
 
 class ConfirmingGeneratorSpec extends ObjectBehavior
 {
-    function let(IO $io, Generator $generator)
+    function let(ConsoleIO $io, Generator $generator)
     {
         $this->beConstructedWith($io, 'Question for {CLASSNAME}', $generator);
     }


### PR DESCRIPTION
Type hint in the `let` and the spec were mismatched, triggering an issue with Prophecy