### PR TITLE
bugfix: return null values on typed methods on Event classes

### DIFF
--- a/spec/PhpSpec/Event/ExampleEventSpec.php
+++ b/spec/PhpSpec/Event/ExampleEventSpec.php
@@ -55,4 +55,18 @@ class ExampleEventSpec extends ObjectBehavior
     {
         $this->getException()->shouldReturn($exception);
     }
+
+    function it_initializes_a_default_result(ExampleNode $example)
+    {
+        $this->beConstructedWith($example);
+
+        $this->getResult()->shouldReturn($this->PASSED);
+    }
+
+    function it_initializes_a_default_time(ExampleNode $example)
+    {
+        $this->beConstructedWith($example);
+
+        $this->getTime()->shouldReturn((double)0.0);
+    }
 }

--- a/spec/PhpSpec/Event/ExpectationEventSpec.php
+++ b/spec/PhpSpec/Event/ExpectationEventSpec.php
@@ -74,4 +74,14 @@ class ExpectationEventSpec extends ObjectBehavior
     {
         $this->getException()->shouldReturn($exception);
     }
+
+    function it_initializes_a_default_result(ExampleNode $example, Matcher $matcher, $subject)
+    {
+        $method = 'calledMethod';
+        $arguments = array('methodArguments');
+
+        $this->beConstructedWith($example, $matcher, $subject, $method, $arguments);
+
+        $this->getResult()->shouldReturn($this->PASSED);
+    }
 }

--- a/spec/PhpSpec/Event/SpecificationEventSpec.php
+++ b/spec/PhpSpec/Event/SpecificationEventSpec.php
@@ -42,4 +42,18 @@ class SpecificationEventSpec extends ObjectBehavior
     {
         $this->getResult()->shouldReturn(Example::FAILED);
     }
+
+    function it_initializes_a_default_result(SpecificationNode $specification)
+    {
+        $this->beConstructedWith($specification);
+
+        $this->getResult()->shouldReturn(Example::PASSED);
+    }
+
+    function it_initializes_a_default_time(SpecificationNode $specification)
+    {
+        $this->beConstructedWith($specification);
+
+        $this->getTime()->shouldReturn((double) 0.0);
+    }
 }

--- a/spec/PhpSpec/Event/SuiteEventSpec.php
+++ b/spec/PhpSpec/Event/SuiteEventSpec.php
@@ -53,4 +53,18 @@ class SuiteEventSpec extends ObjectBehavior
 
         $this->isWorthRerunning()->shouldReturn(false);
     }
+
+    function it_initializes_a_default_result(Suite $suite)
+    {
+        $this->beConstructedWith($suite);
+
+        $this->getResult()->shouldReturn(Example::PASSED);
+    }
+
+    function it_initializes_a_default_time(Suite $suite)
+    {
+        $this->beConstructedWith($suite);
+
+        $this->getTime()->shouldReturn((double) 0.0);
+    }
 }

--- a/src/PhpSpec/Event/ExampleEvent.php
+++ b/src/PhpSpec/Event/ExampleEvent.php
@@ -76,8 +76,8 @@ class ExampleEvent extends Event implements PhpSpecEvent
      */
     public function __construct(
         ExampleNode $example,
-        float $time = null,
-        int $result = null,
+        float $time = 0.0,
+        int $result = self::PASSED,
         \Exception $exception = null
     ) {
         $this->example   = $example;

--- a/src/PhpSpec/Event/ExpectationEvent.php
+++ b/src/PhpSpec/Event/ExpectationEvent.php
@@ -89,7 +89,7 @@ final class ExpectationEvent extends Event implements PhpSpecEvent
         $subject,
         $method,
         $arguments,
-        $result = null,
+        $result = self::PASSED,
         $exception = null
     ) {
         $this->example = $example;

--- a/src/PhpSpec/Event/SpecificationEvent.php
+++ b/src/PhpSpec/Event/SpecificationEvent.php
@@ -42,7 +42,7 @@ class SpecificationEvent extends Event implements PhpSpecEvent
      * @param float             $time
      * @param integer           $result
      */
-    public function __construct(SpecificationNode $specification, float $time = null, int $result = null)
+    public function __construct(SpecificationNode $specification, float $time = 0.0, int $result = 0)
     {
         $this->specification = $specification;
         $this->time          = $time;

--- a/src/PhpSpec/Event/SuiteEvent.php
+++ b/src/PhpSpec/Event/SuiteEvent.php
@@ -46,7 +46,7 @@ class SuiteEvent extends Event implements PhpSpecEvent
      * @param float   $time
      * @param integer $result
      */
-    public function __construct(Suite $suite, float $time = null, int $result = null)
+    public function __construct(Suite $suite, float $time = 0.0, int $result = 0)
     {
         $this->suite  = $suite;
         $this->time   = $time;


### PR DESCRIPTION
Default values to null for fields that are returned with typed value launch TypeError 

Fix #1137 
