### PR TITLE
Allows the property $title of an ExampleNode to be altered.

### DIFF
--- a/docs/cookbook/extensions.rst
+++ b/docs/cookbook/extensions.rst
@@ -75,3 +75,4 @@ Miscellaneous
  * `Data provider <https://github.com/coduo/phpspec-data-provider-extension>`_
  * `Behat Integration <https://github.com/richardmiller/BehatSpec>`_
  * `Example skipping through annotation <https://github.com/akeneo/PhpSpecSkipExampleExtension>`_
+ * `Annotation <https://github.com/drupol/phpspec-annotation>`_

--- a/spec/PhpSpec/Loader/Node/ExampleNodeSpec.php
+++ b/spec/PhpSpec/Loader/Node/ExampleNodeSpec.php
@@ -22,7 +22,15 @@ class ExampleNodeSpec extends ObjectBehavior
         $this->getTitle()->shouldReturn('example node');
     }
 
-    function it_provides_a_link_to_function($function)
+    function it_can_set_a_title()
+    {
+      $this->setTitle('node example');
+      $this->getTitle()->shouldReturn('node example');
+      $this->setTitle('example node');
+    }
+
+
+  function it_provides_a_link_to_function($function)
     {
         $this->getFunctionReflection()->shouldReturn($function);
     }

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -40,8 +40,16 @@ class ExampleNode
      */
     public function __construct(string $title, ReflectionFunctionAbstract $function)
     {
-        $this->title    = $title;
+        $this->setTitle($title);
         $this->function = $function;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle(string $title)
+    {
+      $this->title = $title;
     }
 
     /**


### PR DESCRIPTION
Hello,

I recently wrote my first [PHPSpec extension.](https://github.com/drupol/phpspec-annotation) It allows you to add an annotation to tests methods.

However, I also wanted to alter the title of existing methods but the $title property of an ExampleNode is something that you cannot alter.

This PR allows you to alter of an ExampleNode with a method.

To give you an idea of what I'm trying to achieve, I just updated the code of my extension (https://github.com/drupol/phpspec-annotation/blob/master/src/Listeners/PhpspecAnnotationListener.php#L38), if this PR is accepted, I'll remove the commented line and it will work directly.

Tests are included as well.