### PR TITLE
[RFC] Refactor default matchers into an extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,10 @@
     "autoload": {
         "psr-0": {
             "PhpSpec": "src/"
-        }
+        },
+        "files" : [
+            "src/deprecated.php"
+        ]
     },
 
     "autoload-dev": {

--- a/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\PhpSpec\Matcher;
 
-use PhpSpec\Factory\ReflectionFactory;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Wrapper\Unwrapper;
 use Prophecy\Argument;
@@ -11,12 +10,12 @@ use ArrayObject;
 
 class ThrowMatcherSpec extends ObjectBehavior
 {
-    function let(Unwrapper $unwrapper, Presenter $presenter, ReflectionFactory $factory)
+    function let(Unwrapper $unwrapper, Presenter $presenter)
     {
         $unwrapper->unwrapAll(Argument::any())->willReturnArgument();
         $presenter->presentValue(Argument::any())->willReturn('val1', 'val2');
 
-        $this->beConstructedWith($unwrapper, $presenter, $factory);
+        $this->beConstructedWith($unwrapper, $presenter);
     }
 
     function it_supports_the_throw_alias_for_object_and_exception_name()
@@ -38,11 +37,10 @@ class ThrowMatcherSpec extends ObjectBehavior
         $this->positiveMatch('throw', $arr, array('\Error'))->during('ksort', array());
     }
 
-    function it_accepts_a_method_during_which_an_error_specified_by_instance_should_be_thrown(ArrayObject $arr, ReflectionFactory $factory)
+    function it_accepts_a_method_during_which_an_error_specified_by_instance_should_be_thrown(ArrayObject $arr)
     {
         $error = new \Error();
         $arr->ksort()->will(function() use ($error) { throw $error; });
-        $factory->create(Argument::any())->willReturn(new \ReflectionClass($error));
 
         $this->positiveMatch('throw', $arr, array(new \Error()))->during('ksort', array());
     }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -23,12 +23,11 @@ use PhpSpec\Config\OptionsConfig;
 use PhpSpec\Console\Assembler\PresenterAssembler;
 use PhpSpec\Console\Prompter\Question;
 use PhpSpec\Console\Provider\NamespacesAutocompleteProvider;
-use PhpSpec\Factory\ReflectionFactory;
+use PhpSpec\Extensions\DefaultMatchers;
 use PhpSpec\Formatter as SpecFormatter;
 use PhpSpec\Listener;
 use PhpSpec\Loader;
 use PhpSpec\Locator;
-use PhpSpec\Matcher;
 use PhpSpec\Message\CurrentExampleTracker;
 use PhpSpec\NamespaceProvider\ComposerPsrNamespaceProvider;
 use PhpSpec\NamespaceProvider\NamespaceProvider;
@@ -57,6 +56,7 @@ final class ContainerAssembler
      */
     public function build(IndexedServiceContainer $container)
     {
+        $this->loadExtensions($container);
         $this->setupParameters($container);
         $this->setupIO($container);
         $this->setupEventDispatcher($container);
@@ -70,10 +70,20 @@ final class ContainerAssembler
         $this->setupCommands($container);
         $this->setupResultConverter($container);
         $this->setupRerunner($container);
-        $this->setupMatchers($container);
         $this->setupSubscribers($container);
         $this->setupCurrentExample($container);
         $this->setupShutdown($container);
+    }
+
+    private function loadExtensions(IndexedServiceContainer $container)
+    {
+        $extensions = [
+            new DefaultMatchers\Extension()
+        ];
+
+        foreach ($extensions as $extension) {
+            $extension->load($container, []);
+        }
     }
 
     private function setupParameters(IndexedServiceContainer $container)
@@ -689,82 +699,6 @@ final class ContainerAssembler
         $container->define('access_inspector.visibility', function () {
             return new VisibilityAccessInspector();
         });
-    }
-
-    /**
-     * @param IndexedServiceContainer $container
-     */
-    private function setupMatchers(IndexedServiceContainer $container)
-    {
-        $container->define('matchers.identity', function (IndexedServiceContainer $c) {
-            return new Matcher\IdentityMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.comparison', function (IndexedServiceContainer $c) {
-            return new Matcher\ComparisonMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.throwm', function (IndexedServiceContainer $c) {
-            return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
-        }, ['matchers']);
-        $container->define('matchers.trigger', function (IndexedServiceContainer $c) {
-            return new Matcher\TriggerMatcher($c->get('unwrapper'));
-        }, ['matchers']);
-        $container->define('matchers.type', function (IndexedServiceContainer $c) {
-            return new Matcher\TypeMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.object_state', function (IndexedServiceContainer $c) {
-            return new Matcher\ObjectStateMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.scalar', function (IndexedServiceContainer $c) {
-            return new Matcher\ScalarMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.array_count', function (IndexedServiceContainer $c) {
-            return new Matcher\ArrayCountMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.array_key', function (IndexedServiceContainer $c) {
-            return new Matcher\ArrayKeyMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.array_key_with_value', function (IndexedServiceContainer $c) {
-            return new Matcher\ArrayKeyValueMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.array_contain', function (IndexedServiceContainer $c) {
-            return new Matcher\ArrayContainMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.string_start', function (IndexedServiceContainer $c) {
-            return new Matcher\StringStartMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.string_end', function (IndexedServiceContainer $c) {
-            return new Matcher\StringEndMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.string_regex', function (IndexedServiceContainer $c) {
-            return new Matcher\StringRegexMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.string_contain', function (IndexedServiceContainer $c) {
-            return new Matcher\StringContainMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.traversable_count', function (IndexedServiceContainer $c) {
-            return new Matcher\TraversableCountMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.traversable_key', function (IndexedServiceContainer $c) {
-            return new Matcher\TraversableKeyMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.traversable_key_with_value', function (IndexedServiceContainer $c) {
-            return new Matcher\TraversableKeyValueMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.traversable_contain', function (IndexedServiceContainer $c) {
-            return new Matcher\TraversableContainMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.iterate', function (IndexedServiceContainer $c) {
-            return new Matcher\IterateAsMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.iterate_like', function (IndexedServiceContainer $c) {
-            return new Matcher\IterateLikeMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.start_iterating', function (IndexedServiceContainer $c) {
-            return new Matcher\StartIteratingAsMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.approximately', function (IndexedServiceContainer $c) {
-            return new Matcher\ApproximatelyMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
     }
 
     /**

--- a/src/PhpSpec/Extensions/DefaultMatchers/Extension.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Extension.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace PhpSpec\Extensions\DefaultMatchers;
+
+use PhpSpec\Factory\ReflectionFactory;
+use PhpSpec\Matcher;
+use PhpSpec\ServiceContainer;
+use PhpSpec\ServiceContainer\IndexedServiceContainer;
+
+class Extension implements \PhpSpec\Extension
+{
+    /**
+     * @param ServiceContainer $container
+     * @param array $params
+     */
+    public function load(ServiceContainer $container, array $params)
+    {
+        $container->define('matchers.identity', function (IndexedServiceContainer $c) {
+            return new Matcher\IdentityMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.comparison', function (IndexedServiceContainer $c) {
+            return new Matcher\ComparisonMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.throwm', function (IndexedServiceContainer $c) {
+            return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
+        }, ['matchers']);
+        $container->define('matchers.trigger', function (IndexedServiceContainer $c) {
+            return new Matcher\TriggerMatcher($c->get('unwrapper'));
+        }, ['matchers']);
+        $container->define('matchers.type', function (IndexedServiceContainer $c) {
+            return new Matcher\TypeMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.object_state', function (IndexedServiceContainer $c) {
+            return new Matcher\ObjectStateMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.scalar', function (IndexedServiceContainer $c) {
+            return new Matcher\ScalarMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.array_count', function (IndexedServiceContainer $c) {
+            return new Matcher\ArrayCountMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.array_key', function (IndexedServiceContainer $c) {
+            return new Matcher\ArrayKeyMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.array_key_with_value', function (IndexedServiceContainer $c) {
+            return new Matcher\ArrayKeyValueMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.array_contain', function (IndexedServiceContainer $c) {
+            return new Matcher\ArrayContainMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.string_start', function (IndexedServiceContainer $c) {
+            return new Matcher\StringStartMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.string_end', function (IndexedServiceContainer $c) {
+            return new Matcher\StringEndMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.string_regex', function (IndexedServiceContainer $c) {
+            return new Matcher\StringRegexMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.string_contain', function (IndexedServiceContainer $c) {
+            return new Matcher\StringContainMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.traversable_count', function (IndexedServiceContainer $c) {
+            return new Matcher\TraversableCountMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.traversable_key', function (IndexedServiceContainer $c) {
+            return new Matcher\TraversableKeyMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.traversable_key_with_value', function (IndexedServiceContainer $c) {
+            return new Matcher\TraversableKeyValueMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.traversable_contain', function (IndexedServiceContainer $c) {
+            return new Matcher\TraversableContainMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.iterate', function (IndexedServiceContainer $c) {
+            return new Matcher\IterateAsMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.iterate_like', function (IndexedServiceContainer $c) {
+            return new Matcher\IterateLikeMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.start_iterating', function (IndexedServiceContainer $c) {
+            return new Matcher\StartIteratingAsMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+        $container->define('matchers.approximately', function (IndexedServiceContainer $c) {
+            return new Matcher\ApproximatelyMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+    }
+}

--- a/src/PhpSpec/Extensions/DefaultMatchers/Extension.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Extension.php
@@ -2,7 +2,6 @@
 
 namespace PhpSpec\Extensions\DefaultMatchers;
 
-use PhpSpec\Factory\ReflectionFactory;
 use PhpSpec\Matcher;
 use PhpSpec\ServiceContainer;
 use PhpSpec\ServiceContainer\IndexedServiceContainer;
@@ -22,7 +21,7 @@ class Extension implements \PhpSpec\Extension
             return new Matcher\ComparisonMatcher($c->get('formatter.presenter'));
         }, ['matchers']);
         $container->define('matchers.throwm', function (IndexedServiceContainer $c) {
-            return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
+            return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'));
         }, ['matchers']);
         $container->define('matchers.trigger', function (IndexedServiceContainer $c) {
             return new Matcher\TriggerMatcher($c->get('unwrapper'));

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ApproximatelyMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ApproximatelyMatcher.php
@@ -11,14 +11,25 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
-use PhpSpec\Formatter\Presenter\Presenter;
-use PhpSpec\Exception\Example\NotEqualException;
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Exception\Example\NotEqualException;
+use PhpSpec\Formatter\Presenter\Presenter;
 
-final class ComparisonMatcher extends BasicMatcher
+final class ApproximatelyMatcher extends BasicMatcher
 {
+
+    /**
+     * @var array
+     */
+    private static $keywords = array(
+        'beApproximately',
+        'beEqualToApproximately',
+        'equalApproximately',
+        'returnApproximately'
+    );
+
     /**
      * @var Presenter
      */
@@ -34,16 +45,14 @@ final class ComparisonMatcher extends BasicMatcher
 
     /**
      * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
+     * @param mixed $subject
+     * @param array $arguments
      *
      * @return bool
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return 'beLike' === $name
-            && 1 == \count($arguments)
-        ;
+        return \in_array($name, self::$keywords) && 2 == \count($arguments);
     }
 
     /**
@@ -54,37 +63,28 @@ final class ComparisonMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        return $subject == $arguments[0];
+        $value = (float)$arguments[0];
+        return (abs($subject - $value) < $arguments[1]);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return NotEqualException
-     */
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
-    {
-        return new NotEqualException(sprintf(
-            'Expected %s, but got %s.',
-            $this->presenter->presentValue($arguments[0]),
-            $this->presenter->presentValue($subject)
-        ), $arguments[0], $subject);
-    }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, $subject, array $arguments) : FailureException
     {
         return new FailureException(sprintf(
-            'Did not expect %s, but got one.',
+            'Expected an approximated value of %s, but got %s',
+            $this->presenter->presentValue($arguments[0]),
             $this->presenter->presentValue($subject)
         ));
     }
+
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    {
+        return new FailureException(sprintf(
+            'Did Not expect an approximated value of %s, but got %s',
+            $this->presenter->presentValue($arguments[0]),
+            $this->presenter->presentValue($subject)
+        ));
+    }
+
+
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ArrayContainMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ArrayContainMatcher.php
@@ -11,12 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
 
-final class ArrayCountMatcher extends BasicMatcher
+final class ArrayContainMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -40,9 +40,9 @@ final class ArrayCountMatcher extends BasicMatcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return 'haveCount' === $name
+        return 'contain' === $name
             && 1 == \count($arguments)
-            && (\is_array($subject) || $subject instanceof \Countable)
+            && \is_array($subject)
         ;
     }
 
@@ -54,7 +54,7 @@ final class ArrayCountMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        return $arguments[0] === \count($subject);
+        return \in_array($arguments[0], $subject, true);
     }
 
     /**
@@ -67,10 +67,9 @@ final class ArrayCountMatcher extends BasicMatcher
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s to have %s items, but got %s.',
+            'Expected %s to contain %s, but it does not.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentString(\intval($arguments[0])),
-            $this->presenter->presentString(\count($subject))
+            $this->presenter->presentValue($arguments[0])
         ));
     }
 
@@ -84,9 +83,9 @@ final class ArrayCountMatcher extends BasicMatcher
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s not to have %s items, but got it.',
+            'Expected %s not to contain %s, but it does.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentString(\intval($arguments[0]))
+            $this->presenter->presentValue($arguments[0])
         ));
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ArrayCountMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ArrayCountMatcher.php
@@ -11,12 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
-use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Exception\Example\FailureException;
 
-final class TraversableContainMatcher extends BasicMatcher
+final class ArrayCountMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -32,51 +32,61 @@ final class TraversableContainMatcher extends BasicMatcher
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return bool
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return 'contain' === $name
-            && 1 === \count($arguments)
-            && $subject instanceof \Traversable
+        return 'haveCount' === $name
+            && 1 == \count($arguments)
+            && (\is_array($subject) || $subject instanceof \Countable)
         ;
     }
 
     /**
-     * {@inheritdoc}
+     * @param mixed $subject
+     * @param array $arguments
+     *
+     * @return bool
      */
     protected function matches($subject, array $arguments): bool
     {
-        foreach ($subject as $value) {
-            if ($value === $arguments[0]) {
-                return true;
-            }
-        }
-
-        return false;
+        return $arguments[0] === \count($subject);
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s to contain %s, but it does not.',
+            'Expected %s to have %s items, but got %s.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentValue($arguments[0])
+            $this->presenter->presentString(\intval($arguments[0])),
+            $this->presenter->presentString(\count($subject))
         ));
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
      */
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s not to contain %s, but it does.',
+            'Expected %s not to have %s items, but got it.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentValue($arguments[0])
+            $this->presenter->presentString(\intval($arguments[0]))
         ));
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ArrayKeyMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ArrayKeyMatcher.php
@@ -11,13 +11,13 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
-use ArrayAccess;
-use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Exception\Example\FailureException;
+use ArrayAccess;
 
