### PR TITLE
Add static and return type hints

### DIFF
--- a/docs/manual/upgrading-to-phpspec-4.rst
+++ b/docs/manual/upgrading-to-phpspec-4.rst
@@ -10,6 +10,29 @@ If you are using 3rd party **phpspec** extensions, you may have to increase the 
 
 As PHP 5 is no longer supported language versions, you will need to upgrade to PHP 7 to use **phpspec** 4.
 
+Most methods in PhpSpec now have static type hints and return types, this will affect you when you are overriding
+behaviour from a parent class or implementing an interface.
+
+If you are providing inline matchers in your specs you will need to provide the array type hint:
+
+.. code-block:: php
+
+    function getMatchers()
+    {
+        // return some matchers
+    }
+
+Change to:
+
+.. code-block:: php
+
+    function getMatchers() : array
+    {
+        // return some matchers
+    }
+
+If you are providing custom matchers, you will need to conform to the type hint changes in the Matcher interface.
+
 Upgrading for Extension Authors
 -------------------------------
 

--- a/features/extensions/developer_uses_extension.feature
+++ b/features/extensions/developer_uses_extension.feature
@@ -60,7 +60,7 @@ Feature: Developer uses extension
          *
          * @return bool
          */
-        public function supports($name, $subject, array $arguments)
+        public function supports(string $name, $subject, array $arguments): bool
         {
             return 'beSeven' === $name
                 && is_int($subject)
@@ -74,7 +74,7 @@ Feature: Developer uses extension
          *
          * @return bool
          */
-        protected function matches($subject, array $arguments)
+        protected function matches($subject, array $arguments): bool
         {
             return ($subject === 7);
         }
@@ -86,7 +86,7 @@ Feature: Developer uses extension
          *
          * @return FailureException
          */
-        protected function getFailureException($name, $subject, array $arguments)
+        protected function getFailureException(string $name, $subject, array $arguments): FailureException
         {
             return new FailureException(sprintf(
                 'Seven expected %s to be 7, but it is not.',
@@ -101,7 +101,7 @@ Feature: Developer uses extension
          *
          * @return FailureException
          */
-        protected function getNegativeFailureException($name, $subject, array $arguments)
+        protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
         {
             return new FailureException(sprintf(
                 'Seven did not expect %s to 7, but it is.',

--- a/features/matchers/developer_uses_custom_matcher.feature
+++ b/features/matchers/developer_uses_custom_matcher.feature
@@ -33,7 +33,7 @@ Feature: Developer uses custom matcher
 
     class TotalizeMatcher extends BasicMatcher
     {
-        public function supports($name, $subject, array $arguments)
+        public function supports(string $name, $subject, array $arguments): bool
         {
             return 'totalize' === $name &&
                 is_array($subject) &&
@@ -42,12 +42,12 @@ Feature: Developer uses custom matcher
             ;
         }
 
-        protected function matches($subject, array $arguments)
+        protected function matches($subject, array $arguments): bool
         {
             return array_sum($subject) === $arguments[0];
         }
 
-        protected function getFailureException($name, $subject, array $arguments)
+        protected function getFailureException(string $name, $subject, array $arguments): FailureException
         {
             return new FailureException(sprintf(
                 'Expected to totalize %d, but got %d.',
@@ -56,7 +56,7 @@ Feature: Developer uses custom matcher
             ));
         }
 
-        protected function getNegativeFailureException($name, $subject, array $arguments)
+        protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
         {
             return new FailureException(sprintf(
                 'Expected to not totalize %d, but it does.',

--- a/features/matchers/developer_uses_inline_matcher.feature
+++ b/features/matchers/developer_uses_inline_matcher.feature
@@ -1,4 +1,4 @@
-Feature: Developer uses identity matcher
+Feature: Developer uses inline matcher
   As a Developer
   I want an inline matcher
   So I can create expectations in a language closer to the domain I am describing
@@ -21,7 +21,7 @@ Feature: Developer uses identity matcher
               $this->shouldBePositive();
           }
 
-          function getMatchers()
+          function getMatchers(): array
           {
               return array ('bePositive' => function($subject) {
                   return $subject->getTotal() > 0;
@@ -74,7 +74,7 @@ Feature: Developer uses identity matcher
               $this->shouldTotal(3);
           }
 
-          function getMatchers()
+          function getMatchers() : array
           {
               return array ('total' => function($subject, $total) {
                   return $subject->getTotal() === $total;
@@ -127,7 +127,7 @@ Feature: Developer uses identity matcher
               $this->shouldDoSomething('abc');
           }
 
-          function getMatchers()
+          function getMatchers(): array
           {
               return array ('doSomething' => function($subject, $param) {
                   throw new FailureException(sprintf(

--- a/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
@@ -13,6 +13,8 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
     function let(TypeHintIndex $typeHintIndex, NamespaceResolver $namespaceResolver)
     {
         $this->beConstructedWith($typeHintIndex, $namespaceResolver);
+        $namespaceResolver->resolve(Argument::cetera())->willReturn('someClass');
+        $namespaceResolver->analyse(Argument::any())->willReturn();
     }
 
     function it_is_a_typehint_rewriter()

--- a/spec/PhpSpec/Event/ExampleEventSpec.php
+++ b/spec/PhpSpec/Event/ExampleEventSpec.php
@@ -43,7 +43,7 @@ class ExampleEventSpec extends ObjectBehavior
 
     function it_provides_a_link_to_time()
     {
-        $this->getTime()->shouldReturn(10);
+        $this->getTime()->shouldReturn((double)10.0);
     }
 
     function it_provides_a_link_to_result()

--- a/spec/PhpSpec/Event/SpecificationEventSpec.php
+++ b/spec/PhpSpec/Event/SpecificationEventSpec.php
@@ -35,7 +35,7 @@ class SpecificationEventSpec extends ObjectBehavior
 
     function it_provides_a_link_to_time()
     {
-        $this->getTime()->shouldReturn(10);
+        $this->getTime()->shouldReturn(10.0);
     }
 
     function it_provides_a_link_to_result()

--- a/spec/PhpSpec/Event/SuiteEventSpec.php
+++ b/spec/PhpSpec/Event/SuiteEventSpec.php
@@ -27,7 +27,7 @@ class SuiteEventSpec extends ObjectBehavior
 
     function it_provides_a_link_to_time()
     {
-        $this->getTime()->shouldReturn(10);
+        $this->getTime()->shouldReturn(10.0);
     }
 
     function it_provides_a_link_to_result()

--- a/spec/PhpSpec/Formatter/Presenter/Differ/StringEngineSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Differ/StringEngineSpec.php
@@ -30,7 +30,7 @@ DIFF;
         $this->compare('string1', 'string2')->shouldBeEqualRegardlessOfLineEndings($expected);
     }
 
-    public function getMatchers()
+    public function getMatchers() : array
     {
         return [
             'beEqualRegardlessOfLineEndings' => function ($actual, $expected) {

--- a/spec/PhpSpec/Formatter/ProgressFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/ProgressFormatterSpec.php
@@ -14,6 +14,9 @@ class ProgressFormatterSpec extends ObjectBehavior
     function let(Presenter $presenter, ConsoleIO $io, StatisticsCollector $stats)
     {
         $this->beConstructedWith($presenter, $io, $stats);
+        $io->getBlockWidth()->willReturn(80);
+        $io->isDecorated()->willReturn(false);
+        $io->writeTemp(Argument::cetera())->willReturn();
     }
 
     function it_is_an_event_subscriber()

--- a/spec/PhpSpec/Listener/ClassNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/ClassNotFoundListenerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Listener;
 
+use PhpSpec\Locator\Resource;
 use PhpSpec\Locator\ResourceManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -11,16 +12,26 @@ use PhpSpec\CodeGenerator\GeneratorManager;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Exception\Fracture\ClassNotFoundException as PhpSpecClassException;
-
 use Prophecy\Exception\Doubler\ClassNotFoundException as ProphecyClassException;
 
 class ClassNotFoundListenerSpec extends ObjectBehavior
 {
-    function let(ConsoleIO $io, ResourceManager $resourceManager, GeneratorManager $generatorManager,
-                 SuiteEvent $suiteEvent, ExampleEvent $exampleEvent)
+    function let(
+        ConsoleIO $io,
+        ResourceManager $resourceManager,
+        GeneratorManager $generatorManager,
+        SuiteEvent $suiteEvent,
+        ExampleEvent $exampleEvent,
+        PhpSpecClassException $exception,
+        Resource $resource
+    )
     {
         $io->writeln(Argument::any())->willReturn();
-        $io->askConfirmation(Argument::any())->willReturn();
+        $io->askConfirmation(Argument::any())->willReturn(false);
+
+        $exception->getClassname()->willReturn('SomeClass');
+
+        $resourceManager->createResource(Argument::cetera())->willReturn($resource);
 
         $this->beConstructedWith($io, $resourceManager, $generatorManager);
     }
@@ -35,9 +46,9 @@ class ClassNotFoundListenerSpec extends ObjectBehavior
         $io->askConfirmation(Argument::any())->shouldNotBeenCalled();
     }
 
-    function it_does_not_prompt_for_class_generation_if_non_class_exception_was_thrown($exampleEvent, $suiteEvent, $io, \InvalidArgumentException $exception)
+    function it_does_not_prompt_for_class_generation_if_non_class_exception_was_thrown($exampleEvent, $suiteEvent, $io, \InvalidArgumentException $invalidArgumentException)
     {
-        $exampleEvent->getException()->willReturn($exception);
+        $exampleEvent->getException()->willReturn($invalidArgumentException);
         $io->isCodeGenerationEnabled()->willReturn(true);
 
         $this->afterExample($exampleEvent);
@@ -46,7 +57,18 @@ class ClassNotFoundListenerSpec extends ObjectBehavior
         $io->askConfirmation(Argument::any())->shouldNotBeenCalled();
     }
 
-    function it_prompts_for_class_generation_if_prophecy_classnotfoundexception_was_thrown_and_input_is_interactive($exampleEvent, $suiteEvent, $io, ProphecyClassException $exception)
+    function it_prompts_for_class_generation_if_prophecy_classnotfoundexception_was_thrown_and_input_is_interactive($exampleEvent, $suiteEvent, $io, ProphecyClassException $prophecyException)
+    {
+        $exampleEvent->getException()->willReturn($prophecyException);
+        $io->isCodeGenerationEnabled()->willReturn(true);
+
+        $io->askConfirmation(Argument::any())->shouldBeCalled()->willReturn(false);
+
+        $this->afterExample($exampleEvent);
+        $this->afterSuite($suiteEvent);
+    }
+
+    function it_prompts_for_method_generation_if_phpspec_classnotfoundexception_was_thrown_and_input_is_interactive($exampleEvent, $suiteEvent, $io, PhpSpecClassException $exception)
     {
         $exampleEvent->getException()->willReturn($exception);
         $io->isCodeGenerationEnabled()->willReturn(true);
@@ -57,18 +79,7 @@ class ClassNotFoundListenerSpec extends ObjectBehavior
         $this->afterSuite($suiteEvent);
     }
 
-    function it_prompts_for_method_generation_if_phpspec_classnotfoundexception_was_thrown_and_input_is_interactive($exampleEvent, $suiteEvent, $io, PhpspecClassException $exception)
-    {
-        $exampleEvent->getException()->willReturn($exception);
-        $io->isCodeGenerationEnabled()->willReturn(true);
-
-        $io->askConfirmation(Argument::any())->shouldBeCalled()->willReturn(false);
-
-        $this->afterExample($exampleEvent);
-        $this->afterSuite($suiteEvent);
-    }
-
-    function it_does_not_prompt_for_class_generation_if_input_is_not_interactive($exampleEvent, $suiteEvent, $io, PhpspecClassException $exception)
+    function it_does_not_prompt_for_class_generation_if_input_is_not_interactive($exampleEvent, $suiteEvent, $io, PhpSpecClassException $exception)
     {
         $exampleEvent->getException()->willReturn($exception);
         $io->isCodeGenerationEnabled()->willReturn(false);

--- a/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
@@ -160,7 +160,7 @@ class CollaboratorMethodNotFoundListenerSpec extends ObjectBehavior
         ConsoleIO $io,
         NameChecker $nameChecker
     ) {
-        $exception = new MethodNotFoundException('Error', new DoubleOfInterface(), 'throw');
+        $exception = new MethodNotFoundException('Error',DoubleOfInterface::class, 'throw');
 
         $event->getException()->willReturn($exception);
         $nameChecker->isNameValid('throw')->willReturn(false);
@@ -190,7 +190,7 @@ class CollaboratorMethodNotFoundListenerSpec extends ObjectBehavior
 
     private function callAfterExample($event, $nameChecker, $method, $isNameValid = true)
     {
-        $exception = new MethodNotFoundException('Error', new DoubleOfInterface(), $method);
+        $exception = new MethodNotFoundException('Error', DoubleOfInterface::class, $method);
         $event->getException()->willReturn($exception);
         $nameChecker->isNameValid($method)->willReturn($isNameValid);
 

--- a/spec/PhpSpec/Listener/MethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodNotFoundListenerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Listener;
 
+use PhpSpec\Locator\Resource;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -18,16 +19,21 @@ class MethodNotFoundListenerSpec extends ObjectBehavior
     function let(
         ConsoleIO $io,
         ResourceManager $resourceManager,
+        Resource $resource,
         GeneratorManager $generatorManager,
         SuiteEvent $suiteEvent,
         ExampleEvent $exampleEvent,
         NameChecker $nameChecker
     ) {
         $io->writeln(Argument::any())->willReturn();
-        $io->askConfirmation(Argument::any())->willReturn();
+        $io->askConfirmation(Argument::any())->willReturn(false);
 
         $this->beConstructedWith($io, $resourceManager, $generatorManager, $nameChecker);
         $io->isCodeGenerationEnabled()->willReturn(true);
+
+        $nameChecker->isNameValid(Argument::any())->willReturn(false);
+
+        $resourceManager->createResource(Argument::cetera())->willReturn($resource);
     }
 
     function it_does_not_prompt_for_method_generation_if_no_exception_was_thrown($exampleEvent, $suiteEvent, $io)
@@ -68,6 +74,10 @@ class MethodNotFoundListenerSpec extends ObjectBehavior
     function it_does_not_prompt_for_method_generation_if_input_is_not_interactive($exampleEvent, $suiteEvent, $io, MethodNotFoundException $exception)
     {
         $exampleEvent->getException()->willReturn($exception);
+        $exception->getMethodName()->willReturn('someMethod');
+        $exception->getSubject()->willReturn(new \stdClass);
+        $exception->getArguments()->willReturn([]);
+
         $io->isCodeGenerationEnabled()->willReturn(false);
 
         $this->afterExample($exampleEvent);

--- a/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
@@ -17,14 +17,23 @@ use Prophecy\Argument;
 class MethodReturnedNullListenerSpec extends ObjectBehavior
 {
     function let(
-        ConsoleIO $io, ResourceManager $resourceManager, GeneratorManager $generatorManager,
-        ExampleEvent $exampleEvent, NotEqualException $notEqualException, MethodAnalyser $methodAnalyser
+        ConsoleIO $io,
+        ResourceManager $resourceManager,
+        Resource $resource,
+        GeneratorManager $generatorManager,
+        ExampleEvent $exampleEvent,
+        NotEqualException $notEqualException,
+        MethodAnalyser $methodAnalyser,
+        MethodCallEvent $methodCallEvent
     ) {
         $this->beConstructedWith($io, $resourceManager, $generatorManager, $methodAnalyser);
 
         $exampleEvent->getException()->willReturn($notEqualException);
         $notEqualException->getActual()->willReturn(null);
         $notEqualException->getExpected()->willReturn(100);
+
+        $methodCallEvent->getMethod()->willReturn('foo');
+        $methodCallEvent->getSubject()->willReturn(new \stdClass);
 
         $io->isCodeGenerationEnabled()->willReturn(true);
 
@@ -33,7 +42,9 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         $io->isFakingEnabled()->willReturn(true);
 
         $methodAnalyser->methodIsEmpty(Argument::cetera())->willReturn(true);
-        $methodAnalyser->getMethodOwnerName(Argument::cetera())->willReturn('Foo');;
+        $methodAnalyser->getMethodOwnerName(Argument::cetera())->willReturn('Foo');
+
+        $resourceManager->createResource(Argument::cetera())->willReturn($resource);
     }
 
     function it_is_an_event_listener()

--- a/spec/PhpSpec/Listener/NamedConstructorNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/NamedConstructorNotFoundListenerSpec.php
@@ -7,19 +7,32 @@ use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Exception\Fracture\NamedConstructorNotFoundException;
+use PhpSpec\Locator\Resource;
 use PhpSpec\Locator\ResourceManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class NamedConstructorNotFoundListenerSpec extends ObjectBehavior
 {
-    function let(ConsoleIO $io, ResourceManager $resourceManager, GeneratorManager $generatorManager,
-                 SuiteEvent $suiteEvent, ExampleEvent $exampleEvent)
+    function let(
+        ConsoleIO $io,
+        ResourceManager $resourceManager,
+        Resource $resource,
+        GeneratorManager $generatorManager,
+        SuiteEvent $suiteEvent,
+        ExampleEvent $exampleEvent,
+        NamedConstructorNotFoundException $exception)
     {
         $io->writeln(Argument::any())->willReturn();
-        $io->askConfirmation(Argument::any())->willReturn();
+        $io->askConfirmation(Argument::any())->willReturn(false);
 
         $this->beConstructedWith($io, $resourceManager, $generatorManager);
+
+        $exception->getMethodName()->willReturn('someMethod');
+        $exception->getSubject()->willReturn(new \stdClass());
+        $exception->getArguments()->willReturn([]);
+
+        $resourceManager->createResource(Argument::cetera())->willReturn($resource);
     }
 
     function it_does_not_prompt_for_method_generation_if_no_exception_was_thrown($exampleEvent, $suiteEvent, $io)
@@ -32,9 +45,9 @@ class NamedConstructorNotFoundListenerSpec extends ObjectBehavior
         $io->askConfirmation(Argument::any())->shouldNotBeenCalled();
     }
 
-    function it_does_not_prompt_for_method_generation_if_non_namedconstructornotfoundexception_was_thrown($exampleEvent, $suiteEvent, $io, \InvalidArgumentException $exception)
+    function it_does_not_prompt_for_method_generation_if_non_namedconstructornotfoundexception_was_thrown($exampleEvent, $suiteEvent, $io, \InvalidArgumentException $invalidArgumentException)
     {
-        $exampleEvent->getException()->willReturn($exception);
+        $exampleEvent->getException()->willReturn($invalidArgumentException);
         $io->isCodeGenerationEnabled()->willReturn(true);
 
         $this->afterExample($exampleEvent);

--- a/spec/PhpSpec/Process/ReRunner/CompositeReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/CompositeReRunnerSpec.php
@@ -11,6 +11,9 @@ class CompositeReRunnerSpec extends ObjectBehavior
 {
     function let(PlatformSpecificReRunner $reRunner1, PlatformSpecificReRunner $reRunner2)
     {
+        $reRunner1->isSupported()->willReturn(false);
+        $reRunner2->isSupported()->willReturn(false);
+
         $this->beConstructedWith(
             array(
                 $reRunner1->getWrappedObject(),

--- a/spec/PhpSpec/Runner/CollaboratorManagerSpec.php
+++ b/spec/PhpSpec/Runner/CollaboratorManagerSpec.php
@@ -15,6 +15,7 @@ class CollaboratorManagerSpec extends ObjectBehavior
     function let(Presenter $presenter)
     {
         $this->beConstructedWith($presenter);
+        $presenter->presentString(Argument::cetera())->willReturn('someString');
     }
 
     function it_stores_collaborators_by_name($collaborator)

--- a/spec/PhpSpec/Runner/MatcherManagerSpec.php
+++ b/spec/PhpSpec/Runner/MatcherManagerSpec.php
@@ -13,6 +13,8 @@ class MatcherManagerSpec extends ObjectBehavior
     function let(Presenter $presenter)
     {
         $this->beConstructedWith($presenter);
+        $presenter->presentString(Argument::cetera())->willReturn('some strong');
+        $presenter->presentValue(Argument::cetera())->willReturn('some value');
     }
 
     function it_searches_in_registered_matchers(Matcher $matcher)

--- a/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
@@ -18,10 +18,17 @@ use Prophecy\Argument;
 class CallerSpec extends ObjectBehavior
 {
     function let(WrappedObject $wrappedObject, ExampleNode $example, Dispatcher $dispatcher,
-                 ExceptionFactory $exceptions, Wrapper $wrapper, AccessInspector $accessInspector)
+                 ExceptionFactory $exceptions, Wrapper $wrapper, AccessInspector $accessInspector, Subject $subject)
     {
         $this->beConstructedWith($wrappedObject, $example, $dispatcher,
             $exceptions, $wrapper, $accessInspector);
+        $wrapper->wrap(Argument::cetera())->willReturn($subject);
+
+        $wrappedObject->isInstantiated()->willReturn(false);
+        $wrappedObject->getClassName()->willReturn(null);
+        $wrappedObject->getInstance()->willReturn(null);
+
+        $accessInspector->isMethodCallable(Argument::cetera())->willReturn(false);
     }
 
     function it_dispatches_method_call_events(Dispatcher $dispatcher, WrappedObject $wrappedObject,

--- a/spec/PhpSpec/Wrapper/Subject/Expectation/DecoratorSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/DecoratorSpec.php
@@ -33,7 +33,7 @@ class DecoratorSpec extends ObjectBehavior
 
 class Decorator extends AbstractDecorator
 {
-    public function match($alias, $subject, array $arguments = array())
+    public function match(string $alias, $subject, array $arguments = array())
     {
     }
 }

--- a/spec/PhpSpec/Wrapper/Subject/WrappedObjectSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/WrappedObjectSpec.php
@@ -67,7 +67,7 @@ class WrappedObjectSpec extends ObjectBehavior
 
         $this->callOnWrappedObject('beConstructedWith', array(array('now')));
         $this->callOnWrappedObject('instantiate', array());
-        $this->shouldThrow('PhpSpec\Exception\Wrapper\SubjectException')->duringBeConstructedWith('tomorrow');
+        $this->shouldThrow('PhpSpec\Exception\Wrapper\SubjectException')->duringBeConstructedWith(['tomorrow']);
     }
 
     function it_throws_an_exception_when_trying_to_change_factory_method_after_instantiation()
@@ -96,6 +96,6 @@ class WrappedObjectSpec extends ObjectBehavior
 
         $this->callOnWrappedObject('beConstructedThrough', array('createFromFormat',array('d-m-Y', '01-01-1980')));
         $this->callOnWrappedObject('instantiate', array());
-        $this->shouldThrow('PhpSpec\Exception\Wrapper\SubjectException')->duringBeConstructedWith('tomorrow');
+        $this->shouldThrow('PhpSpec\Exception\Wrapper\SubjectException')->duringBeConstructedWith(['tomorrow']);
     }
 }

--- a/src/PhpSpec/CodeAnalysis/NamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/NamespaceResolver.php
@@ -17,5 +17,5 @@ interface NamespaceResolver
 {
     public function analyse(string $code);
 
-    public function resolve(string $typeAlias);
+    public function resolve(string $typeAlias) : string;
 }

--- a/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
@@ -30,7 +30,7 @@ final class StaticRejectingNamespaceResolver implements NamespaceResolver
         $this->namespaceResolver->analyse($code);
     }
 
-    public function resolve(string $typeAlias)
+    public function resolve(string $typeAlias) : string
     {
         $this->guardNonObjectTypeHints($typeAlias);
 

--- a/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
@@ -108,7 +108,7 @@ class ExistingConstructorTemplate
     /**
      * @return string
      */
-    private function getCreateObjectTemplate()
+    private function getCreateObjectTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/named_constructor_create_object.template');
     }
@@ -116,7 +116,7 @@ class ExistingConstructorTemplate
     /**
      * @return string
      */
-    private function getExceptionTemplate()
+    private function getExceptionTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/named_constructor_exception.template');
     }

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -47,10 +47,10 @@ class OptionsConfig
      * @param string|bool $bootstrapPath
      */
     public function __construct(
-        $stopOnFailureEnabled,
-        $codeGenerationEnabled,
-        $reRunEnabled,
-        $fakingEnabled,
+        bool $stopOnFailureEnabled,
+        bool $codeGenerationEnabled,
+        bool $reRunEnabled,
+        bool $fakingEnabled,
         $bootstrapPath
     ) {
         $this->stopOnFailureEnabled  = $stopOnFailureEnabled;
@@ -63,7 +63,7 @@ class OptionsConfig
     /**
      * @return bool
      */
-    public function isStopOnFailureEnabled()
+    public function isStopOnFailureEnabled(): bool
     {
         return $this->stopOnFailureEnabled;
     }
@@ -71,7 +71,7 @@ class OptionsConfig
     /**
      * @return bool
      */
-    public function isCodeGenerationEnabled()
+    public function isCodeGenerationEnabled(): bool
     {
         return $this->codeGenerationEnabled;
     }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -46,7 +46,7 @@ final class Application extends BaseApplication
         parent::__construct('phpspec', $version);
     }
 
-    public function getContainer() : ServiceContainer
+    public function getContainer(): ServiceContainer
     {
         return $this->container;
     }
@@ -54,7 +54,7 @@ final class Application extends BaseApplication
     /**
      * @return int
      */
-    public function doRun(InputInterface $input, OutputInterface $output)
+    public function doRun(InputInterface $input, OutputInterface $output): int
     {
         $helperSet = $this->getHelperSet();
         $this->container->set('console.input', $input);
@@ -194,7 +194,7 @@ final class Application extends BaseApplication
      *
      * @throws \RuntimeException
      */
-    protected function parseConfigurationFile(InputInterface $input)
+    protected function parseConfigurationFile(InputInterface $input): array
     {
         $paths = array('phpspec.yml','phpspec.yml.dist', '.phpspec.yml');
 

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -171,7 +171,7 @@ EOF
             list($_, $locator, $linenum) = $matches;
         }
 
-        $suite       = $container->get('loader.resource_loader')->load($locator, $linenum);
+        $suite       = $container->get('loader.resource_loader')->load((string)$locator, $linenum);
         $suiteRunner = $container->get('runner.suite');
 
         return $container->get('console.result_converter')->convert(

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -110,12 +110,12 @@ class ConsoleIO implements IO
         return $this->lastMessage;
     }
 
-    public function writeln(string $message = '', int $indent = 0)
+    public function writeln(string $message = '', int $indent = null)
     {
         $this->write($message, $indent, true);
     }
 
-    public function writeTemp(string $message, int $indent = 0)
+    public function writeTemp(string $message, int $indent = null)
     {
         $this->write($message, $indent);
         $this->hasTempString = true;
@@ -141,7 +141,7 @@ class ConsoleIO implements IO
         $this->write($this->lastMessage);
     }
 
-    public function write(string $message, int $indent = 0, $newline = false)
+    public function write(string $message, int $indent = null, bool $newline = false)
     {
         if ($this->hasTempString) {
             $this->hasTempString = false;
@@ -158,12 +158,12 @@ class ConsoleIO implements IO
         $this->lastMessage = $message.($newline ? "\n" : '');
     }
 
-    public function overwriteln($message = '', int $indent = 0)
+    public function overwriteln(string $message = '', int $indent = null)
     {
         $this->overwrite($message, $indent, true);
     }
 
-    public function overwrite(string $message, int $indent = 0, bool $newline = false)
+    public function overwrite(string $message, int $indent = null, bool $newline = false)
     {
         if (null !== $indent) {
             $message = $this->indentText($message, $indent);

--- a/src/PhpSpec/Console/Formatter.php
+++ b/src/PhpSpec/Console/Formatter.php
@@ -27,7 +27,7 @@ class Formatter extends OutputFormatter
      *
      * @param array $styles
      */
-    public function __construct($decorated = false, array $styles = array())
+    public function __construct(bool $decorated = false, array $styles = array())
     {
         parent::__construct($decorated, $styles);
 

--- a/src/PhpSpec/Console/ResultConverter.php
+++ b/src/PhpSpec/Console/ResultConverter.php
@@ -27,7 +27,7 @@ class ResultConverter
      *
      * @return int
      */
-    public function convert($result)
+    public function convert($result): int
     {
         switch ($result) {
             case ExampleEvent::PASSED:

--- a/src/PhpSpec/Event/ExampleEvent.php
+++ b/src/PhpSpec/Event/ExampleEvent.php
@@ -13,6 +13,8 @@
 
 namespace PhpSpec\Event;
 
+use PhpSpec\Loader\Node\SpecificationNode;
+use PhpSpec\Loader\Suite;
 use Symfony\Component\EventDispatcher\Event;
 use PhpSpec\Loader\Node\ExampleNode;
 
@@ -74,8 +76,8 @@ class ExampleEvent extends Event implements PhpSpecEvent
      */
     public function __construct(
         ExampleNode $example,
-        $time = null,
-        $result = null,
+        float $time = null,
+        int $result = null,
         \Exception $exception = null
     ) {
         $this->example   = $example;
@@ -87,23 +89,23 @@ class ExampleEvent extends Event implements PhpSpecEvent
     /**
      * @return ExampleNode
      */
-    public function getExample()
+    public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
     /**
-     * @return \PhpSpec\Loader\Node\SpecificationNode
+     * @return SpecificationNode
      */
-    public function getSpecification()
+    public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
     /**
-     * @return \PhpSpec\Loader\Suite
+     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->getSpecification()->getSuite();
     }
@@ -111,7 +113,7 @@ class ExampleEvent extends Event implements PhpSpecEvent
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->example->getTitle();
     }
@@ -119,7 +121,7 @@ class ExampleEvent extends Event implements PhpSpecEvent
     /**
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->exception->getMessage();
     }
@@ -127,7 +129,7 @@ class ExampleEvent extends Event implements PhpSpecEvent
     /**
      * @return array
      */
-    public function getBacktrace()
+    public function getBacktrace(): array
     {
         return $this->exception->getTrace();
     }
@@ -135,7 +137,7 @@ class ExampleEvent extends Event implements PhpSpecEvent
     /**
      * @return float
      */
-    public function getTime()
+    public function getTime(): float
     {
         return $this->time;
     }
@@ -143,13 +145,13 @@ class ExampleEvent extends Event implements PhpSpecEvent
     /**
      * @return integer
      */
-    public function getResult()
+    public function getResult(): int
     {
         return $this->result;
     }
 
     /**
-     * @return \Exception
+     * @return \Exception|null
      */
     public function getException()
     {

--- a/src/PhpSpec/Event/ExpectationEvent.php
+++ b/src/PhpSpec/Event/ExpectationEvent.php
@@ -13,6 +13,8 @@
 
 namespace PhpSpec\Event;
 
+use PhpSpec\Loader\Node\SpecificationNode;
+use PhpSpec\Loader\Suite;
 use Symfony\Component\EventDispatcher\Event;
 use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\Matcher\Matcher;
@@ -102,7 +104,7 @@ final class ExpectationEvent extends Event implements PhpSpecEvent
     /**
      * @return Matcher
      */
-    public function getMatcher()
+    public function getMatcher(): Matcher
     {
         return $this->matcher;
     }
@@ -110,23 +112,23 @@ final class ExpectationEvent extends Event implements PhpSpecEvent
     /**
      * @return ExampleNode
      */
-    public function getExample()
+    public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
     /**
-     * @return \PhpSpec\Loader\Node\SpecificationNode
+     * @return SpecificationNode
      */
-    public function getSpecification()
+    public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
     /**
-     * @return \PhpSpec\Loader\Suite
+     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->example->getSpecification()->getSuite();
     }
@@ -142,7 +144,7 @@ final class ExpectationEvent extends Event implements PhpSpecEvent
     /**
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -150,13 +152,13 @@ final class ExpectationEvent extends Event implements PhpSpecEvent
     /**
      * @return array
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }
 
     /**
-     * @return \Exception
+     * @return \Exception|null
      */
     public function getException()
     {
@@ -166,7 +168,7 @@ final class ExpectationEvent extends Event implements PhpSpecEvent
     /**
      * @return integer
      */
-    public function getResult()
+    public function getResult(): int
     {
         return $this->result;
     }

--- a/src/PhpSpec/Event/FileCreationEvent.php
+++ b/src/PhpSpec/Event/FileCreationEvent.php
@@ -31,7 +31,7 @@ final class FileCreationEvent extends Event implements PhpSpecEvent
     /**
      * @return string
      */
-    public function getFilePath()
+    public function getFilePath(): string
     {
         return $this->filepath;
     }

--- a/src/PhpSpec/Event/MethodCallEvent.php
+++ b/src/PhpSpec/Event/MethodCallEvent.php
@@ -14,6 +14,8 @@
 namespace PhpSpec\Event;
 
 use PhpSpec\Loader\Node\ExampleNode;
+use PhpSpec\Loader\Node\SpecificationNode;
+use PhpSpec\Loader\Suite;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -65,23 +67,23 @@ class MethodCallEvent extends Event implements PhpSpecEvent
     /**
      * @return ExampleNode
      */
-    public function getExample()
+    public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
     /**
-     * @return \PhpSpec\Loader\Node\SpecificationNode
+     * @return SpecificationNode
      */
-    public function getSpecification()
+    public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
     /**
-     * @return \PhpSpec\Loader\Suite
+     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->example->getSpecification()->getSuite();
     }
@@ -97,7 +99,7 @@ class MethodCallEvent extends Event implements PhpSpecEvent
     /**
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -105,7 +107,7 @@ class MethodCallEvent extends Event implements PhpSpecEvent
     /**
      * @return array
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }

--- a/src/PhpSpec/Event/SpecificationEvent.php
+++ b/src/PhpSpec/Event/SpecificationEvent.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Event;
 
+use PhpSpec\Loader\Suite;
 use Symfony\Component\EventDispatcher\Event;
 use PhpSpec\Loader\Node\SpecificationNode;
 
@@ -41,7 +42,7 @@ class SpecificationEvent extends Event implements PhpSpecEvent
      * @param float             $time
      * @param integer           $result
      */
-    public function __construct(SpecificationNode $specification, $time = null, $result = null)
+    public function __construct(SpecificationNode $specification, float $time = null, int $result = null)
     {
         $this->specification = $specification;
         $this->time          = $time;
@@ -51,7 +52,7 @@ class SpecificationEvent extends Event implements PhpSpecEvent
     /**
      * @return SpecificationNode
      */
-    public function getSpecification()
+    public function getSpecification(): SpecificationNode
     {
         return $this->specification;
     }
@@ -59,15 +60,15 @@ class SpecificationEvent extends Event implements PhpSpecEvent
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->specification->getTitle();
     }
 
     /**
-     * @return \PhpSpec\Loader\Suite
+     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->specification->getSuite();
     }
@@ -75,7 +76,7 @@ class SpecificationEvent extends Event implements PhpSpecEvent
     /**
      * @return float
      */
-    public function getTime()
+    public function getTime(): float
     {
         return $this->time;
     }
@@ -83,7 +84,7 @@ class SpecificationEvent extends Event implements PhpSpecEvent
     /**
      * @return integer
      */
-    public function getResult()
+    public function getResult(): int
     {
         return $this->result;
     }

--- a/src/PhpSpec/Event/SuiteEvent.php
+++ b/src/PhpSpec/Event/SuiteEvent.php
@@ -46,7 +46,7 @@ class SuiteEvent extends Event implements PhpSpecEvent
      * @param float   $time
      * @param integer $result
      */
-    public function __construct(Suite $suite, $time = null, $result = null)
+    public function __construct(Suite $suite, float $time = null, int $result = null)
     {
         $this->suite  = $suite;
         $this->time   = $time;
@@ -56,7 +56,7 @@ class SuiteEvent extends Event implements PhpSpecEvent
     /**
      * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->suite;
     }
@@ -64,7 +64,7 @@ class SuiteEvent extends Event implements PhpSpecEvent
     /**
      * @return float
      */
-    public function getTime()
+    public function getTime(): float
     {
         return $this->time;
     }
@@ -72,7 +72,7 @@ class SuiteEvent extends Event implements PhpSpecEvent
     /**
      * @return integer
      */
-    public function getResult()
+    public function getResult(): int
     {
         return $this->result;
     }
@@ -80,7 +80,7 @@ class SuiteEvent extends Event implements PhpSpecEvent
     /**
      * @return bool
      */
-    public function isWorthRerunning()
+    public function isWorthRerunning(): bool
     {
         return $this->worthRerunning;
     }

--- a/src/PhpSpec/Exception/Example/ErrorException.php
+++ b/src/PhpSpec/Exception/Example/ErrorException.php
@@ -39,7 +39,7 @@ class ErrorException extends ExampleException
      * @param string $file    error file
      * @param string $line    error line
      */
-    public function __construct($level, $message, $file, $line)
+    public function __construct(string $level, string $message, string $file, string $line)
     {
         parent::__construct(sprintf(
             '%s: %s in %s line %d',

--- a/src/PhpSpec/Exception/Example/NotEqualException.php
+++ b/src/PhpSpec/Exception/Example/NotEqualException.php
@@ -33,7 +33,7 @@ class NotEqualException extends FailureException
      * @param mixed  $expected
      * @param mixed  $actual
      */
-    public function __construct($message, $expected, $actual)
+    public function __construct(string $message, $expected, $actual)
     {
         parent::__construct($message);
 
@@ -60,7 +60,7 @@ class NotEqualException extends FailureException
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return var_export(array($this->expected, $this->actual), true);
     }

--- a/src/PhpSpec/Exception/Example/PendingException.php
+++ b/src/PhpSpec/Exception/Example/PendingException.php
@@ -21,7 +21,7 @@ class PendingException extends ExampleException
     /**
      * @param string $text
      */
-    public function __construct($text = 'write pending example')
+    public function __construct(string $text = 'write pending example')
     {
         parent::__construct(sprintf('todo: %s', $text));
     }

--- a/src/PhpSpec/Exception/Example/SkippingException.php
+++ b/src/PhpSpec/Exception/Example/SkippingException.php
@@ -18,7 +18,7 @@ class SkippingException extends ExampleException
     /**
      * @param string $text
      */
-    public function __construct($text)
+    public function __construct(string $text)
     {
         parent::__construct(sprintf('skipped: %s', $text));
     }

--- a/src/PhpSpec/Exception/Exception.php
+++ b/src/PhpSpec/Exception/Exception.php
@@ -28,7 +28,7 @@ class Exception extends \Exception
     /**
      * @return ReflectionFunctionAbstract
      */
-    public function getCause()
+    public function getCause(): ReflectionFunctionAbstract
     {
         return $this->cause;
     }

--- a/src/PhpSpec/Exception/ExceptionFactory.php
+++ b/src/PhpSpec/Exception/ExceptionFactory.php
@@ -42,7 +42,7 @@ class ExceptionFactory
      *
      * @return Fracture\NamedConstructorNotFoundException
      */
-    public function namedConstructorNotFound($classname, $method, array $arguments = array())
+    public function namedConstructorNotFound(string $classname, string $method, array $arguments = array()): Fracture\NamedConstructorNotFoundException
     {
         $instantiator = new Instantiator();
         $subject = $instantiator->instantiate($classname);
@@ -64,7 +64,7 @@ class ExceptionFactory
      *
      * @return Fracture\MethodNotFoundException
      */
-    public function methodNotFound($classname, $method, array $arguments = array())
+    public function methodNotFound(string $classname, string $method, array $arguments = array()): Fracture\MethodNotFoundException
     {
         $instantiator = new Instantiator();
         $subject = $instantiator->instantiate($classname);
@@ -85,7 +85,7 @@ class ExceptionFactory
      *
      * @return Fracture\MethodNotVisibleException
      */
-    public function methodNotVisible($classname, $method, array $arguments = array())
+    public function methodNotVisible(string $classname, string $method, array $arguments = array()): Fracture\MethodNotVisibleException
     {
         $instantiator = new Instantiator();
         $subject = $instantiator->instantiate($classname);
@@ -104,7 +104,7 @@ class ExceptionFactory
      *
      * @return Fracture\ClassNotFoundException
      */
-    public function classNotFound($classname)
+    public function classNotFound(string $classname): Fracture\ClassNotFoundException
     {
         $message = sprintf('Class %s does not exist.', $this->presenter->presentString($classname));
 
@@ -117,7 +117,7 @@ class ExceptionFactory
      *
      * @return Fracture\PropertyNotFoundException
      */
-    public function propertyNotFound($subject, $property)
+    public function propertyNotFound($subject, $property): Fracture\PropertyNotFoundException
     {
         $message = sprintf('Property %s not found.', $this->presenter->presentString($property));
 
@@ -129,7 +129,7 @@ class ExceptionFactory
      *
      * @return SubjectException
      */
-    public function callingMethodOnNonObject($method)
+    public function callingMethodOnNonObject(string $method): SubjectException
     {
         return new SubjectException(sprintf(
             'Call to a member function %s on a non-object.',
@@ -142,7 +142,7 @@ class ExceptionFactory
      *
      * @return SubjectException
      */
-    public function settingPropertyOnNonObject($property)
+    public function settingPropertyOnNonObject(string $property): SubjectException
     {
         return new SubjectException(sprintf(
             'Setting property %s on a non-object.',
@@ -155,7 +155,7 @@ class ExceptionFactory
      *
      * @return SubjectException
      */
-    public function gettingPropertyOnNonObject($property)
+    public function gettingPropertyOnNonObject(string $property): SubjectException
     {
         return new SubjectException(sprintf(
             'Getting property %s on a non-object.',

--- a/src/PhpSpec/Exception/Fracture/ClassNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/ClassNotFoundException.php
@@ -27,7 +27,7 @@ class ClassNotFoundException extends FractureException
      * @param string $message
      * @param string $classname
      */
-    public function __construct($message, $classname)
+    public function __construct(string $message, string $classname)
     {
         parent::__construct($message);
 
@@ -37,7 +37,7 @@ class ClassNotFoundException extends FractureException
     /**
      * @return string
      */
-    public function getClassname()
+    public function getClassname(): string
     {
         return $this->classname;
     }

--- a/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
@@ -33,11 +33,11 @@ class CollaboratorNotFoundException extends FractureException
      * @param string|null $className
      */
     public function __construct(
-        $message,
-        $code = 0,
+        string $message,
+        int $code = 0,
         Exception $previous = null,
         ReflectionParameter $reflectionParameter = null,
-        $className = null
+        string $className = null
     ) {
         if ($reflectionParameter) {
             $this->collaboratorName = $this->extractCollaboratorName($reflectionParameter);
@@ -52,7 +52,7 @@ class CollaboratorNotFoundException extends FractureException
     /**
      * @return string
      */
-    public function getCollaboratorName()
+    public function getCollaboratorName(): string
     {
         return $this->collaboratorName;
     }
@@ -62,7 +62,7 @@ class CollaboratorNotFoundException extends FractureException
      *
      * @return string
      */
-    private function extractCollaboratorName(ReflectionParameter $parameter)
+    private function extractCollaboratorName(ReflectionParameter $parameter): string
     {
         if (preg_match(self::CLASSNAME_REGEX, (string)$parameter, $matches)) {
             return $matches['classname'];

--- a/src/PhpSpec/Exception/Fracture/InterfaceNotImplementedException.php
+++ b/src/PhpSpec/Exception/Fracture/InterfaceNotImplementedException.php
@@ -34,7 +34,7 @@ class InterfaceNotImplementedException extends FractureException
      * @param mixed  $subject
      * @param string $interface
      */
-    public function __construct($message, $subject, $interface)
+    public function __construct(string $message, $subject, $interface)
     {
         parent::__construct($message);
 
@@ -53,7 +53,7 @@ class InterfaceNotImplementedException extends FractureException
     /**
      * @return string
      */
-    public function getInterface()
+    public function getInterface(): string
     {
         return $this->interface;
     }

--- a/src/PhpSpec/Exception/Fracture/MethodInvocationException.php
+++ b/src/PhpSpec/Exception/Fracture/MethodInvocationException.php
@@ -40,7 +40,7 @@ abstract class MethodInvocationException extends FractureException
      * @param string $method
      * @param array  $arguments
      */
-    public function __construct($message, $subject, $method, array $arguments = array())
+    public function __construct(string $message, $subject, $method, array $arguments = array())
     {
         parent::__construct($message);
 
@@ -60,7 +60,7 @@ abstract class MethodInvocationException extends FractureException
     /**
      * @return string
      */
-    public function getMethodName()
+    public function getMethodName(): string
     {
         return $this->method;
     }
@@ -68,7 +68,7 @@ abstract class MethodInvocationException extends FractureException
     /**
      * @return array
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }

--- a/src/PhpSpec/Exception/Fracture/PropertyNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/PropertyNotFoundException.php
@@ -34,7 +34,7 @@ class PropertyNotFoundException extends FractureException
      * @param mixed  $subject
      * @param string $property
      */
-    public function __construct($message, $subject, $property)
+    public function __construct(string $message, $subject, $property)
     {
         parent::__construct($message);
 
@@ -53,7 +53,7 @@ class PropertyNotFoundException extends FractureException
     /**
      * @return string
      */
-    public function getProperty()
+    public function getProperty(): string
     {
         return $this->property;
     }

--- a/src/PhpSpec/Exception/Wrapper/MatcherNotFoundException.php
+++ b/src/PhpSpec/Exception/Wrapper/MatcherNotFoundException.php
@@ -42,7 +42,7 @@ class MatcherNotFoundException extends Exception
      * @param mixed  $subject
      * @param array  $arguments
      */
-    public function __construct($message, $keyword, $subject, array $arguments)
+    public function __construct(string $message, string $keyword, $subject, array $arguments)
     {
         parent::__construct($message);
 
@@ -54,7 +54,7 @@ class MatcherNotFoundException extends Exception
     /**
      * @return string
      */
-    public function getKeyword()
+    public function getKeyword(): string
     {
         return $this->keyword;
     }
@@ -70,7 +70,7 @@ class MatcherNotFoundException extends Exception
     /**
      * @return array
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }

--- a/src/PhpSpec/Factory/ReflectionFactory.php
+++ b/src/PhpSpec/Factory/ReflectionFactory.php
@@ -23,7 +23,7 @@ class ReflectionFactory
      * @param $class
      * @return \ReflectionClass
      */
-    public function create($class)
+    public function create($class): \ReflectionClass
     {
         return new \ReflectionClass($class);
     }

--- a/src/PhpSpec/Formatter/BasicFormatter.php
+++ b/src/PhpSpec/Formatter/BasicFormatter.php
@@ -48,7 +48,7 @@ abstract class BasicFormatter implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         $events = array(
             'beforeSuite', 'afterSuite',
@@ -62,7 +62,7 @@ abstract class BasicFormatter implements EventSubscriberInterface
     /**
      * @return IO
      */
-    protected function getIO()
+    protected function getIO(): IO
     {
         return $this->io;
     }
@@ -70,7 +70,7 @@ abstract class BasicFormatter implements EventSubscriberInterface
     /**
      * @return Presenter
      */
-    protected function getPresenter()
+    protected function getPresenter(): Presenter
     {
         return $this->presenter;
     }
@@ -78,7 +78,7 @@ abstract class BasicFormatter implements EventSubscriberInterface
     /**
      * @return StatisticsCollector
      */
-    protected function getStatisticsCollector()
+    protected function getStatisticsCollector(): StatisticsCollector
     {
         return $this->stats;
     }

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -18,6 +18,7 @@ use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Exception\Example\PendingException;
 use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\IO\IO;
 use PhpSpec\Listener\StatisticsCollector;
 use PhpSpec\Message\CurrentExampleTracker;
 
@@ -40,9 +41,9 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
     }
 
     /**
-     * @return ConsoleIO
+     * @return IO
      */
-    protected function getIO()
+    protected function getIO(): IO
     {
         return $this->io;
     }
@@ -73,7 +74,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
      * @param ExampleEvent $event
      * @param string $type
      */
-    protected function printSpecificException(ExampleEvent $event, $type)
+    protected function printSpecificException(ExampleEvent $event, string $type)
     {
         $title = str_replace('\\', DIRECTORY_SEPARATOR, $event->getSpecification()->getTitle());
         $message = $this->getPresenter()->presentException($event->getException(), $this->io->isVerbose());

--- a/src/PhpSpec/Formatter/Html/HtmlIO.php
+++ b/src/PhpSpec/Formatter/Html/HtmlIO.php
@@ -28,7 +28,7 @@ final class HtmlIO implements IO
     /**
      * @return bool
      */
-    public function isVerbose()
+    public function isVerbose(): bool
     {
         return true;
     }

--- a/src/PhpSpec/Formatter/Html/ReportFailedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportFailedItem.php
@@ -51,7 +51,7 @@ class ReportFailedItem
     /**
      * @param int $index
      */
-    public function write($index)
+    public function write(int $index)
     {
         $code = $this->presenter->presentException($this->event->getException(), true);
         $this->template->render(
@@ -70,7 +70,7 @@ class ReportFailedItem
     /**
      * @return string
      */
-    private function formatBacktrace()
+    private function formatBacktrace(): string
     {
         $backtrace = '';
         foreach ($this->event->getBacktrace() as $step) {

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -60,7 +60,7 @@ class ReportItemFactory
      *
      * @throws InvalidExampleResultException
      */
-    private function invalidResultException($result)
+    private function invalidResultException(int $result)
     {
         throw new InvalidExampleResultException(
             "Unrecognised example result $result"

--- a/src/PhpSpec/Formatter/Html/Template.php
+++ b/src/PhpSpec/Formatter/Html/Template.php
@@ -37,7 +37,7 @@ final class Template implements TemplateInterface
      * @param string $text
      * @param array  $templateVars
      */
-    public function render($text, array $templateVars = array())
+    public function render(string $text, array $templateVars = array())
     {
         if (file_exists($text)) {
             $text = file_get_contents($text);
@@ -52,7 +52,7 @@ final class Template implements TemplateInterface
      *
      * @return array
      */
-    private function extractKeys(array $templateVars)
+    private function extractKeys(array $templateVars): array
     {
         return array_map(function ($e) {
             return '{'.$e.'}';

--- a/src/PhpSpec/Formatter/JUnitFormatter.php
+++ b/src/PhpSpec/Formatter/JUnitFormatter.php
@@ -74,7 +74,7 @@ final class JUnitFormatter extends BasicFormatter
      *
      * @return array
      */
-    public function getTestCaseNodes()
+    public function getTestCaseNodes(): array
     {
         return $this->testCaseNodes;
     }
@@ -94,7 +94,7 @@ final class JUnitFormatter extends BasicFormatter
      *
      * @return array
      */
-    public function getTestSuiteNodes()
+    public function getTestSuiteNodes(): array
     {
         return $this->testSuiteNodes;
     }
@@ -114,7 +114,7 @@ final class JUnitFormatter extends BasicFormatter
      *
      * @return array
      */
-    public function getExampleStatusCounts()
+    public function getExampleStatusCounts(): array
     {
         return $this->exampleStatusCounts;
     }

--- a/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
@@ -15,12 +15,12 @@ namespace PhpSpec\Formatter\Presenter\Differ;
 
 final class ArrayEngine extends StringEngine
 {
-    public function supports($expected, $actual)
+    public function supports($expected, $actual) : bool
     {
         return is_array($expected) && is_array($actual);
     }
 
-    public function compare($expected, $actual)
+    public function compare($expected, $actual) : string
     {
         $expectedString = $this->convertArrayToString($expected);
         $actualString   = $this->convertArrayToString($actual);

--- a/src/PhpSpec/Formatter/Presenter/Differ/DifferEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/DifferEngine.php
@@ -21,7 +21,7 @@ interface DifferEngine
      *
      * @return bool
      */
-    public function supports($expected, $actual);
+    public function supports($expected, $actual): bool;
 
     /**
      * @param mixed $expected
@@ -29,5 +29,5 @@ interface DifferEngine
      *
      * @return string
      */
-    public function compare($expected, $actual);
+    public function compare($expected, $actual): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
@@ -42,7 +42,7 @@ final class ObjectEngine implements DifferEngine
      *
      * @return bool
      */
-    public function supports($expected, $actual)
+    public function supports($expected, $actual): bool
     {
         return is_object($expected) && is_object($actual);
     }
@@ -53,7 +53,7 @@ final class ObjectEngine implements DifferEngine
      *
      * @return string
      */
-    public function compare($expected, $actual)
+    public function compare($expected, $actual): string
     {
         return $this->stringDiffer->compare(
             $this->exporter->export($expected),

--- a/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
@@ -15,12 +15,12 @@ namespace PhpSpec\Formatter\Presenter\Differ;
 
 class StringEngine implements DifferEngine
 {
-    public function supports($expected, $actual)
+    public function supports($expected, $actual): bool
     {
         return is_string($expected) && is_string($actual);
     }
 
-    public function compare($expected, $actual)
+    public function compare($expected, $actual): string
     {
         $expected = explode("\n", (string) $expected);
         $actual   = explode("\n", (string) $actual);

--- a/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
@@ -21,7 +21,7 @@ abstract class AbstractPhpSpecExceptionPresenter
      * @param Exception $exception
      * @return string
      */
-    public function presentException(Exception $exception)
+    public function presentException(Exception $exception): string
     {
         list($file, $line) = $this->getExceptionExamplePosition($exception);
 
@@ -32,7 +32,7 @@ abstract class AbstractPhpSpecExceptionPresenter
      * @param Exception $exception
      * @return array
      */
-    private function getExceptionExamplePosition(Exception $exception)
+    private function getExceptionExamplePosition(Exception $exception): array
     {
         $cause = $exception->getCause();
 
@@ -56,5 +56,5 @@ abstract class AbstractPhpSpecExceptionPresenter
      *
      * @return string
      */
-    abstract protected function presentFileCode($file, $lineno, $context = 6);
+    abstract protected function presentFileCode(string $file, int $lineno, int $context = 6): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
@@ -37,7 +37,7 @@ class CallArgumentsPresenter
      * @param UnexpectedCallException $exception
      * @return string
      */
-    public function presentDifference(UnexpectedCallException $exception)
+    public function presentDifference(UnexpectedCallException $exception): string
     {
         $actualArguments = $exception->getArguments();
         $methodProphecies = $exception->getObjectProphecy()->getMethodProphecies($exception->getMethodName());
@@ -66,7 +66,7 @@ class CallArgumentsPresenter
      * @param MethodProphecy[] $methodProphecies
      * @return bool
      */
-    private function noMethodPropheciesForUnexpectedCall(array $methodProphecies)
+    private function noMethodPropheciesForUnexpectedCall(array $methodProphecies): bool
     {
         return count($methodProphecies) === 0;
     }
@@ -75,12 +75,12 @@ class CallArgumentsPresenter
      * @param MethodProphecy[] $methodProphecies
      * @param UnexpectedCallException $exception
      *
-     * @return MethodProphecy
+     * @return MethodProphecy|null
      */
     private function findFirstUnexpectedArgumentsCallProphecy(
         array $methodProphecies,
         UnexpectedCallException $exception
-    ) {
+    ){
         $objectProphecy = $exception->getObjectProphecy();
 
         foreach ($methodProphecies as $methodProphecy) {
@@ -95,6 +95,8 @@ class CallArgumentsPresenter
 
             return $methodProphecy;
         }
+
+        return null;
     }
 
     /**
@@ -103,7 +105,7 @@ class CallArgumentsPresenter
      *
      * @return bool
      */
-    private function parametersCountMismatch(array $expectedTokens, array $actualArguments)
+    private function parametersCountMismatch(array $expectedTokens, array $actualArguments): bool
     {
         return count($expectedTokens) !== count($actualArguments);
     }
@@ -113,7 +115,7 @@ class CallArgumentsPresenter
      *
      * @return array
      */
-    private function convertArgumentTokensToDiffableValues(array $tokens)
+    private function convertArgumentTokensToDiffableValues(array $tokens): array
     {
         $values = array();
         foreach ($tokens as $token) {
@@ -133,7 +135,7 @@ class CallArgumentsPresenter
      *
      * @return string
      */
-    private function generateArgumentsDifferenceText(array $actualArguments, array $expectedArguments)
+    private function generateArgumentsDifferenceText(array $actualArguments, array $expectedArguments): string
     {
         $text = '';
         foreach($actualArguments as $i => $actualArgument) {

--- a/src/PhpSpec/Formatter/Presenter/Exception/ExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/ExceptionElementPresenter.php
@@ -20,26 +20,26 @@ interface ExceptionElementPresenter
      * @param \Exception $exception
      * @return string
      */
-    public function presentExceptionThrownMessage(\Exception $exception);
+    public function presentExceptionThrownMessage(\Exception $exception): string;
 
     /**
      * @param string $number
      * @param string $line
      * @return string
      */
-    public function presentCodeLine($number, $line);
+    public function presentCodeLine(string $number, string $line): string;
 
     /**
      * @param string $line
      * @return string
      */
-    public function presentHighlight($line);
+    public function presentHighlight(string $line): string;
 
     /**
      * @param string $header
      * @return string
      */
-    public function presentExceptionTraceHeader($header);
+    public function presentExceptionTraceHeader(string $header): string;
 
     /**
      * @param string $class
@@ -48,12 +48,12 @@ interface ExceptionElementPresenter
      * @param array $args
      * @return string
      */
-    public function presentExceptionTraceMethod($class, $type, $method, array $args);
+    public function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string;
 
     /**
      * @param string $function
      * @param array $args
      * @return string
      */
-    public function presentExceptionTraceFunction($function, array $args);
+    public function presentExceptionTraceFunction(string $function, array $args): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/ExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/ExceptionPresenter.php
@@ -20,5 +20,5 @@ interface ExceptionPresenter
      * @param bool $verbose
      * @return string
      */
-    public function presentException(\Exception $exception, $verbose = false);
+    public function presentException(\Exception $exception, bool $verbose = false): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
@@ -35,7 +35,7 @@ final class GenericPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPre
      *
      * @return string
      */
-    protected function presentFileCode($file, $lineno, $context = 6)
+    protected function presentFileCode(string $file, int $lineno, int $context = 6): string
     {
         $lines  = explode(PHP_EOL, file_get_contents($file));
         $offset = max(0, $lineno - ceil($context / 2));

--- a/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
@@ -22,7 +22,7 @@ final class HtmlPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresen
      *
      * @return string
      */
-    protected function presentFileCode($file, $lineno, $context = 6)
+    protected function presentFileCode(string $file, int $lineno, int $context = 6): string
     {
         $lines  = explode(PHP_EOL, file_get_contents($file));
         $offset = max(0, $lineno - ceil($context / 2));

--- a/src/PhpSpec/Formatter/Presenter/Exception/PhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/PhpSpecExceptionPresenter.php
@@ -22,5 +22,5 @@ interface PhpSpecExceptionPresenter
      * @param Exception $exception
      * @return string
      */
-    public function presentException(Exception $exception);
+    public function presentException(Exception $exception): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
@@ -42,7 +42,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      * @param \Exception $exception
      * @return string
      */
-    public function presentExceptionThrownMessage(\Exception $exception)
+    public function presentExceptionThrownMessage(\Exception $exception): string
     {
         return sprintf(
             'Exception %s has been thrown.',
@@ -55,7 +55,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      * @param string $line
      * @return string
      */
-    public function presentCodeLine($number, $line)
+    public function presentCodeLine(string $number, string $line): string
     {
         return sprintf('%s %s', $number, $line);
     }
@@ -64,7 +64,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      * @param string $line
      * @return string
      */
-    public function presentHighlight($line)
+    public function presentHighlight(string $line): string
     {
         return $line;
     }
@@ -73,7 +73,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      * @param string $header
      * @return string
      */
-    public function presentExceptionTraceHeader($header)
+    public function presentExceptionTraceHeader(string $header): string
     {
         return $header;
     }
@@ -85,7 +85,7 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      * @param array $args
      * @return string
      */
-    public function presentExceptionTraceMethod($class, $type, $method, array $args)
+    public function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         return sprintf('   %s%s%s(%s)', $class, $type, $method, $this->presentExceptionTraceArguments($args));
     }
@@ -95,16 +95,16 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      * @param array $args
      * @return string
      */
-    public function presentExceptionTraceFunction($function, array $args)
+    public function presentExceptionTraceFunction(string $function, array $args): string
     {
         return sprintf('   %s(%s)', $function, $this->presentExceptionTraceArguments($args));
     }
 
     /**
      * @param array $args
-     * @return array
+     * @return string
      */
-    private function presentExceptionTraceArguments(array $args)
+    private function presentExceptionTraceArguments(array $args): string
     {
         return implode(', ', array_map(array($this->valuePresenter, 'presentValue'), $args));
     }

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -79,7 +79,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      * @param bool $verbose
      * @return string
      */
-    public function presentException(\Exception $exception, $verbose = false)
+    public function presentException(\Exception $exception, bool $verbose = false): string
     {
         if ($exception instanceof PhpSpecException) {
             $presentation = wordwrap($exception->getMessage(), 120);
@@ -101,7 +101,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      * @param string $presentation
      * @return string
      */
-    private function getVerbosePresentation(\Exception $exception, $presentation)
+    private function getVerbosePresentation(\Exception $exception, string $presentation): string
     {
         if ($exception instanceof NotEqualException) {
             if ($diff = $this->presentExceptionDifference($exception)) {
@@ -125,7 +125,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      *
      * @return string
      */
-    private function presentExceptionDifference(NotEqualException $exception)
+    private function presentExceptionDifference(NotEqualException $exception): string
     {
         return $this->differ->compare($exception->getExpected(), $exception->getActual());
     }
@@ -135,7 +135,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      *
      * @return string
      */
-    private function presentExceptionStackTrace(\Exception $exception)
+    private function presentExceptionStackTrace(\Exception $exception): string
     {
         $offset = 0;
         $text = '';
@@ -166,7 +166,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      *
      * @return string
      */
-    private function presentExceptionTraceHeader($header)
+    private function presentExceptionTraceHeader(string $header): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceHeader($header) . PHP_EOL;
     }
@@ -179,7 +179,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      *
      * @return string
      */
-    private function presentExceptionTraceMethod($class, $type, $method, array $args)
+    private function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceMethod($class, $type, $method, $args) . PHP_EOL;
     }
@@ -190,7 +190,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      *
      * @return string
      */
-    private function presentExceptionTraceFunction($function, array $args)
+    private function presentExceptionTraceFunction(string $function, array $args): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceFunction($function, $args) . PHP_EOL;
     }
@@ -202,7 +202,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      *
      * @return string
      */
-    private function presentExceptionTraceLocation($offset, $file, $line)
+    private function presentExceptionTraceLocation(int $offset, string $file, int $line): string
     {
         return $this->presentExceptionTraceHeader(sprintf(
             "%2d %s:%d",
@@ -216,7 +216,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      * @param array $call
      * @return bool
      */
-    private function shouldStopTracePresentation(array $call)
+    private function shouldStopTracePresentation(array $call): bool
     {
         return isset($call['file']) && false !== strpos($call['file'], $this->runnerPath);
     }
@@ -225,7 +225,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      * @param array $call
      * @return bool
      */
-    private function shouldSkipTracePresentation(array $call)
+    private function shouldSkipTracePresentation(array $call): bool
     {
         if (isset($call['file']) && 0 === strpos($call['file'], $this->phpspecPath)) {
             return true;
@@ -239,7 +239,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      * @param int $offset
      * @return string
      */
-    private function presentExceptionTraceDetails(array $call, $offset)
+    private function presentExceptionTraceDetails(array $call, int $offset): string
     {
         $text = '';
 

--- a/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
@@ -42,7 +42,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
      * @param \Exception $exception
      * @return string
      */
-    public function presentExceptionThrownMessage(\Exception $exception)
+    public function presentExceptionThrownMessage(\Exception $exception): string
     {
         return sprintf(
             'Exception <label>%s</label> has been thrown.',
@@ -55,7 +55,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
      * @param string $line
      * @return string
      */
-    public function presentCodeLine($number, $line)
+    public function presentCodeLine(string $number, string $line): string
     {
         return sprintf('<lineno>%s</lineno> <code>%s</code>', $number, $line);
     }
@@ -64,7 +64,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
      * @param string $line
      * @return string
      */
-    public function presentHighlight($line)
+    public function presentHighlight(string $line): string
     {
         return sprintf('<hl>%s</hl>', $line);
     }
@@ -73,7 +73,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
      * @param string $header
      * @return string
      */
-    public function presentExceptionTraceHeader($header)
+    public function presentExceptionTraceHeader(string $header): string
     {
         return sprintf('<trace>%s</trace>', $header);
     }
@@ -85,7 +85,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
      * @param array $args
      * @return string
      */
-    public function presentExceptionTraceMethod($class, $type, $method, array $args)
+    public function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         $template = '   <trace><trace-class>%s</trace-class><trace-type>%s</trace-type>'.
             '<trace-func>%s</trace-func>(<trace-args>%s</trace-args>)</trace>';
@@ -98,7 +98,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
      * @param array $args
      * @return string
      */
-    public function presentExceptionTraceFunction($function, array $args)
+    public function presentExceptionTraceFunction(string $function, array $args): string
     {
         $template = '   <trace><trace-func>%s</trace-func>(<trace-args>%s</trace-args>)</trace>';
 
@@ -107,9 +107,9 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
 
     /**
      * @param array $args
-     * @return array
+     * @return string
      */
-    private function presentExceptionTraceArguments(array $args)
+    private function presentExceptionTraceArguments(array $args): string
     {
         $valuePresenter = $this->valuePresenter;
 

--- a/src/PhpSpec/Formatter/Presenter/Presenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Presenter.php
@@ -23,5 +23,5 @@ interface Presenter extends ExceptionPresenter, ValuePresenter
      *
      * @return string
      */
-    public function presentString($string);
+    public function presentString(string $string): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
@@ -43,7 +43,7 @@ final class SimplePresenter implements Presenter
      *
      * @return string
      */
-    public function presentValue($value)
+    public function presentValue($value): string
     {
         return $this->valuePresenter->presentValue($value);
     }
@@ -54,7 +54,7 @@ final class SimplePresenter implements Presenter
      *
      * @return string
      */
-    public function presentException(\Exception $exception, $verbose = false)
+    public function presentException(\Exception $exception, bool $verbose = false): string
     {
         return $this->exceptionPresenter->presentException($exception, $verbose);
     }
@@ -64,7 +64,7 @@ final class SimplePresenter implements Presenter
      *
      * @return string
      */
-    public function presentString($string)
+    public function presentString(string $string): string
     {
         return $string;
     }

--- a/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
@@ -33,7 +33,7 @@ final class TaggingPresenter implements Presenter
      * @param bool $verbose
      * @return string
      */
-    public function presentException(\Exception $exception, $verbose = false)
+    public function presentException(\Exception $exception, bool $verbose = false): string
     {
         return $this->presenter->presentException($exception, $verbose);
     }
@@ -43,7 +43,7 @@ final class TaggingPresenter implements Presenter
      *
      * @return string
      */
-    public function presentString($string)
+    public function presentString(string $string): string
     {
         return sprintf('<value>%s</value>', $string);
     }
@@ -52,7 +52,7 @@ final class TaggingPresenter implements Presenter
      * @param mixed $value
      * @return string
      */
-    public function presentValue($value)
+    public function presentValue($value): string
     {
         return $this->presentString($this->presenter->presentValue($value));
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
@@ -19,7 +19,7 @@ final class ArrayTypePresenter implements TypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value)
+    public function supports($value): bool
     {
         return 'array' === strtolower(gettype($value));
     }
@@ -28,7 +28,7 @@ final class ArrayTypePresenter implements TypePresenter
      * @param mixed $value
      * @return string
      */
-    public function present($value)
+    public function present($value): string
     {
         return sprintf('[array:%d]', count($value));
     }
@@ -36,7 +36,7 @@ final class ArrayTypePresenter implements TypePresenter
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 20;
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
@@ -21,7 +21,7 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value)
+    public function supports($value): bool
     {
         return $value instanceof \Exception;
     }
@@ -30,7 +30,7 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
      * @param mixed $value
      * @return string
      */
-    public function present($value)
+    public function present($value): string
     {
         $label = 'exc';
 
@@ -50,7 +50,7 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 60;
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
@@ -19,7 +19,7 @@ final class BooleanTypePresenter implements TypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value)
+    public function supports($value): bool
     {
         return 'boolean' === strtolower(gettype($value));
     }
@@ -28,7 +28,7 @@ final class BooleanTypePresenter implements TypePresenter
      * @param mixed $value
      * @return string
      */
-    public function present($value)
+    public function present($value): string
     {
         return $value ? 'true' : 'false';
     }
@@ -36,7 +36,7 @@ final class BooleanTypePresenter implements TypePresenter
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 40;
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
@@ -34,7 +34,7 @@ final class CallableTypePresenter implements TypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value)
+    public function supports($value): bool
     {
         return is_callable($value);
     }
@@ -43,7 +43,7 @@ final class CallableTypePresenter implements TypePresenter
      * @param mixed $value
      * @return string
      */
-    public function present($value)
+    public function present($value): string
     {
         if (is_array($value)) {
             $type = is_object($value[0]) ? $this->presenter->presentValue($value[0]) : $value[0];
@@ -64,7 +64,7 @@ final class CallableTypePresenter implements TypePresenter
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 70;
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
@@ -36,7 +36,7 @@ final class ComposedValuePresenter implements ValuePresenter
      * @param mixed $value
      * @return string
      */
-    public function presentValue($value)
+    public function presentValue($value): string
     {
         foreach ($this->typePresenters as $typePresenter) {
             if ($typePresenter->supports($value)) {

--- a/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
@@ -19,7 +19,7 @@ final class NullTypePresenter implements TypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value)
+    public function supports($value): bool
     {
         return null === $value;
     }
@@ -28,7 +28,7 @@ final class NullTypePresenter implements TypePresenter
      * @param mixed $value
      * @return string
      */
-    public function present($value)
+    public function present($value): string
     {
         return 'null';
     }
@@ -36,7 +36,7 @@ final class NullTypePresenter implements TypePresenter
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 50;
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
@@ -19,7 +19,7 @@ final class ObjectTypePresenter implements TypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value)
+    public function supports($value): bool
     {
         return 'object' === strtolower(gettype($value));
     }
@@ -28,7 +28,7 @@ final class ObjectTypePresenter implements TypePresenter
      * @param mixed $value
      * @return string
      */
-    public function present($value)
+    public function present($value): string
     {
         return sprintf('[obj:%s]', get_class($value));
     }
@@ -36,7 +36,7 @@ final class ObjectTypePresenter implements TypePresenter
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 30;
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
@@ -19,7 +19,7 @@ final class QuotingStringTypePresenter implements StringTypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value)
+    public function supports($value): bool
     {
         return 'string' === strtolower(gettype($value));
     }
@@ -28,7 +28,7 @@ final class QuotingStringTypePresenter implements StringTypePresenter
      * @param mixed $value
      * @return string
      */
-    public function present($value)
+    public function present($value): string
     {
         return sprintf('"%s"', $value);
     }
@@ -36,7 +36,7 @@ final class QuotingStringTypePresenter implements StringTypePresenter
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 10;
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -29,7 +29,7 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value)
+    public function supports($value): bool
     {
         return $this->stringTypePresenter->supports($value);
     }
@@ -38,7 +38,7 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
      * @param mixed $value
      * @return string
      */
-    public function present($value)
+    public function present($value): string
     {
         if (25 > strlen($value) && false === strpos($value, "\n")) {
             return $this->stringTypePresenter->present($value);
@@ -51,7 +51,7 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return $this->stringTypePresenter->getPriority();
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
@@ -20,16 +20,16 @@ interface TypePresenter
      * @param mixed $value
      * @return bool
      */
-    public function supports($value);
+    public function supports($value): bool;
 
     /**
      * @param mixed $value
      * @return string
      */
-    public function present($value);
+    public function present($value): string;
 
     /**
      * @return int
      */
-    public function getPriority();
+    public function getPriority(): int;
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
@@ -20,5 +20,5 @@ interface ValuePresenter
      * @param mixed $value
      * @return string
      */
-    public function presentValue($value);
+    public function presentValue($value): string;
 }

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -68,7 +68,7 @@ final class ProgressFormatter extends ConsoleFormatter
      * @param $counts
      * @return array
      */
-    private function getPercentages($total, $counts)
+    private function getPercentages($total, $counts): array
     {
         return array_map(
             function ($count) use ($total) {
@@ -88,7 +88,7 @@ final class ProgressFormatter extends ConsoleFormatter
      * @param array $counts
      * @return array
      */
-    private function getBarLengths($counts)
+    private function getBarLengths(array $counts): array
     {
         $stats = $this->getStatisticsCollector();
         $totalSpecsCount = $stats->getTotalSpecsCount();
@@ -109,7 +109,7 @@ final class ProgressFormatter extends ConsoleFormatter
      * @param  boolean $isDecorated
      * @return array
      */
-    private function formatProgressOutput($barLengths, $percents, $isDecorated)
+    private function formatProgressOutput(array $barLengths, array $percents, bool $isDecorated): array
     {
         $size = $this->getIO()->getBlockWidth();
         $progress = array();
@@ -146,7 +146,7 @@ final class ProgressFormatter extends ConsoleFormatter
      * @param array     $progress
      * @param int       $total
      */
-    private function updateProgressBar(ConsoleIO $io, array $progress, $total)
+    private function updateProgressBar(ConsoleIO $io, array $progress, int $total)
     {
         if ($io->isDecorated()) {
             $progressBar = implode('', $progress);

--- a/src/PhpSpec/Formatter/TapFormatter.php
+++ b/src/PhpSpec/Formatter/TapFormatter.php
@@ -123,7 +123,7 @@ final class TapFormatter extends ConsoleFormatter
      * @param int $result
      * @return string
      */
-    private function getResultData(ExampleEvent $event, $result = null)
+    private function getResultData(ExampleEvent $event, int $result = null): string
     {
         if (null === $result) {
             return $this->stripNewlines($event->getException()->getMessage());
@@ -159,7 +159,7 @@ final class TapFormatter extends ConsoleFormatter
      * @param string $string
      * @return string
      */
-    private function stripNewlines($string)
+    private function stripNewlines(string $string): string
     {
         return str_replace(array("\r\n", "\n", "\r"), ' / ', $string);
     }
@@ -168,7 +168,7 @@ final class TapFormatter extends ConsoleFormatter
      * @param string $string
      * @return string
      */
-    private function indent($string)
+    private function indent(string $string): string
     {
         return preg_replace(
             array("%(^[^\n\r])%", "%([\n\r]{1,2})%", "%\s+...[\n\r]{1,2}\s+---%"),

--- a/src/PhpSpec/Formatter/Template.php
+++ b/src/PhpSpec/Formatter/Template.php
@@ -19,5 +19,5 @@ interface Template
      * @param string $text
      * @param array  $templateVars
      */
-    public function render($text, array $templateVars = array());
+    public function render(string $text, array $templateVars = array());
 }

--- a/src/PhpSpec/Listener/ClassNotFoundListener.php
+++ b/src/PhpSpec/Listener/ClassNotFoundListener.php
@@ -44,7 +44,7 @@ final class ClassNotFoundListener implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             'afterExample' => array('afterExample', 10),

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -79,7 +79,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             'afterExample' => array('afterExample', 10),
@@ -113,7 +113,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
      * @param string $classname
      * @return mixed
      */
-    private function getDoubledInterface($classname)
+    private function getDoubledInterface(string $classname)
     {
         if (class_parents($classname) !== array('stdClass'=>'stdClass')) {
             return;
@@ -173,7 +173,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
      * @param mixed $prophecyArguments
      * @return array
      */
-    private function getRealArguments($prophecyArguments)
+    private function getRealArguments($prophecyArguments): array
     {
         if ($prophecyArguments instanceof ArgumentsWildcard) {
             return $prophecyArguments->getTokens();

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -18,6 +18,7 @@ use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Exception\Fracture\CollaboratorNotFoundException;
+use PhpSpec\Locator\Resource;
 use PhpSpec\Locator\ResourceManager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -58,7 +59,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             'afterExample' => array('afterExample', 10),
@@ -107,7 +108,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
      * @param Resource $resource
      * @return bool
      */
-    private function resourceIsInSpecNamespace($exception, $resource)
+    private function resourceIsInSpecNamespace(CollaboratorNotFoundException $exception, Resource $resource): bool
     {
         return strpos($exception->getCollaboratorName(), $resource->getSpecNamespace()) === 0;
     }

--- a/src/PhpSpec/Listener/StopOnFailureListener.php
+++ b/src/PhpSpec/Listener/StopOnFailureListener.php
@@ -36,7 +36,7 @@ final class StopOnFailureListener implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             'afterExample' => array('afterExample', -100),

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -38,7 +38,7 @@ class ExampleNode
      * @param string                     $title
      * @param ReflectionFunctionAbstract $function
      */
-    public function __construct($title, ReflectionFunctionAbstract $function)
+    public function __construct(string $title, ReflectionFunctionAbstract $function)
     {
         $this->title    = $title;
         $this->function = $function;
@@ -47,7 +47,7 @@ class ExampleNode
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -55,7 +55,7 @@ class ExampleNode
     /**
      * @param bool $isPending
      */
-    public function markAsPending($isPending = true)
+    public function markAsPending(bool $isPending = true)
     {
         $this->isPending = $isPending;
     }
@@ -63,7 +63,7 @@ class ExampleNode
     /**
      * @return bool
      */
-    public function isPending()
+    public function isPending(): bool
     {
         return $this->isPending;
     }
@@ -71,7 +71,7 @@ class ExampleNode
     /**
      * @return ReflectionFunctionAbstract
      */
-    public function getFunctionReflection()
+    public function getFunctionReflection(): ReflectionFunctionAbstract
     {
         return $this->function;
     }
@@ -95,7 +95,7 @@ class ExampleNode
     /**
      * @return int
      */
-    public function getLineNumber()
+    public function getLineNumber(): int
     {
         return $this->function->isClosure() ? 0 : $this->function->getStartLine();
     }

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -45,7 +45,7 @@ class SpecificationNode implements \Countable
      * @param ReflectionClass   $class
      * @param Resource $resource
      */
-    public function __construct($title, ReflectionClass $class, Resource $resource)
+    public function __construct(string $title, ReflectionClass $class, Resource $resource)
     {
         $this->title    = $title;
         $this->class    = $class;
@@ -55,7 +55,7 @@ class SpecificationNode implements \Countable
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -63,7 +63,7 @@ class SpecificationNode implements \Countable
     /**
      * @return ReflectionClass
      */
-    public function getClassReflection()
+    public function getClassReflection(): ReflectionClass
     {
         return $this->class;
     }
@@ -71,7 +71,7 @@ class SpecificationNode implements \Countable
     /**
      * @return Resource
      */
-    public function getResource()
+    public function getResource(): Resource
     {
         return $this->resource;
     }
@@ -112,7 +112,7 @@ class SpecificationNode implements \Countable
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->examples);
     }

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -47,7 +47,7 @@ class ResourceLoader
      *
      * @return Suite
      */
-    public function load($locator, $line = null)
+    public function load(string $locator = '', int $line = null): Suite
     {
         $suite = new Suite();
         foreach ($this->manager->locateResources($locator) as $resource) {
@@ -103,7 +103,7 @@ class ResourceLoader
      *
      * @return bool
      */
-    private function lineIsInsideMethod($line, ReflectionMethod $method)
+    private function lineIsInsideMethod(int $line, ReflectionMethod $method): bool
     {
         $line = intval($line);
 

--- a/src/PhpSpec/Loader/SpecTransformer.php
+++ b/src/PhpSpec/Loader/SpecTransformer.php
@@ -15,5 +15,5 @@ namespace PhpSpec\Loader;
 
 interface SpecTransformer
 {
-    function transform($spec);
+    function transform(string $spec): string;
 }

--- a/src/PhpSpec/Loader/Suite.php
+++ b/src/PhpSpec/Loader/Suite.php
@@ -38,9 +38,9 @@ class Suite implements \Countable
     }
 
     /**
-     * @return number
+     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return array_sum(array_map('count', $this->specs));
     }

--- a/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
@@ -26,7 +26,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param string $typehint
      */
-    public function add($class, $method, $argument, $typehint)
+    public function add(string $class, string $method, string $argument, string $typehint)
     {
         $this->store($class, $method, $argument, $typehint);
     }
@@ -37,7 +37,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param \Exception $exception
      */
-    public function addInvalid($class, $method, $argument, \Exception $exception)
+    public function addInvalid(string $class, string $method, string $argument, \Exception $exception)
     {
         $this->store($class, $method, $argument, $exception);
     }
@@ -48,7 +48,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param mixed $typehint
      */
-    private function store($class, $method, $argument, $typehint)
+    private function store(string $class, string $method, string $argument, $typehint)
     {
         $class = strtolower($class);
         $method = strtolower($method);
@@ -71,7 +71,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      *
      * @return string|null
      */
-    public function lookup($class, $method, $argument)
+    public function lookup(string $class, string $method, string $argument)
     {
         $class = strtolower($class);
         $method = strtolower($method);

--- a/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
@@ -21,7 +21,7 @@ interface TypeHintIndex
      * @param string $argument
      * @param string $typehint
      */
-    public function add($class, $method, $argument, $typehint);
+    public function add(string $class, string $method, string $argument, string $typehint);
 
     /**
      * @param string $class
@@ -29,13 +29,14 @@ interface TypeHintIndex
      * @param string $argument
      * @param \Exception $exception
      */
-    public function addInvalid($class, $method, $argument, \Exception $exception);
+    public function addInvalid(string $class, string $method, string $argument, \Exception $exception);
 
     /**
      * @param string $class
      * @param string $method
      * @param string $argument
-     * @return string
+     *
+     * @return string|null
      */
-    public function lookup($class, $method, $argument);
+    public function lookup(string $class, string $method, string $argument);
 }

--- a/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
@@ -36,7 +36,7 @@ final class TypeHintRewriter implements SpecTransformer
      *
      * @return string
      */
-    function transform($spec)
+    function transform(string $spec): string
     {
         return $this->rewriter->rewrite($spec);
     }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -63,11 +63,11 @@ class PSR0Locator implements ResourceLocator
      */
     public function __construct(
         Filesystem $filesystem,
-        $srcNamespace = '',
-        $specNamespacePrefix = 'spec',
-        $srcPath = 'src',
-        $specPath = '.',
-        $psr4Prefix = null
+        string $srcNamespace = '',
+        string $specNamespacePrefix = 'spec',
+        string $srcPath = 'src',
+        string $specPath = '.',
+        string $psr4Prefix = null
     ) {
         $this->filesystem = $filesystem;
         $sepr = DIRECTORY_SEPARATOR;
@@ -110,7 +110,7 @@ class PSR0Locator implements ResourceLocator
     /**
      * @return string
      */
-    public function getFullSrcPath()
+    public function getFullSrcPath(): string
     {
         return $this->fullSrcPath;
     }
@@ -118,7 +118,7 @@ class PSR0Locator implements ResourceLocator
     /**
      * @return string
      */
-    public function getFullSpecPath()
+    public function getFullSpecPath(): string
     {
         return $this->fullSpecPath;
     }
@@ -126,7 +126,7 @@ class PSR0Locator implements ResourceLocator
     /**
      * @return string
      */
-    public function getSrcNamespace()
+    public function getSrcNamespace(): string
     {
         return $this->srcNamespace;
     }
@@ -134,7 +134,7 @@ class PSR0Locator implements ResourceLocator
     /**
      * @return string
      */
-    public function getSpecNamespace()
+    public function getSpecNamespace(): string
     {
         return $this->specNamespace;
     }
@@ -152,7 +152,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return bool
      */
-    public function supportsQuery($query)
+    public function supportsQuery(string $query): bool
     {
         $path = $this->getQueryPath($query);
 
@@ -168,7 +168,7 @@ class PSR0Locator implements ResourceLocator
     /**
      * @return boolean
      */
-    public function isPSR4()
+    public function isPSR4(): bool
     {
         return $this->psr4Prefix !== null;
     }
@@ -178,7 +178,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return Resource[]
      */
-    public function findResources($query)
+    public function findResources(string $query)
     {
         $path = $this->getQueryPath($query);
 
@@ -212,7 +212,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return bool
      */
-    public function supportsClass($classname)
+    public function supportsClass(string $classname): bool
     {
         $classname = str_replace('/', '\\', $classname);
 
@@ -227,7 +227,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return null|PSR0Resource
      */
-    public function createResource($classname)
+    public function createResource(string $classname)
     {
         $classname = ltrim($classname, '\\');
         $this->validatePsr0Classname($classname);
@@ -252,7 +252,7 @@ class PSR0Locator implements ResourceLocator
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 0;
     }
@@ -262,7 +262,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return PSR0Resource[]
      */
-    protected function findSpecResources($path)
+    protected function findSpecResources(string $path)
     {
         if (!$this->filesystem->pathExists($path)) {
             return array();
@@ -322,7 +322,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return PSR0Resource
      */
-    private function createResourceFromSpecFile($path)
+    private function createResourceFromSpecFile(string $path): PSR0Resource
     {
         $classname = $this->findSpecClassname($path);
 
@@ -355,7 +355,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @throws InvalidArgumentException
      */
-    private function validatePsr0Classname($classname)
+    private function validatePsr0Classname(string $classname)
     {
         $pattern = '/\A([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*[\/\\\\]?)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\z/';
 
@@ -373,7 +373,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return string
      */
-    private function getQueryPath($query)
+    private function getQueryPath(string $query): string
     {
         $sepr = DIRECTORY_SEPARATOR;
         $replacedQuery = str_replace(array('\\', '/'), $sepr, $query);
@@ -398,7 +398,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return bool
      */
-    private function queryContainsQualifiedClassName($query)
+    private function queryContainsQualifiedClassName(string $query): bool
     {
         return $this->queryContainsBlackslashes($query) && !$this->isWindowsPath($query);
     }
@@ -408,7 +408,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return bool
      */
-    private function queryContainsBlackslashes($query)
+    private function queryContainsBlackslashes(string $query): bool
     {
         return false !== strpos($query, '\\');
     }
@@ -418,7 +418,7 @@ class PSR0Locator implements ResourceLocator
      *
      * @return bool
      */
-    private function isWindowsPath($query)
+    private function isWindowsPath(string $query): bool
     {
         return preg_match('/^\w:/', $query);
     }

--- a/src/PhpSpec/Locator/PSR0/PSR0Resource.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Resource.php
@@ -37,9 +37,9 @@ final class PSR0Resource implements Resource
     }
 
     /**
-     * @return mixed
+     * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return end($this->parts);
     }
@@ -47,7 +47,7 @@ final class PSR0Resource implements Resource
     /**
      * @return string
      */
-    public function getSpecName()
+    public function getSpecName(): string
     {
         return $this->getName().'Spec';
     }
@@ -55,7 +55,7 @@ final class PSR0Resource implements Resource
     /**
      * @return string
      */
-    public function getSrcFilename()
+    public function getSrcFilename(): string
     {
         if ($this->locator->isPSR4()) {
             return $this->locator->getFullSrcPath().implode(DIRECTORY_SEPARATOR, $this->parts).'.php';
@@ -71,7 +71,7 @@ final class PSR0Resource implements Resource
     /**
      * @return string
      */
-    public function getSrcNamespace()
+    public function getSrcNamespace(): string
     {
         $nsParts = $this->parts;
         array_pop($nsParts);
@@ -82,7 +82,7 @@ final class PSR0Resource implements Resource
     /**
      * @return string
      */
-    public function getSrcClassname()
+    public function getSrcClassname(): string
     {
         return $this->locator->getSrcNamespace().implode('\\', $this->parts);
     }
@@ -90,7 +90,7 @@ final class PSR0Resource implements Resource
     /**
      * @return string
      */
-    public function getSpecFilename()
+    public function getSpecFilename(): string
     {
         if ($this->locator->isPSR4()) {
             return $this->locator->getFullSpecPath().
@@ -108,7 +108,7 @@ final class PSR0Resource implements Resource
     /**
      * @return string
      */
-    public function getSpecNamespace()
+    public function getSpecNamespace(): string
     {
         $nsParts = $this->parts;
         array_pop($nsParts);
@@ -119,7 +119,7 @@ final class PSR0Resource implements Resource
     /**
      * @return string
      */
-    public function getSpecClassname()
+    public function getSpecClassname(): string
     {
         return $this->locator->getSpecNamespace().implode('\\', $this->parts).'Spec';
     }

--- a/src/PhpSpec/Locator/PrioritizedResourceManager.php
+++ b/src/PhpSpec/Locator/PrioritizedResourceManager.php
@@ -39,7 +39,7 @@ final class PrioritizedResourceManager implements ResourceManager
      *
      * @return Resource[]
      */
-    public function locateResources($query)
+    public function locateResources(string $query)
     {
         $resources = array();
         foreach ($this->locators as $locator) {
@@ -65,7 +65,7 @@ final class PrioritizedResourceManager implements ResourceManager
      *
      * @throws \RuntimeException
      */
-    public function createResource($classname)
+    public function createResource(string $classname): Resource
     {
         foreach ($this->locators as $locator) {
             if ($locator->supportsClass($classname)) {

--- a/src/PhpSpec/Locator/Resource.php
+++ b/src/PhpSpec/Locator/Resource.php
@@ -18,40 +18,40 @@ interface Resource
     /**
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * @return string
      */
-    public function getSpecName();
+    public function getSpecName(): string;
 
     /**
      * @return string
      */
-    public function getSrcFilename();
+    public function getSrcFilename(): string;
 
     /**
      * @return string
      */
-    public function getSrcNamespace();
+    public function getSrcNamespace(): string;
 
     /**
      * @return string
      */
-    public function getSrcClassname();
+    public function getSrcClassname(): string;
 
     /**
      * @return string
      */
-    public function getSpecFilename();
+    public function getSpecFilename(): string;
 
     /**
      * @return string
      */
-    public function getSpecNamespace();
+    public function getSpecNamespace(): string;
 
     /**
      * @return string
      */
-    public function getSpecClassname();
+    public function getSpecClassname(): string;
 }

--- a/src/PhpSpec/Locator/ResourceLocator.php
+++ b/src/PhpSpec/Locator/ResourceLocator.php
@@ -25,31 +25,31 @@ interface ResourceLocator
      *
      * @return boolean
      */
-    public function supportsQuery($query);
+    public function supportsQuery(string $query): bool;
 
     /**
      * @param string $query
      *
      * @return Resource[]
      */
-    public function findResources($query);
+    public function findResources(string $query);
 
     /**
      * @param string $classname
      *
      * @return boolean
      */
-    public function supportsClass($classname);
+    public function supportsClass(string $classname): bool;
 
     /**
      * @param string $classname
      *
      * @return Resource|null
      */
-    public function createResource($classname);
+    public function createResource(string $classname);
 
     /**
      * @return integer
      */
-    public function getPriority();
+    public function getPriority(): int;
 }

--- a/src/PhpSpec/Locator/ResourceManager.php
+++ b/src/PhpSpec/Locator/ResourceManager.php
@@ -20,12 +20,12 @@ interface ResourceManager
      *
      * @return \PhpSpec\Locator\Resource[]
      */
-    public function locateResources($query);
+    public function locateResources(string $query);
 
     /**
      * @param string $classname
      *
      * @return \PhpSpec\Locator\Resource
      */
-    public function createResource($classname);
+    public function createResource(string $classname): \PhpSpec\Locator\Resource;
 }

--- a/src/PhpSpec/Matcher/ApproximatelyMatcher.php
+++ b/src/PhpSpec/Matcher/ApproximatelyMatcher.php
@@ -50,7 +50,7 @@ final class ApproximatelyMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return in_array($name, self::$keywords) && 2 == count($arguments);
     }
@@ -61,14 +61,14 @@ final class ApproximatelyMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         $value = (float)$arguments[0];
         return (abs($subject - $value) < $arguments[1]);
     }
 
 
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments) : FailureException
     {
         return new FailureException(sprintf(
             'Expected an approximated value of %s, but got %s',
@@ -77,7 +77,7 @@ final class ApproximatelyMatcher extends BasicMatcher
         ));
     }
 
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Did Not expect an approximated value of %s, but got %s',

--- a/src/PhpSpec/Matcher/ArrayContainMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayContainMatcher.php
@@ -38,7 +38,7 @@ final class ArrayContainMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'contain' === $name
             && 1 == count($arguments)
@@ -52,7 +52,7 @@ final class ArrayContainMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         return in_array($arguments[0], $subject, true);
     }
@@ -64,7 +64,7 @@ final class ArrayContainMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to contain %s, but it does not.',
@@ -80,7 +80,7 @@ final class ArrayContainMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to contain %s, but it does.',

--- a/src/PhpSpec/Matcher/ArrayCountMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayCountMatcher.php
@@ -38,7 +38,7 @@ final class ArrayCountMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveCount' === $name
             && 1 == count($arguments)
@@ -52,7 +52,7 @@ final class ArrayCountMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         return $arguments[0] === count($subject);
     }
@@ -64,7 +64,7 @@ final class ArrayCountMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to have %s items, but got %s.',
@@ -81,7 +81,7 @@ final class ArrayCountMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have %s items, but got it.',

--- a/src/PhpSpec/Matcher/ArrayKeyMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyMatcher.php
@@ -39,7 +39,7 @@ final class ArrayKeyMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveKey' === $name
             && 1 == count($arguments)
@@ -53,7 +53,7 @@ final class ArrayKeyMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         $key = $arguments[0];
 
@@ -71,7 +71,7 @@ final class ArrayKeyMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to have %s key, but it does not.',
@@ -87,7 +87,7 @@ final class ArrayKeyMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have %s key, but it does.',

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -39,7 +39,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return
             (is_array($subject) || $subject instanceof \ArrayAccess) &&
@@ -54,7 +54,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         $key = $arguments[0];
         $value  = $arguments[1];
@@ -73,7 +73,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         $key = $arguments[0];
 
@@ -100,7 +100,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have %s key, but it does.',

--- a/src/PhpSpec/Matcher/BasicMatcher.php
+++ b/src/PhpSpec/Matcher/BasicMatcher.php
@@ -26,7 +26,7 @@ abstract class BasicMatcher implements Matcher
      *
      *   @throws FailureException
      */
-    final public function positiveMatch($name, $subject, array $arguments)
+    final public function positiveMatch(string $name, $subject, array $arguments)
     {
         if (false === $this->matches($subject, $arguments)) {
             throw $this->getFailureException($name, $subject, $arguments);
@@ -44,7 +44,7 @@ abstract class BasicMatcher implements Matcher
      *
      * @throws FailureException
      */
-    final public function negativeMatch($name, $subject, array $arguments)
+    final public function negativeMatch(string $name, $subject, array $arguments)
     {
         if (true === $this->matches($subject, $arguments)) {
             throw $this->getNegativeFailureException($name, $subject, $arguments);
@@ -56,7 +56,7 @@ abstract class BasicMatcher implements Matcher
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 100;
     }
@@ -67,7 +67,7 @@ abstract class BasicMatcher implements Matcher
      *
      * @return boolean
      */
-    abstract protected function matches($subject, array $arguments);
+    abstract protected function matches($subject, array $arguments): bool;
 
     /**
      * @param string $name
@@ -76,7 +76,7 @@ abstract class BasicMatcher implements Matcher
      *
      * @return FailureException
      */
-    abstract protected function getFailureException($name, $subject, array $arguments);
+    abstract protected function getFailureException(string $name, $subject, array $arguments): FailureException;
 
     /**
      * @param string $name
@@ -85,5 +85,5 @@ abstract class BasicMatcher implements Matcher
      *
      * @return FailureException
      */
-    abstract protected function getNegativeFailureException($name, $subject, array $arguments);
+    abstract protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException;
 }

--- a/src/PhpSpec/Matcher/CallbackMatcher.php
+++ b/src/PhpSpec/Matcher/CallbackMatcher.php
@@ -36,7 +36,7 @@ final class CallbackMatcher extends BasicMatcher
      * @param callable           $callback
      * @param Presenter $presenter
      */
-    public function __construct($name, $callback, Presenter $presenter)
+    public function __construct(string $name, callable $callback, Presenter $presenter)
     {
         $this->name      = $name;
         $this->callback  = $callback;
@@ -50,18 +50,18 @@ final class CallbackMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return $name === $this->name;
     }
 
     /**
-     * @param string $subject
-     * @param array  $arguments
+     * @param mixed $subject
+     * @param array $arguments
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         array_unshift($arguments, $subject);
 
@@ -75,7 +75,7 @@ final class CallbackMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             '%s expected to %s(%s), but it is not.',
@@ -92,7 +92,7 @@ final class CallbackMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             '%s not expected to %s(%s), but it did.',

--- a/src/PhpSpec/Matcher/ComparisonMatcher.php
+++ b/src/PhpSpec/Matcher/ComparisonMatcher.php
@@ -39,7 +39,7 @@ final class ComparisonMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'beLike' === $name
             && 1 == count($arguments)
@@ -52,7 +52,7 @@ final class ComparisonMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         return $subject == $arguments[0];
     }
@@ -64,7 +64,7 @@ final class ComparisonMatcher extends BasicMatcher
      *
      * @return NotEqualException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new NotEqualException(sprintf(
             'Expected %s, but got %s.',
@@ -80,7 +80,7 @@ final class ComparisonMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Did not expect %s, but got one.',

--- a/src/PhpSpec/Matcher/IdentityMatcher.php
+++ b/src/PhpSpec/Matcher/IdentityMatcher.php
@@ -48,7 +48,7 @@ final class IdentityMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return in_array($name, self::$keywords)
             && 1 == count($arguments)
@@ -61,7 +61,7 @@ final class IdentityMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         return $subject === $arguments[0];
     }
@@ -71,9 +71,9 @@ final class IdentityMatcher extends BasicMatcher
      * @param mixed  $subject
      * @param array  $arguments
      *
-     * @return NotEqualException
+     * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new NotEqualException(sprintf(
             'Expected %s, but got %s.',
@@ -89,7 +89,7 @@ final class IdentityMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Did not expect %s, but got one.',

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -70,7 +70,7 @@ final class IterablesMatcher
      *
      * @return bool
      */
-    private function isIterable($variable)
+    private function isIterable($variable): bool
     {
         return is_array($variable) || $variable instanceof \Traversable;
     }
@@ -80,7 +80,7 @@ final class IterablesMatcher
      *
      * @return \Iterator
      */
-    private function createIteratorFromIterable($iterable)
+    private function createIteratorFromIterable($iterable): \Iterator
     {
         if (is_array($iterable)) {
             return new \ArrayIterator($iterable);

--- a/src/PhpSpec/Matcher/Iterate/SubjectElementDoesNotMatchException.php
+++ b/src/PhpSpec/Matcher/Iterate/SubjectElementDoesNotMatchException.php
@@ -24,7 +24,7 @@ class SubjectElementDoesNotMatchException extends FailureException
      * @param string $expectedKey
      * @param string $expectedValue
      */
-    public function __construct($elementNumber, $subjectKey, $subjectValue, $expectedKey, $expectedValue)
+    public function __construct(int $elementNumber, string $subjectKey, string $subjectValue, string $expectedKey, string $expectedValue)
     {
         parent::__construct(sprintf(
             'Expected subject to have element #%d with key %s and value %s, but got key %s and value %s.',

--- a/src/PhpSpec/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Matcher/IterateAsMatcher.php
@@ -35,7 +35,7 @@ final class IterateAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return in_array($name, ['iterateAs', 'yield'])
             && 1 === count($arguments)
@@ -47,7 +47,7 @@ final class IterateAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function positiveMatch($name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments)
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0]);
@@ -61,7 +61,7 @@ final class IterateAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function negativeMatch($name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments)
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
@@ -75,7 +75,7 @@ final class IterateAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority() : int
     {
         return 100;
     }

--- a/src/PhpSpec/Matcher/Matcher.php
+++ b/src/PhpSpec/Matcher/Matcher.php
@@ -24,7 +24,7 @@ interface Matcher
      *
      * @return Boolean
      */
-    public function supports($name, $subject, array $arguments);
+    public function supports(string $name, $subject, array $arguments): bool;
 
     /**
      * Evaluates positive match.
@@ -33,7 +33,7 @@ interface Matcher
      * @param mixed  $subject
      * @param array  $arguments
      */
-    public function positiveMatch($name, $subject, array $arguments);
+    public function positiveMatch(string $name, $subject, array $arguments);
 
     /**
      * Evaluates negative match.
@@ -42,12 +42,12 @@ interface Matcher
      * @param mixed  $subject
      * @param array  $arguments
      */
-    public function negativeMatch($name, $subject, array $arguments);
+    public function negativeMatch(string $name, $subject, array $arguments);
 
     /**
      * Returns matcher priority.
      *
      * @return integer
      */
-    public function getPriority();
+    public function getPriority(): int;
 }

--- a/src/PhpSpec/Matcher/MatchersProvider.php
+++ b/src/PhpSpec/Matcher/MatchersProvider.php
@@ -18,5 +18,5 @@ interface MatchersProvider
     /**
      * @return array
      */
-    public function getMatchers();
+    public function getMatchers(): array;
 }

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -43,7 +43,7 @@ final class ObjectStateMatcher implements Matcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return is_object($subject) && !is_callable($subject)
             && (0 === strpos($name, 'be') || 0 === strpos($name, 'have'))
@@ -58,7 +58,7 @@ final class ObjectStateMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      */
-    public function positiveMatch($name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments)
     {
         preg_match(self::$regex, $name, $matches);
         $method   = ('be' === $matches[1] ? 'is' : 'has').ucfirst($matches[2]);
@@ -84,7 +84,7 @@ final class ObjectStateMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      */
-    public function negativeMatch($name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments)
     {
         preg_match(self::$regex, $name, $matches);
         $method   = ('be' === $matches[1] ? 'is' : 'has').ucfirst($matches[2]);
@@ -105,7 +105,7 @@ final class ObjectStateMatcher implements Matcher
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 50;
     }
@@ -117,7 +117,7 @@ final class ObjectStateMatcher implements Matcher
      *
      * @return FailureException
      */
-    private function getFailureExceptionFor($callable, $expectedBool, $result)
+    private function getFailureExceptionFor(callable $callable, bool $expectedBool, bool $result): FailureException
     {
         return new FailureException(sprintf(
             "Expected %s to return %s, but got %s.",

--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -40,7 +40,7 @@ final class ScalarMatcher implements Matcher
      *
      * @return Boolean
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         $checkerName = $this->getCheckerName($name);
 
@@ -57,7 +57,7 @@ final class ScalarMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @return boolean
      */
-    public function positiveMatch($name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments)
     {
         $checker = $this->getCheckerName($name);
 
@@ -84,7 +84,7 @@ final class ScalarMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @return boolean
      */
-    public function negativeMatch($name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments)
     {
         $checker = $this->getCheckerName($name);
 
@@ -106,7 +106,7 @@ final class ScalarMatcher implements Matcher
      *
      * @return integer
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 50;
     }
@@ -116,7 +116,7 @@ final class ScalarMatcher implements Matcher
      *
      * @return string|boolean
      */
-    private function getCheckerName($name)
+    private function getCheckerName(string $name)
     {
         if (0 !== strpos($name, 'be')) {
             return false;

--- a/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
@@ -35,7 +35,7 @@ final class StartIteratingAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return in_array($name, ['startIteratingAs', 'startYielding'])
             && 1 === count($arguments)
@@ -47,7 +47,7 @@ final class StartIteratingAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function positiveMatch($name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments)
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0]);
@@ -61,7 +61,7 @@ final class StartIteratingAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function negativeMatch($name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments)
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
@@ -75,7 +75,7 @@ final class StartIteratingAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority() : int
     {
         return 100;
     }

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -34,7 +34,7 @@ final class StringContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments) : bool
     {
         return 'contain' === $name
             && is_string($subject)
@@ -45,7 +45,7 @@ final class StringContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments) : bool
     {
         return false !== strpos($subject, $arguments[0]);
     }
@@ -53,7 +53,7 @@ final class StringContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to contain %s, but it does not.',
@@ -65,7 +65,7 @@ final class StringContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to contain %s, but it does.',

--- a/src/PhpSpec/Matcher/StringEndMatcher.php
+++ b/src/PhpSpec/Matcher/StringEndMatcher.php
@@ -38,7 +38,7 @@ final class StringEndMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'endWith' === $name
             && is_string($subject)
@@ -52,7 +52,7 @@ final class StringEndMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         return $arguments[0] === substr($subject, 0 - strlen($arguments[0]));
     }
@@ -64,7 +64,7 @@ final class StringEndMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to end with %s, but it does not.',
@@ -80,7 +80,7 @@ final class StringEndMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to end with %s, but it does.',

--- a/src/PhpSpec/Matcher/StringRegexMatcher.php
+++ b/src/PhpSpec/Matcher/StringRegexMatcher.php
@@ -38,7 +38,7 @@ final class StringRegexMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'match' === $name
             && is_string($subject)
@@ -52,7 +52,7 @@ final class StringRegexMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         return (Boolean) preg_match($arguments[0], $subject);
     }
@@ -64,7 +64,7 @@ final class StringRegexMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to match %s regex, but it does not.',
@@ -80,7 +80,7 @@ final class StringRegexMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to match %s regex, but it does.',

--- a/src/PhpSpec/Matcher/StringStartMatcher.php
+++ b/src/PhpSpec/Matcher/StringStartMatcher.php
@@ -38,7 +38,7 @@ final class StringStartMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'startWith' === $name
             && is_string($subject)
@@ -52,7 +52,7 @@ final class StringStartMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         return 0 === strpos($subject, $arguments[0]);
     }
@@ -64,7 +64,7 @@ final class StringStartMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to start with %s, but it does not.',
@@ -80,7 +80,7 @@ final class StringStartMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to start with %s, but it does.',

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -63,7 +63,7 @@ final class ThrowMatcher implements Matcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'throw' === $name;
     }
@@ -75,7 +75,7 @@ final class ThrowMatcher implements Matcher
      *
      * @return DelayedCall
      */
-    public function positiveMatch($name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyPositive'), $subject, $arguments);
     }
@@ -87,7 +87,7 @@ final class ThrowMatcher implements Matcher
      *
      * @return DelayedCall
      */
-    public function negativeMatch($name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyNegative'), $subject, $arguments);
     }
@@ -100,7 +100,7 @@ final class ThrowMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \PhpSpec\Exception\Example\NotEqualException
      */
-    public function verifyPositive($callable, array $arguments, $exception = null)
+    public function verifyPositive(callable $callable, array $arguments, $exception = null)
     {
         $exceptionThrown = null;
 
@@ -169,7 +169,7 @@ final class ThrowMatcher implements Matcher
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function verifyNegative($callable, array $arguments, $exception = null)
+    public function verifyNegative(callable $callable, array $arguments, $exception = null)
     {
         $exceptionThrown = null;
 
@@ -234,7 +234,7 @@ final class ThrowMatcher implements Matcher
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 1;
     }
@@ -246,7 +246,7 @@ final class ThrowMatcher implements Matcher
      *
      * @return DelayedCall
      */
-    private function getDelayedCall($check, $subject, array $arguments)
+    private function getDelayedCall(callable $check, $subject, array $arguments): DelayedCall
     {
         $exception = $this->getException($arguments);
         $unwrapper = $this->unwrapper;

--- a/src/PhpSpec/Matcher/TraversableContainMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableContainMatcher.php
@@ -34,7 +34,7 @@ final class TraversableContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'contain' === $name
             && 1 === count($arguments)
@@ -45,7 +45,7 @@ final class TraversableContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         foreach ($subject as $value) {
             if ($value === $arguments[0]) {
@@ -59,7 +59,7 @@ final class TraversableContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to contain %s, but it does not.',
@@ -71,7 +71,7 @@ final class TraversableContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to contain %s, but it does.',

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -38,7 +38,7 @@ final class TraversableCountMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveCount' === $name
             && 1 === count($arguments)
@@ -49,7 +49,7 @@ final class TraversableCountMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function positiveMatch($name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments)
     {
         $countDifference = $this->countDifference($subject, (int) $arguments[0]);
 
@@ -68,7 +68,7 @@ final class TraversableCountMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function negativeMatch($name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments)
     {
         $count = $this->countDifference($subject, (int) $arguments[0]);
 
@@ -86,7 +86,7 @@ final class TraversableCountMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority() : int
     {
         return 100;
     }
@@ -97,7 +97,7 @@ final class TraversableCountMatcher implements Matcher
      *
      * @return int self::*
      */
-    private function countDifference(\Traversable $subject, $expected)
+    private function countDifference(\Traversable $subject, int $expected): int
     {
         $count = 0;
         foreach ($subject as $value) {

--- a/src/PhpSpec/Matcher/TraversableKeyMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyMatcher.php
@@ -35,7 +35,7 @@ final class TraversableKeyMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveKey' === $name
             && 1 === count($arguments)
@@ -46,7 +46,7 @@ final class TraversableKeyMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         foreach ($subject as $key => $value) {
             if ($key === $arguments[0]) {
@@ -60,7 +60,7 @@ final class TraversableKeyMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to have %s key, but it does not.',
@@ -72,7 +72,7 @@ final class TraversableKeyMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have %s key, but it does.',

--- a/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
@@ -35,7 +35,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments) : bool
     {
         return 'haveKeyWithValue' === $name
             && 2 === count($arguments)
@@ -46,7 +46,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments) : bool
     {
         foreach ($subject as $key => $value) {
             if ($key === $arguments[0] && $value === $arguments[1]) {
@@ -60,7 +60,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to have an element with %s key and %s value, but it does not.',
@@ -73,7 +73,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have an element with %s key and %s value, but it does.',

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -40,7 +40,7 @@ final class TriggerMatcher implements Matcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'trigger' === $name;
     }
@@ -52,7 +52,7 @@ final class TriggerMatcher implements Matcher
      *
      * @return DelayedCall
      */
-    public function positiveMatch($name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyPositive'), $subject, $arguments);
     }
@@ -64,7 +64,7 @@ final class TriggerMatcher implements Matcher
      *
      * @return DelayedCall
      */
-    public function negativeMatch($name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyNegative'), $subject, $arguments);
     }
@@ -77,7 +77,7 @@ final class TriggerMatcher implements Matcher
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function verifyPositive(callable $callable, array $arguments, $level = null, $message = null)
+    public function verifyPositive(callable $callable, array $arguments, int $level = null, string $message = null)
     {
         $triggered = 0;
 
@@ -110,7 +110,7 @@ final class TriggerMatcher implements Matcher
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function verifyNegative(callable $callable, array $arguments, $level = null, $message = null)
+    public function verifyNegative(callable $callable, array $arguments, int $level = null, string $message = null)
     {
         $triggered = 0;
 
@@ -143,7 +143,7 @@ final class TriggerMatcher implements Matcher
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 1;
     }
@@ -155,7 +155,7 @@ final class TriggerMatcher implements Matcher
      *
      * @return DelayedCall
      */
-    private function getDelayedCall($check, $subject, array $arguments)
+    private function getDelayedCall(callable $check, $subject, array $arguments): DelayedCall
     {
         $unwrapper = $this->unwrapper;
         list($level, $message) = $this->unpackArguments($arguments);
@@ -186,7 +186,7 @@ final class TriggerMatcher implements Matcher
     /**
      * @return array
      */
-    private function unpackArguments(array $arguments)
+    private function unpackArguments(array $arguments): array
     {
         $count = count($arguments);
 

--- a/src/PhpSpec/Matcher/TypeMatcher.php
+++ b/src/PhpSpec/Matcher/TypeMatcher.php
@@ -47,7 +47,7 @@ final class TypeMatcher extends BasicMatcher
      *
      * @return bool
      */
-    public function supports($name, $subject, array $arguments)
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return in_array($name, self::$keywords)
             && 1 == count($arguments)
@@ -60,7 +60,7 @@ final class TypeMatcher extends BasicMatcher
      *
      * @return bool
      */
-    protected function matches($subject, array $arguments)
+    protected function matches($subject, array $arguments): bool
     {
         return (null !== $subject) && ($subject instanceof $arguments[0]);
     }
@@ -72,7 +72,7 @@ final class TypeMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getFailureException($name, $subject, array $arguments)
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected an instance of %s, but got %s.',
@@ -88,7 +88,7 @@ final class TypeMatcher extends BasicMatcher
      *
      * @return FailureException
      */
-    protected function getNegativeFailureException($name, $subject, array $arguments)
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Did not expect instance of %s, but got %s.',

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -19,7 +19,7 @@ class ComposerPsrNamespaceProvider
      */
     private $specPrefix;
 
-    public function __construct($rootDirectory, $specPrefix)
+    public function __construct(string $rootDirectory, string $specPrefix)
     {
         $this->rootDirectory = $rootDirectory;
         $this->specPrefix = $specPrefix;
@@ -32,7 +32,7 @@ class ComposerPsrNamespaceProvider
      *                      'My\PSR0Namespace' => '',
      *                  ]
      */
-    public function getNamespaces()
+    public function getNamespaces() : array
     {
         $vendors = array();
         foreach (get_declared_classes() as $class) {

--- a/src/PhpSpec/NamespaceProvider/NamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/NamespaceProvider.php
@@ -11,5 +11,5 @@ interface NamespaceProvider
      * @return string[] a map associating a namespace to a location, e.g
      *                  ['My\Namespace' => 'my/location/relative/to/spec/or/src/directory']
      */
-    public function getNamespaces();
+    public function getNamespaces() : array;
 }

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -70,7 +70,7 @@ abstract class ObjectBehavior implements
      * @link http://phpspec.net/cookbook/matchers.html Matchers cookbook
      * @return array a list of inline matchers
      */
-    public function getMatchers()
+    public function getMatchers() : array
     {
         return array();
     }
@@ -104,7 +104,7 @@ abstract class ObjectBehavior implements
      *
      * @return Subject
      */
-    public function offsetExists($key)
+    public function offsetExists($key): Subject
     {
         return $this->object->offsetExists($key);
     }
@@ -116,7 +116,7 @@ abstract class ObjectBehavior implements
      *
      * @return Subject
      */
-    public function offsetGet($key)
+    public function offsetGet($key): Subject
     {
         return $this->object->offsetGet($key);
     }
@@ -150,7 +150,7 @@ abstract class ObjectBehavior implements
      *
      * @return mixed
      */
-    public function __call($method, array $arguments = array())
+    public function __call(string $method, array $arguments = array())
     {
         return call_user_func_array(array($this->object, $method), $arguments);
     }
@@ -161,7 +161,7 @@ abstract class ObjectBehavior implements
      * @param string $property
      * @param mixed  $value
      */
-    public function __set($property, $value)
+    public function __set(string $property, $value)
     {
         $this->object->$property = $value;
     }
@@ -173,7 +173,7 @@ abstract class ObjectBehavior implements
      *
      * @return mixed
      */
-    public function __get($property)
+    public function __get(string $property)
     {
         return $this->object->$property;
     }

--- a/src/PhpSpec/Process/Context/ExecutionContext.php
+++ b/src/PhpSpec/Process/Context/ExecutionContext.php
@@ -18,15 +18,15 @@ interface ExecutionContext
     /**
      * @param string $type
      */
-    public function addGeneratedType($type);
+    public function addGeneratedType(string $type);
 
     /**
      * @return array
      */
-    public function getGeneratedTypes();
+    public function getGeneratedTypes(): array;
 
     /**
      * @return array
      */
-    public function asEnv();
+    public function asEnv(): array;
 }

--- a/src/PhpSpec/Process/Context/JsonExecutionContext.php
+++ b/src/PhpSpec/Process/Context/JsonExecutionContext.php
@@ -26,7 +26,7 @@ final class JsonExecutionContext implements ExecutionContext
      *
      * @return JsonExecutionContext
      */
-    public static function fromEnv($env)
+    public static function fromEnv(array $env): JsonExecutionContext
     {
         $executionContext = new JsonExecutionContext();
 
@@ -44,7 +44,7 @@ final class JsonExecutionContext implements ExecutionContext
     /**
      * @param string $generatedType
      */
-    public function addGeneratedType($generatedType)
+    public function addGeneratedType(string $generatedType)
     {
         $this->generatedTypes[] = $generatedType;
     }
@@ -52,15 +52,15 @@ final class JsonExecutionContext implements ExecutionContext
     /**
      * @return array
      */
-    public function getGeneratedTypes()
+    public function getGeneratedTypes(): array
     {
         return $this->generatedTypes;
     }
 
     /**
-     * @return string
+     * @return array
      */
-    public function asEnv()
+    public function asEnv(): array
     {
         return array(
             self::ENV_NAME => json_encode(

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -39,7 +39,7 @@ final class PcntlReRunner extends PhpExecutableReRunner
     /**
      * @return bool
      */
-    public function isSupported()
+    public function isSupported(): bool
     {
         return (php_sapi_name() == 'cli')
             && $this->getExecutablePath()

--- a/src/PhpSpec/Process/ReRunner/PlatformSpecificReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PlatformSpecificReRunner.php
@@ -22,5 +22,5 @@ interface PlatformSpecificReRunner extends ReRunner
      *
      * @return bool
      */
-    public function isSupported();
+    public function isSupported(): bool;
 }

--- a/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
@@ -39,7 +39,7 @@ final class ProcOpenReRunner extends PhpExecutableReRunner
     /**
      * @return boolean
      */
-    public function isSupported()
+    public function isSupported(): bool
     {
         return (php_sapi_name() == 'cli')
             && $this->getExecutablePath()

--- a/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
@@ -39,7 +39,7 @@ final class WindowsPassthruReRunner extends PhpExecutableReRunner
     /**
      * @return boolean
      */
-    public function isSupported()
+    public function isSupported(): bool
     {
         return (php_sapi_name() == 'cli')
             && $this->getExecutablePath()

--- a/src/PhpSpec/Runner/CollaboratorManager.php
+++ b/src/PhpSpec/Runner/CollaboratorManager.php
@@ -39,9 +39,9 @@ class CollaboratorManager
 
     /**
      * @param string       $name
-     * @param Collaborator $collaborator
+     * @param object $collaborator
      */
-    public function set($name, $collaborator)
+    public function set(string $name, $collaborator)
     {
         $this->collaborators[$name] = $collaborator;
     }
@@ -51,7 +51,7 @@ class CollaboratorManager
      *
      * @return bool
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         return isset($this->collaborators[$name]);
     }
@@ -59,11 +59,11 @@ class CollaboratorManager
     /**
      * @param string $name
      *
-     * @return Collaborator
+     * @return object
      *
      * @throws \PhpSpec\Exception\Wrapper\CollaboratorException
      */
-    public function get($name)
+    public function get(string $name)
     {
         if (!$this->has($name)) {
             throw new CollaboratorException(
@@ -79,7 +79,7 @@ class CollaboratorManager
      *
      * @return array
      */
-    public function getArgumentsFor(ReflectionFunctionAbstract $function)
+    public function getArgumentsFor(ReflectionFunctionAbstract $function): array
     {
         $parameters = array();
         foreach ($function->getParameters() as $parameter) {

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -69,7 +69,7 @@ class ExampleRunner
      *
      * @return int
      */
-    public function run(ExampleNode $example)
+    public function run(ExampleNode $example): int
     {
         $startTime = microtime(true);
         $this->dispatcher->dispatch(

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -62,7 +62,7 @@ final class CollaboratorsMaintainer implements Maintainer
      *
      * @return bool
      */
-    public function supports(ExampleNode $example)
+    public function supports(ExampleNode $example): bool
     {
         return true;
     }
@@ -108,7 +108,7 @@ final class CollaboratorsMaintainer implements Maintainer
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 50;
     }
@@ -152,7 +152,7 @@ final class CollaboratorsMaintainer implements Maintainer
      *
      * @return Collaborator
      */
-    private function getOrCreateCollaborator(CollaboratorManager $collaborators, $name)
+    private function getOrCreateCollaborator(CollaboratorManager $collaborators, string $name): Collaborator
     {
         if (!$collaborators->has($name)) {
             $collaborator = new Collaborator($this->prophet->prophesize());
@@ -168,7 +168,7 @@ final class CollaboratorsMaintainer implements Maintainer
      * @param string $className
      * @throws CollaboratorNotFoundException
      */
-    private function throwCollaboratorNotFound($e, $parameter, $className = null)
+    private function throwCollaboratorNotFound(\Exception $e, \ReflectionParameter $parameter = null, string $className = null)
     {
         throw new CollaboratorNotFoundException(
             sprintf('Collaborator does not exist '),
@@ -184,7 +184,7 @@ final class CollaboratorsMaintainer implements Maintainer
      *
      * @return string
      */
-    private function getParameterTypeFromIndex(\ReflectionClass $classRefl, \ReflectionParameter $parameter)
+    private function getParameterTypeFromIndex(\ReflectionClass $classRefl, \ReflectionParameter $parameter): string
     {
         return $this->typeHintIndex->lookup(
             $classRefl->getName(),
@@ -198,11 +198,11 @@ final class CollaboratorsMaintainer implements Maintainer
      *
      * @return string
      */
-    private function getParameterTypeFromReflection(\ReflectionParameter $parameter)
+    private function getParameterTypeFromReflection(\ReflectionParameter $parameter): string
     {
         try {
             if (null === $class = $parameter->getClass()) {
-                return null;
+                return '';
             }
 
             return $class->getName();

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -33,7 +33,7 @@ final class ErrorMaintainer implements Maintainer
     /**
      * @param integer $errorLevel
      */
-    public function __construct($errorLevel)
+    public function __construct(int $errorLevel)
     {
         $this->errorLevel = $errorLevel;
     }
@@ -43,7 +43,7 @@ final class ErrorMaintainer implements Maintainer
      *
      * @return bool
      */
-    public function supports(ExampleNode $example)
+    public function supports(ExampleNode $example): bool
     {
         return true;
     }
@@ -83,7 +83,7 @@ final class ErrorMaintainer implements Maintainer
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 999;
     }
@@ -104,7 +104,7 @@ final class ErrorMaintainer implements Maintainer
      *
      * @throws ExampleException\ErrorException
      */
-    final public function errorHandler($level, $message, $file, $line)
+    final public function errorHandler(int $level, string $message, string $file, int $line): Boolean
     {
         $regex = '/^Argument (\d)+ passed to (?:(?P<class>[\w\\\]+)::)?(\w+)\(\)' .
                  ' must (?:be an instance of|implement interface) ([\w\\\]+),(?: instance of)? ([\w\\\]+) given/';

--- a/src/PhpSpec/Runner/Maintainer/LetAndLetgoMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/LetAndLetgoMaintainer.php
@@ -25,7 +25,7 @@ class LetAndLetgoMaintainer implements Maintainer
      *
      * @return bool
      */
-    public function supports(ExampleNode $example)
+    public function supports(ExampleNode $example): bool
     {
         return $example->getSpecification()->getClassReflection()->hasMethod('let')
             || $example->getSpecification()->getClassReflection()->hasMethod('letgo')
@@ -75,7 +75,7 @@ class LetAndLetgoMaintainer implements Maintainer
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 10;
     }

--- a/src/PhpSpec/Runner/Maintainer/Maintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/Maintainer.php
@@ -25,7 +25,7 @@ interface Maintainer
      *
      * @return boolean
      */
-    public function supports(ExampleNode $example);
+    public function supports(ExampleNode $example): bool;
 
     /**
      * @param ExampleNode            $example
@@ -56,5 +56,5 @@ interface Maintainer
     /**
      * @return integer
      */
-    public function getPriority();
+    public function getPriority(): int;
 }

--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -52,7 +52,7 @@ final class MatchersMaintainer implements Maintainer
      *
      * @return bool
      */
-    public function supports(ExampleNode $example)
+    public function supports(ExampleNode $example): bool
     {
         return true;
     }
@@ -106,7 +106,7 @@ final class MatchersMaintainer implements Maintainer
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 50;
     }

--- a/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
@@ -64,7 +64,7 @@ final class SubjectMaintainer implements Maintainer
      *
      * @return boolean
      */
-    public function supports(ExampleNode $example)
+    public function supports(ExampleNode $example): bool
     {
         return $example->getSpecification()->getClassReflection()->implementsInterface(
             'PhpSpec\Wrapper\SubjectContainer'
@@ -109,7 +109,7 @@ final class SubjectMaintainer implements Maintainer
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 100;
     }

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -66,7 +66,7 @@ class MatcherManager
      *
      * @throws \PhpSpec\Exception\Wrapper\MatcherNotFoundException
      */
-    public function find($keyword, $subject, array $arguments)
+    public function find(string $keyword, $subject, array $arguments): Matcher
     {
         foreach ($this->matchers as $matcher) {
             if (true === $matcher->supports($keyword, $subject, $arguments)) {

--- a/src/PhpSpec/Runner/SuiteRunner.php
+++ b/src/PhpSpec/Runner/SuiteRunner.php
@@ -44,7 +44,7 @@ class SuiteRunner
      *
      * @return integer
      */
-    public function run(Suite $suite)
+    public function run(Suite $suite): int
     {
         $this->dispatcher->dispatch('beforeSuite', new SuiteEvent($suite));
 

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -14,7 +14,7 @@ interface ServiceContainer
      * @param string $id
      * @param mixed $value
      */
-    public function setParam($id, $value);
+    public function setParam(string $id, $value);
 
     /**
      * Gets a param from the container or a default value.
@@ -24,7 +24,7 @@ interface ServiceContainer
      *
      * @return mixed
      */
-    public function getParam($id, $default = null);
+    public function getParam(string $id, $default = null);
 
     /**
      * Sets a object to be used as a service
@@ -35,7 +35,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set($id, $service, $tags = []);
+    public function set(string $id, $service, array $tags = []);
 
     /**
      * Sets a factory for the service creation. The same service will
@@ -47,7 +47,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
-    public function define($id, callable $definition, $tags = []);
+    public function define(string $id, callable $definition, array $tags = []);
 
     /**
      * Retrieves a service from the container
@@ -58,15 +58,15 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function get($id);
+    public function get(string $id);
 
     /**
      * Determines whether a service is defined
      *
-     * @param $id
+     * @param string $id
      * @return bool
      */
-    public function has($id);
+    public function has(string $id): bool;
 
     /**
      * Removes a service from the container
@@ -75,7 +75,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function remove($id);
+    public function remove(string $id);
 
     /**
      * Finds all services tagged with a particular string
@@ -84,5 +84,5 @@ interface ServiceContainer
      *
      * @return array
      */
-    public function getByTag($tag);
+    public function getByTag(string $tag): array;
 }

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -53,7 +53,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param string $id
      * @param mixed  $value
      */
-    public function setParam($id, $value)
+    public function setParam(string $id, $value)
     {
         $this->parameters[$id] = $value;
     }
@@ -66,7 +66,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @return mixed
      */
-    public function getParam($id, $default = null)
+    public function getParam(string $id, $default = null)
     {
         return isset($this->parameters[$id]) ? $this->parameters[$id] : $default;
     }
@@ -80,7 +80,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set($id, $service, $tags = [])
+    public function set(string $id, $service, array $tags = [])
     {
         if (!is_object($service)) {
             throw new InvalidArgumentException(sprintf(
@@ -103,7 +103,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param callable $definition
      * @param array    $tags
      */
-    public function define($id, callable $definition, $tags = [])
+    public function define(string $id, callable $definition, array $tags = [])
     {
         $this->definitions[$id] = $definition;
         unset($this->services[$id]);
@@ -120,7 +120,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function get($id)
+    public function get(string $id)
     {
         if (!array_key_exists($id, $this->services)) {
             if (!array_key_exists($id, $this->definitions)) {
@@ -139,7 +139,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param string $id
      * @return bool
      */
-    public function has($id)
+    public function has(string $id): bool
     {
         return array_key_exists($id, $this->definitions) || array_key_exists($id, $this->services) ;
     }
@@ -151,7 +151,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function remove($id)
+    public function remove(string $id)
     {
         if (!$this->has($id)) {
             throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
@@ -166,7 +166,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param string $id
      * @param array  $tags
      */
-    private function indexTags($id, array $tags)
+    private function indexTags(string $id, array $tags)
     {
         foreach ($tags as $tag) {
             $this->tags[$tag][] = $id;
@@ -180,7 +180,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @return array
      */
-    public function getByTag($tag)
+    public function getByTag(string $tag): array
     {
         return array_map([$this, 'get'], isset($this->tags[$tag]) ? $this->tags[$tag] : []);
     }

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -24,7 +24,7 @@ final class ClassFileAnalyser
      * @param string $class
      * @return int
      */
-    public function getStartLineOfFirstMethod($class)
+    public function getStartLineOfFirstMethod(string $class): int
     {
         $tokens = $this->getTokensForClass($class);
         $index = $this->offsetForDocblock($tokens, $this->findIndexOfFirstMethod($tokens));
@@ -35,7 +35,7 @@ final class ClassFileAnalyser
      * @param string $class
      * @return int
      */
-    public function getEndLineOfLastMethod($class)
+    public function getEndLineOfLastMethod(string $class): int
     {
         $tokens = $this->getTokensForClass($class);
         $index = $this->findEndOfLastMethod($tokens, $this->findIndexOfClassEnd($tokens));
@@ -46,7 +46,7 @@ final class ClassFileAnalyser
      * @param string $class
      * @return bool
      */
-    public function classHasMethods($class)
+    public function classHasMethods(string $class): bool
     {
         foreach ($this->getTokensForClass($class) as $token) {
             if (!is_array($token)) {
@@ -66,7 +66,7 @@ final class ClassFileAnalyser
      * @param string $methodName
      * @return int
      */
-    public function getEndLineOfNamedMethod($class, $methodName)
+    public function getEndLineOfNamedMethod(string $class, string $methodName): int
     {
         $tokens = $this->getTokensForClass($class);
 
@@ -78,7 +78,7 @@ final class ClassFileAnalyser
      * @param array $tokens
      * @return int
      */
-    private function findIndexOfFirstMethod(array $tokens)
+    private function findIndexOfFirstMethod(array $tokens): int
     {
         for ($i = 0, $max = count($tokens); $i < $max; $i++) {
             if ($this->tokenIsFunction($tokens[$i])) {
@@ -92,7 +92,7 @@ final class ClassFileAnalyser
      * @param int $index
      * @return int
      */
-    private function offsetForDocblock(array $tokens, $index)
+    private function offsetForDocblock(array $tokens, int $index): int
     {
         $allowedTokens = array(
             T_FINAL,
@@ -127,7 +127,7 @@ final class ClassFileAnalyser
      * @param $class
      * @return array
      */
-    private function getTokensForClass($class)
+    private function getTokensForClass($class): array
     {
         $hash = md5($class);
 
@@ -143,7 +143,7 @@ final class ClassFileAnalyser
      * @param string $methodName
      * @return int
      */
-    private function findIndexOfNamedMethodEnd(array $tokens, $methodName)
+    private function findIndexOfNamedMethodEnd(array $tokens, string $methodName): int
     {
         $index = $this->findIndexOfNamedMethod($tokens, $methodName);
         return $this->findIndexOfMethodOrClassEnd($tokens, $index);
@@ -155,7 +155,7 @@ final class ClassFileAnalyser
      * @return int
      * @throws NamedMethodNotFoundException
      */
-    private function findIndexOfNamedMethod(array $tokens, $methodName)
+    private function findIndexOfNamedMethod(array $tokens, string $methodName): int
     {
         $searching = false;
 
@@ -191,7 +191,7 @@ final class ClassFileAnalyser
      * @param int $index
      * @return int
      */
-    private function findIndexOfMethodOrClassEnd(array $tokens, $index)
+    private function findIndexOfMethodOrClassEnd(array $tokens, int $index): int
     {
         $braceCount = 0;
 
@@ -225,7 +225,7 @@ final class ClassFileAnalyser
      * @param mixed $token
      * @return bool
      */
-    private function tokenIsFunction($token)
+    private function tokenIsFunction($token): bool
     {
         return is_array($token) && $token[0] === T_FUNCTION;
     }
@@ -234,7 +234,7 @@ final class ClassFileAnalyser
      * @param array $tokens
      * @return int
      */
-    private function findIndexOfClassEnd(array $tokens)
+    private function findIndexOfClassEnd(array $tokens): int
     {
         $classTokens = array_filter($tokens, function ($token) {
             return is_array($token) && $token[0] === T_CLASS;
@@ -248,7 +248,7 @@ final class ClassFileAnalyser
      * @param int $index
      * @return int
      */
-    public function findEndOfLastMethod(array $tokens, $index)
+    public function findEndOfLastMethod(array $tokens, int $index): int
     {
         for ($i = $index - 1; $i > 0; $i--) {
             if ($tokens[$i] == "}") {

--- a/src/PhpSpec/Util/Filesystem.php
+++ b/src/PhpSpec/Util/Filesystem.php
@@ -22,7 +22,7 @@ class Filesystem
      *
      * @return bool
      */
-    public function pathExists($path)
+    public function pathExists(string $path): bool
     {
         return file_exists($path);
     }
@@ -32,7 +32,7 @@ class Filesystem
      *
      * @return string
      */
-    public function getFileContents($path)
+    public function getFileContents(string $path): string
     {
         return file_get_contents($path);
     }
@@ -41,7 +41,7 @@ class Filesystem
      * @param string $path
      * @param string $content
      */
-    public function putFileContents($path, $content)
+    public function putFileContents(string $path, string $content)
     {
         file_put_contents($path, $content);
     }
@@ -51,7 +51,7 @@ class Filesystem
      *
      * @return bool
      */
-    public function isDirectory($path)
+    public function isDirectory(string $path): bool
     {
         return is_dir($path);
     }
@@ -59,7 +59,7 @@ class Filesystem
     /**
      * @param string $path
      */
-    public function makeDirectory($path)
+    public function makeDirectory(string $path)
     {
         mkdir($path, 0777, true);
     }
@@ -69,7 +69,7 @@ class Filesystem
      *
      * @return \SplFileInfo[]
      */
-    public function findSpecFilesIn($path)
+    public function findSpecFilesIn(string $path)
     {
         $finder = Finder::create()
             ->files()

--- a/src/PhpSpec/Util/Instantiator.php
+++ b/src/PhpSpec/Util/Instantiator.php
@@ -22,7 +22,7 @@ class Instantiator
      *
      * @return object
      */
-    public function instantiate($className)
+    public function instantiate(string $className)
     {
         if (!class_exists($className)) {
             throw new ClassNotFoundException("Class $className does not exist.", $className);

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -23,7 +23,7 @@ class MethodAnalyser
      *
      * @return boolean
      */
-    public function methodIsEmpty($class, $method)
+    public function methodIsEmpty(string $class, string $method): bool
     {
         return $this->reflectionMethodIsEmpty(new \ReflectionMethod($class, $method));
     }
@@ -33,7 +33,7 @@ class MethodAnalyser
      *
      * @return bool
      */
-    public function reflectionMethodIsEmpty(\ReflectionMethod $method)
+    public function reflectionMethodIsEmpty(\ReflectionMethod $method): bool
     {
         if ($this->isNotImplementedInPhp($method)) {
             return false;
@@ -51,7 +51,7 @@ class MethodAnalyser
      *
      * @return string
      */
-    public function getMethodOwnerName($class, $method)
+    public function getMethodOwnerName(string $class, string $method): string
     {
         $reflectionMethod = new \ReflectionMethod($class, $method);
         $startLine = $reflectionMethod->getStartLine();
@@ -66,7 +66,7 @@ class MethodAnalyser
      *
      * @return string
      */
-    private function getCodeBody(\ReflectionMethod $reflectionMethod)
+    private function getCodeBody(\ReflectionMethod $reflectionMethod): string
     {
         $endLine = $reflectionMethod->getEndLine();
         $startLine = $reflectionMethod->getStartLine();
@@ -86,7 +86,7 @@ class MethodAnalyser
      *
      * @return \ReflectionClass
      */
-    private function getMethodOwner(\ReflectionMethod $reflectionMethod, $methodStartLine, $methodEndLine)
+    private function getMethodOwner(\ReflectionMethod $reflectionMethod, int $methodStartLine, int $methodEndLine): \ReflectionClass
     {
         $reflectionClass = $reflectionMethod->getDeclaringClass();
 
@@ -104,7 +104,7 @@ class MethodAnalyser
      *
      * @return null|\ReflectionClass
      */
-    private function getDeclaringTrait(array $traits, $file, $start, $end)
+    private function getDeclaringTrait(array $traits, string $file, int $start, int $end)
     {
         foreach ($traits as $trait) {
             if ($trait->getFileName() == $file && $trait->getStartLine() <= $start && $trait->getEndLine() >= $end) {
@@ -122,7 +122,7 @@ class MethodAnalyser
      * @param  string $code
      * @return string
      */
-    private function stripComments($code)
+    private function stripComments(string $code): string
     {
         $tokens = token_get_all('<?php ' . $code);
 
@@ -146,7 +146,7 @@ class MethodAnalyser
      * @param  string $codeWithoutComments
      * @return bool
      */
-    private function codeIsOnlyBlocksAndWhitespace($codeWithoutComments)
+    private function codeIsOnlyBlocksAndWhitespace(string $codeWithoutComments): bool
     {
         return (bool) preg_match('/^[\s{}]*$/s', $codeWithoutComments);
     }
@@ -155,7 +155,7 @@ class MethodAnalyser
      * @param  \ReflectionMethod $method
      * @return bool
      */
-    private function isNotImplementedInPhp(\ReflectionMethod $method)
+    private function isNotImplementedInPhp(\ReflectionMethod $method): bool
     {
         $filename = $method->getDeclaringClass()->getFileName();
 

--- a/src/PhpSpec/Util/NameChecker.php
+++ b/src/PhpSpec/Util/NameChecker.php
@@ -20,5 +20,5 @@ interface NameChecker
      *
      * @return bool
      */
-    public function isNameValid($name);
+    public function isNameValid(string $name): bool;
 }

--- a/src/PhpSpec/Util/ReservedWordsMethodNameChecker.php
+++ b/src/PhpSpec/Util/ReservedWordsMethodNameChecker.php
@@ -101,7 +101,7 @@ final class ReservedWordsMethodNameChecker implements NameChecker
     /**
      * {@inheritdoc}
      */
-    public function isNameValid($name)
+    public function isNameValid(string $name): bool
     {
         return !in_array(strtolower($name), $this->reservedWords);
     }

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -33,7 +33,7 @@ final class Collaborator implements ObjectWrapper
     /**
      * @param string $classOrInterface
      */
-    public function beADoubleOf($classOrInterface)
+    public function beADoubleOf(string $classOrInterface)
     {
         if (interface_exists($classOrInterface)) {
             $this->prophecy->willImplement($classOrInterface);
@@ -53,7 +53,7 @@ final class Collaborator implements ObjectWrapper
     /**
      * @param string $interface
      */
-    public function implement($interface)
+    public function implement(string $interface)
     {
         $this->prophecy->willImplement($interface);
     }
@@ -64,7 +64,7 @@ final class Collaborator implements ObjectWrapper
      *
      * @return mixed
      */
-    public function __call($method, array $arguments)
+    public function __call(string $method, array $arguments)
     {
         return call_user_func_array(array($this->prophecy, '__call'), array($method, $arguments));
     }
@@ -73,7 +73,7 @@ final class Collaborator implements ObjectWrapper
      * @param string $parameter
      * @param mixed  $value
      */
-    public function __set($parameter, $value)
+    public function __set(string $parameter, $value)
     {
         $this->prophecy->$parameter = $value;
     }
@@ -83,7 +83,7 @@ final class Collaborator implements ObjectWrapper
      *
      * @return mixed
      */
-    public function __get($parameter)
+    public function __get(string $parameter)
     {
         return $this->prophecy->$parameter;
     }

--- a/src/PhpSpec/Wrapper/DelayedCall.php
+++ b/src/PhpSpec/Wrapper/DelayedCall.php
@@ -23,7 +23,7 @@ class DelayedCall
     /**
      * @param callable $callable
      */
-    public function __construct($callable)
+    public function __construct(callable $callable)
     {
         $this->callable = $callable;
     }
@@ -34,7 +34,7 @@ class DelayedCall
      *
      * @return mixed
      */
-    public function __call($method, array $arguments)
+    public function __call(string $method, array $arguments)
     {
         return call_user_func($this->callable, $method, $arguments);
     }

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -168,7 +168,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      * @param string $className
      * @param array  $arguments
      */
-    public function beAnInstanceOf($className, array $arguments = array())
+    public function beAnInstanceOf(string $className, array $arguments = array())
     {
         $this->wrappedObject->beAnInstanceOf($className, $arguments);
     }
@@ -208,7 +208,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return Subject
      */
-    public function callOnWrappedObject($method, array $arguments = array())
+    public function callOnWrappedObject(string $method, array $arguments = array()): Subject
     {
         return $this->caller->call($method, $arguments);
     }
@@ -219,7 +219,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return mixed
      */
-    public function setToWrappedObject($property, $value = null)
+    public function setToWrappedObject(string $property, $value = null)
     {
         return $this->caller->set($property, $value);
     }
@@ -229,7 +229,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return string|Subject
      */
-    public function getFromWrappedObject($property)
+    public function getFromWrappedObject(string $property)
     {
         return $this->caller->get($property);
     }
@@ -239,7 +239,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return Subject
      */
-    public function offsetExists($key)
+    public function offsetExists($key): Subject
     {
         return $this->wrap($this->arrayAccess->offsetExists($key));
     }
@@ -249,7 +249,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return Subject
      */
-    public function offsetGet($key)
+    public function offsetGet($key): Subject
     {
         return $this->wrap($this->arrayAccess->offsetGet($key));
     }
@@ -277,7 +277,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return mixed|Subject
      */
-    public function __call($method, array $arguments = array())
+    public function __call(string $method, array $arguments = array())
     {
         if (0 === strpos($method, 'should')) {
             return $this->callExpectation($method, $arguments);
@@ -297,7 +297,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     /**
      * @return Subject
      */
-    public function __invoke()
+    public function __invoke(): Subject
     {
         return $this->caller->call('__invoke', func_get_args());
     }
@@ -308,7 +308,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return mixed
      */
-    public function __set($property, $value = null)
+    public function __set(string $property, $value = null)
     {
         return $this->caller->set($property, $value);
     }
@@ -318,17 +318,17 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return string|Subject
      */
-    public function __get($property)
+    public function __get(string $property)
     {
         return $this->caller->get($property);
     }
 
     /**
-     * @param string $value
+     * @param mixed $value
      *
      * @return Subject
      */
-    private function wrap($value)
+    private function wrap($value) : Subject
     {
         return $this->wrapper->wrap($value);
     }
@@ -339,7 +339,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return mixed
      */
-    private function callExpectation($method, array $arguments)
+    private function callExpectation(string $method, array $arguments)
     {
         $subject = $this->makeSureWeHaveASubject();
 

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -85,7 +85,7 @@ class Caller
      * @throws \PhpSpec\Exception\Fracture\MethodNotVisibleException
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
-    public function call($method, array $arguments = array())
+    public function call(string $method, array $arguments = array()): Subject
     {
         if (null === $this->getWrappedObject()) {
             throw $this->callingMethodOnNonObject($method);
@@ -111,7 +111,7 @@ class Caller
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      * @throws \PhpSpec\Exception\Fracture\PropertyNotFoundException
      */
-    public function set($property, $value = null)
+    public function set(string $property, $value = null)
     {
         if (null === $this->getWrappedObject()) {
             throw $this->settingPropertyOnNonObject($property);
@@ -135,7 +135,7 @@ class Caller
      * @throws \PhpSpec\Exception\Fracture\PropertyNotFoundException
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
-    public function get($property)
+    public function get(string $property)
     {
         if ($this->lookingForConstants($property) && $this->constantDefined($property)) {
             return constant($this->wrappedObject->getClassName().'::'.$property);
@@ -188,7 +188,7 @@ class Caller
      *
      * @return bool
      */
-    private function isObjectPropertyReadable($property)
+    private function isObjectPropertyReadable(string $property): bool
     {
         $subject = $this->getWrappedObject();
 
@@ -200,7 +200,7 @@ class Caller
      *
      * @return bool
      */
-    private function isObjectPropertyWritable($property)
+    private function isObjectPropertyWritable(string $property): bool
     {
         $subject = $this->getWrappedObject();
 
@@ -212,7 +212,7 @@ class Caller
      *
      * @return bool
      */
-    private function isObjectMethodCallable($method)
+    private function isObjectMethodCallable(string $method): bool
     {
         return $this->accessInspector->isMethodCallable($this->getWrappedObject(), $method);
     }
@@ -242,7 +242,7 @@ class Caller
      *
      * @return Subject
      */
-    private function invokeAndWrapMethodResult($subject, $method, array $arguments = array())
+    private function invokeAndWrapMethodResult($subject, $method, array $arguments = array()): Subject
     {
         $this->dispatcher->dispatch(
             'beforeMethodCall',
@@ -264,7 +264,7 @@ class Caller
      *
      * @return Subject
      */
-    private function wrap($value)
+    private function wrap($value): Subject
     {
         return $this->wrapper->wrap($value);
     }
@@ -321,7 +321,7 @@ class Caller
      *
      * @return bool
      */
-    private function detectMissingConstructorMessage(ReflectionException $exception)
+    private function detectMissingConstructorMessage(ReflectionException $exception): bool
     {
         return strpos(
             $exception->getMessage(),
@@ -332,7 +332,7 @@ class Caller
     /**
      * @return \PhpSpec\Exception\Fracture\ClassNotFoundException
      */
-    private function classNotFound()
+    private function classNotFound(): \PhpSpec\Exception\Fracture\ClassNotFoundException
     {
         return $this->exceptionFactory->classNotFound($this->wrappedObject->getClassName());
     }
@@ -343,7 +343,7 @@ class Caller
      *
      * @return \PhpSpec\Exception\Fracture\MethodNotFoundException|\PhpSpec\Exception\Fracture\MethodNotVisibleException
      */
-    private function namedConstructorNotFound($method, array $arguments = array())
+    private function namedConstructorNotFound(string $method, array $arguments = array())
     {
         $className = $this->wrappedObject->getClassName();
 
@@ -371,7 +371,7 @@ class Caller
      *
      * @return \PhpSpec\Exception\Fracture\PropertyNotFoundException
      */
-    private function propertyNotFound($property)
+    private function propertyNotFound(string $property): \PhpSpec\Exception\Fracture\PropertyNotFoundException
     {
         return $this->exceptionFactory->propertyNotFound($this->getWrappedObject(), $property);
     }
@@ -381,7 +381,7 @@ class Caller
      *
      * @return \PhpSpec\Exception\Wrapper\SubjectException
      */
-    private function callingMethodOnNonObject($method)
+    private function callingMethodOnNonObject(string $method): \PhpSpec\Exception\Wrapper\SubjectException
     {
         return $this->exceptionFactory->callingMethodOnNonObject($method);
     }
@@ -391,7 +391,7 @@ class Caller
      *
      * @return \PhpSpec\Exception\Wrapper\SubjectException
      */
-    private function settingPropertyOnNonObject($property)
+    private function settingPropertyOnNonObject(string $property): \PhpSpec\Exception\Wrapper\SubjectException
     {
         return $this->exceptionFactory->settingPropertyOnNonObject($property);
     }
@@ -401,7 +401,7 @@ class Caller
      *
      * @return \PhpSpec\Exception\Wrapper\SubjectException
      */
-    private function accessingPropertyOnNonObject($property)
+    private function accessingPropertyOnNonObject(string $property): \PhpSpec\Exception\Wrapper\SubjectException
     {
         return $this->exceptionFactory->gettingPropertyOnNonObject($property);
     }
@@ -411,7 +411,7 @@ class Caller
      *
      * @return bool
      */
-    private function lookingForConstants($property)
+    private function lookingForConstants(string $property): bool
     {
         return null !== $this->wrappedObject->getClassName() &&
             $property === strtoupper($property);
@@ -422,7 +422,7 @@ class Caller
      *
      * @return bool
      */
-    public function constantDefined($property)
+    public function constantDefined(string $property): bool
     {
         return defined($this->wrappedObject->getClassName().'::'.$property);
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -35,14 +35,14 @@ final class ConstructorDecorator extends Decorator implements Expectation
      * @param array         $arguments
      * @param WrappedObject $wrappedObject
      *
-     * @return boolean
+     * @return mixed
      *
      * @throws \Exception
      * @throws \PhpSpec\Exception\Example\ErrorException
      * @throws \Exception
      * @throws \PhpSpec\Exception\Fracture\FractureException
      */
-    public function match($alias, $subject, array $arguments = array(), WrappedObject $wrappedObject = null)
+    public function match(string $alias, $subject, array $arguments = array(), WrappedObject $wrappedObject = null)
     {
         try {
             $wrapped = $subject->getWrappedObject();

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
@@ -31,7 +31,7 @@ abstract class Decorator implements Expectation
     /**
      * @return Expectation
      */
-    public function getExpectation()
+    public function getExpectation(): Expectation
     {
         return $this->expectation;
     }
@@ -47,7 +47,7 @@ abstract class Decorator implements Expectation
     /**
      * @return Expectation
      */
-    public function getNestedExpectation()
+    public function getNestedExpectation(): Expectation
     {
         $expectation = $this->getExpectation();
         while ($expectation instanceof Decorator) {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
@@ -57,13 +57,13 @@ final class DispatcherDecorator extends Decorator implements Expectation
      * @param  string  $alias
      * @param  mixed   $subject
      * @param  array   $arguments
-     * @return boolean
+     * @return mixed
      *
      * @throws \Exception
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \Exception
      */
-    public function match($alias, $subject, array $arguments = array())
+    public function match(string $alias, $subject, array $arguments = array())
     {
         $this->dispatcher->dispatch(
             'beforeExpectation',

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -54,7 +54,7 @@ abstract class DuringCall
      *
      * @return $this
      */
-    public function match($alias, $subject, array $arguments = array(), $wrappedObject = null)
+    public function match(string $alias, $subject, array $arguments = array(), $wrappedObject = null)
     {
         $this->subject = $subject;
         $this->arguments = $arguments;
@@ -69,7 +69,7 @@ abstract class DuringCall
      *
      * @return mixed
      */
-    public function during($method, array $arguments = array())
+    public function during(string $method, array $arguments = array())
     {
         if ($method === '__construct') {
             $this->subject->beAnInstanceOf($this->wrappedObject->getClassName(), $arguments);
@@ -106,7 +106,7 @@ abstract class DuringCall
      *
      * @throws MatcherException
      */
-    public function __call($method, array $arguments = array())
+    public function __call(string $method, array $arguments = array())
     {
         if (preg_match('/^during(.+)$/', $method, $matches)) {
             return $this->during(lcfirst($matches[1]), $arguments);
@@ -123,7 +123,7 @@ abstract class DuringCall
     /**
      * @return array
      */
-    protected function getArguments()
+    protected function getArguments(): array
     {
         return $this->arguments;
     }
@@ -131,7 +131,7 @@ abstract class DuringCall
     /**
      * @return Matcher
      */
-    protected function getMatcher()
+    protected function getMatcher(): Matcher
     {
         return $this->matcher;
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Expectation.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Expectation.php
@@ -22,5 +22,5 @@ interface Expectation
      *
      * @return mixed
      */
-    public function match($alias, $subject, array $arguments = array());
+    public function match(string $alias, $subject, array $arguments = array());
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Negative.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Negative.php
@@ -37,7 +37,7 @@ final class Negative implements Expectation
      *
      * @return mixed
      */
-    public function match($alias, $subject, array $arguments = array())
+    public function match(string $alias, $subject, array $arguments = array())
     {
         return $this->matcher->negativeMatch($alias, $subject, $arguments);
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Positive.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Positive.php
@@ -37,7 +37,7 @@ final class Positive implements Expectation
      *
      * @return mixed
      */
-    public function match($alias, $subject, array $arguments = array())
+    public function match(string $alias, $subject, array $arguments = array())
     {
         return $this->matcher->positiveMatch($alias, $subject, $arguments);
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ThrowExpectation.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ThrowExpectation.php
@@ -21,5 +21,5 @@ interface ThrowExpectation extends Expectation
      *
      * @return mixed
      */
-    public function during($method, array $arguments = array());
+    public function during(string $method, array $arguments = array());
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
@@ -39,7 +39,7 @@ final class UnwrapDecorator extends Decorator implements Expectation
      *
      * @return mixed
      */
-    public function match($alias, $subject, array $arguments = array())
+    public function match(string $alias, $subject, array $arguments = array())
     {
         $arguments = $this->unwrapper->unwrapAll($arguments);
 

--- a/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
+++ b/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
@@ -58,7 +58,7 @@ class ExpectationFactory
      *
      * @return Expectation
      */
-    public function create($expectation, $subject, array $arguments = array())
+    public function create(string $expectation, $subject, array $arguments = array()): Expectation
     {
         if (0 === strpos($expectation, 'shouldNot')) {
             return $this->createNegative(lcfirst(substr($expectation, 9)), $subject, $arguments);
@@ -76,7 +76,7 @@ class ExpectationFactory
      *
      * @return Expectation
      */
-    private function createPositive($name, $subject, array $arguments = array())
+    private function createPositive(string $name, $subject, array $arguments = array()): Expectation
     {
         if (strtolower($name) === 'throw') {
             return $this->createDecoratedExpectation("PositiveThrow", $name, $subject, $arguments);
@@ -96,7 +96,7 @@ class ExpectationFactory
      *
      * @return Expectation
      */
-    private function createNegative($name, $subject, array $arguments = array())
+    private function createNegative(string $name, $subject, array $arguments = array()): Expectation
     {
         if (strtolower($name) === 'throw') {
             return $this->createDecoratedExpectation("NegativeThrow", $name, $subject, $arguments);
@@ -117,7 +117,7 @@ class ExpectationFactory
      *
      * @return Expectation
      */
-    private function createDecoratedExpectation($expectation, $name, $subject, array $arguments)
+    private function createDecoratedExpectation(string $expectation, string $name, $subject, array $arguments): Expectation
     {
         $matcher = $this->findMatcher($name, $subject, $arguments);
         $expectation = "\\PhpSpec\\Wrapper\\Subject\\Expectation\\".$expectation;
@@ -138,7 +138,7 @@ class ExpectationFactory
      *
      * @return Matcher
      */
-    private function findMatcher($name, $subject, array $arguments = array())
+    private function findMatcher(string $name, $subject, array $arguments = array()): Matcher
     {
         $unwrapper = new Unwrapper();
         $arguments = $unwrapper->unwrapAll($arguments);
@@ -152,7 +152,7 @@ class ExpectationFactory
      *
      * @return ConstructorDecorator
      */
-    private function decoratedExpectation(Expectation $expectation, Matcher $matcher)
+    private function decoratedExpectation(Expectation $expectation, Matcher $matcher): ConstructorDecorator
     {
         $dispatcherDecorator = new DispatcherDecorator($expectation, $this->dispatcher, $matcher, $this->example);
         $unwrapperDecorator = new UnwrapDecorator($dispatcherDecorator, new Unwrapper());

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -54,7 +54,7 @@ class SubjectWithArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -129,7 +129,7 @@ class SubjectWithArrayAccess
     /**
      * @return InterfaceNotImplementedException
      */
-    private function interfaceNotImplemented()
+    private function interfaceNotImplemented(): InterfaceNotImplementedException
     {
         return new InterfaceNotImplementedException(
             sprintf(
@@ -147,7 +147,7 @@ class SubjectWithArrayAccess
      *
      * @return SubjectException
      */
-    private function cantUseAsArray($subject)
+    private function cantUseAsArray($subject): SubjectException
     {
         return new SubjectException(sprintf(
             'Can not use %s as array.',

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -65,7 +65,7 @@ class WrappedObject
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
-    public function beAnInstanceOf($classname, array $arguments = array())
+    public function beAnInstanceOf(string $classname, array $arguments = array())
     {
         if (!is_string($classname)) {
             throw new SubjectException(sprintf(
@@ -86,7 +86,7 @@ class WrappedObject
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
-    public function beConstructedWith($args)
+    public function beConstructedWith(array $args)
     {
         if (null === $this->classname) {
             throw new SubjectException(sprintf(
@@ -135,7 +135,7 @@ class WrappedObject
     /**
      * @return bool
      */
-    public function isInstantiated()
+    public function isInstantiated(): bool
     {
         return $this->isInstantiated;
     }
@@ -143,13 +143,13 @@ class WrappedObject
     /**
      * @param boolean $instantiated
      */
-    public function setInstantiated($instantiated)
+    public function setInstantiated(bool $instantiated)
     {
         $this->isInstantiated = $instantiated;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getClassName()
     {
@@ -159,7 +159,7 @@ class WrappedObject
     /**
      * @param string $classname
      */
-    public function setClassName($classname)
+    public function setClassName(string $classname)
     {
         $this->classname = $classname;
     }
@@ -167,7 +167,7 @@ class WrappedObject
     /**
      * @return array
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }
@@ -217,7 +217,7 @@ class WrappedObject
      *
      * @return object
      */
-    private function instantiateFromCallback($factoryCallable)
+    private function instantiateFromCallback(callable $factoryCallable)
     {
         $instance = call_user_func_array($factoryCallable, $this->arguments);
 

--- a/src/PhpSpec/Wrapper/Unwrapper.php
+++ b/src/PhpSpec/Wrapper/Unwrapper.php
@@ -23,7 +23,7 @@ class Unwrapper implements RevealerInterface
      *
      * @return array
      */
-    public function unwrapAll(array $arguments)
+    public function unwrapAll(array $arguments): array
     {
         if (null === $arguments) {
             return array();

--- a/src/PhpSpec/Wrapper/Wrapper.php
+++ b/src/PhpSpec/Wrapper/Wrapper.php
@@ -73,7 +73,7 @@ class Wrapper
      *
      * @return Subject
      */
-    public function wrap($value = null)
+    public function wrap($value = null): Subject
     {
         $wrappedObject = new WrappedObject($value, $this->presenter);
         $caller = $this->createCaller($wrappedObject);
@@ -95,7 +95,7 @@ class Wrapper
      *
      * @return Caller
      */
-    private function createCaller(WrappedObject $wrappedObject)
+    private function createCaller(WrappedObject $wrappedObject): Caller
     {
         $exceptionFactory = new ExceptionFactory($this->presenter);
 


### PR DESCRIPTION
Continuing from the work @Sam-Burns did, I've added type hints for the remaining classes

This was done in an automated way, with me needing to modify several stubs to get the suite running again.

I afterwards hand-audited the interfaces to make sure there were no missing hints, but there may be some missing on classes.