### PR TITLE
Fix bug when parameters can be ignored from config file

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -369,7 +369,7 @@ class ApplicationContext implements Context
 
         return $string;
     }
-    
+
     /**
      * @Then I should not be prompted for more questions
      */

--- a/features/extensions/developer_uses_bootstrap_config_key_in_any_place.feature
+++ b/features/extensions/developer_uses_bootstrap_config_key_in_any_place.feature
@@ -1,0 +1,62 @@
+Feature: Developer uses bootstrap config key in any place
+  As a Developer
+  I want to place configuration options at any part of the config file
+
+  Scenario: Extension does not break container parameters
+    Given the config file contains:
+    """
+    extensions:
+      Example1\PhpSpec\LoadsConsoleIoExtension\Extension: ~
+
+    bootstrap: NotExisting.php
+    """
+    And the class file "src/Example1/PhpSpec/LoadsConsoleIoExtension/Extension.php" contains:
+    """
+    <?php
+
+    namespace Example1\PhpSpec\LoadsConsoleIoExtension;
+
+    use PhpSpec\Extension as PhpSpecExtension;
+    use PhpSpec\ServiceContainer;
+
+    class Extension implements PhpSpecExtension
+    {
+        public function load(ServiceContainer $container, array $params)
+        {
+            $container->get('console.io');
+        }
+    }
+
+    """
+    And the spec file "spec/Example1/DummySpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Example1;
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class DummySpec extends ObjectBehavior
+    {
+        function it_is_initializable()
+        {
+            $this->shouldHaveType('Example1\Dummy');
+        }
+    }
+
+    """
+    And the class file "src/Example1/Dummy.php" contains:
+    """
+    <?php
+
+    namespace Example1;
+
+    class Dummy
+    {
+    }
+
+    """
+    When I run phpspec
+    Then I should see "Bootstrap file 'NotExisting.php' does not exist"
+    And the suite should not pass

--- a/features/extensions/developer_uses_bootstrap_config_key_in_any_place.feature
+++ b/features/extensions/developer_uses_bootstrap_config_key_in_any_place.feature
@@ -28,7 +28,7 @@ Feature: Developer uses bootstrap config key in any place
     }
 
     """
-    And the spec file "spec/Example1/DummySpec.php" contains:
+    And the spec file "spec/Example1/TestConfigSpec.php" contains:
     """
     <?php
 
@@ -37,22 +37,22 @@ Feature: Developer uses bootstrap config key in any place
     use PhpSpec\ObjectBehavior;
     use Prophecy\Argument;
 
-    class DummySpec extends ObjectBehavior
+    class TestConfigSpec extends ObjectBehavior
     {
         function it_is_initializable()
         {
-            $this->shouldHaveType('Example1\Dummy');
+            $this->shouldHaveType('Example1\TestConfig');
         }
     }
 
     """
-    And the class file "src/Example1/Dummy.php" contains:
+    And the class file "src/Example1/TestConfig.php" contains:
     """
     <?php
 
     namespace Example1;
 
-    class Dummy
+    class TestConfig
     {
     }
 

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -154,20 +154,15 @@ final class Application extends BaseApplication
                 }
             }
             elseif ('matchers' === $key && is_array($val)) {
-                foreach ($val as $class) {
-                    $container->define(sprintf('matchers.%s', $class), function () use ($class) {
-                        return new $class();
-                    }, ['matchers']);
-                }
+                $this->registerCustomMatchers($container, $val);
             }
-
         }
     }
 
     private function populateContainerParameters(IndexedServiceContainer $container, array $config)
     {
         foreach ($config as $key => $val) {
-            if ('extensions' !== $key && 'matchers'!== $key) {
+            if ('extensions' !== $key && 'matchers' !== $key) {
                 $container->setParam($key, $val);
             }
         }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -145,6 +145,8 @@ final class Application extends BaseApplication
     {
         $config = $this->parseConfigurationFile($input);
 
+        $this->populateContainerParameters($container, $config);
+
         foreach ($config as $key => $val) {
             if ('extensions' === $key && is_array($val)) {
                 foreach ($val as $class => $extensionConfig) {
@@ -152,9 +154,20 @@ final class Application extends BaseApplication
                 }
             }
             elseif ('matchers' === $key && is_array($val)) {
-                $this->registerCustomMatchers($container, $val);
+                foreach ($val as $class) {
+                    $container->define(sprintf('matchers.%s', $class), function () use ($class) {
+                        return new $class();
+                    }, ['matchers']);
+                }
             }
-            else {
+
+        }
+    }
+
+    private function populateContainerParameters(IndexedServiceContainer $container, array $config)
+    {
+        foreach ($config as $key => $val) {
+            if ('extensions' !== $key && 'matchers'!== $key) {
                 $container->setParam($key, $val);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Problem
================

There is a bug when you add parameters (e.g. `bootstrap`) **after** `extensions` key in the configuration file which leads to ignoring them completely by `$container`.

#### How to reproduce?

Consider the following config:

```yml
suites:
    some_suite:
        namespace: Some

extensions:
    Memio\SpecGen\MemioSpecGenExtension: ~
    
bootstrap: NotExistingBootstrapFile.php
```

Please note the extension `Memio\SpecGen\MemioSpecGenExtension`. 

When I run `bin/phpspec run`, it does not complain about not existing file. And here is a reason:

```php

// PhpSpec\Console\Application class

protected function loadConfigurationFile(InputInterface $input, IndexedServiceContainer $container)
{
    $config = $this->parseConfigurationFile($input);

    foreach ($config as $key => $val) {
        if ('extensions' === $key && is_array($val)) {
            foreach ($val as $class => $extensionConfig) {
                $this->loadExtension($container, $class, $extensionConfig ?: []);
            }
        }
        [...simplified...]
        else {
            $container->setParam($key, $val);
        }
    }
}
```

This code iterates through keys from `phpspec.yml` file and if it is `extensions` key - it loads all extensions, otherwise, it populates container parameter.

So when `bootstrap` parameter is placed **after** `extensions` key, it is handled after all extensions are loaded.

The good example to reproduce this issue is a `Memio\SpecGen\MemioSpecGenExtension` extensions because in `load` method it calls `$container->get('console.io')` which in its turn calls the following PhpSpec's container code:

```php
$container->define('console.io', function (IndexedServiceContainer $c) {
    return new ConsoleIO(
        $c->get('console.input'),
        $c->get('console.output'),
        new OptionsConfig(
            $c->getParam('stop_on_failure', false),
            $c->getParam('code_generation', true),
            $c->getParam('rerun', true),
            $c->getParam('fake', false),
            $c->getParam('bootstrap', false) // <----------- THIS PARAMETER IS NOT YET POPULATED
        ),
        $c->get('console.prompter')
    );
});
```

So, at the time when extension loads `console.io` service and creates `OptionsConfig` object, our parameter `bootstrap` **is not yet loaded**.

There is a simple workaround to move `bootstrap` parameter *before* `extensions` key in the config, in this case, container populates it and then loads extensions.

Proposed solution
============

I just moved code that populates the container with parameters **before** any extension is loaded. 

In this case, even if any extensions calls `$container->get('console.io')` we will have our container populated with all parameters by that time.

That's it!