### PR TITLE
Fix internal type error during presenting diff in verbose mode

### DIFF
--- a/features/formatter/developer_is_shown_diffs.feature
+++ b/features/formatter/developer_is_shown_diffs.feature
@@ -564,3 +564,43 @@ Feature: Developer is shown diffs
             +            Integer euismod in nunc nec lobortis",
                ]
       """
+
+  Scenario: Integer diff in verbose mode
+    Given the spec file "spec/Diffs/DiffExample11/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Diffs\DiffExample11;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_is_equal()
+          {
+              $this->calculate()->shouldReturn(2);
+          }
+      }
+
+      """
+    And the class file "src/Diffs/DiffExample11/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Diffs\DiffExample11;
+
+      class Calculator
+      {
+          public function calculate()
+          {
+              return 1;
+          }
+      }
+
+      """
+    When I run phpspec with the "verbose" option
+    Then I should see:
+      """
+        expected [integer:2], but got [integer:1]
+      """

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -127,7 +127,9 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      */
     private function presentExceptionDifference(NotEqualException $exception): string
     {
-        return $this->differ->compare($exception->getExpected(), $exception->getActual());
+        $diff = $this->differ->compare($exception->getExpected(), $exception->getActual());
+
+        return $diff === null ? '' : $diff;
     }
 
     /**


### PR DESCRIPTION
Faced with this recently after upgrading to PHPSpec 4.

Error details:
```
Type error: Return value of PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter::presentExceptionDifference() must be of the type string, null returned in src\PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter.php:132
        Stack trace:
        #0 src\PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter.php(107): PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter->presentExceptionDifference(Object(PhpSpec\Exception\Example\NotEqualException))
        #1 src\PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter.php(96): PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter->getVerbosePresentation(Object(PhpSpec\Exception\Example\NotEqualException), 'Expected <value...')
        #2 src\PhpSpec\Formatter\Presenter\SimplePresenter.php(59): PhpSpec\Formatter\Presenter\Exception\SimpleExceptionPresenter->presentException(Object(PhpSpec\Exception\Example\NotEqualException), true)
        #3 src\PhpSpec\Formatter\Presenter\TaggingPresenter.php(38): PhpSpec\Formatter\Presenter\SimplePresenter->presentException(Object(PhpSpec\Exception\Example\NotEqualException), true)
        #4 src\PhpSpec\Formatter\ConsoleFormatter.php(80): PhpSpec\Formatter\Presenter\TaggingPresenter->presentException(Object(PhpSpec\Exception\Example\NotEqualException), true)
        #5 src\PhpSpec\Formatter\ConsoleFormatter.php(67): PhpSpec\Formatter\ConsoleFormatter->printSpecificException(Object(PhpSpec\Event\ExampleEvent), 'failed')
        #6 src\PhpSpec\Formatter\ProgressFormatter.php(28): PhpSpec\Formatter\ConsoleFormatter->printException(Object(PhpSpec\Event\ExampleEvent))
```

The issue is related to the fact that `Differ` implicitly returns null when none of `DifferEngine`'s support provided parameters:
https://github.com/phpspec/phpspec/blob/39ce1f63bbeed92b80f0e99752f9d3574e6f25c3/src/PhpSpec/Formatter/Presenter/Differ/Differ.php#L30-L37


There is another usage of `Differ::diff()`, but in this place `string` will always be returned:
https://github.com/phpspec/phpspec/blob/1785d775ade690622f46004cbf0dba4d150b0511/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php#L138-L150
