### PR TITLE
Describe autocompletion refactor + fix trailing slash

### DIFF
--- a/spec/PhpSpec/Console/Provider/NamespacesAutocompleteProviderSpec.php
+++ b/spec/PhpSpec/Console/Provider/NamespacesAutocompleteProviderSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\PhpSpec\Console\Provider;
 
-use PhpSpec\Console\Provider\NamespacesAutocompleteProvider;
+use PhpSpec\Locator\SrcPathLocator;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\Finder;
@@ -10,9 +10,10 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class NamespacesAutocompleteProviderSpec extends ObjectBehavior
 {
-    function let(Finder $finder)
+    function let(Finder $finder, SrcPathLocator $locator)
     {
-        $this->beConstructedWith($finder);
+        $this->beConstructedWith($finder, [$locator]);
+        $locator->getFullSrcPath()->willReturn('/app/src');
     }
 
     function it_returns_empty_array_if_nothing_found($finder)
@@ -21,7 +22,7 @@ class NamespacesAutocompleteProviderSpec extends ObjectBehavior
         $finder->name('*.php')->willReturn($finder);
         $finder->in(['/app/src'])->willReturn([]);
 
-        $namespaces = $this->getNamespaces(['/app/src'])->shouldHaveCount(0);
+        $this->getNamespaces()->shouldHaveCount(0);
     }
 
     function it_returns_namespaces_from_php_files(
@@ -38,7 +39,7 @@ class NamespacesAutocompleteProviderSpec extends ObjectBehavior
         $file2->getContents()->willReturn('<?php namespace App\Foo; class Bar {}');
         $file3->getContents()->willReturn('<?php namespace App\Bar; class Foo {}');
 
-        $namespaces = $this->getNamespaces(['/app/src']);
+        $namespaces = $this->getNamespaces();
 
         $namespaces->shouldHaveCount(3);
         $namespaces->shouldContain('App\\');

--- a/spec/PhpSpec/Console/Provider/NamespacesAutocompleteProviderSpec.php
+++ b/spec/PhpSpec/Console/Provider/NamespacesAutocompleteProviderSpec.php
@@ -41,8 +41,8 @@ class NamespacesAutocompleteProviderSpec extends ObjectBehavior
         $namespaces = $this->getNamespaces(['/app/src']);
 
         $namespaces->shouldHaveCount(3);
-        $namespaces->shouldContain('App');
-        $namespaces->shouldContain('App\Foo');
-        $namespaces->shouldContain('App\Bar');
+        $namespaces->shouldContain('App\\');
+        $namespaces->shouldContain('App\\Foo\\');
+        $namespaces->shouldContain('App\\Bar\\');
     }
 }

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -545,12 +545,6 @@ class PSR0LocatorSpec extends ObjectBehavior
         $this->supportsQuery('Test\\Namespace\\PhpSpec\\Console\\Application')->shouldReturn(true);
     }
 
-    function it_returns_src_path(Filesystem $filesystem)
-    {
-        $this->beConstructedWith($filesystem, '', 'spec', $this->srcPath, $this->specPath);
-        $this->getSrcPath()->shouldReturn($this->srcPath.DIRECTORY_SEPARATOR);
-    }
-
     private function convert_to_path($path)
     {
         if ('/' === DIRECTORY_SEPARATOR) {

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -71,7 +71,7 @@ EOF
             $questionHelper = $this->getApplication()->getHelperSet()->get('question');
             $question = new Question('<info>Enter class to describe: </info>');
 
-            $question->setAutocompleterValues($this->getNamespaces());
+            $question->setAutocompleterValues(array_map([$this, 'escapePathForTerminal'], $this->getNamespaces()));
             $classname = $questionHelper->ask($input, $output, $question);
         }
 
@@ -97,5 +97,13 @@ EOF
         }
 
         return $container->get('console.autocomplete_provider')->getNamespaces($srcPaths);
