### PR TITLE
Fix invalid ErrorMaintainer spec path and namespace

### DIFF
--- a/spec/PhpSpec/Runner/Maintainer/ErrorMaintainerSpec.php
+++ b/spec/PhpSpec/Runner/Maintainer/ErrorMaintainerSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Phpspec\Runner\Maintainer;
+namespace spec\PhpSpec\Runner\Maintainer;
 
 use PhpSpec\Exception\Example as ExampleException;
 use PhpSpec\ObjectBehavior;


### PR DESCRIPTION
My previous PR intoduce spec with wrong path and namespace :(. This fix it.