### PR TITLE
Allow objects again

### DIFF
--- a/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorMethodNotFoundListenerSpec.php
@@ -160,7 +160,7 @@ class CollaboratorMethodNotFoundListenerSpec extends ObjectBehavior
         ConsoleIO $io,
         NameChecker $nameChecker
     ) {
-        $exception = new MethodNotFoundException('Error',DoubleOfInterface::class, 'throw');
+        $exception = new MethodNotFoundException('Error', new DoubleOfInterface(), 'throw');
 
         $event->getException()->willReturn($exception);
         $nameChecker->isNameValid('throw')->willReturn(false);

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -113,13 +113,13 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
      * @param string|object $classname
      * @return mixed
      */
-    private function getDoubledInterface($classname)
+    private function getDoubledInterface($class)
     {
-        if (class_parents($classname) !== array('stdClass'=>'stdClass')) {
+        if (class_parents($class) !== array('stdClass'=>'stdClass')) {
             return;
         }
 
-        $interfaces = array_filter(class_implements($classname),
+        $interfaces = array_filter(class_implements($class),
             function ($interface) {
                 return !preg_match('/^Prophecy/', $interface);
             }

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -110,10 +110,10 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
     }
 
     /**
-     * @param string $classname
+     * @param string|object $classname
      * @return mixed
      */
-    private function getDoubledInterface(string $classname)
+    private function getDoubledInterface($classname)
     {
         if (class_parents($classname) !== array('stdClass'=>'stdClass')) {
             return;


### PR DESCRIPTION
All functions used on that parameter in that method allow both strings
or objects.
Fixes #1147, introduced by bea979615e5d5c855e186974caf2ac11607c54a7