+    }
+
+    /**
+     * Make path safe to echo to the terminal (to get around symfony/console issue #24652)
+     */
+    private function escapePathForTerminal(string $path) : string
+    {
+        return str_replace('\\', '/', $path);
     }
 }

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -91,8 +91,8 @@ EOF
         $srcPaths = array();
 
         foreach ($container->getByTag('locator.locators') as $locator) {
-            if ($locator instanceof \PhpSpec\Locator\PSR0\PSR0Locator) {
-                $srcPaths[] = $locator->getSrcPath();
+            if ($locator instanceof \PhpSpec\Locator\SrcPathLocator) {
+                $srcPaths[] = $locator->getFullSrcPath();
             }
         }
 

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -87,16 +87,7 @@ EOF
      */
     private function getNamespaces()
     {
-        $container = $this->getApplication()->getContainer();
-        $srcPaths = array();
-
-        foreach ($container->getByTag('locator.locators') as $locator) {
-            if ($locator instanceof \PhpSpec\Locator\SrcPathLocator) {
-                $srcPaths[] = $locator->getFullSrcPath();
-            }
-        }
-
-        return $container->get('console.autocomplete_provider')->getNamespaces($srcPaths);
+        return $this->getApplication()->getContainer()->get('console.autocomplete_provider')->getNamespaces();
     }
 
     /**

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -112,8 +112,11 @@ final class ContainerAssembler
         $container->define('util.filesystem', function () {
             return new Filesystem();
         });
-        $container->define('console.autocomplete_provider', function () {
-            return new NamespacesAutocompleteProvider(new Finder());
+        $container->define('console.autocomplete_provider', function (IndexedServiceContainer $container) {
+            return new NamespacesAutocompleteProvider(
+                new Finder(),
+                $container->getByTag('locator.locators')
+            );
         });
     }
 

--- a/src/PhpSpec/Console/Provider/NamespacesAutocompleteProvider.php
+++ b/src/PhpSpec/Console/Provider/NamespacesAutocompleteProvider.php
@@ -57,8 +57,8 @@ final class NamespacesAutocompleteProvider
 
                 foreach ($namespaceParts as $part) {
                     $namespace .= $part;
-                    $namespaces[] = $namespace;
                     $namespace .= '\\';
+                    $namespaces[] = $namespace;
                 }
 
                 break;

--- a/src/PhpSpec/Console/Provider/NamespacesAutocompleteProvider.php
+++ b/src/PhpSpec/Console/Provider/NamespacesAutocompleteProvider.php
@@ -13,6 +13,8 @@
 
 namespace PhpSpec\Console\Provider;
 
+use PhpSpec\Locator\ResourceLocator;
+use PhpSpec\Locator\SrcPathLocator;
 use Symfony\Component\Finder\Finder;
 
 final class NamespacesAutocompleteProvider
@@ -22,22 +24,28 @@ final class NamespacesAutocompleteProvider
      */
     private $finder;
 
-    public function __construct(Finder $finder)
+    private $paths = [];
+
+    public function __construct(Finder $finder, array $locators)
     {
+        foreach ($locators as $locator) {
+            if ($locator instanceof SrcPathLocator) {
+                $this->paths[] = $locator->getFullSrcPath();
+            }
+        }
+
         $this->finder = $finder;
     }
 
     /**
      * Get namespaces from paths.
      *
-     * @param  array $paths
-     *
      * @return array of namespases
      */
-    public function getNamespaces(array $paths)
+    public function getNamespaces()
     {
         $namespaces = [];
-        foreach ($this->finder->files()->name('*.php')->in($paths) as $phpFile) {
+        foreach ($this->finder->files()->name('*.php')->in($this->paths) as $phpFile) {
             $tokens = token_get_all($phpFile->getContents());
             foreach ($tokens as $index => $token) {
                 if (!is_array($token) || T_NAMESPACE !== $token[0]) {

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -14,10 +14,11 @@
 namespace PhpSpec\Locator\PSR0;
 
 use PhpSpec\Locator\ResourceLocator;
+use PhpSpec\Locator\SrcPathLocator;
 use PhpSpec\Util\Filesystem;
 use InvalidArgumentException;
 
-class PSR0Locator implements ResourceLocator
+class PSR0Locator implements ResourceLocator, SrcPathLocator
 {
     /**
      * @var string
@@ -113,14 +114,6 @@ class PSR0Locator implements ResourceLocator
     public function getFullSrcPath(): string
     {
         return $this->fullSrcPath;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSrcPath()
-    {
-        return $this->srcPath;
     }
 
     /**

--- a/src/PhpSpec/Locator/SrcPathLocator.php
+++ b/src/PhpSpec/Locator/SrcPathLocator.php
@@ -1,0 +1,10 @@
+<?php
+namespace PhpSpec\Locator;
+
+interface SrcPathLocator
+{
+    /**
+     * @return string
+     */
+    public function getFullSrcPath(): string;
+}


### PR DESCRIPTION
I wanted to have the trailing slash included in the autocomplete feature that @fullpipe contributed, and ended up moving some responsibilities around.

Note that this hasn't been included in a release yet so BC issues may be false alarms

![autocomplete](https://user-images.githubusercontent.com/237866/31996557-e43c6560-b980-11e7-9b0d-76d1cdc90fe6.gif)