### PR TITLE
Fix the appveyor build

### DIFF
--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -81,7 +81,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     public function iShouldSeeAnErrorAboutTheMissingAutoloader()
     {
         if (!preg_match('/autoload/', $this->process->getErrorOutput().$this->process->getOutput())) {
-            throw new \Exception('There was no error regarding a missing autoloader:');
+            throw new \Exception(sprintf('There was no error regarding a missing autoloader: %s', $this->process->getErrorOutput().$this->process->getOutput()));
         }
     }
 

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -42,6 +42,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
             'SHELL_INTERACTIVE' => true,
             'HOME' => getenv('HOME'),
             'PATH' => getenv('PATH'),
+            'COLUMNS' => 80,
         );
 
         $this->process = $process = new Process($command);


### PR DESCRIPTION
* Include the test output in the exception message so a failing test could be understod.
* Update the message we look for to "could not be loaded". Output on windows is misaligned (see screenshot below).

<img width="961" alt="image" src="https://user-images.githubusercontent.com/190447/40004654-0af6d87e-578e-11e8-8c01-d6568eb64a81.png">

