### PR TITLE
Added check for mismatched spec path and defined namespace

### DIFF
--- a/features/exception_handling/developer_is_shown_runtime_errors.feature
+++ b/features/exception_handling/developer_is_shown_runtime_errors.feature
@@ -85,3 +85,19 @@ Feature: Developer is shown runtime errors
       """
     When I run phpspec
     Then I should see "1 passed, 1 broken"
+
+  Scenario: Runtime error when mismatched spec path and defined namespace
+    Given the spec file "spec/Message/Fatal3/RuntimeSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\Message\MismatchedNamespace;
+
+    use PhpSpec\ObjectBehavior;
+
+    class RuntimeSpec extends ObjectBehavior
+    {
+    }
+    """
+    When I run phpspec
+    Then I should see "1 broken"

--- a/spec/PhpSpec/Loader/ResourceLoaderSpec.php
+++ b/spec/PhpSpec/Loader/ResourceLoaderSpec.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace spec\PhpSpec\Loader;
+
+use PhpSpec\Loader\Node\SpecificationNode;
+use PhpSpec\Locator\Resource;
+use PhpSpec\Locator\ResourceManager;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Util\MethodAnalyser;
+
+class ResourceLoaderSpec extends ObjectBehavior
+{
+
+    public function let(
+        ResourceManager $resourceManager,
+        MethodAnalyser $methodAnalyser
+    ) {
+        $this->beConstructedWith(
+            $resourceManager,
+            $methodAnalyser
+        );
+    }
+
+    public function it_should_add_error_to_specification_when_mismatched_defined_spec_path_and_defined_namespace(
+        Resource $resource,
+        ResourceManager $resourceManager
+    ) {
+        $expectedMessage = 'Spec path does not match defined namespace.';
+
+        $resource->getSrcClassname()->willReturn('src/classname');
+        $resource->getSrcFilename()->willReturn('src/filename.php');
+        $resource->getSpecClassname()->willReturn('spec/mismatched/classname');
+        $resource->getSpecFilename()->willReturn('spec/filename.php');
+
+        $resourceManager->locateResources('locator')->willReturn([$resource]);
+
+        $this->load('locator')->shouldMatchExampleClosureExceptionMessage($expectedMessage);
+    }
+
+    public function getMatchers(): array
+    {
+        return [
+            'matchExampleClosureExceptionMessage' => function (\PhpSpec\Loader\Suite $suite, string $expectedMessage) {
+                /**@var $spec SpecificationNode[] */
+                $specs = $suite->getSpecifications();
+
+                $examples = $specs[0]->getExamples();
+                $reflectionFunction = $examples[0]->getFunctionReflection();
+
+                try {
+                    $reflectionFunction->invokeArgs([]);
+                } catch (\Error $e) {
+                    return $e->getMessage() === $expectedMessage;
+                }
+
+                return false;
+            },
+        ];
+    }
+}

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -61,6 +61,8 @@ class ResourceLoader
                 }
             }
             if (!class_exists($resource->getSpecClassname(), false)) {
+                $error = new \Error('Spec path does not match defined namespace.');
+                $this->addErrorThrowingExampleToSuite($resource, $suite, $error);
                 continue;
             }
 


### PR DESCRIPTION
Currently in case there is mismatch between spec class and defined namespace tests are silently ignored. This PR solves it by reporting the case.

Solves #354