-final class ArrayKeyValueMatcher extends BasicMatcher
+final class ArrayKeyMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -41,15 +41,14 @@ final class ArrayKeyValueMatcher extends BasicMatcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return
-            (\is_array($subject) || $subject instanceof \ArrayAccess) &&
-            'haveKeyWithValue' === $name &&
-            2 == \count($arguments)
+        return 'haveKey' === $name
+            && 1 == \count($arguments)
+            && (\is_array($subject) || $subject instanceof ArrayAccess)
         ;
     }
 
     /**
-     * @param ArrayAccess|array $subject
+     * @param mixed $subject
      * @param array $arguments
      *
      * @return bool
@@ -57,13 +56,12 @@ final class ArrayKeyValueMatcher extends BasicMatcher
     protected function matches($subject, array $arguments): bool
     {
         $key = $arguments[0];
-        $value  = $arguments[1];
 
         if ($subject instanceof ArrayAccess) {
-            return $subject->offsetExists($key) && $subject->offsetGet($key) === $value;
+            return $subject->offsetExists($key);
         }
 
-        return (isset($subject[$key]) || array_key_exists($arguments[0], $subject)) && $subject[$key] === $value;
+        return isset($subject[$key]) || array_key_exists($arguments[0], $subject);
     }
 
     /**
@@ -75,21 +73,10 @@ final class ArrayKeyValueMatcher extends BasicMatcher
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
-        $key = $arguments[0];
-
-        if (!$this->offsetExists($key, $subject)) {
-            return new FailureException(sprintf('Expected %s to have key %s, but it didn\'t.',
-                $this->presenter->presentValue($subject),
-                $this->presenter->presentString($key)
-            ));
-        }
-
         return new FailureException(sprintf(
-            'Expected %s to have value %s for %s key, but found %s.',
+            'Expected %s to have %s key, but it does not.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentValue($arguments[1]),
-            $this->presenter->presentString($key),
-            $this->presenter->presentValue($subject[$key])
+            $this->presenter->presentString($arguments[0])
         ));
     }
 
@@ -107,10 +94,5 @@ final class ArrayKeyValueMatcher extends BasicMatcher
             $this->presenter->presentValue($subject),
             $this->presenter->presentString($arguments[0])
         ));
-    }
-
-    private function offsetExists($key, $subject)
-    {
-        return ($subject instanceof ArrayAccess && $subject->offsetExists($key)) || array_key_exists($key, $subject);
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ArrayKeyValueMatcher.php
@@ -11,13 +11,13 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
-use PhpSpec\Formatter\Presenter\Presenter;
-use PhpSpec\Exception\Example\FailureException;
 use ArrayAccess;
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\Presenter;
 
-final class ArrayKeyMatcher extends BasicMatcher
+final class ArrayKeyValueMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -41,14 +41,15 @@ final class ArrayKeyMatcher extends BasicMatcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return 'haveKey' === $name
-            && 1 == \count($arguments)
-            && (\is_array($subject) || $subject instanceof ArrayAccess)
+        return
+            (\is_array($subject) || $subject instanceof \ArrayAccess) &&
+            'haveKeyWithValue' === $name &&
+            2 == \count($arguments)
         ;
     }
 
     /**
-     * @param mixed $subject
+     * @param ArrayAccess|array $subject
      * @param array $arguments
      *
      * @return bool
@@ -56,12 +57,13 @@ final class ArrayKeyMatcher extends BasicMatcher
     protected function matches($subject, array $arguments): bool
     {
         $key = $arguments[0];
+        $value  = $arguments[1];
 
         if ($subject instanceof ArrayAccess) {
-            return $subject->offsetExists($key);
+            return $subject->offsetExists($key) && $subject->offsetGet($key) === $value;
         }
 
-        return isset($subject[$key]) || array_key_exists($arguments[0], $subject);
+        return (isset($subject[$key]) || array_key_exists($arguments[0], $subject)) && $subject[$key] === $value;
     }
 
     /**
@@ -73,10 +75,21 @@ final class ArrayKeyMatcher extends BasicMatcher
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
+        $key = $arguments[0];
+
+        if (!$this->offsetExists($key, $subject)) {
+            return new FailureException(sprintf('Expected %s to have key %s, but it didn\'t.',
+                $this->presenter->presentValue($subject),
+                $this->presenter->presentString($key)
+            ));
+        }
+
         return new FailureException(sprintf(
-            'Expected %s to have %s key, but it does not.',
+            'Expected %s to have value %s for %s key, but found %s.',
             $this->presenter->presentValue($subject),
-            $this->presenter->presentString($arguments[0])
+            $this->presenter->presentValue($arguments[1]),
+            $this->presenter->presentString($key),
+            $this->presenter->presentValue($subject[$key])
         ));
     }
 
@@ -94,5 +107,10 @@ final class ArrayKeyMatcher extends BasicMatcher
             $this->presenter->presentValue($subject),
             $this->presenter->presentString($arguments[0])
         ));
+    }
+
+    private function offsetExists($key, $subject)
+    {
+        return ($subject instanceof ArrayAccess && $subject->offsetExists($key)) || array_key_exists($key, $subject);
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/BasicMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/BasicMatcher.php
@@ -11,9 +11,10 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Matcher\Matcher;
 
 abstract class BasicMatcher implements Matcher
 {

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ComparisonMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ComparisonMatcher.php
@@ -11,12 +11,13 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Exception\Example\NotEqualException;
 use PhpSpec\Exception\Example\FailureException;
 
-final class StringRegexMatcher extends BasicMatcher
+final class ComparisonMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -40,8 +41,7 @@ final class StringRegexMatcher extends BasicMatcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return 'match' === $name
-            && \is_string($subject)
+        return 'beLike' === $name
             && 1 == \count($arguments)
         ;
     }
@@ -54,7 +54,7 @@ final class StringRegexMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        return (Boolean) preg_match($arguments[0], $subject);
+        return $subject == $arguments[0];
     }
 
     /**
@@ -62,15 +62,15 @@ final class StringRegexMatcher extends BasicMatcher
      * @param mixed  $subject
      * @param array  $arguments
      *
-     * @return FailureException
+     * @return NotEqualException
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
-        return new FailureException(sprintf(
-            'Expected %s to match %s regex, but it does not.',
-            $this->presenter->presentString($subject),
-            $this->presenter->presentString($arguments[0])
-        ));
+        return new NotEqualException(sprintf(
+            'Expected %s, but got %s.',
+            $this->presenter->presentValue($arguments[0]),
+            $this->presenter->presentValue($subject)
+        ), $arguments[0], $subject);
     }
 
     /**
@@ -83,9 +83,8 @@ final class StringRegexMatcher extends BasicMatcher
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s not to match %s regex, but it does.',
-            $this->presenter->presentString($subject),
-            $this->presenter->presentString($arguments[0])
+            'Did not expect %s, but got one.',
+            $this->presenter->presentValue($subject)
         ));
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/Iterate/IterablesMatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpSpec\Matcher\Iterate;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/Iterate/SubjectElementDoesNotMatchException.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/Iterate/SubjectElementDoesNotMatchException.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher\Iterate;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate;
 
 use PhpSpec\Exception\Example\FailureException;
 

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/Iterate/SubjectHasFewerElementsException.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/Iterate/SubjectHasFewerElementsException.php
@@ -11,12 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher\Iterate;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate;
 
-class SubjectHasMoreElementsException extends \LengthException
+class SubjectHasFewerElementsException extends \LengthException
 {
     public function __construct()
     {
-        parent::__construct('Subject has more elements than expected.');
+        parent::__construct('Subject has fewer elements than expected.');
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/Iterate/SubjectHasMoreElementsException.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/Iterate/SubjectHasMoreElementsException.php
@@ -11,12 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher\Iterate;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate;
 
-class SubjectHasFewerElementsException extends \LengthException
+class SubjectHasMoreElementsException extends \LengthException
 {
     public function __construct()
     {
-        parent::__construct('Subject has fewer elements than expected.');
+        parent::__construct('Subject has more elements than expected.');
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/IterateAsMatcher.php
@@ -11,13 +11,14 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
+use PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate\IterablesMatcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
-use PhpSpec\Matcher\Iterate\IterablesMatcher;
+use PhpSpec\Matcher\Matcher;
 
-final class StartIteratingAsMatcher implements Matcher
+final class IterateAsMatcher implements Matcher
 {
     /**
      * @var IterablesMatcher
@@ -37,7 +38,7 @@ final class StartIteratingAsMatcher implements Matcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return \in_array($name, ['startIteratingAs', 'startYielding'])
+        return \in_array($name, ['iterateAs', 'yield'])
             && 1 === \count($arguments)
             && ($subject instanceof \Traversable || \is_array($subject))
             && ($arguments[0] instanceof \Traversable || \is_array($arguments[0]))
@@ -51,10 +52,10 @@ final class StartIteratingAsMatcher implements Matcher
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0]);
-        } catch (Iterate\SubjectHasMoreElementsException $exception) {
-            // everything's all right
         } catch (Iterate\SubjectHasFewerElementsException $exception) {
-            throw new FailureException('Expected subject to have the same or more elements than matched value, but it has fewer.', 0, $exception);
+            throw new FailureException('Expected subject to have the same number of elements than matched value, but it has fewer.', 0, $exception);
+        } catch (Iterate\SubjectHasMoreElementsException $exception) {
+            throw new FailureException('Expected subject to have the same number of elements than matched value, but it has more.', 0, $exception);
         }
     }
 
@@ -69,7 +70,7 @@ final class StartIteratingAsMatcher implements Matcher
             return;
         }
 
-        throw new FailureException('Expected subject not to start iterating the same as matched value, but it does.');
+        throw new FailureException('Expected subject not to iterate the same as matched value, but it does.');
     }
 
     /**

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/IterateLikeMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/IterateLikeMatcher.php
@@ -11,11 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
+use PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate\IterablesMatcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
-use PhpSpec\Matcher\Iterate\IterablesMatcher;
+use PhpSpec\Matcher\Matcher;
 
 final class IterateLikeMatcher implements Matcher
 {

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ObjectStateMatcher.php
@@ -11,11 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Fracture\MethodNotFoundException;
+use PhpSpec\Matcher\Matcher;
 
 final class ObjectStateMatcher implements Matcher
 {

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ScalarMatcher.php
@@ -11,10 +11,11 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Matcher\Matcher;
 
 final class ScalarMatcher implements Matcher
 {

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StartIteratingAsMatcher.php
@@ -11,13 +11,14 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
+use PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate\IterablesMatcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
-use PhpSpec\Matcher\Iterate\IterablesMatcher;
+use PhpSpec\Matcher\Matcher;
 
-final class IterateAsMatcher implements Matcher
+final class StartIteratingAsMatcher implements Matcher
 {
     /**
      * @var IterablesMatcher
@@ -37,7 +38,7 @@ final class IterateAsMatcher implements Matcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return \in_array($name, ['iterateAs', 'yield'])
+        return \in_array($name, ['startIteratingAs', 'startYielding'])
             && 1 === \count($arguments)
             && ($subject instanceof \Traversable || \is_array($subject))
             && ($arguments[0] instanceof \Traversable || \is_array($arguments[0]))
@@ -51,10 +52,10 @@ final class IterateAsMatcher implements Matcher
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0]);
-        } catch (Iterate\SubjectHasFewerElementsException $exception) {
-            throw new FailureException('Expected subject to have the same number of elements than matched value, but it has fewer.', 0, $exception);
         } catch (Iterate\SubjectHasMoreElementsException $exception) {
-            throw new FailureException('Expected subject to have the same number of elements than matched value, but it has more.', 0, $exception);
+            // everything's all right
+        } catch (Iterate\SubjectHasFewerElementsException $exception) {
+            throw new FailureException('Expected subject to have the same or more elements than matched value, but it has fewer.', 0, $exception);
         }
     }
 
@@ -69,7 +70,7 @@ final class IterateAsMatcher implements Matcher
             return;
         }
 
-        throw new FailureException('Expected subject not to iterate the same as matched value, but it does.');
+        throw new FailureException('Expected subject not to start iterating the same as matched value, but it does.');
     }
 
     /**

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StringContainMatcher.php
@@ -11,12 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
-use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\Presenter;
 
-final class StringEndMatcher extends BasicMatcher
+final class StringContainMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -32,58 +32,43 @@ final class StringEndMatcher extends BasicMatcher
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, $subject, array $arguments) : bool
     {
-        return 'endWith' === $name
+        return 'contain' === $name
             && \is_string($subject)
-            && 1 == \count($arguments)
-        ;
+            && 1 === \count($arguments)
+            && \is_string($arguments[0]);
     }
 
     /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    protected function matches($subject, array $arguments): bool
+    protected function matches($subject, array $arguments) : bool
     {
-        return $arguments[0] === substr($subject, 0 - \strlen($arguments[0]));
+        return false !== strpos($subject, $arguments[0]);
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
+     * {@inheritdoc}
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s to end with %s, but it does not.',
+            'Expected %s to contain %s, but it does not.',
             $this->presenter->presentString($subject),
             $this->presenter->presentString($arguments[0])
         ));
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
+     * {@inheritdoc}
      */
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s not to end with %s, but it does.',
+            'Expected %s not to contain %s, but it does.',
             $this->presenter->presentString($subject),
             $this->presenter->presentString($arguments[0])
         ));

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StringEndMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StringEndMatcher.php
@@ -11,25 +11,13 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
-use PhpSpec\Exception\Example\FailureException;
-use PhpSpec\Exception\Example\NotEqualException;
 use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Exception\Example\FailureException;
 
