### PR TITLE
Added Symfony 4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
         "phpspec/prophecy":         "^1.5",
         "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "^1.0 || ^2.0 || ^3.0",
-        "symfony/console":          "^3.2",
-        "symfony/event-dispatcher": "^3.2",
-        "symfony/process":          "^3.2",
-        "symfony/finder":           "^3.2",
-        "symfony/yaml":             "^3.2",
+        "symfony/console":          "^3.2 || ^4.0@beta",
+        "symfony/event-dispatcher": "^3.2 || ^4.0@beta",
+        "symfony/process":          "^3.2 || ^4.0@beta",
+        "symfony/finder":           "^3.2 || ^4.0@beta",
+        "symfony/yaml":             "^3.2 || ^4.0@beta",
         "doctrine/instantiator":    "^1.0.5",
         "ext-tokenizer":            "*"
     },
 
     "require-dev": {
         "behat/behat":           "^3.3",
-        "symfony/filesystem":    "^3.2",
+        "symfony/filesystem":    "^3.2 || ^4.0@beta",
         "phpunit/phpunit":       "^5.7|^6.0"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
         "phpspec/prophecy":         "^1.5",
         "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "^1.0 || ^2.0 || ^3.0",
-        "symfony/console":          "^3.2 || ^4.0@beta",
-        "symfony/event-dispatcher": "^3.2 || ^4.0@beta",
-        "symfony/process":          "^3.2 || ^4.0@beta",
-        "symfony/finder":           "^3.2 || ^4.0@beta",
-        "symfony/yaml":             "^3.2 || ^4.0@beta",
+        "symfony/console":          "^3.2 || ^4.0",
+        "symfony/event-dispatcher": "^3.2 || ^4.0",
+        "symfony/process":          "^3.2 || ^4.0",
+        "symfony/finder":           "^3.2 || ^4.0",
+        "symfony/yaml":             "^3.2 || ^4.0",
         "doctrine/instantiator":    "^1.0.5",
         "ext-tokenizer":            "*"
     },
 
     "require-dev": {
         "behat/behat":           "^3.3",
-        "symfony/filesystem":    "^3.2 || ^4.0@beta",
+        "symfony/filesystem":    "^3.2 || ^4.0",
         "phpunit/phpunit":       "^5.7|^6.0"
     },
 


### PR DESCRIPTION
Good news everyone!

According to its tests, phpspec is compatible with Symfony 4!
Now the bad news is that phpspec depends on Behat which prevents `symfony/console` and `symfony/yaml` to be upgraded, but at least there's no effort to do in phpspec.

I'd be happy to wait for Symfony 4 stable to be released before merging this Pull request, what do you think?