### PR TITLE
Check that the location exists

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -317,6 +317,9 @@ class ApplicationContext implements Context
      */
     public function thereIsAPsrNamespaceConfiguredForTheFolder($namespaceType, $namespace, $source)
     {
+        if (!is_dir(__DIR__ . '/src')) {
+            mkdir(__DIR__ . '/src');
+        }
         require_once __DIR__ .'/autoloader/fake_autoload.php';
     }
 

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -67,7 +67,8 @@ class ComposerPsrNamespaceProvider
         foreach ($prefixes as $namespace => $psrPrefix) {
             foreach ($psrPrefix as $location) {
                 foreach ($vendors as $vendor) {
-                    if (strpos(realpath($location), $vendor) === 0) {
+                    $realPath = realpath($location);
+                    if ($realPath === false || strpos($realPath, $vendor) === 0) {
                         break 2;
                     }
                 }


### PR DESCRIPTION
This might happen when a package declares test namespaces but ignores them
when generating the archive.
Fixes #1174