-final class ApproximatelyMatcher extends BasicMatcher
+final class StringEndMatcher extends BasicMatcher
 {
-
-    /**
-     * @var array
-     */
-    private static $keywords = array(
-        'beApproximately',
-        'beEqualToApproximately',
-        'equalApproximately',
-        'returnApproximately'
-    );
-
     /**
      * @var Presenter
      */
@@ -45,14 +33,17 @@ final class ApproximatelyMatcher extends BasicMatcher
 
     /**
      * @param string $name
-     * @param mixed $subject
-     * @param array $arguments
+     * @param mixed  $subject
+     * @param array  $arguments
      *
      * @return bool
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return \in_array($name, self::$keywords) && 2 == \count($arguments);
+        return 'endWith' === $name
+            && \is_string($subject)
+            && 1 == \count($arguments)
+        ;
     }
 
     /**
@@ -63,28 +54,38 @@ final class ApproximatelyMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        $value = (float)$arguments[0];
-        return (abs($subject - $value) < $arguments[1]);
+        return $arguments[0] === substr($subject, 0 - \strlen($arguments[0]));
     }
 
-
-    protected function getFailureException(string $name, $subject, array $arguments) : FailureException
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
+     */
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected an approximated value of %s, but got %s',
-            $this->presenter->presentValue($arguments[0]),
-            $this->presenter->presentValue($subject)
+            'Expected %s to end with %s, but it does not.',
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
         ));
     }
 
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
+     */
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Did Not expect an approximated value of %s, but got %s',
-            $this->presenter->presentValue($arguments[0]),
-            $this->presenter->presentValue($subject)
+            'Expected %s not to end with %s, but it does.',
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
         ));
     }
