### PR TITLE
Fix white on white bug in console formatter

### DIFF
--- a/src/PhpSpec/Console/Formatter.php
+++ b/src/PhpSpec/Console/Formatter.php
@@ -35,21 +35,21 @@ class Formatter extends OutputFormatter
         $this->setStyle('pending-bg', new OutputFormatterStyle('black', 'yellow', array('bold')));
 
         $this->setStyle('skipped', new OutputFormatterStyle('cyan'));
-        $this->setStyle('skipped-bg', new OutputFormatterStyle('white', 'cyan', array('bold')));
+        $this->setStyle('skipped-bg', new OutputFormatterStyle(null, 'cyan', array('bold')));
 
         $this->setStyle('failed', new OutputFormatterStyle('red'));
-        $this->setStyle('failed-bg', new OutputFormatterStyle('white', 'red', array('bold')));
+        $this->setStyle('failed-bg', new OutputFormatterStyle(null, 'red', array('bold')));
 
         $this->setStyle('broken', new OutputFormatterStyle('magenta'));
-        $this->setStyle('broken-bg', new OutputFormatterStyle('white', 'magenta', array('bold')));
+        $this->setStyle('broken-bg', new OutputFormatterStyle(null, 'magenta', array('bold')));
 
         $this->setStyle('passed', new OutputFormatterStyle('green'));
         $this->setStyle('passed-bg', new OutputFormatterStyle('black', 'green', array('bold')));
 
         $this->setStyle('value', new OutputFormatterStyle('yellow'));
         $this->setStyle('lineno', new OutputFormatterStyle(null));
-        $this->setStyle('code', new OutputFormatterStyle('white'));
-        $this->setStyle('label', new OutputFormatterStyle('white', null, array('bold')));
+        $this->setStyle('code', new OutputFormatterStyle(null));
+        $this->setStyle('label', new OutputFormatterStyle(null, null, array('bold')));
         $this->setStyle('hl', new OutputFormatterStyle('black', 'yellow', array('bold')));
         $this->setStyle('question', new OutputFormatterStyle('black', 'yellow', array('bold')));
 

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -60,7 +60,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
             $this->printSpecificException($event, 'pending');
         } elseif ($exception instanceof SkippingException) {
             if ($this->io->isVerbose()) {
-                $this->printSpecificException($event, 'skipped ');
+                $this->printSpecificException($event, 'skipped');
             }
         } elseif (ExampleEvent::FAILED === $event->getResult()) {
             $this->printSpecificException($event, 'failed');


### PR DESCRIPTION
With a white background, we don't see the exception being printed:

<img width="833" alt="screen shot 2017-08-05 at 17 50 51" src="https://user-images.githubusercontent.com/144535/28997241-bd17ad9a-7a07-11e7-906a-a5444b9ef6d1.png">

with this fix we can:

<img width="842" alt="screen shot 2017-08-05 at 17 51 02" src="https://user-images.githubusercontent.com/144535/28997207-d328c926-7a06-11e7-8082-8b7376c661d5.png">

Incidentally, this also fixes the formater tag appearing here:

<img width="1084" alt="screen shot 2017-08-05 at 17 50 26" src="https://user-images.githubusercontent.com/144535/28997209-d32c49b6-7a06-11e7-9f16-f9bab02162ee.png">

and, with the fix:

<img width="816" alt="screen shot 2017-08-05 at 17 50 12" src="https://user-images.githubusercontent.com/144535/28997247-d977308c-7a07-11e7-92a6-320a5a28fe8f.png">