### PR TITLE
Add two more renamed interfaces to upgrade docs

### DIFF
--- a/docs/manual/upgrading-to-phpspec-3.rst
+++ b/docs/manual/upgrading-to-phpspec-3.rst
@@ -71,6 +71,8 @@ changes you will need to make in your code.
 - ``PhpSpec\Formatter\Presenter\Differ\EngineInterface`` is now ``PhpSpec\Formatter\Presenter\Differ\DifferEngine``
 - ``PhpSpec\Matcher\MatcherInterface`` is now ``PhpSpec\Matcher\Matcher``
 - ``PhpSpec\Matcher\MatchersProviderInterface`` is now ``PhpSpec\Matcher\MatchersProvider``
+- ``PhpSpec\SpecificationInterface`` is now ``PhpSpec\Specification``
+- ``PhpSpec\Runner\Maintainer\MaintainerInterface`` is now ``PhpSpec\Runner\Maintainer\Maintainer``
 
 Some methods have a different signature:
 


### PR DESCRIPTION
Maybe it is too late, but recently I've updated extension to be compatible with PHPSpec 3 and found that these two extensions are not listed in upgrade docs.