-
-
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StringRegexMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StringRegexMatcher.php
@@ -11,22 +11,13 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
 
-final class TypeMatcher extends BasicMatcher
+final class StringRegexMatcher extends BasicMatcher
 {
-    /**
-     * @var array
-     */
-    private static $keywords = array(
-        'beAnInstanceOf',
-        'returnAnInstanceOf',
-        'haveType',
-        'implement'
-    );
     /**
      * @var Presenter
      */
@@ -49,7 +40,8 @@ final class TypeMatcher extends BasicMatcher
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return \in_array($name, self::$keywords)
+        return 'match' === $name
+            && \is_string($subject)
             && 1 == \count($arguments)
         ;
     }
@@ -62,7 +54,7 @@ final class TypeMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        return (null !== $subject) && ($subject instanceof $arguments[0]);
+        return (Boolean) preg_match($arguments[0], $subject);
     }
 
     /**
@@ -75,9 +67,9 @@ final class TypeMatcher extends BasicMatcher
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected an instance of %s, but got %s.',
-            $this->presenter->presentString($arguments[0]),
-            $this->presenter->presentValue($subject)
+            'Expected %s to match %s regex, but it does not.',
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
         ));
     }
 
@@ -91,9 +83,9 @@ final class TypeMatcher extends BasicMatcher
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Did not expect instance of %s, but got %s.',
-            $this->presenter->presentString($arguments[0]),
-            $this->presenter->presentValue($subject)
+            'Expected %s not to match %s regex, but it does.',
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
         ));
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StringStartMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/StringStartMatcher.php
@@ -11,13 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
-use ArrayAccess;
 
-final class TraversableKeyMatcher extends BasicMatcher
+final class StringStartMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -33,51 +32,60 @@ final class TraversableKeyMatcher extends BasicMatcher
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return bool
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return 'haveKey' === $name
-            && 1 === \count($arguments)
-            && $subject instanceof \Traversable
+        return 'startWith' === $name
+            && \is_string($subject)
+            && 1 == \count($arguments)
         ;
     }
 
     /**
-     * {@inheritdoc}
+     * @param mixed $subject
+     * @param array $arguments
+     *
+     * @return bool
      */
     protected function matches($subject, array $arguments): bool
     {
-        foreach ($subject as $key => $value) {
-            if ($key === $arguments[0]) {
-                return true;
-            }
-        }
-
-        return false;
+        return 0 === strpos($subject, $arguments[0]);
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s to have %s key, but it does not.',
-            $this->presenter->presentValue($subject),
-            $this->presenter->presentValue($arguments[0])
+            'Expected %s to start with %s, but it does not.',
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
         ));
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
      */
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s not to have %s key, but it does.',
-            $this->presenter->presentValue($subject),
-            $this->presenter->presentValue($arguments[0])
+            'Expected %s not to start with %s, but it does.',
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
         ));
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/ThrowMatcher.php
@@ -11,12 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Matcher\Matcher;
 use PhpSpec\Wrapper\Unwrapper;
 use PhpSpec\Wrapper\DelayedCall;
