### PR TITLE
Add scenario for handling php7 errors by throw matcher, minor simplifications

### DIFF
--- a/features/matchers/developer_uses_throw_matcher.feature
+++ b/features/matchers/developer_uses_throw_matcher.feature
@@ -213,3 +213,44 @@ Feature: Developer uses throw matcher
       """
     When I run phpspec
     Then the suite should pass
+
+  Scenario: Throw matcher supports Error
+    Given the spec file "spec/Runner/ThrowExample6/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\ThrowExample6;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_throws_error_during_division_by_zero()
+          {
+              $this->shouldThrow(new \DivisionByZeroError())->duringDivide(10, 0);
+          }
+      }
+
+      """
+    And the class file "src/Runner/ThrowExample6/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Runner\ThrowExample6;
+
+      class Calculator
+      {
+          public function divide(int $dividend, int $divider): float
+          {
+              if ($divider === 0) {
+                  throw new \DivisionByZeroError();
+              }
+
+              return $dividend / $divider;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -293,8 +293,6 @@ final class ThrowMatcher implements Matcher
         if (\is_object($arguments[0])) {
             if ($arguments[0] instanceof \Throwable) {
                 return $arguments[0];
-            } elseif ($arguments[0] instanceof \Exception) {
-                return $arguments[0];
             }
         }
 


### PR DESCRIPTION
I was looking through issues labeled with `quick-pick` and found #769
I've started work by adding a feature, and it passed without any code chances cause it was implemented in 9024e848. 
This scenario does not bring much value cause there is a spec for ThrowMatcher, but it should not hurt too.

Also exception argument type check is simplified a bit. 

Closes #769. It can be closed even without this PR merged, cause it was fixed previously.
