### PR TITLE
Avoid deprecated symfony/console method call in tests

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -49,12 +49,18 @@ class ApplicationContext implements Context
 
         $this->application = new Application('2.1-dev');
         $this->application->setAutoExit(false);
-        $this->application->setTerminalDimensions(130, 30);
+        $this->setFixedTerminalDimensions();
 
         $this->tester = new ApplicationTester($this->application);
 
         $this->setupReRunner();
         $this->setupPrompter();
+    }
+
+    private function setFixedTerminalDimensions()
+    {
+        putenv('COLUMNS=130');
+        putenv('LINES=30');
     }
 
     private function setupPrompter()


### PR DESCRIPTION
That method will be removed when `symfony/console` 4 will be released.

Closes #740 (the issue is already fixed, but now fix is compatible with `symfony/console` v4).

> The actual output should wrap better IMO

@ciaranmcnulty, I'm not sure if I understand that phrase. If you meant something else I can check if it can be improved.
