### PR TITLE
Clarify inline matcher signature in docs

### DIFF
--- a/docs/cookbook/matchers.rst
+++ b/docs/cookbook/matchers.rst
@@ -642,7 +642,7 @@ You can create custom matchers by providing them in ``getMatchers`` method.
             $this->getOptions()->shouldHaveValue('diegoholiveira');
         }
 
-        public function getMatchers()
+        public function getMatchers(): array
         {
             return [
                 'haveKey' => function ($subject, $key) {
@@ -675,7 +675,7 @@ your inline matcher should throw `FailureException`:
             $this->getOptions()->shouldHaveValue('diegoholiveira');
         }
 
-        public function getMatchers()
+        public function getMatchers(): array
         {
             return [
                 'haveKey' => function ($subject, $key) {


### PR DESCRIPTION
without array typehint it generate
PHP Fatal error:  Declaration of spec\*Spec::getMatchers() must be compatible with PhpSpec\Matcher\MatchersProvider::getMatchers(): array