### PR TITLE
Phpstan

### DIFF
--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -122,7 +122,7 @@ class ConsoleIO implements IO
     }
 
     /**
-     * @return string|null
+     * @return ?string
      */
     public function cutTemp()
     {

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -36,7 +36,7 @@ class ReportItemFactory
      * @param ExampleEvent $event
      * @param Presenter    $presenter
      *
-     * @return ReportFailedItem|ReportPassedItem|ReportPendingItem
+     * @return ReportFailedItem|ReportPassedItem|ReportPendingItem|ReportSkippedItem
      */
     public function create(ExampleEvent $event, Presenter $presenter)
     {

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -184,7 +184,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
 
     /**
      * @param ExampleEvent $event
-     * @return bool|\Exception
+     * @return void|MethodNotFoundException
      */
     private function getMethodNotFoundException(ExampleEvent $event)
     {

--- a/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
@@ -69,7 +69,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $method
      * @param string $argument
      *
-     * @return string|null
+     * @return string|false
      */
     public function lookup(string $class, string $method, string $argument)
     {

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -277,7 +277,7 @@ final class ThrowMatcher implements Matcher
     /**
      * @param array $arguments
      *
-     * @return null|string
+     * @return null|string|\Throwable
      * @throws \PhpSpec\Exception\Example\MatcherException
      */
     private function getException(array $arguments)

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -16,6 +16,7 @@ namespace PhpSpec\Matcher;
 use PhpSpec\Wrapper\Unwrapper;
 use PhpSpec\Wrapper\DelayedCall;
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Exception\Example\MatcherException;
 use PhpSpec\Exception\Fracture\MethodNotFoundException;
 
 final class TriggerMatcher implements Matcher

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -196,7 +196,7 @@ final class CollaboratorsMaintainer implements Maintainer
     /**
      * @param \ReflectionParameter $parameter
      *
-     * @return string
+     * @return string|null
      */
     private function getParameterTypeFromReflection(\ReflectionParameter $parameter): string
     {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
@@ -28,7 +28,7 @@ final class UnwrapDecorator extends Decorator implements Expectation
      */
     public function __construct(Expectation $expectation, Unwrapper $unwrapper)
     {
-        $this->setExpectation($expectation);
+        parent::__construct($expectation);
         $this->unwrapper = $unwrapper;
     }
 


### PR DESCRIPTION
Run with `docker run --rm -v $PWD:/app tommymuehle/docker-phpstan analyse -l5  /app/src`
There a few errors left, but those are mostly false positives:

<details>

```
 ------ ------------------------------------------------------------------ 
  Line   src/PhpSpec/Listener/MethodReturnedNullListener.php               
 ------ ------------------------------------------------------------------ 
  123    Array (PhpSpec\Event\MethodCallEvent[]) does not accept mixed[].  
 ------ ------------------------------------------------------------------ 

 ------ -------------------------------------------------------- 
  Line   src/PhpSpec/Listener/ClassNotFoundListener.php          
 ------ -------------------------------------------------------- 
  69     Call to an undefined method Exception::getClassname().  
 ------ -------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   src/PhpSpec/Listener/CollaboratorNotFoundListener.php                    
 ------ ------------------------------------------------------------------------- 
  92     Parameter #2 $resource of method                                         
         PhpSpec\Listener\CollaboratorNotFoundListener::resourceIsInSpecNamespac  
         e() expects resource, PhpSpec\Locator\Resource given.                    
  112    Cannot call method getSpecNamespace() on resource.                       
 ------ ------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php              
 ------ ------------------------------------------------------------------------- 
  99     Call to method                                                           
         Prophecy\Exception\Doubler\MethodNotFoundException::getClassname() with  
         incorrect case: getClassName                                             
 ------ ------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   src/PhpSpec/Wrapper/Subject/Caller.php                                   
 ------ ------------------------------------------------------------------------- 
  235    Method ReflectionClass::newInstance() invoked with 0 parameters, 1       
         required.                                                                
  350    Method PhpSpec\Wrapper\Subject\Caller::namedConstructorNotFound()        
         should return                                                            
         PhpSpec\Exception\Fracture\MethodNotFoundException|PhpSpec\Exception\Fr  
         acture\MethodNotVisibleException but returns                             
         PhpSpec\Exception\Fracture\NamedConstructorNotFoundException.            
 ------ ------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------- 
  Line   src/PhpSpec/Wrapper/Subject/WrappedObject.php                       
 ------ -------------------------------------------------------------------- 
  206    Method ReflectionClass::newInstance() invoked with 0 parameters, 1  
         required.                                                           
 ------ -------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------ 
  Line   src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php         
 ------ ------------------------------------------------------------------------ 
  44     PhpSpec\Wrapper\Subject\Expectation\DispatcherDecorator::__construct()  
         does not call parent constructor from                                   
         PhpSpec\Wrapper\Subject\Expectation\Decorator.                          
 ------ ------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------- 
  Line   src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php         
 ------ ------------------------------------------------------------------------- 
  27     PhpSpec\Wrapper\Subject\Expectation\ConstructorDecorator::__construct()  
         does not call parent constructor from                                    
         PhpSpec\Wrapper\Subject\Expectation\Decorator.                           
  60     Undefined variable: $wrapped                                             
 ------ ------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   src/PhpSpec/Wrapper/Subject.php                                          
 ------ ------------------------------------------------------------------------- 
  244    Parameter #1 $value of method PhpSpec\Wrapper\Subject::wrap() expects    
         string, bool given.                                                      
  349    Method PhpSpec\Wrapper\Subject\Expectation\Expectation::match() invoked  
         with 4 parameters, 2-3 required.                                         
  352    Method PhpSpec\Wrapper\Subject\Expectation\Expectation::match() invoked  
         with 4 parameters, 2-3 required.                                         
 ------ ------------------------------------------------------------------------- 

 ------ ----------------------------------- 
  Line   src/PhpSpec/Console/ConsoleIO.php  
 ------ ----------------------------------- 
  255    Undefined variable: $i             
 ------ ----------------------------------- 

 ------ -------------------------------------------------------- 
  Line   src/PhpSpec/Console/Command/RunCommand.php              
 ------ -------------------------------------------------------- 
  141    Call to an undefined method                             
         Symfony\Component\Console\Application::getContainer().  
 ------ -------------------------------------------------------- 

 ------ -------------------------------------------------------- 
  Line   src/PhpSpec/Console/Command/DescribeCommand.php         
 ------ -------------------------------------------------------- 
  64     Call to an undefined method                             
         Symfony\Component\Console\Application::getContainer().  
 ------ -------------------------------------------------------- 

 ------ ------------------------------------------------------------------------ 
  Line   src/PhpSpec/Matcher/TraversableCountMatcher.php                         
 ------ ------------------------------------------------------------------------ 
  60     Parameter #1 $string of method                                          
         PhpSpec\Formatter\Presenter\Presenter::presentString() expects string,  
         int given.                                                              
  79     Parameter #1 $string of method                                          
         PhpSpec\Formatter\Presenter\Presenter::presentString() expects string,  
         int given.                                                              
 ------ ------------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------- 
  Line   src/PhpSpec/Matcher/ObjectStateMatcher.php                            
 ------ ---------------------------------------------------------------------- 
  75     Parameter #1 $callable of method                                      
         PhpSpec\Matcher\ObjectStateMatcher::getFailureExceptionFor() expects  
         callable, mixed[] given.                                              
  101    Parameter #1 $callable of method                                      
         PhpSpec\Matcher\ObjectStateMatcher::getFailureExceptionFor() expects  
         callable, mixed[] given.                                              
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/PhpSpec/Loader/Node/SpecificationNode.php                         
 ------ ---------------------------------------------------------------------- 
  52     Property PhpSpec\Loader\Node\SpecificationNode::$resource (resource)  
         does not accept PhpSpec\Locator\Resource.                             
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php                      
 ------ ----------------------------------------------------------------------- 
  121    Parameter #1 $level of class PhpSpec\Exception\Example\ErrorException  
         constructor expects string, int given.                                 
  121    Parameter #4 $line of class PhpSpec\Exception\Example\ErrorException   
         constructor expects string, int given.                                 
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------- 
  Line   src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php  
 ------ ----------------------------------------------------- 
  89     Cannot call method getSrcClassname() on resource.    
  92     Call to an undefined method                          
         PhpSpec\Specification::setSpecificationSubject().    
 ------ ----------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   src/PhpSpec/%       
```

</details>