### PR TITLE
Remove unnecessary skips

### DIFF
--- a/spec/PhpSpec/Exception/ErrorExceptionSpec.php
+++ b/spec/PhpSpec/Exception/ErrorExceptionSpec.php
@@ -2,8 +2,6 @@
 
 namespace spec\PhpSpec\Exception;
 
-use PhpSpec\Exception\ErrorException;
-use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -13,10 +11,6 @@ class ErrorExceptionSpec extends ObjectBehavior
 
     function let()
     {
-        if (!class_exists('\Error')) {
-            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
-        }
-
         $this->beConstructedWith($this->error = new \Error('This is an error', 42));
     }
 

--- a/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\Exception\ErrorException;
-use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -27,10 +26,6 @@ class BaseExceptionTypePresenterSpec extends ObjectBehavior
 
     function it_should_present_an_error_as_a_string()
     {
-        if (!class_exists('\Error')) {
-            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
-        }
-
         $this->present(new ErrorException(new \Error('foo')))
             ->shouldReturn('[err:Error("foo")]');
     }

--- a/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
@@ -7,7 +7,6 @@ use PhpSpec\ObjectBehavior;
 use PhpSpec\Wrapper\Unwrapper;
 use Prophecy\Argument;
 use PhpSpec\Formatter\Presenter\Presenter;
-use PhpSpec\Exception\Example\SkippingException;
 use ArrayObject;
 
 class ThrowMatcherSpec extends ObjectBehavior
@@ -34,10 +33,6 @@ class ThrowMatcherSpec extends ObjectBehavior
 
     function it_accepts_a_method_during_which_an_error_specified_by_class_name_should_be_thrown(ArrayObject $arr)
     {
-        if (!class_exists('\Error')) {
-            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
-        }
-
         $arr->ksort()->willThrow('\Error');
 
         $this->positiveMatch('throw', $arr, array('\Error'))->during('ksort', array());
@@ -45,10 +40,6 @@ class ThrowMatcherSpec extends ObjectBehavior
 
     function it_accepts_a_method_during_which_an_error_specified_by_instance_should_be_thrown(ArrayObject $arr, ReflectionFactory $factory)
     {
-        if (!class_exists('\Error')) {
-            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
-        }
-
         $error = new \Error();
         $arr->ksort()->will(function() use ($error) { throw $error; });
         $factory->create(Argument::any())->willReturn(new \ReflectionClass($error));
@@ -63,19 +54,11 @@ class ThrowMatcherSpec extends ObjectBehavior
 
     function it_accepts_a_method_during_which_an_error_should_not_be_thrown(ArrayObject $arr)
     {
-        if (!class_exists('\Error')) {
-            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
-        }
-
-        $this->negativeMatch('throw', $arr, array('\Error'))->during('ksort', array());
+       $this->negativeMatch('throw', $arr, array('\Error'))->during('ksort', array());
     }
 
     function it_throws_a_failure_exception_with_the_thrown_exceptions_message_if_a_positive_match_failed(Presenter $presenter)
     {
-        if (!class_exists('\Error')) {
-            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
-        }
-
         $actually_thrown_error = new \Error('This is a test Error');
 
         $callable = function () use ($actually_thrown_error) { throw $actually_thrown_error; };

--- a/spec/PhpSpec/Matcher/TriggerMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/TriggerMatcherSpec.php
@@ -2,12 +2,9 @@
 
 namespace spec\PhpSpec\Matcher;
 
-use PhpSpec\Factory\ReflectionFactory;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Wrapper\Unwrapper;
 use Prophecy\Argument;
-use PhpSpec\Formatter\Presenter\Presenter;
-use PhpSpec\Exception\Example\SkippingException;
 use ArrayObject;
 
 class TriggerMatcherSpec extends ObjectBehavior

--- a/spec/PhpSpec/Runner/ExampleRunnerSpec.php
+++ b/spec/PhpSpec/Runner/ExampleRunnerSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\PhpSpec\Runner;
 
-use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Runner\Maintainer\LetAndLetgoMaintainer;
 use Prophecy\Argument;
@@ -93,10 +92,6 @@ class ExampleRunnerSpec extends ObjectBehavior
         EventDispatcherInterface $dispatcher,
         ExampleNode $example, ReflectionMethod $exampReflection, Specification $context
     ) {
-        if (!class_exists('\Error')) {
-            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
-        }
-
         $example->isPending()->willReturn(false);
 
         $exampReflection->getParameters()->willReturn(array());

--- a/spec/PhpSpec/Util/MethodAnalyserSpec.php
+++ b/spec/PhpSpec/Util/MethodAnalyserSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\PhpSpec\Util;
 
-use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 


### PR DESCRIPTION
We no longer need to detect PHP7 features in the test suite