### PR TITLE
Fix invalid typehint on Boolean instead of bool

### DIFF
--- a/spec/Phpspec/Runner/Maintainer/ErrorMaintainerSpec.php
+++ b/spec/Phpspec/Runner/Maintainer/ErrorMaintainerSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace spec\Phpspec\Runner\Maintainer;
+
+use PhpSpec\Exception\Example as ExampleException;
+use PhpSpec\ObjectBehavior;
+use Phpspec\Runner\Maintainer\ErrorMaintainer;
+
+class ErrorMaintainerSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(0);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ErrorMaintainer::class);
+    }
+
+    function it_return_false_when_error_suppresed_or_no_error_reporting()
+    {
+        $oldLevel = error_reporting(0);
+        $this->errorHandler(0, 'error message', 'file', 1)->shouldBe(false);
+        error_reporting($oldLevel);
+    }
+
+    function it_return_true_when_recoverable_level_and_message_match()
+    {
+        $msg = 'Argument 1 passed to ' . self::class . '::test() must be an instance of string, string given';
+        $this->errorHandler(E_RECOVERABLE_ERROR, $msg, 'file', 1)->shouldBe(true);
+    }
+
+    function it_throws_error_exception_when_message_not_match()
+    {
+        $this->shouldThrow(ExampleException\ErrorException::class)
+             ->during('errorHandler', [0, 'error message', 'file', 1]);
+    }
+}

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -100,11 +100,11 @@ final class ErrorMaintainer implements Maintainer
      * @param string  $file
      * @param integer $line
      *
-     * @return Boolean
+     * @return bool
      *
      * @throws ExampleException\ErrorException
      */
-    final public function errorHandler(int $level, string $message, string $file, int $line): Boolean
+    final public function errorHandler(int $level, string $message, string $file, int $line): bool
     {
         $regex = '/^Argument (\d)+ passed to (?:(?P<class>[\w\\\]+)::)?(\w+)\(\)' .
                  ' must (?:be an instance of|implement interface) ([\w\\\]+),(?: instance of)? ([\w\\\]+) given/';


### PR DESCRIPTION
Cause of exception [err:TypeError("Return value of PhpSpec\Runner\Maintainer\ErrorMaintainer::errorHandler() must be an instance of PhpSpec\Runner\Maintainer\Boolean, boolean returned")] has been thrown.