### PR TITLE
Fix matching float values

### DIFF
--- a/features/matchers/developer_uses_float_value_matcher.feature
+++ b/features/matchers/developer_uses_float_value_matcher.feature
@@ -1,0 +1,448 @@
+Feature: Developer uses float value matcher
+  As a Developer
+  I want a float value matcher
+  In order to match the float value of a number against an expectation
+
+  Scenario: "Return" alias matching using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample1/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample1;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldReturn(0.2);
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample1/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample1;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Return" alias not matching using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample2/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample2;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldNotReturn(0);
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample2/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample2;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Return" alias not matching type using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample3/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample3;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldNotReturn("0.2");
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample3/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample3;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Be" alias matching using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample4/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample4;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldBe(0.2);
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample4/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample4;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Be" alias not matching using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample5/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample5;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldNotBe(0);
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample5/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample5;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Be" alias not matching type using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample6/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample6;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldNotBe("0.2");
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample6/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample6;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Equal" alias matching using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample7/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample7;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldEqual(0.2);
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample7/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample7;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Equal" alias not matching using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample8/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample8;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldNotEqual(0);
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample8/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample8;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Equal" alias not matching type using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample9/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample9;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldNotEqual("0.2");
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample9/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample9;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "BeEqualTo" alias matching using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample10/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample10;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldEqual(0.2);
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample10/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample10;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Equal" alias not matching using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample11/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample11;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldNotEqual(0);
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample11/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample11;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass
+
+  Scenario: "Equal" alias not matching type using float value matcher
+    Given the spec file "spec/Matchers/FloatValueExample12/CalculatorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatValueExample12;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class CalculatorSpec extends ObjectBehavior
+      {
+          function it_subtracts_two_numbers()
+          {
+              $this->subtract(1.2, 1)->shouldNotEqual("0.2");
+          }
+      }
+
+      """
+    And the class file "src/Matchers/FloatValueExample12/Calculator.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatValueExample12;
+
+      class Calculator
+      {
+          public function subtract($x, $y)
+          {
+              return $x - $y;
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass

--- a/spec/PhpSpec/Matcher/FloatValueMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/FloatValueMatcherSpec.php
@@ -57,9 +57,9 @@ class FloatValueMatcherSpec extends ObjectBehavior
 
     function it_does_not_match_different_float_values(Presenter $presenter)
     {
-        $presenter->presentValue(Argument::any())->willReturn('0.0000012', '0.0000011');
+        $presenter->presentValue(Argument::any())->willReturn('0.00010000000000002', '0.00010000000000001');
 
-        $this->shouldThrow(new FailureException('Expected 0.0000012, but got 0.0000011.'))
-            ->duringPositiveMatch('be', 0.0000012, [0.0000011]);
+        $this->shouldThrow(new FailureException('Expected 0.00010000000000002, but got 0.00010000000000001.'))
+            ->duringPositiveMatch('be', 0.00010000000000001, [0.00010000000000002]);
     }
 }

--- a/spec/PhpSpec/Matcher/FloatValueMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/FloatValueMatcherSpec.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace spec\PhpSpec\Matcher;
+
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Matcher\Matcher;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class FloatValueMatcherSpec extends ObjectBehavior
+{
+    function let(Presenter $presenter)
+    {
+        $this->beConstructedWith($presenter);
+    }
+
+    function it_is_a_matcher()
+    {
+        $this->shouldBeAnInstanceOf(Matcher::class);
+    }
+
+    function it_responds_to_return()
+    {
+        $this->supports('return', 1.2, [1.2])->shouldReturn(true);
+    }
+
+    function it_responds_to_be()
+    {
+        $this->supports('be', 1.2, [1.2])->shouldReturn(true);
+    }
+
+    function it_responds_to_equal()
+    {
+        $this->supports('equal', 1.2, [1.2])->shouldReturn(true);
+    }
+
+    function it_responds_to_beEqualTo()
+    {
+        $this->supports('beEqualTo', 1.2, [1.2])->shouldReturn(true);
+    }
+
+    function it_matches_float_values()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('be', 1.2, [1.2]);
+    }
+
+    function it_matches_subtracted_float_values()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('be', (1.2 - 1), [0.1 + 0.1]);
+    }
+
+    function it_matches_multiplied_float_values()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('be', (2.3 * 1.5), [3.45]);
+    }
+
+    function it_does_not_match_different_float_values(Presenter $presenter)
+    {
+        $presenter->presentValue(Argument::any())->willReturn('0.0000012', '0.0000011');
+
+        $this->shouldThrow(new FailureException('Expected 0.0000012, but got 0.0000011.'))
+            ->duringPositiveMatch('be', 0.0000012, [0.0000011]);
+    }
+}

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -708,6 +708,9 @@ final class ContainerAssembler
         $container->define('matchers.comparison', function (IndexedServiceContainer $c) {
             return new Matcher\ComparisonMatcher($c->get('formatter.presenter'));
         }, ['matchers']);
+        $container->define('matchers.float_value', function (IndexedServiceContainer $c) {
+            return new Matcher\FloatValueMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
         $container->define('matchers.throwm', function (IndexedServiceContainer $c) {
             return new Matcher\ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
         }, ['matchers']);

--- a/src/PhpSpec/Matcher/FloatValueMatcher.php
+++ b/src/PhpSpec/Matcher/FloatValueMatcher.php
@@ -67,7 +67,7 @@ final class FloatValueMatcher extends BasicMatcher
     protected function matches($subject, array $arguments): bool
     {
         if (extension_loaded('bcmath')) {
-            return \bccomp($subject, $arguments[0], 20) === 0;
+            return \bccomp($subject, $arguments[0], 17) == 0;
         }
 
         return (string) $subject === (string) $arguments[0];

--- a/src/PhpSpec/Matcher/FloatValueMatcher.php
+++ b/src/PhpSpec/Matcher/FloatValueMatcher.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Matcher;
+
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Exception\Example\NotEqualException;
+use PhpSpec\Formatter\Presenter\Presenter;
+
+final class FloatValueMatcher extends BasicMatcher
+{
+    /**
+     * @var array
+     */
+    private static $keywords = [
+        'return',
+        'be',
+        'equal',
+        'beEqualTo'
+    ];
+
+    /**
+     * @var Presenter
+     */
+    private $presenter;
+
+    /**
+     * @param Presenter $presenter
+     */
+    public function __construct(Presenter $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(string $name, $subject, array $arguments): bool
+    {
+        return \is_float($subject)
+            && \in_array($name, self::$keywords)
+            && 1 === \count($arguments)
+            && \is_float($arguments[0]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 150;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function matches($subject, array $arguments): bool
+    {
+        if (extension_loaded('bcmath')) {
+            return \bccomp($subject, $arguments[0], 20) === 0;
+        }
+
+        return (string) $subject === (string) $arguments[0];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    {
+        return new NotEqualException(sprintf(
+            'Expected %s, but got %s.',
+            $this->presenter->presentValue($arguments[0]),
+            $this->presenter->presentValue($subject)
+        ), $arguments[0], $subject);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    {
+        return new FailureException(sprintf(
+            'Did not expect %s, but got one.',
+            $this->presenter->presentValue($subject)
+        ));
+    }
+}


### PR DESCRIPTION
Currently `IdentityMatcher` for simple spec using float values like 
```
$this->subtract(1.2, 1)->shouldReturn(0.2);
```
 returns false instead of true for correct implementation. 

Float values comparison in PHP is a tricky thing. Matching by identity doesn't always return the result we expect. Example:
```php
$a = 0.3 - 0.1;
$b = 0.1 + 0.1;

var_dump($a === $b); // false
var_dump($a == $b); // false
```

To fix it I'd like to introduce `FloatValueMatcher` (I'm open to suggestions with better naming).
Current implementation fixes issue for IdentityMatcher, I would need to add also similar fix for ComparisonMatcher. Creating WIP PR to get some feedback.

Todo:
- [ ] update docs
- [ ] implement fix for ComparisonMatcher