### PR TITLE
Add support for .yaml extension for configuration

### DIFF
--- a/docs/cookbook/configuration.rst
+++ b/docs/cookbook/configuration.rst
@@ -11,6 +11,8 @@ You can use a different config file name and path with the ``--config`` option:
 
     $ bin/phpspec run --config path/to/different-phpspec.yml
 
+You can use the ``.yaml`` extension in place of ``.yml`` if preferred.
+
 You can also specify default values for config variables across all repositories by creating
 the file ``.phpspec.yml`` in your home folder (Unix systems). phpspec will use your personal preference for
 all settings that are not defined in the project's configuration.

--- a/docs/cookbook/console.rst
+++ b/docs/cookbook/console.rst
@@ -5,7 +5,7 @@ The phpspec console command uses Symfony's console component. This means
 that it inherits the `default Symfony console command and options <http://symfony.com/doc/current/components/console/usage.html>`_.
 
 **phpspec** has an additional global option to let you specify a config file
-other than `phpspec.yml` or `phpspec.yml.dist`:
+other than `phpspec.yml`, `.phpspec.yml`, or `phpspec.yml.dist`:
 
 .. code-block:: bash
 

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -204,7 +204,7 @@ final class Application extends BaseApplication
      */
     protected function parseConfigurationFile(InputInterface $input): array
     {
-        $paths = array('phpspec.yml','phpspec.yml.dist', '.phpspec.yml');
+        $paths = array('phpspec.yml', '.phpspec.yml', 'phpspec.yml.dist', 'phpspec.yaml', '.phpspec.yaml', 'phpspec.yaml.dist');
 
         if ($customPath = $input->getParameterOption(array('-c','--config'))) {
             if (!file_exists($customPath)) {


### PR DESCRIPTION
Added support for the `.yaml` extension, Symfony has renamed their default configuration file extensions from `.yml` to `.yaml` so this adds support for the alternative extension also, I have also reordered the priority since I think `.phpspec.yml` should be prioritised over a `phpspec.yml.dist`, I can change this back if preferred.