### PR TITLE
fully quantify native function invocation

### DIFF
--- a/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
@@ -50,7 +50,7 @@ final class StaticRejectingNamespaceResolver implements NamespaceResolver
             'iterable',
         ];
 
-        if (in_array($typeAlias, $nonObjectTypes, true)) {
+        if (\in_array($typeAlias, $nonObjectTypes, true)) {
             throw new DisallowedNonObjectTypehintException("Non-object type $typeAlias cannot be resolved within a namespace");
         }
     }

--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -47,7 +47,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
                         $this->currentNamespace = trim($this->currentNamespace);
                         $this->state = self::STATE_DEFAULT;
                     }
-                    elseif (is_array($token)) {
+                    elseif (\is_array($token)) {
                         $this->currentNamespace .= $token[1];
                     }
                     break;
@@ -59,7 +59,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
                     elseif (',' == $token) {
                         $this->storeCurrentUse();
                     }
-                    elseif (is_array($token)) {
+                    elseif (\is_array($token)) {
                         $this->currentUse = $this->currentUseGroup . trim($token[1]);
                     }
                     break;
@@ -76,17 +76,17 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
                     elseif (',' == $token) {
                         $this->storeCurrentUse();
                     }
-                    elseif (is_array($token)) {
+                    elseif (\is_array($token)) {
                         $this->currentUse .= $token[1];
                     }
                     break;
                 default:
-                    if (is_array($token) && T_NAMESPACE == $token[0]) {
+                    if (\is_array($token) && T_NAMESPACE == $token[0]) {
                         $this->state = self::STATE_READING_NAMESPACE;
                         $this->currentNamespace = '';
                         $this->uses = array();
                     }
-                    elseif (is_array($token) && T_USE == $token[0]) {
+                    elseif (\is_array($token) && T_USE == $token[0]) {
                         $this->state = self::STATE_READING_USE;
                         $this->currentUse = '';
                     }

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -137,14 +137,14 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     private function tokensToString(array $tokens) : string
     {
         return join('', array_map(function ($token) {
-            return is_array($token) ? $token[1] : $token;
+            return \is_array($token) ? $token[1] : $token;
         }, $tokens));
     }
 
     private function extractTypehints(array &$tokens, int $index, array $token)
     {
         $typehint = '';
-        for ($i = $index - 1; in_array($tokens[$i][0], $this->typehintTokens); $i--) {
+        for ($i = $index - 1; \in_array($tokens[$i][0], $this->typehintTokens); $i--) {
             $typehint = $tokens[$i][1] . $typehint;
 
             if (T_WHITESPACE !== $tokens[$i][0]) {
@@ -178,7 +178,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
      */
     private function tokenHasType($token, string $type) : bool
     {
-        return is_array($token) && $type == $token[0];
+        return \is_array($token) && $type == $token[0];
     }
 
     private function shouldExtractTokensOfClass(string $className) : bool
@@ -191,6 +191,6 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
      */
     private function isToken($token, string $string) : bool
     {
-        return $token == $string || (is_array($token) && $token[1] == $string);
+        return $token == $string || (\is_array($token) && $token[1] == $string);
     }
 }

--- a/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
@@ -54,8 +54,8 @@ class CreateObjectTemplate
      */
     private function getValues() : array
     {
-        $argString = count($this->arguments)
-            ? '$argument'.implode(', $argument', range(1, count($this->arguments)))
+        $argString = \count($this->arguments)
+            ? '$argument'.implode(', $argument', range(1, \count($this->arguments)))
             : ''
         ;
 

--- a/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
@@ -55,7 +55,7 @@ class ExistingConstructorTemplate
             }
         }
 
-        return $constructorArguments == count($this->arguments);
+        return $constructorArguments == \count($this->arguments);
     }
 
     private function getExceptionContent() : string
@@ -91,8 +91,8 @@ class ExistingConstructorTemplate
      */
     private function getValues(bool $constructorArguments = false) : array
     {
-        $argString = count($this->arguments)
-            ? '$argument'.implode(', $argument', range(1, count($this->arguments)))
+        $argString = \count($this->arguments)
+            ? '$argument'.implode(', $argument', range(1, \count($this->arguments)))
             : ''
         ;
 

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -73,8 +73,8 @@ final class MethodGenerator implements Generator
         $name      = $data['name'];
         $arguments = $data['arguments'];
 
-        $argString = count($arguments)
-            ? '$argument'.implode(', $argument', range(1, count($arguments)))
+        $argString = \count($arguments)
+            ? '$argument'.implode(', $argument', range(1, \count($arguments)))
             : ''
         ;
 

--- a/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
@@ -97,8 +97,8 @@ final class MethodSignatureGenerator implements Generator
 
     private function buildArgumentString(array $arguments) : string
     {
-        $argString = count($arguments)
-            ? '$argument' . implode(', $argument', range(1, count($arguments)))
+        $argString = \count($arguments)
+            ? '$argument' . implode(', $argument', range(1, \count($arguments)))
             : '';
         return $argString;
     }

--- a/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
@@ -46,7 +46,7 @@ final class OneTimeGenerator implements Generator
     public function generate(Resource $resource, array $data)
     {
         $classname = $resource->getSrcClassname();
-        if (in_array($classname, $this->alreadyGenerated)) {
+        if (\in_array($classname, $this->alreadyGenerated)) {
             return;
         }
 

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -61,13 +61,13 @@ final class TokenizedCodeWriter implements CodeWriter
     private function insertStringAfterLine(string $target, string $toInsert, int $line, bool $leadingNewline = true) : string
     {
         $lines = explode("\n", $target);
-        $lastLines = array_slice($lines, $line);
+        $lastLines = \array_slice($lines, $line);
         $toInsert = trim($toInsert, "\n\r");
         if ($leadingNewline) {
             $toInsert = "\n" . $toInsert;
         }
         array_unshift($lastLines, $toInsert);
-        array_splice($lines, $line, count($lines), $lastLines);
+        array_splice($lines, $line, \count($lines), $lastLines);
 
         return implode("\n", $lines);
     }
@@ -76,9 +76,9 @@ final class TokenizedCodeWriter implements CodeWriter
     {
         $line--;
         $lines = explode("\n", $target);
-        $lastLines = array_slice($lines, $line);
+        $lastLines = \array_slice($lines, $line);
         array_unshift($lastLines, trim($toInsert, "\n\r") . "\n");
-        array_splice($lines, $line, count($lines), $lastLines);
+        array_splice($lines, $line, \count($lines), $lastLines);
 
         return implode("\n", $lines);
     }
@@ -90,7 +90,7 @@ final class TokenizedCodeWriter implements CodeWriter
         $inString = false;
         $searchPattern = array();
 
-        for ($i = count($tokens) - 1; $i >= 0; $i--) {
+        for ($i = \count($tokens) - 1; $i >= 0; $i--) {
             $token = $tokens[$i];
 
             if ($token === '}' && !$inString) {
@@ -112,11 +112,11 @@ final class TokenizedCodeWriter implements CodeWriter
                 return $this->insertStringAfterLine($class, $method, $line, $token[0] === T_COMMENT ?: $prependNewLine);
             }
 
-            array_unshift($searchPattern, is_array($token) ? $token[1] : $token);
+            array_unshift($searchPattern, \is_array($token) ? $token[1] : $token);
 
             if ($token === '{') {
                 $search = implode('', $searchPattern);
-                $position = strpos($class, $search) + strlen($search) - 1;
+                $position = strpos($class, $search) + \strlen($search) - 1;
 
                 return substr_replace($class, "\n" . $method . "\n", $position, 0);
             }
@@ -128,6 +128,6 @@ final class TokenizedCodeWriter implements CodeWriter
      */
     private function isWritePoint($token) : bool
     {
-        return is_array($token) && ($token[1] === "\n" || $token[0] === T_COMMENT);
+        return \is_array($token) && ($token[1] === "\n" || $token[0] === T_COMMENT);
     }
 }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -132,12 +132,12 @@ final class Application extends BaseApplication
         $this->populateContainerParameters($container, $config);
 
         foreach ($config as $key => $val) {
-            if ('extensions' === $key && is_array($val)) {
+            if ('extensions' === $key && \is_array($val)) {
                 foreach ($val as $class => $extensionConfig) {
                     $this->loadExtension($container, $class, $extensionConfig ?: []);
                 }
             }
-            elseif ('matchers' === $key && is_array($val)) {
+            elseif ('matchers' === $key && \is_array($val)) {
                 $this->registerCustomMatchers($container, $val);
             }
         }
@@ -184,7 +184,7 @@ final class Application extends BaseApplication
             throw new InvalidConfigurationException(sprintf('Extension class `%s` does not exist.', $extensionClass));
         }
 
-        if (!is_array($config)) {
+        if (!\is_array($config)) {
             throw new InvalidConfigurationException('Extension configuration must be an array or null.');
         }
 
@@ -250,7 +250,7 @@ final class Application extends BaseApplication
 
     private function addPathsToEachSuiteConfig(string $configDir, array $config) : array
     {
-        if (isset($config['suites']) && is_array($config['suites'])) {
+        if (isset($config['suites']) && \is_array($config['suites'])) {
             foreach ($config['suites'] as $suiteKey => $suiteConfig) {
                 $config['suites'][$suiteKey] = str_replace('%paths.config%', $configDir, $suiteConfig);
             }

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -174,15 +174,15 @@ class ConsoleIO implements IO
         }
 
         $commonPrefix = $this->getCommonPrefix($message, $this->lastMessage);
-        $newSuffix = substr($message, strlen($commonPrefix));
-        $oldSuffix = substr($this->lastMessage, strlen($commonPrefix));
+        $newSuffix = substr($message, \strlen($commonPrefix));
+        $oldSuffix = substr($this->lastMessage, \strlen($commonPrefix));
 
-        $overwriteLength = strlen(strip_tags($oldSuffix));
+        $overwriteLength = \strlen(strip_tags($oldSuffix));
 
         $this->write(str_repeat("\x08", $overwriteLength));
         $this->write($newSuffix);
 
-        $fill = $overwriteLength - strlen(strip_tags($newSuffix));
+        $fill = $overwriteLength - \strlen(strip_tags($newSuffix));
         if ($fill > 0) {
             $this->write(str_repeat(' ', $fill));
             $this->write(str_repeat("\x08", $fill));
@@ -197,7 +197,7 @@ class ConsoleIO implements IO
 
     private function getCommonPrefix(string $stringA, string $stringB)
     {
-        for ($i = 0, $len = min(strlen($stringA), strlen($stringB)); $i<$len; $i++) {
+        for ($i = 0, $len = min(\strlen($stringA), \strlen($stringB)); $i<$len; $i++) {
             if ($stringA[$i] != $stringB[$i]) {
                 break;
             }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -393,7 +393,7 @@ final class ContainerAssembler
             $suites = $c->getParam('suites', array('main' => ''));
 
             foreach ($suites as $name => $suite) {
-                $suite      = is_array($suite) ? $suite : array('namespace' => $suite);
+                $suite      = \is_array($suite) ? $suite : array('namespace' => $suite);
                 $defaults = array(
                     'namespace'     => '',
                     'spec_prefix'   => 'spec',

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -98,7 +98,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
     {
         if (
             (null !== $error && ($currentExample->getCurrentExample() || $error['type'] == E_ERROR)) ||
-            (is_null($currentExample->getCurrentExample()) && defined('HHVM_VERSION'))
+            (\is_null($currentExample->getCurrentExample()) && \defined('HHVM_VERSION'))
         ) {
             ini_set('display_errors', "stderr");
             $failedOpen = ($this->io->isDecorated()) ? '<failed>' : '';

--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -28,7 +28,7 @@ final class DotFormatter extends ConsoleFormatter
      */
     public function beforeSuite(SuiteEvent $event)
     {
-        $this->examplesCount = count($event->getSuite());
+        $this->examplesCount = \count($event->getSuite());
     }
 
     /**
@@ -70,7 +70,7 @@ final class DotFormatter extends ConsoleFormatter
         }
 
         if ($lastRow || $endOfRow) {
-            $length = strlen((string) $this->examplesCount);
+            $length = \strlen((string) $this->examplesCount);
             $format = sprintf(' %%%dd / %%%dd', $length, $length);
 
             $io->write(sprintf($format, $eventsCount, $this->examplesCount));
@@ -142,7 +142,7 @@ final class DotFormatter extends ConsoleFormatter
             $counts[] = sprintf('<%s>%d %s</%s>', $type, $count, $type, $type);
         }
 
-        if (count($counts)) {
+        if (\count($counts)) {
             $this->getIO()->write(sprintf("(%s)", implode(', ', $counts)));
         }
     }

--- a/src/PhpSpec/Formatter/JUnitFormatter.php
+++ b/src/PhpSpec/Formatter/JUnitFormatter.php
@@ -134,7 +134,7 @@ final class JUnitFormatter extends BasicFormatter
 
         $this->exampleStatusCounts[$event->getResult()]++;
 
-        if (in_array($event->getResult(), array(ExampleEvent::BROKEN, ExampleEvent::FAILED))) {
+        if (\in_array($event->getResult(), array(ExampleEvent::BROKEN, ExampleEvent::FAILED))) {
             $exception = $event->getException();
             $testCaseNode .= sprintf(
                 '>'."\n".
@@ -146,7 +146,7 @@ final class JUnitFormatter extends BasicFormatter
                 '</system-err>'."\n".
                 '</testcase>',
                 $this->resultTags[$event->getResult()],
-                get_class($exception),
+                \get_class($exception),
                 htmlspecialchars($exception->getMessage()),
                 $exception->getTraceAsString()
             );
@@ -175,7 +175,7 @@ final class JUnitFormatter extends BasicFormatter
             '</testsuite>',
             $event->getTitle(),
             $event->getTime(),
-            count($this->testCaseNodes),
+            \count($this->testCaseNodes),
             $this->exampleStatusCounts[ExampleEvent::FAILED],
             $this->exampleStatusCounts[ExampleEvent::BROKEN],
             $this->exampleStatusCounts[ExampleEvent::PENDING] + $this->exampleStatusCounts[ExampleEvent::SKIPPED],
@@ -199,8 +199,8 @@ final class JUnitFormatter extends BasicFormatter
             '</testsuites>',
             $event->getTime(),
             $stats->getEventsCount(),
-            count($stats->getFailedEvents()),
-            count($stats->getBrokenEvents()),
+            \count($stats->getFailedEvents()),
+            \count($stats->getBrokenEvents()),
             implode("\n", $this->testSuiteNodes)
         );
 

--- a/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
@@ -17,7 +17,7 @@ final class ArrayEngine extends StringEngine
 {
     public function supports($expected, $actual) : bool
     {
-        return is_array($expected) && is_array($actual);
+        return \is_array($expected) && \is_array($actual);
     }
 
     public function compare($expected, $actual) : string
@@ -32,7 +32,7 @@ final class ArrayEngine extends StringEngine
     {
         $str = str_pad('', $pad, ' ').'[';
         foreach ($a as $key => $val) {
-            switch ($type = strtolower(gettype($val))) {
+            switch ($type = strtolower(\gettype($val))) {
                 case 'array':
                     $line = sprintf(
                         '%s => %s,',
@@ -50,7 +50,7 @@ final class ArrayEngine extends StringEngine
                     $line = sprintf(
                         '%s => %s#%s,',
                         $key,
-                        get_class($val),
+                        \get_class($val),
                         spl_object_hash($val)
                     );
                     break;

--- a/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
@@ -44,7 +44,7 @@ final class ObjectEngine implements DifferEngine
      */
     public function supports($expected, $actual): bool
     {
-        return is_object($expected) && is_object($actual);
+        return \is_object($expected) && \is_object($actual);
     }
 
     /**

--- a/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
@@ -17,7 +17,7 @@ class StringEngine implements DifferEngine
 {
     public function supports($expected, $actual): bool
     {
-        return is_string($expected) && is_string($actual);
+        return \is_string($expected) && \is_string($actual);
     }
 
     public function compare($expected, $actual): string

--- a/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
@@ -47,7 +47,7 @@ class CallArgumentsPresenter
         }
 
         $presentedMethodProphecy = $this->findFirstUnexpectedArgumentsCallProphecy($methodProphecies, $exception);
-        if (is_null($presentedMethodProphecy)) {
+        if (\is_null($presentedMethodProphecy)) {
             return '';
         }
 
@@ -68,7 +68,7 @@ class CallArgumentsPresenter
      */
     private function noMethodPropheciesForUnexpectedCall(array $methodProphecies): bool
     {
-        return count($methodProphecies) === 0;
+        return \count($methodProphecies) === 0;
     }
 
     /**
@@ -89,7 +89,7 @@ class CallArgumentsPresenter
                 $methodProphecy->getArgumentsWildcard()
             );
 
-            if (count($calls)) {
+            if (\count($calls)) {
                 continue;
             }
 
@@ -107,7 +107,7 @@ class CallArgumentsPresenter
      */
     private function parametersCountMismatch(array $expectedTokens, array $actualArguments): bool
     {
-        return count($expectedTokens) !== count($actualArguments);
+        return \count($expectedTokens) !== \count($actualArguments);
     }
 
     /**
@@ -140,8 +140,8 @@ class CallArgumentsPresenter
         $text = '';
         foreach($actualArguments as $i => $actualArgument) {
             $expectedArgument = $expectedArguments[$i];
-            $actualArgument = is_null($actualArgument) ? 'null' : $actualArgument;
-            $expectedArgument = is_null($expectedArgument) ? 'null' : $expectedArgument;
+            $actualArgument = \is_null($actualArgument) ? 'null' : $actualArgument;
+            $expectedArgument = \is_null($expectedArgument) ? 'null' : $expectedArgument;
 
             $text .= $this->differ->compare($expectedArgument, $actualArgument);
         }

--- a/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
@@ -39,7 +39,7 @@ final class GenericPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPre
     {
         $lines  = explode(PHP_EOL, file_get_contents($file));
         $offset = max(0, $lineno - ceil($context / 2));
-        $lines  = array_slice($lines, $offset, $context);
+        $lines  = \array_slice($lines, $offset, $context);
 
         $text = PHP_EOL;
         foreach ($lines as $line) {

--- a/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
@@ -26,7 +26,7 @@ final class HtmlPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresen
     {
         $lines  = explode(PHP_EOL, file_get_contents($file));
         $offset = max(0, $lineno - ceil($context / 2));
-        $lines  = array_slice($lines, $offset, $context);
+        $lines  = \array_slice($lines, $offset, $context);
 
         $text = PHP_EOL;
 

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -144,7 +144,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
 
         $text .= $this->presentExceptionTraceLocation($offset++, $exception->getFile(), $exception->getLine());
         $text .= $this->presentExceptionTraceFunction(
-            'throw new '.get_class($exception),
+            'throw new '.\get_class($exception),
             array($exception->getMessage())
         );
 

--- a/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
@@ -21,7 +21,7 @@ final class ArrayTypePresenter implements TypePresenter
      */
     public function supports($value): bool
     {
-        return 'array' === strtolower(gettype($value));
+        return 'array' === strtolower(\gettype($value));
     }
 
     /**
@@ -30,7 +30,7 @@ final class ArrayTypePresenter implements TypePresenter
      */
     public function present($value): string
     {
-        return sprintf('[array:%d]', count($value));
+        return sprintf('[array:%d]', \count($value));
     }
 
     /**

--- a/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
@@ -42,7 +42,7 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
         return sprintf(
             '[%s:%s("%s")]',
             $label,
-            get_class($value),
+            \get_class($value),
             $value->getMessage()
         );
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
@@ -21,7 +21,7 @@ final class BooleanTypePresenter implements TypePresenter
      */
     public function supports($value): bool
     {
-        return 'boolean' === strtolower(gettype($value));
+        return 'boolean' === strtolower(\gettype($value));
     }
 
     /**

--- a/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
@@ -45,8 +45,8 @@ final class CallableTypePresenter implements TypePresenter
      */
     public function present($value): string
     {
-        if (is_array($value)) {
-            $type = is_object($value[0]) ? $this->presenter->presentValue($value[0]) : $value[0];
+        if (\is_array($value)) {
+            $type = \is_object($value[0]) ? $this->presenter->presentValue($value[0]) : $value[0];
             return sprintf('%s::%s()', $type, $value[1]);
         }
 
@@ -54,8 +54,8 @@ final class CallableTypePresenter implements TypePresenter
             return '[closure]';
         }
 
-        if (is_object($value)) {
-            return sprintf('[obj:%s]', get_class($value));
+        if (\is_object($value)) {
+            return sprintf('[obj:%s]', \get_class($value));
         }
 
         return sprintf('[%s()]', $value);

--- a/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
@@ -44,6 +44,6 @@ final class ComposedValuePresenter implements ValuePresenter
             }
         }
 
-        return sprintf('[%s:%s]', strtolower(gettype($value)), $value);
+        return sprintf('[%s:%s]', strtolower(\gettype($value)), $value);
     }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
@@ -21,7 +21,7 @@ final class ObjectTypePresenter implements TypePresenter
      */
     public function supports($value): bool
     {
-        return 'object' === strtolower(gettype($value));
+        return 'object' === strtolower(\gettype($value));
     }
 
     /**
@@ -30,7 +30,7 @@ final class ObjectTypePresenter implements TypePresenter
      */
     public function present($value): string
     {
-        return sprintf('[obj:%s]', get_class($value));
+        return sprintf('[obj:%s]', \get_class($value));
     }
 
     /**

--- a/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
@@ -21,7 +21,7 @@ final class QuotingStringTypePresenter implements StringTypePresenter
      */
     public function supports($value): bool
     {
-        return 'string' === strtolower(gettype($value));
+        return 'string' === strtolower(\gettype($value));
     }
 
     /**

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -40,7 +40,7 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
      */
     public function present($value): string
     {
-        if (25 > strlen($value) && false === strpos($value, "\n")) {
+        if (25 > \strlen($value) && false === strpos($value, "\n")) {
             return $this->stringTypePresenter->present($value);
         }
 

--- a/src/PhpSpec/Formatter/PrettyFormatter.php
+++ b/src/PhpSpec/Formatter/PrettyFormatter.php
@@ -66,7 +66,7 @@ final class PrettyFormatter extends ConsoleFormatter
             'broken' => $this->getStatisticsCollector()->getBrokenEvents(),
             'skipped' => $this->getStatisticsCollector()->getSkippedEvents(),
         ) as $status => $events) {
-            if (!count($events)) {
+            if (!\count($events)) {
                 continue;
             }
 
@@ -91,7 +91,7 @@ final class PrettyFormatter extends ConsoleFormatter
         }
 
         $io->write(sprintf("%d examples ", $this->getStatisticsCollector()->getEventsCount()));
-        if (count($counts)) {
+        if (\count($counts)) {
             $io->write(sprintf("(%s)", implode(', ', $counts)));
         }
 

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -55,7 +55,7 @@ final class ProgressFormatter extends ConsoleFormatter
         $count = $stats->getEventsCount();
         $plural = $count !== 1 ? 's' : '';
         $io->write(sprintf("%d example%s ", $count, $plural));
-        if (count($counts)) {
+        if (\count($counts)) {
             $io->write(sprintf("(%s)", implode(', ', $counts)));
         }
 
@@ -120,7 +120,7 @@ final class ProgressFormatter extends ConsoleFormatter
             $size = $size - $length;
 
             if ($isDecorated) {
-                if ($length > strlen($text) + 2) {
+                if ($length > \strlen($text) + 2) {
                     $text = str_pad($text, $length, ' ', STR_PAD_BOTH);
                 } else {
                     $text = str_pad('', $length, ' ');
@@ -150,7 +150,7 @@ final class ProgressFormatter extends ConsoleFormatter
     {
         if ($io->isDecorated()) {
             $progressBar = implode('', $progress);
-            $pad = $this->getIO()->getBlockWidth() - strlen(strip_tags($progressBar));
+            $pad = $this->getIO()->getBlockWidth() - \strlen(strip_tags($progressBar));
             $io->writeTemp($progressBar.str_repeat(' ', $pad + 1).$total);
         } else {
             $io->writeTemp('/'.implode('/', $progress).'/  '.$total.' examples');

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -125,7 +125,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
             }
         );
 
-        if (count($interfaces) !== 1) {
+        if (\count($interfaces) !== 1) {
             return;
         }
 
@@ -145,7 +145,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
             }
 
             foreach ($methods as $method => $arguments) {
-                if (in_array($method, $this->wrongMethodNames)) {
+                if (\in_array($method, $this->wrongMethodNames)) {
                     continue;
                 }
 

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -70,7 +70,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
             return;
         }
 
-        $classname = get_class($exception->getSubject());
+        $classname = \get_class($exception->getSubject());
         $methodName = $exception->getMethodName();
         $this->methods[$classname .'::'.$methodName] = $exception->getArguments();
         $this->checkIfMethodNameAllowed($methodName);
@@ -85,7 +85,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         foreach ($this->methods as $call => $arguments) {
             list($classname, $method) = explode('::', $call);
 
-            if (in_array($method, $this->wrongMethodNames)) {
+            if (\in_array($method, $this->wrongMethodNames)) {
                 continue;
             }
 

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -99,9 +99,9 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
             return;
         }
 
-        if (is_object($exception->getExpected())
-         || is_array($exception->getExpected())
-         || is_resource($exception->getExpected())
+        if (\is_object($exception->getExpected())
+         || \is_array($exception->getExpected())
+         || \is_resource($exception->getExpected())
         ) {
             return;
         }
@@ -110,7 +110,7 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
             return;
         }
 
-        $class = get_class($this->lastMethodCallEvent->getSubject());
+        $class = \get_class($this->lastMethodCallEvent->getSubject());
         $method = $this->lastMethodCallEvent->getMethod();
 
         if (!$this->methodAnalyser->methodIsEmpty($class, $method)) {
@@ -143,7 +143,7 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
         foreach ($this->nullMethods as $methodString => $failedCall) {
             $failedCall['expected'] = array_unique($failedCall['expected']);
 
-            if (count($failedCall['expected'])>1) {
+            if (\count($failedCall['expected'])>1) {
                 continue;
             }
 

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -53,7 +53,7 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
             return;
         }
 
-        $className = get_class($exception->getSubject());
+        $className = \get_class($exception->getSubject());
         $this->methods[$className .'::'.$exception->getMethodName()] = $exception->getArguments();
     }
 

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -70,7 +70,7 @@ class StatisticsCollector implements EventSubscriberInterface
 
     public function beforeSuite(SuiteEvent $suiteEvent)
     {
-        $this->totalSpecsCount = count($suiteEvent->getSuite()->getSpecifications());
+        $this->totalSpecsCount = \count($suiteEvent->getSuite()->getSpecifications());
     }
 
     public function getGlobalResult()
@@ -117,11 +117,11 @@ class StatisticsCollector implements EventSubscriberInterface
     public function getCountsHash()
     {
         return array(
-            'passed'  => count($this->getPassedEvents()),
-            'pending' => count($this->getPendingEvents()),
-            'skipped' => count($this->getSkippedEvents()),
-            'failed'  => count($this->getFailedEvents()),
-            'broken'  => count($this->getBrokenEvents()),
+            'passed'  => \count($this->getPassedEvents()),
+            'pending' => \count($this->getPendingEvents()),
+            'skipped' => \count($this->getSkippedEvents()),
+            'failed'  => \count($this->getFailedEvents()),
+            'broken'  => \count($this->getBrokenEvents()),
         );
     }
 
@@ -132,7 +132,7 @@ class StatisticsCollector implements EventSubscriberInterface
 
     public function getEventsCount()
     {
-        return count($this->getAllEvents());
+        return \count($this->getAllEvents());
     }
 
     public function getTotalSpecsCount()

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -114,6 +114,6 @@ class SpecificationNode implements \Countable
      */
     public function count(): int
     {
-        return count($this->examples);
+        return \count($this->examples);
     }
 }

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -105,7 +105,7 @@ class ResourceLoader
      */
     private function lineIsInsideMethod(int $line, ReflectionMethod $method): bool
     {
-        $line = intval($line);
+        $line = \intval($line);
 
         return $line >= $method->getStartLine() && $line <= $method->getEndLine();
     }

--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -22,7 +22,7 @@ class StreamWrapper
 
     public static function register()
     {
-        if (in_array('phpspec', stream_get_wrappers())) {
+        if (\in_array('phpspec', stream_get_wrappers())) {
             stream_wrapper_unregister('phpspec');
         }
         stream_wrapper_register('phpspec', 'PhpSpec\Loader\StreamWrapper');
@@ -40,7 +40,7 @@ class StreamWrapper
 
     public static function wrapPath($path)
     {
-        if (!defined('HHVM_VERSION'))
+        if (!\defined('HHVM_VERSION'))
         {
             return 'phpspec://' . $path;
         }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -76,12 +76,12 @@ class PSR0Locator implements ResourceLocator
         $this->specPath      = rtrim(realpath($specPath), '/\\').$sepr;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\').'\\', '\\');
         $this->psr4Prefix    = (null === $psr4Prefix) ? null : ltrim(trim($psr4Prefix, ' \\').'\\', '\\');
-        if (null !== $this->psr4Prefix  && substr($this->srcNamespace, 0, strlen($psr4Prefix)) !== $psr4Prefix) {
+        if (null !== $this->psr4Prefix  && substr($this->srcNamespace, 0, \strlen($psr4Prefix)) !== $psr4Prefix) {
             throw new InvalidArgumentException('PSR4 prefix doesn\'t match given class namespace.'.PHP_EOL);
         }
         $srcNamespacePath = null === $this->psr4Prefix ?
             $this->srcNamespace :
-            substr($this->srcNamespace, strlen($this->psr4Prefix));
+            substr($this->srcNamespace, \strlen($this->psr4Prefix));
         $this->specNamespace = $specNamespacePrefix ?
             trim($specNamespacePrefix, ' \\').'\\'.$this->srcNamespace :
             $this->srcNamespace;
@@ -191,14 +191,14 @@ class PSR0Locator implements ResourceLocator
         }
 
         if ($path && 0 === strpos($path, $this->fullSrcPath)) {
-            $path = $this->fullSpecPath.substr($path, strlen($this->fullSrcPath));
+            $path = $this->fullSpecPath.substr($path, \strlen($this->fullSrcPath));
             $path = preg_replace('/\.php/', 'Spec.php', $path);
 
             return $this->findSpecResources($path);
         }
 
         if ($path && 0 === strpos($path, $this->srcPath)) {
-            $path = $this->fullSpecPath.substr($path, strlen($this->srcPath));
+            $path = $this->fullSpecPath.substr($path, \strlen($this->srcPath));
             $path = preg_replace('/\.php/', 'Spec.php', $path);
 
             return $this->findSpecResources($path);
@@ -235,13 +235,13 @@ class PSR0Locator implements ResourceLocator
         $classname = str_replace('/', '\\', $classname);
 
         if (0 === strpos($classname, $this->specNamespace)) {
-            $relative = substr($classname, strlen($this->specNamespace));
+            $relative = substr($classname, \strlen($this->specNamespace));
 
             return new PSR0Resource(explode('\\', $relative), $this);
         }
 
         if ('' === $this->srcNamespace || 0 === strpos($classname, $this->srcNamespace)) {
-            $relative = substr($classname, strlen($this->srcNamespace));
+            $relative = substr($classname, \strlen($this->srcNamespace));
 
             return new PSR0Resource(explode('\\', $relative), $this);
         }
@@ -291,7 +291,7 @@ class PSR0Locator implements ResourceLocator
         $namespace = '';
         $content   = $this->filesystem->getFileContents($path);
         $tokens    = token_get_all($content);
-        $count     = count($tokens);
+        $count     = \count($tokens);
 
         for ($i = 0; $i < $count; $i++) {
             if ($tokens[$i][0] === T_NAMESPACE) {
@@ -341,7 +341,7 @@ class PSR0Locator implements ResourceLocator
             ));
         }
 
-        $classname = substr($classname, strlen($specNamespace));
+        $classname = substr($classname, \strlen($specNamespace));
 
         // cut "Spec" from the end
         $classname = preg_replace('/Spec$/', '', $classname);
@@ -381,7 +381,7 @@ class PSR0Locator implements ResourceLocator
         if ($this->queryContainsQualifiedClassName($query)) {
             $namespacedQuery = null === $this->psr4Prefix ?
                 $replacedQuery :
-                substr($replacedQuery, strlen($this->srcNamespace));
+                substr($replacedQuery, \strlen($this->srcNamespace));
 
             $path = $this->fullSpecPath . $namespacedQuery . 'Spec.php';
 

--- a/src/PhpSpec/Matcher/ApproximatelyMatcher.php
+++ b/src/PhpSpec/Matcher/ApproximatelyMatcher.php
@@ -52,7 +52,7 @@ final class ApproximatelyMatcher extends BasicMatcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return in_array($name, self::$keywords) && 2 == count($arguments);
+        return \in_array($name, self::$keywords) && 2 == \count($arguments);
     }
 
     /**

--- a/src/PhpSpec/Matcher/ArrayContainMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayContainMatcher.php
@@ -41,8 +41,8 @@ final class ArrayContainMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'contain' === $name
-            && 1 == count($arguments)
-            && is_array($subject)
+            && 1 == \count($arguments)
+            && \is_array($subject)
         ;
     }
 
@@ -54,7 +54,7 @@ final class ArrayContainMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        return in_array($arguments[0], $subject, true);
+        return \in_array($arguments[0], $subject, true);
     }
 
     /**

--- a/src/PhpSpec/Matcher/ArrayCountMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayCountMatcher.php
@@ -41,8 +41,8 @@ final class ArrayCountMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveCount' === $name
-            && 1 == count($arguments)
-            && (is_array($subject) || $subject instanceof \Countable)
+            && 1 == \count($arguments)
+            && (\is_array($subject) || $subject instanceof \Countable)
         ;
     }
 
@@ -54,7 +54,7 @@ final class ArrayCountMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        return $arguments[0] === count($subject);
+        return $arguments[0] === \count($subject);
     }
 
     /**
@@ -69,8 +69,8 @@ final class ArrayCountMatcher extends BasicMatcher
         return new FailureException(sprintf(
             'Expected %s to have %s items, but got %s.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentString(intval($arguments[0])),
-            $this->presenter->presentString(count($subject))
+            $this->presenter->presentString(\intval($arguments[0])),
+            $this->presenter->presentString(\count($subject))
         ));
     }
 
@@ -86,7 +86,7 @@ final class ArrayCountMatcher extends BasicMatcher
         return new FailureException(sprintf(
             'Expected %s not to have %s items, but got it.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentString(intval($arguments[0]))
+            $this->presenter->presentString(\intval($arguments[0]))
         ));
     }
 }

--- a/src/PhpSpec/Matcher/ArrayKeyMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyMatcher.php
@@ -42,8 +42,8 @@ final class ArrayKeyMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveKey' === $name
-            && 1 == count($arguments)
-            && (is_array($subject) || $subject instanceof ArrayAccess)
+            && 1 == \count($arguments)
+            && (\is_array($subject) || $subject instanceof ArrayAccess)
         ;
     }
 

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -42,9 +42,9 @@ final class ArrayKeyValueMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return
-            (is_array($subject) || $subject instanceof \ArrayAccess) &&
+            (\is_array($subject) || $subject instanceof \ArrayAccess) &&
             'haveKeyWithValue' === $name &&
-            2 == count($arguments)
+            2 == \count($arguments)
         ;
     }
 

--- a/src/PhpSpec/Matcher/CallbackMatcher.php
+++ b/src/PhpSpec/Matcher/CallbackMatcher.php
@@ -65,7 +65,7 @@ final class CallbackMatcher extends BasicMatcher
     {
         array_unshift($arguments, $subject);
 
-        return (Boolean) call_user_func_array($this->callback, $arguments);
+        return (Boolean) \call_user_func_array($this->callback, $arguments);
     }
 
     /**

--- a/src/PhpSpec/Matcher/ComparisonMatcher.php
+++ b/src/PhpSpec/Matcher/ComparisonMatcher.php
@@ -42,7 +42,7 @@ final class ComparisonMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'beLike' === $name
-            && 1 == count($arguments)
+            && 1 == \count($arguments)
         ;
     }
 

--- a/src/PhpSpec/Matcher/IdentityMatcher.php
+++ b/src/PhpSpec/Matcher/IdentityMatcher.php
@@ -50,8 +50,8 @@ final class IdentityMatcher extends BasicMatcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return in_array($name, self::$keywords)
-            && 1 == count($arguments)
+        return \in_array($name, self::$keywords)
+            && 1 == \count($arguments)
         ;
     }
 

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -72,7 +72,7 @@ final class IterablesMatcher
      */
     private function isIterable($variable): bool
     {
-        return is_array($variable) || $variable instanceof \Traversable;
+        return \is_array($variable) || $variable instanceof \Traversable;
     }
 
     /**
@@ -82,7 +82,7 @@ final class IterablesMatcher
      */
     private function createIteratorFromIterable($iterable): \Iterator
     {
-        if (is_array($iterable)) {
+        if (\is_array($iterable)) {
             return new \ArrayIterator($iterable);
         }
 

--- a/src/PhpSpec/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Matcher/IterateAsMatcher.php
@@ -37,10 +37,10 @@ final class IterateAsMatcher implements Matcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return in_array($name, ['iterateAs', 'yield'])
-            && 1 === count($arguments)
-            && ($subject instanceof \Traversable || is_array($subject))
-            && ($arguments[0] instanceof \Traversable || is_array($arguments[0]))
+        return \in_array($name, ['iterateAs', 'yield'])
+            && 1 === \count($arguments)
+            && ($subject instanceof \Traversable || \is_array($subject))
+            && ($arguments[0] instanceof \Traversable || \is_array($arguments[0]))
         ;
     }
 

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -45,7 +45,7 @@ final class ObjectStateMatcher implements Matcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return is_object($subject) && !is_callable($subject)
+        return \is_object($subject) && !is_callable($subject)
             && (0 === strpos($name, 'be') || 0 === strpos($name, 'have'))
         ;
     }
@@ -71,7 +71,7 @@ final class ObjectStateMatcher implements Matcher
             ), $subject, $method, $arguments);
         }
 
-        if (true !== $result = call_user_func_array($callable, $arguments)) {
+        if (true !== $result = \call_user_func_array($callable, $arguments)) {
             throw $this->getFailureExceptionFor($callable, true, $result);
         }
     }
@@ -97,7 +97,7 @@ final class ObjectStateMatcher implements Matcher
             ), $subject, $method, $arguments);
         }
 
-        if (false !== $result = call_user_func_array($callable, $arguments)) {
+        if (false !== $result = \call_user_func_array($callable, $arguments)) {
             throw $this->getFailureExceptionFor($callable, false, $result);
         }
     }

--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -61,7 +61,7 @@ final class ScalarMatcher implements Matcher
     {
         $checker = $this->getCheckerName($name);
 
-        if (!call_user_func($checker, $subject)) {
+        if (!\call_user_func($checker, $subject)) {
             throw new FailureException(sprintf(
                 '%s expected to return %s, but it did not.',
                 $this->presenter->presentString(sprintf(
@@ -88,7 +88,7 @@ final class ScalarMatcher implements Matcher
     {
         $checker = $this->getCheckerName($name);
 
-        if (call_user_func($checker, $subject)) {
+        if (\call_user_func($checker, $subject)) {
             throw new FailureException(sprintf(
                 '%s not expected to return %s, but it did.',
                 $this->presenter->presentString(sprintf(

--- a/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
@@ -37,10 +37,10 @@ final class StartIteratingAsMatcher implements Matcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return in_array($name, ['startIteratingAs', 'startYielding'])
-            && 1 === count($arguments)
-            && ($subject instanceof \Traversable || is_array($subject))
-            && ($arguments[0] instanceof \Traversable || is_array($arguments[0]))
+        return \in_array($name, ['startIteratingAs', 'startYielding'])
+            && 1 === \count($arguments)
+            && ($subject instanceof \Traversable || \is_array($subject))
+            && ($arguments[0] instanceof \Traversable || \is_array($arguments[0]))
         ;
     }
 

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -37,9 +37,9 @@ final class StringContainMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments) : bool
     {
         return 'contain' === $name
-            && is_string($subject)
-            && 1 === count($arguments)
-            && is_string($arguments[0]);
+            && \is_string($subject)
+            && 1 === \count($arguments)
+            && \is_string($arguments[0]);
     }
 
     /**

--- a/src/PhpSpec/Matcher/StringEndMatcher.php
+++ b/src/PhpSpec/Matcher/StringEndMatcher.php
@@ -41,8 +41,8 @@ final class StringEndMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'endWith' === $name
-            && is_string($subject)
-            && 1 == count($arguments)
+            && \is_string($subject)
+            && 1 == \count($arguments)
         ;
     }
 
@@ -54,7 +54,7 @@ final class StringEndMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        return $arguments[0] === substr($subject, 0 - strlen($arguments[0]));
+        return $arguments[0] === substr($subject, 0 - \strlen($arguments[0]));
     }
 
     /**

--- a/src/PhpSpec/Matcher/StringRegexMatcher.php
+++ b/src/PhpSpec/Matcher/StringRegexMatcher.php
@@ -41,8 +41,8 @@ final class StringRegexMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'match' === $name
-            && is_string($subject)
-            && 1 == count($arguments)
+            && \is_string($subject)
+            && 1 == \count($arguments)
         ;
     }
 

--- a/src/PhpSpec/Matcher/StringStartMatcher.php
+++ b/src/PhpSpec/Matcher/StringStartMatcher.php
@@ -41,8 +41,8 @@ final class StringStartMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'startWith' === $name
-            && is_string($subject)
-            && 1 == count($arguments)
+            && \is_string($subject)
+            && 1 == \count($arguments)
         ;
     }
 

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -105,7 +105,7 @@ final class ThrowMatcher implements Matcher
         $exceptionThrown = null;
 
         try {
-            call_user_func_array($callable, $arguments);
+            \call_user_func_array($callable, $arguments);
         } catch (\Exception $e) {
             $exceptionThrown = $e;
         } catch (\Throwable $e) {
@@ -137,10 +137,10 @@ final class ThrowMatcher implements Matcher
             );
         }
 
-        if (is_object($exception)) {
+        if (\is_object($exception)) {
             $exceptionRefl = $this->factory->create($exception);
             foreach ($exceptionRefl->getProperties() as $property) {
-                if (in_array($property->getName(), self::$ignoredProperties, true)) {
+                if (\in_array($property->getName(), self::$ignoredProperties, true)) {
                     continue;
                 }
 
@@ -174,7 +174,7 @@ final class ThrowMatcher implements Matcher
         $exceptionThrown = null;
 
         try {
-            call_user_func_array($callable, $arguments);
+            \call_user_func_array($callable, $arguments);
         } catch (\Exception $e) {
             $exceptionThrown = $e;
         } catch (\Throwable $e) {
@@ -192,10 +192,10 @@ final class ThrowMatcher implements Matcher
 
         if ($exceptionThrown && $exceptionThrown instanceof $exception) {
             $invalidProperties = array();
-            if (is_object($exception)) {
+            if (\is_object($exception)) {
                 $exceptionRefl = $this->factory->create($exception);
                 foreach ($exceptionRefl->getProperties() as $property) {
-                    if (in_array($property->getName(), self::$ignoredProperties, true)) {
+                    if (\in_array($property->getName(), self::$ignoredProperties, true)) {
                         continue;
                     }
 
@@ -214,7 +214,7 @@ final class ThrowMatcher implements Matcher
             }
 
             $withProperties = '';
-            if (count($invalidProperties) > 0) {
+            if (\count($invalidProperties) > 0) {
                 $withProperties = sprintf(
                     ' with'.PHP_EOL.'%s,'.PHP_EOL,
                     implode(",\n", $invalidProperties)
@@ -262,14 +262,14 @@ final class ThrowMatcher implements Matcher
                 list($class, $methodName) = array($subject, $methodName);
                 if (!method_exists($class, $methodName) && !method_exists($class, '__call')) {
                     throw new MethodNotFoundException(
-                        sprintf('Method %s::%s not found.', get_class($class), $methodName),
+                        sprintf('Method %s::%s not found.', \get_class($class), $methodName),
                         $class,
                         $methodName,
                         $arguments
                     );
                 }
 
-                return call_user_func($check, $callable, $arguments, $exception);
+                return \call_user_func($check, $callable, $arguments, $exception);
             }
         );
     }
@@ -282,15 +282,15 @@ final class ThrowMatcher implements Matcher
      */
     private function getException(array $arguments)
     {
-        if (0 === count($arguments)) {
+        if (0 === \count($arguments)) {
             return null;
         }
 
-        if (is_string($arguments[0])) {
+        if (\is_string($arguments[0])) {
             return $arguments[0];
         }
 
-        if (is_object($arguments[0])) {
+        if (\is_object($arguments[0])) {
             if ($arguments[0] instanceof \Throwable) {
                 return $arguments[0];
             } elseif ($arguments[0] instanceof \Exception) {

--- a/src/PhpSpec/Matcher/TraversableContainMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableContainMatcher.php
@@ -37,7 +37,7 @@ final class TraversableContainMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'contain' === $name
-            && 1 === count($arguments)
+            && 1 === \count($arguments)
             && $subject instanceof \Traversable
         ;
     }

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -41,7 +41,7 @@ final class TraversableCountMatcher implements Matcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveCount' === $name
-            && 1 === count($arguments)
+            && 1 === \count($arguments)
             && $subject instanceof \Traversable
         ;
     }

--- a/src/PhpSpec/Matcher/TraversableKeyMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyMatcher.php
@@ -38,7 +38,7 @@ final class TraversableKeyMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveKey' === $name
-            && 1 === count($arguments)
+            && 1 === \count($arguments)
             && $subject instanceof \Traversable
         ;
     }

--- a/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
@@ -38,7 +38,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments) : bool
     {
         return 'haveKeyWithValue' === $name
-            && 2 === count($arguments)
+            && 2 === \count($arguments)
             && $subject instanceof \Traversable
         ;
     }

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -83,17 +83,17 @@ final class TriggerMatcher implements Matcher
 
         $prevHandler = set_error_handler(function ($type, $str, $file, $line, $context) use (&$prevHandler, $level, $message, &$triggered) {
             if (null !== $level && $level !== $type) {
-                return null !== $prevHandler && call_user_func($prevHandler, $type, $str, $file, $line, $context);
+                return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }
 
             if (null !== $message && false === strpos($str, $message)) {
-                return null !== $prevHandler && call_user_func($prevHandler, $type, $str, $file, $line, $context);
+                return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }
 
             ++$triggered;
         });
 
-        call_user_func_array($callable, $arguments);
+        \call_user_func_array($callable, $arguments);
 
         restore_error_handler();
 
@@ -116,17 +116,17 @@ final class TriggerMatcher implements Matcher
 
         $prevHandler = set_error_handler(function ($type, $str, $file, $line, $context) use (&$prevHandler, $level, $message, &$triggered) {
             if (null !== $level && $level !== $type) {
-                return null !== $prevHandler && call_user_func($prevHandler, $type, $str, $file, $line, $context);
+                return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }
 
             if (null !== $message && false === strpos($str, $message)) {
-                return null !== $prevHandler && call_user_func($prevHandler, $type, $str, $file, $line, $context);
+                return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }
 
             ++$triggered;
         });
 
-        call_user_func_array($callable, $arguments);
+        \call_user_func_array($callable, $arguments);
 
         restore_error_handler();
 
@@ -171,14 +171,14 @@ final class TriggerMatcher implements Matcher
                 list($class, $methodName) = array($subject, $methodName);
                 if (!method_exists($class, $methodName) && !method_exists($class, '__call')) {
                     throw new MethodNotFoundException(
-                        sprintf('Method %s::%s not found.', get_class($class), $methodName),
+                        sprintf('Method %s::%s not found.', \get_class($class), $methodName),
                         $class,
                         $methodName,
                         $arguments
                     );
                 }
 
-                return call_user_func($check, $callable, $arguments, $level, $message);
+                return \call_user_func($check, $callable, $arguments, $level, $message);
             }
         );
     }
@@ -188,7 +188,7 @@ final class TriggerMatcher implements Matcher
      */
     private function unpackArguments(array $arguments): array
     {
-        $count = count($arguments);
+        $count = \count($arguments);
 
         if (0 === $count) {
             return array(null, null);

--- a/src/PhpSpec/Matcher/TypeMatcher.php
+++ b/src/PhpSpec/Matcher/TypeMatcher.php
@@ -49,8 +49,8 @@ final class TypeMatcher extends BasicMatcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return in_array($name, self::$keywords)
-            && 1 == count($arguments)
+        return \in_array($name, self::$keywords)
+            && 1 == \count($arguments)
         ;
     }
 

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -64,7 +64,7 @@ class ComposerPsrNamespaceProvider
                 if (strpos($namespace, $this->specPrefix) !== 0) {
                     $namespaces[$namespace] = substr(
                         realpath($location),
-                        strlen(realpath($this->rootDirectory)) + 1 // trailing slash
+                        \strlen(realpath($this->rootDirectory)) + 1 // trailing slash
                     );
                 }
             }

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -152,7 +152,7 @@ abstract class ObjectBehavior implements
      */
     public function __call(string $method, array $arguments = array())
     {
-        return call_user_func_array(array($this->object, $method), $arguments);
+        return \call_user_func_array(array($this->object, $method), $arguments);
     }
 
     /**
@@ -185,6 +185,6 @@ abstract class ObjectBehavior implements
      */
     public function __invoke()
     {
-        return call_user_func_array(array($this->object, '__invoke'), func_get_args());
+        return \call_user_func_array(array($this->object, '__invoke'), \func_get_args());
     }
 }

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
@@ -46,9 +46,9 @@ final class SuitePrerequisites implements PrerequisiteTester
         if ($undefinedTypes) {
             throw new PrerequisiteFailedException(sprintf(
                 "The type%s %s %s generated but could not be loaded. Do you need to configure an autoloader?\n",
-                count($undefinedTypes) > 1 ? 's' : '',
+                \count($undefinedTypes) > 1 ? 's' : '',
                 join(', ', $undefinedTypes),
-                count($undefinedTypes) > 1 ? 'were' : 'was'
+                \count($undefinedTypes) > 1 ? 'were' : 'was'
             ));
         }
     }

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -44,7 +44,7 @@ final class PcntlReRunner extends PhpExecutableReRunner
         return (php_sapi_name() == 'cli')
             && $this->getExecutablePath()
             && function_exists('pcntl_exec')
-            && !defined('HHVM_VERSION');
+            && !\defined('HHVM_VERSION');
     }
 
     /**

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -112,7 +112,7 @@ final class ErrorMaintainer implements Maintainer
         if (E_RECOVERABLE_ERROR === $level && preg_match($regex, $message, $matches)) {
             $class = $matches['class'];
 
-            if (in_array('PhpSpec\Specification', class_implements($class))) {
+            if (\in_array('PhpSpec\Specification', class_implements($class))) {
                 return true;
             }
         }

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -82,10 +82,10 @@ final class IndexedServiceContainer implements ServiceContainer
      */
     public function set(string $id, $service, array $tags = [])
     {
-        if (!is_object($service)) {
+        if (!\is_object($service)) {
             throw new InvalidArgumentException(sprintf(
                 'Service should be an object, but %s given.',
-                gettype($service)
+                \gettype($service)
             ));
         }
 
@@ -127,7 +127,7 @@ final class IndexedServiceContainer implements ServiceContainer
                 throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
             }
 
-            $this->services[$id] = call_user_func($this->definitions[$id], $this);
+            $this->services[$id] = \call_user_func($this->definitions[$id], $this);
         }
 
         return $this->services[$id];
@@ -207,7 +207,7 @@ final class IndexedServiceContainer implements ServiceContainer
     public function configure()
     {
         foreach ($this->configurators as $configurator) {
-            call_user_func($configurator, $this);
+            \call_user_func($configurator, $this);
         }
     }
 }

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -49,7 +49,7 @@ final class ClassFileAnalyser
     public function classHasMethods(string $class): bool
     {
         foreach ($this->getTokensForClass($class) as $token) {
-            if (!is_array($token)) {
+            if (!\is_array($token)) {
                 continue;
             }
 
@@ -80,7 +80,7 @@ final class ClassFileAnalyser
      */
     private function findIndexOfFirstMethod(array $tokens): int
     {
-        for ($i = 0, $max = count($tokens); $i < $max; $i++) {
+        for ($i = 0, $max = \count($tokens); $i < $max; $i++) {
             if ($this->tokenIsFunction($tokens[$i])) {
                 return $i;
             }
@@ -107,11 +107,11 @@ final class ClassFileAnalyser
         for ($i = $index - 1; $i >= 0; $i--) {
             $token = $tokens[$i];
 
-            if (!is_array($token)) {
+            if (!\is_array($token)) {
                 return $index;
             }
 
-            if (in_array($token[0], $allowedTokens)) {
+            if (\in_array($token[0], $allowedTokens)) {
                 continue;
             }
 
@@ -131,7 +131,7 @@ final class ClassFileAnalyser
     {
         $hash = md5($class);
 
-        if (!in_array($hash, $this->tokenLists)) {
+        if (!\in_array($hash, $this->tokenLists)) {
             $this->tokenLists[$hash] = token_get_all($class);
         }
 
@@ -159,10 +159,10 @@ final class ClassFileAnalyser
     {
         $searching = false;
 
-        for ($i = 0, $max = count($tokens); $i < $max; $i++) {
+        for ($i = 0, $max = \count($tokens); $i < $max; $i++) {
             $token = $tokens[$i];
 
-            if (!is_array($token)) {
+            if (!\is_array($token)) {
                 continue;
             }
 
@@ -195,7 +195,7 @@ final class ClassFileAnalyser
     {
         $braceCount = 0;
 
-        for ($i = $index, $max = count($tokens); $i < $max; $i++) {
+        for ($i = $index, $max = \count($tokens); $i < $max; $i++) {
             $token = $tokens[$i];
 
             if ('{' === $token || $this->isSpecialBraceToken($token)) {
@@ -214,7 +214,7 @@ final class ClassFileAnalyser
 
     private function isSpecialBraceToken($token)
     {
-        if (!is_array($token)) {
+        if (!\is_array($token)) {
             return false;
         }
 
@@ -227,7 +227,7 @@ final class ClassFileAnalyser
      */
     private function tokenIsFunction($token): bool
     {
-        return is_array($token) && $token[0] === T_FUNCTION;
+        return \is_array($token) && $token[0] === T_FUNCTION;
     }
 
     /**
@@ -237,7 +237,7 @@ final class ClassFileAnalyser
     private function findIndexOfClassEnd(array $tokens): int
     {
         $classTokens = array_filter($tokens, function ($token) {
-            return is_array($token) && $token[0] === T_CLASS;
+            return \is_array($token) && $token[0] === T_CLASS;
         });
         $classTokenIndex = key($classTokens);
         return $this->findIndexOfMethodOrClassEnd($tokens, $classTokenIndex) - 1;

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -74,7 +74,7 @@ class MethodAnalyser
 
         $length = $endLine - $startLine;
         $lines = file(StreamWrapper::wrapPath($reflectionClass->getFileName()));
-        $code = join(PHP_EOL, array_slice($lines, $startLine - 1, $length + 1));
+        $code = join(PHP_EOL, \array_slice($lines, $startLine - 1, $length + 1));
 
         return preg_replace('/.*function[^{]+{/s', '', $code);
     }
@@ -133,7 +133,7 @@ class MethodAnalyser
             array_filter(
                 $tokens,
                 function ($token) {
-                    return is_array($token) && in_array($token[0], array(T_COMMENT, T_DOC_COMMENT));
+                    return \is_array($token) && \in_array($token[0], array(T_COMMENT, T_DOC_COMMENT));
                 })
         );
 

--- a/src/PhpSpec/Util/ReservedWordsMethodNameChecker.php
+++ b/src/PhpSpec/Util/ReservedWordsMethodNameChecker.php
@@ -103,6 +103,6 @@ final class ReservedWordsMethodNameChecker implements NameChecker
      */
     public function isNameValid(string $name): bool
     {
-        return !in_array(strtolower($name), $this->reservedWords);
+        return !\in_array(strtolower($name), $this->reservedWords);
     }
 }

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -66,7 +66,7 @@ final class Collaborator implements ObjectWrapper
      */
     public function __call(string $method, array $arguments)
     {
-        return call_user_func_array(array($this->prophecy, '__call'), array($method, $arguments));
+        return \call_user_func_array(array($this->prophecy, '__call'), array($method, $arguments));
     }
 
     /**

--- a/src/PhpSpec/Wrapper/DelayedCall.php
+++ b/src/PhpSpec/Wrapper/DelayedCall.php
@@ -36,6 +36,6 @@ class DelayedCall
      */
     public function __call(string $method, array $arguments)
     {
-        return call_user_func($this->callable, $method, $arguments);
+        return \call_user_func($this->callable, $method, $arguments);
     }
 }

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -178,7 +178,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      */
     public function beConstructedWith()
     {
-        $this->wrappedObject->beConstructedWith(func_get_args());
+        $this->wrappedObject->beConstructedWith(\func_get_args());
     }
 
     /**
@@ -299,7 +299,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      */
     public function __invoke(): Subject
     {
-        return $this->caller->call('__invoke', func_get_args());
+        return $this->caller->call('__invoke', \func_get_args());
     }
 
     /**

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -163,7 +163,7 @@ class Caller
             return $this->wrappedObject->getInstance();
         }
 
-        if (null === $this->wrappedObject->getClassName() || !is_string($this->wrappedObject->getClassName())) {
+        if (null === $this->wrappedObject->getClassName() || !\is_string($this->wrappedObject->getClassName())) {
             return $this->wrappedObject->getInstance();
         }
 
@@ -171,7 +171,7 @@ class Caller
             throw $this->classNotFound();
         }
 
-        if (is_object($this->wrappedObject->getInstance())) {
+        if (\is_object($this->wrappedObject->getInstance())) {
             $this->wrappedObject->setInstantiated(true);
             $instance = $this->wrappedObject->getInstance();
         } else {
@@ -192,7 +192,7 @@ class Caller
     {
         $subject = $this->getWrappedObject();
 
-        return is_object($subject) && $this->accessInspector->isPropertyReadable($subject, $property);
+        return \is_object($subject) && $this->accessInspector->isPropertyReadable($subject, $property);
     }
 
     /**
@@ -204,7 +204,7 @@ class Caller
     {
         $subject = $this->getWrappedObject();
 
-        return is_object($subject) && $this->accessInspector->isPropertyWritable($subject, $property);
+        return \is_object($subject) && $this->accessInspector->isPropertyWritable($subject, $property);
     }
 
     /**
@@ -228,7 +228,7 @@ class Caller
 
         $reflection = new ReflectionClass($this->wrappedObject->getClassName());
 
-        if (count($this->wrappedObject->getArguments())) {
+        if (\count($this->wrappedObject->getArguments())) {
             return $this->newInstanceWithArguments($reflection);
         }
 
@@ -249,7 +249,7 @@ class Caller
             new MethodCallEvent($this->example, $subject, $method, $arguments)
         );
 
-        $returnValue = call_user_func_array(array($subject, $method), $arguments);
+        $returnValue = \call_user_func_array(array($subject, $method), $arguments);
 
         $this->dispatcher->dispatch(
             'afterMethodCall',
@@ -302,10 +302,10 @@ class Caller
     {
         $method = $this->wrappedObject->getFactoryMethod();
 
-        if (!is_array($method)) {
+        if (!\is_array($method)) {
             $className = $this->wrappedObject->getClassName();
 
-            if (is_string($method) && !method_exists($className, $method)) {
+            if (\is_string($method) && !method_exists($className, $method)) {
                 throw $this->namedConstructorNotFound(
                     $method,
                     $this->wrappedObject->getArguments()
@@ -313,7 +313,7 @@ class Caller
             }
         }
 
-        return call_user_func_array($method, $this->wrappedObject->getArguments());
+        return \call_user_func_array($method, $this->wrappedObject->getArguments());
     }
 
     /**
@@ -424,6 +424,6 @@ class Caller
      */
     public function constantDefined(string $property): bool
     {
-        return defined($this->wrappedObject->getClassName().'::'.$property);
+        return \defined($this->wrappedObject->getClassName().'::'.$property);
     }
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -88,7 +88,7 @@ abstract class DuringCall
     public function duringInstantiation()
     {
         if ($factoryMethod = $this->wrappedObject->getFactoryMethod()) {
-            $method = is_array($factoryMethod) ? $factoryMethod[1] : $factoryMethod;
+            $method = \is_array($factoryMethod) ? $factoryMethod[1] : $factoryMethod;
         } else {
             $method = '__construct';
         }

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -119,9 +119,9 @@ class SubjectWithArrayAccess
      */
     private function checkIfSubjectImplementsArrayAccess($subject)
     {
-        if (is_object($subject) && !($subject instanceof \ArrayAccess)) {
+        if (\is_object($subject) && !($subject instanceof \ArrayAccess)) {
             throw $this->interfaceNotImplemented();
-        } elseif (!($subject instanceof \ArrayAccess) && !is_array($subject)) {
+        } elseif (!($subject instanceof \ArrayAccess) && !\is_array($subject)) {
             throw $this->cantUseAsArray($subject);
         }
     }

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -53,8 +53,8 @@ class WrappedObject
     {
         $this->instance = $instance;
         $this->presenter = $presenter;
-        if (is_object($this->instance)) {
-            $this->classname = get_class($this->instance);
+        if (\is_object($this->instance)) {
+            $this->classname = \get_class($this->instance);
             $this->isInstantiated = true;
         }
     }
@@ -67,7 +67,7 @@ class WrappedObject
      */
     public function beAnInstanceOf(string $classname, array $arguments = array())
     {
-        if (!is_string($classname)) {
+        if (!\is_string($classname)) {
             throw new SubjectException(sprintf(
                 'Behavior subject classname should be a string, %s given.',
                 $this->presenter->presentValue($classname)
@@ -108,7 +108,7 @@ class WrappedObject
      */
     public function beConstructedThrough($factoryMethod, array $arguments = array())
     {
-        if (is_string($factoryMethod) &&
+        if (\is_string($factoryMethod) &&
             false === strpos($factoryMethod, '::') &&
             method_exists($this->classname, $factoryMethod)
         ) {
@@ -219,14 +219,14 @@ class WrappedObject
      */
     private function instantiateFromCallback(callable $factoryCallable)
     {
-        $instance = call_user_func_array($factoryCallable, $this->arguments);
+        $instance = \call_user_func_array($factoryCallable, $this->arguments);
 
-        if (!is_object($instance)) {
+        if (!\is_object($instance)) {
             throw new FactoryDoesNotReturnObjectException(sprintf(
                 'The method %s::%s did not return an object, returned %s instead',
                 $this->factoryMethod[0],
                 $this->factoryMethod[1],
-                gettype($instance)
+                \gettype($instance)
             ));
         }
 

--- a/src/PhpSpec/Wrapper/Unwrapper.php
+++ b/src/PhpSpec/Wrapper/Unwrapper.php
@@ -39,11 +39,11 @@ class Unwrapper implements RevealerInterface
      */
     public function unwrapOne($argument)
     {
-        if (is_array($argument)) {
+        if (\is_array($argument)) {
             return array_map(array($this, 'unwrapOne'), $argument);
         }
 
-        if (!is_object($argument)) {
+        if (!\is_object($argument)) {
             return $argument;
         }
 


### PR DESCRIPTION
This is the 2nd go at https://github.com/phpspec/phpspec/pull/1148

I have prefixed all native function calls with `\` as suggested by @nicolas-grekas

Again, on the https://github.com/Sylius/Sylius testsuite, (just the code analysis stage)
Blackfire before:
https://blackfire.io/profiles/394774de-ade8-4c03-a62b-be9ab8060b75/graph
After:
https://blackfire.io/profiles/e2ee0855-f82a-4f3b-aaa6-10c78278b421/graph
Comparison:
https://blackfire.io/profiles/compare/7886df20-3b18-4070-a634-552013797fae/graph

Without blackfire:
before:
```
time bin/phpspec run
bin/phpspec run  6.04s user 0.25s system 99% cpu 6.311 total
```
after:
```
time bin/phpspec run
bin/phpspec run  5.40s user 0.22s system 99% cpu 5.636 total
```

Around 10% faster in real terms.