### PR TITLE
Speed up code analysis

### DIFF
--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -47,7 +47,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
                         $this->currentNamespace = trim($this->currentNamespace);
                         $this->state = self::STATE_DEFAULT;
                     }
-                    elseif (is_array($token)) {
+                    elseif (((array) $token === $token)) {
                         $this->currentNamespace .= $token[1];
                     }
                     break;
@@ -59,7 +59,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
                     elseif (',' == $token) {
                         $this->storeCurrentUse();
                     }
-                    elseif (is_array($token)) {
+                    elseif (((array) $token === $token)) {
                         $this->currentUse = $this->currentUseGroup . trim($token[1]);
                     }
                     break;
@@ -76,17 +76,17 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
                     elseif (',' == $token) {
                         $this->storeCurrentUse();
                     }
-                    elseif (is_array($token)) {
+                    elseif (((array) $token === $token)) {
                         $this->currentUse .= $token[1];
                     }
                     break;
                 default:
-                    if (is_array($token) && T_NAMESPACE == $token[0]) {
+                    if (((array) $token === $token) && T_NAMESPACE == $token[0]) {
                         $this->state = self::STATE_READING_NAMESPACE;
                         $this->currentNamespace = '';
                         $this->uses = array();
                     }
-                    elseif (is_array($token) && T_USE == $token[0]) {
+                    elseif (((array) $token === $token) && T_USE == $token[0]) {
                         $this->state = self::STATE_READING_USE;
                         $this->currentUse = '';
                     }

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -137,7 +137,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     private function tokensToString(array $tokens) : string
     {
         return join('', array_map(function ($token) {
-            return is_array($token) ? $token[1] : $token;
+            return ((array) $token === $token) ? $token[1] : $token;
         }, $tokens));
     }
 
@@ -178,7 +178,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
      */
     private function tokenHasType($token, string $type) : bool
     {
-        return is_array($token) && $type == $token[0];
+        return ((array) $token === $token) && $type == $token[0];
     }
 
     private function shouldExtractTokensOfClass(string $className) : bool
@@ -191,6 +191,6 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
      */
     private function isToken($token, string $string) : bool
     {
-        return $token == $string || (is_array($token) && $token[1] == $string);
+        return $token == $string || (((array) $token === $token) && $token[1] == $string);
     }
 }


### PR DESCRIPTION
I noticed when running the https://github.com/Sylius/Sylius test suite that the time to wait before the specs starting running was surprisingly long, so I thought I'd investigate.

The issue seems to be that `is_array` is pretty slow, and noticeably so on a large test suite like sylius where it's called 18,689,042 times

Profile before commit:
https://blackfire.io/profiles/1f53b17c-25ce-4534-9d5a-8f80bc5f80fc/graph

After:
https://blackfire.io/profiles/94c981eb-f7cb-48d0-8a69-c3150ad067c7/graph

Comparison:
https://blackfire.io/profiles/compare/c5bb8576-d83c-4ce0-80f4-89d0448aac64/graph

A pretty decent speed up of "-48%"