### PR TITLE
Try to load all config paths until the file exists

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -225,6 +225,10 @@ final class Application extends BaseApplication
     private function extractConfigFromFirstParsablePath(array $paths) : array
     {
         foreach ($paths as $path) {
+            if (!file_exists($path)) {
+                continue;
+            }
+
             $config = $this->parseConfigFromExistingPath($path);
 
             return $this->addPathsToEachSuiteConfig(dirname($path), $config);


### PR DESCRIPTION
Fixes regression introduced by #1173 to fix #1172