### PR TITLE
[RFC] Add strict types to class template

### DIFF
--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -10,6 +10,7 @@ Feature: Developer generates a class
     Then a new class should be generated in the "src/CodeGeneration/ClassExample1/Markdown.php":
       """
       <?php
+      declare(strict_types=1);
 
       namespace CodeGeneration\ClassExample1;
 
@@ -60,6 +61,7 @@ Feature: Developer generates a class
     Then a new class should be generated in the "src/MyNamespace/Markdown.php":
     """
     <?php
+    declare(strict_types=1);
 
     namespace Behat\Tests\MyNamespace;
 
@@ -76,6 +78,7 @@ Feature: Developer generates a class
     Then a new class should be generated in the "src/CodeGeneration/ClassExample1/Text/Markdown.php":
       """
       <?php
+      declare(strict_types=1);
 
       namespace CodeGeneration\ClassExample1;
 
@@ -92,6 +95,7 @@ Feature: Developer generates a class
     Then a new class should be generated in the "src/CodeGeneration/Class_Example2/Text/Markdown.php":
       """
       <?php
+      declare(strict_types=1);
 
       namespace CodeGeneration\Class_Example2;
 
@@ -150,6 +154,7 @@ Feature: Developer generates a class
     Then the class in "src/CodeGeneration/MethodExample2/ForgotPassword.php" should contain:
     """
     <?php
+    declare(strict_types=1);
 
     namespace CodeGeneration\MethodExample2;
 

--- a/features/code_generation/developer_generates_collaborator.feature
+++ b/features/code_generation/developer_generates_collaborator.feature
@@ -77,6 +77,7 @@ Feature: Developer generates a collaborator
     Then the class in "src/CodeGeneration/CollaboratorExample2/Parser.php" should contain:
       """
       <?php
+      declare(strict_types=1);
 
       namespace CodeGeneration\CollaboratorExample2;
 

--- a/features/code_generation/developer_generates_collaborator_from_use_group.feature
+++ b/features/code_generation/developer_generates_collaborator_from_use_group.feature
@@ -77,6 +77,7 @@ Feature: Developer generates a collaborator
     Then the class in "src/CodeGeneration/CollaboratorExample2/Parser.php" should contain:
       """
       <?php
+      declare(strict_types=1);
 
       namespace CodeGeneration\CollaboratorExample2;
 
@@ -120,6 +121,7 @@ Feature: Developer generates a collaborator
     Then the class in "src/CodeGeneration/CollaboratorExample3/Tokenizer.php" should contain:
       """
       <?php
+      declare(strict_types=1);
 
       namespace CodeGeneration\CollaboratorExample3;
 

--- a/features/config/developer_can_use_config_dir_in_paths.feature
+++ b/features/config/developer_can_use_config_dir_in_paths.feature
@@ -73,6 +73,7 @@ Feature: Config directory can be used in spec and src paths
     Then a new class should be generated in the "Awesome/src/MilkyWay/OrionCygnusArm/Pleiades/Alcyone.php":
       """
       <?php
+      declare(strict_types=1);
 
       namespace MilkyWay\OrionCygnusArm\Pleiades;
 
@@ -94,6 +95,7 @@ Feature: Config directory can be used in spec and src paths
     Then a new class should be generated in the "src/MilkyWay/OrionCygnusArm/BehiveCluster.php":
       """
       <?php
+      declare(strict_types=1);
 
       namespace MilkyWay\OrionCygnusArm;
 

--- a/src/PhpSpec/CodeGenerator/Generator/templates/class.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/class.template
@@ -1,4 +1,5 @@
-<?php%namespace_block%
+<?php
+declare(strict_types=1);%namespace_block%
 
 class %name%
 {

--- a/src/PhpSpec/CodeGenerator/Generator/templates/interface.template
+++ b/src/PhpSpec/CodeGenerator/Generator/templates/interface.template
@@ -1,4 +1,5 @@
-<?php%namespace_block%
+<?php
+declare(strict_types=1);%namespace_block%
 
 interface %name%
 {


### PR DESCRIPTION
Hey there.
Since PHPSpec 4 requires PHP 7 it makes sense to add strict types declaration to generated classes and interfaces by default.

But there are several questions that might be discussed:
1. Is it okay at all?
I think using strict types by default on PHP 7 for all new classes will allow to see errors early, and they will be marked explicitly. So developers will be happier.

2. Is it a BC break?
I don't think so. I can't imagine scenario where this change will break anything since it changes only newly generated files. But maybe you see such scenarios.

3. Where should `declare` block be placed?
I've seen two main formats by now. The first one places `declare` block on the next line after opening `<?php` tag:
```php
<?php
declare(strict_types=1);

namespace Acme;

class Foo {}
```

The second one puts `declare` block on the same line with opening `<?php` tag:
```php
<?php declare(strict_types=1);

namespace Acme;

class Foo {}
```

The first one seems more standard for me, PHP documentation [uses it in examples](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.strict). The second one is a bit more compact.

There is also a variation of the first format:
```php
<?php

declare(strict_types=1);

namespace Acme;

class Foo {}
```

There is additional empty line between opening tag and `declare` block.

This PR uses first format.

What do you think about this?