-use PhpSpec\Factory\ReflectionFactory;
 use PhpSpec\Exception\Example\MatcherException;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Example\NotEqualException;

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TraversableContainMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TraversableContainMatcher.php
@@ -11,12 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
-use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\Presenter;
 
-final class StringStartMatcher extends BasicMatcher
+final class TraversableContainMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -32,60 +32,51 @@ final class StringStartMatcher extends BasicMatcher
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
-        return 'startWith' === $name
-            && \is_string($subject)
-            && 1 == \count($arguments)
+        return 'contain' === $name
+            && 1 === \count($arguments)
+            && $subject instanceof \Traversable
         ;
     }
 
     /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     protected function matches($subject, array $arguments): bool
     {
-        return 0 === strpos($subject, $arguments[0]);
+        foreach ($subject as $value) {
+            if ($value === $arguments[0]) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
+     * {@inheritdoc}
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s to start with %s, but it does not.',
-            $this->presenter->presentString($subject),
-            $this->presenter->presentString($arguments[0])
+            'Expected %s to contain %s, but it does not.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($arguments[0])
         ));
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
+     * {@inheritdoc}
      */
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s not to start with %s, but it does.',
-            $this->presenter->presentString($subject),
-            $this->presenter->presentString($arguments[0])
+            'Expected %s not to contain %s, but it does.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($arguments[0])
         ));
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TraversableCountMatcher.php
@@ -11,10 +11,11 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Matcher\Matcher;
 
 final class TraversableCountMatcher implements Matcher
 {

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TraversableKeyMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TraversableKeyMatcher.php
@@ -11,12 +11,13 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
-use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Exception\Example\FailureException;
+use ArrayAccess;
 
-final class StringContainMatcher extends BasicMatcher
+final class TraversableKeyMatcher extends BasicMatcher
 {
     /**
      * @var Presenter
@@ -34,20 +35,26 @@ final class StringContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    public function supports(string $name, $subject, array $arguments) : bool
+    public function supports(string $name, $subject, array $arguments): bool
     {
-        return 'contain' === $name
-            && \is_string($subject)
+        return 'haveKey' === $name
             && 1 === \count($arguments)
-            && \is_string($arguments[0]);
+            && $subject instanceof \Traversable
+        ;
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function matches($subject, array $arguments) : bool
+    protected function matches($subject, array $arguments): bool
     {
-        return false !== strpos($subject, $arguments[0]);
+        foreach ($subject as $key => $value) {
+            if ($key === $arguments[0]) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -56,9 +63,9 @@ final class StringContainMatcher extends BasicMatcher
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s to contain %s, but it does not.',
-            $this->presenter->presentString($subject),
-            $this->presenter->presentString($arguments[0])
+            'Expected %s to have %s key, but it does not.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($arguments[0])
         ));
     }
 
@@ -68,9 +75,9 @@ final class StringContainMatcher extends BasicMatcher
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Expected %s not to contain %s, but it does.',
-            $this->presenter->presentString($subject),
-            $this->presenter->presentString($arguments[0])
+            'Expected %s not to have %s key, but it does.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($arguments[0])
         ));
     }
 }

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TraversableKeyValueMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TraversableKeyValueMatcher.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TriggerMatcher.php
@@ -11,8 +11,9 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
+use PhpSpec\Matcher\Matcher;
 use PhpSpec\Wrapper\Unwrapper;
 use PhpSpec\Wrapper\DelayedCall;
 use PhpSpec\Exception\Example\FailureException;

--- a/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TypeMatcher.php
+++ b/src/PhpSpec/Extensions/DefaultMatchers/Matcher/TypeMatcher.php
@@ -11,22 +11,21 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpSpec\Matcher;
+namespace PhpSpec\Extensions\DefaultMatchers\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
-use PhpSpec\Exception\Example\NotEqualException;
 
-final class IdentityMatcher extends BasicMatcher
+final class TypeMatcher extends BasicMatcher
 {
     /**
      * @var array
      */
     private static $keywords = array(
-        'return',
-        'be',
-        'equal',
-        'beEqualTo'
+        'beAnInstanceOf',
+        'returnAnInstanceOf',
+        'haveType',
+        'implement'
     );
     /**
      * @var Presenter
@@ -63,7 +62,7 @@ final class IdentityMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        return $subject === $arguments[0];
+        return (null !== $subject) && ($subject instanceof $arguments[0]);
     }
 
     /**
@@ -75,11 +74,11 @@ final class IdentityMatcher extends BasicMatcher
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
-        return new NotEqualException(sprintf(
-            'Expected %s, but got %s.',
-            $this->presenter->presentValue($arguments[0]),
+        return new FailureException(sprintf(
+            'Expected an instance of %s, but got %s.',
+            $this->presenter->presentString($arguments[0]),
             $this->presenter->presentValue($subject)
-        ), $arguments[0], $subject);
+        ));
     }
 
     /**
@@ -92,7 +91,8 @@ final class IdentityMatcher extends BasicMatcher
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
-            'Did not expect %s, but got one.',
+            'Did not expect instance of %s, but got %s.',
+            $this->presenter->presentString($arguments[0]),
             $this->presenter->presentValue($subject)
         ));
     }

--- a/src/PhpSpec/Factory/ReflectionFactory.php
+++ b/src/PhpSpec/Factory/ReflectionFactory.php
@@ -16,6 +16,8 @@ namespace PhpSpec\Factory;
 /**
  * Class ReflectionFactory is a simple factory wrapper to create reflection
  * classes
+ *
+ * @deprecated
  */
 class ReflectionFactory
 {

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -40,20 +40,13 @@ final class ThrowMatcher implements Matcher
     private $presenter;
 
     /**
-     * @var ReflectionFactory
-     */
-    private $factory;
-
-    /**
      * @param Unwrapper              $unwrapper
      * @param Presenter              $presenter
-     * @param ReflectionFactory|null $factory
      */
-    public function __construct(Unwrapper $unwrapper, Presenter $presenter, ReflectionFactory $factory)
+    public function __construct(Unwrapper $unwrapper, Presenter $presenter)
     {
         $this->unwrapper = $unwrapper;
         $this->presenter = $presenter;
-        $this->factory   = $factory;
     }
 
     /**
@@ -138,7 +131,7 @@ final class ThrowMatcher implements Matcher
         }
 
         if (\is_object($exception)) {
-            $exceptionRefl = $this->factory->create($exception);
+            $exceptionRefl = new \ReflectionClass($exception);
             foreach ($exceptionRefl->getProperties() as $property) {
                 if (\in_array($property->getName(), self::$ignoredProperties, true)) {
                     continue;
@@ -193,7 +186,7 @@ final class ThrowMatcher implements Matcher
         if ($exceptionThrown && $exceptionThrown instanceof $exception) {
             $invalidProperties = array();
             if (\is_object($exception)) {
-                $exceptionRefl = $this->factory->create($exception);
+                $exceptionRefl = new \ReflectionClass($exception);
                 foreach ($exceptionRefl->getProperties() as $property) {
                     if (\in_array($property->getName(), self::$ignoredProperties, true)) {
                         continue;

--- a/src/deprecated.php
+++ b/src/deprecated.php
@@ -1,0 +1,41 @@
+<?php
+
+spl_autoload_register(function ($class) {
+
+    $deprecatedClasses = [
+        'PhpSpec\Matcher\ApproximatelyMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ApproximatelyMatcher',
+        'PhpSpec\Matcher\ArrayContainMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ArrayContainMatcher',
+        'PhpSpec\Matcher\ArrayCountMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ArrayCountMatcher',
+        'PhpSpec\Matcher\ArrayKeyMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ArrayKeyMatcher',
+        'PhpSpec\Matcher\ArrayKeyValueMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ArrayKeyValueMatcher',
+        'PhpSpec\Matcher\BasicMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\BasicMatcher',
+        'PhpSpec\Matcher\CallbackMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\CallbackMatcher',
+        'PhpSpec\Matcher\ComparisonMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ComparisonMatcher',
+        'PhpSpec\Matcher\IdentityMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\IdentityMatcher',
+        'PhpSpec\Matcher\Iterate\IterablesMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate\IterablesMatcher',
+        'PhpSpec\Matcher\Iterate\SubjectElementDoesNotMatchException' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate\SubjectElementDoesNotMatchException',
+        'PhpSpec\Matcher\Iterate\SubjectHasFewerElementsException' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate\SubjectHasFewerElementsException',
+        'PhpSpec\Matcher\Iterate\SubjectHasMoreElementsException' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\Iterate\SubjectHasMoreElementsException',
+        'PhpSpec\Matcher\IterateAsMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\IterateAsMatcher',
+        'PhpSpec\Matcher\IterateLikeMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\IterateLikeMatcher',
+        'PhpSpec\Matcher\ObjectStateMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ObjectStateMatcher',
+        'PhpSpec\Matcher\ScalarMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ScalarMatcher',
+        'PhpSpec\Matcher\StartIteratingAsMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\StartIteratingAsMatcher',
+        'PhpSpec\Matcher\StringContainMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\StringContainMatcher',
+        'PhpSpec\Matcher\StringEndMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\StringEndMatcher',
+        'PhpSpec\Matcher\StringRegexMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\StringRegexMatcher',
+        'PhpSpec\Matcher\StringStartMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\StringStartMatcher',
+        'PhpSpec\Matcher\ThrowMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\ThrowMatcher',
+        'PhpSpec\Matcher\TraversableContainMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\TraversableContainMatcher',
+        'PhpSpec\Matcher\TraversableCountMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\TraversableCountMatcher',
+        'PhpSpec\Matcher\TraversableKeyMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\TraversableKeyMatcher',
+        'PhpSpec\Matcher\TraversableKeyValueMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\TraversableKeyValueMatcher',
+        'PhpSpec\Matcher\TriggerMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\TriggerMatcher',
+        'PhpSpec\Matcher\TypeMatcher' => 'PhpSpec\Extensions\DefaultMatchers\Matcher\TypeMatcher',
+    ];
+    
+    if (array_key_exists($class, $deprecatedClasses)) {
+        $new = $deprecatedClasses[$class];
+        class_alias($new, $class);
+    }
+});


### PR DESCRIPTION
I want to start decomposing the *Assembler objects into internal extensions and this seemed like a good place to start.

The idea will be to take things like the prophecy integration, the symfony console, etc and end up with a stack of core extensions, similar to behat. 

An end goal may be to decouple into separate repos