### PR TITLE
Add `void` typehints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 
     "require": {
         "php":                      "^7.1, <7.3",
-        "phpspec/prophecy":         "^1.5",
+        "phpspec/prophecy":         "^1.7",
         "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "^1.0 || ^2.0 || ^3.0",
         "symfony/console":          "^3.4 || ^4.0",

--- a/features/bootstrap/Fake/ReRunner.php
+++ b/features/bootstrap/Fake/ReRunner.php
@@ -16,7 +16,7 @@ class ReRunner implements BaseReRunner
         return true;
     }
 
-    public function reRunSuite()
+    public function reRunSuite() : void
     {
         $this->hasBeenReRun = true;
     }

--- a/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriterSpec.php
@@ -14,11 +14,15 @@ class TokenizedTypeHintRewriterSpec extends ObjectBehavior
     {
         $this->beConstructedWith($typeHintIndex, $namespaceResolver);
         $namespaceResolver->resolve(Argument::cetera())->willReturn('someClass');
-        $namespaceResolver->analyse(Argument::any())->willReturn();
+        $namespaceResolver->analyse(Argument::any())->shouldBeCalled();
     }
 
-    function it_is_a_typehint_rewriter()
+    function it_is_a_typehint_rewriter(TypeHintIndex $typeHintIndex, NamespaceResolver $namespaceResolver)
     {
+        $this->beConstructedWith($typeHintIndex, $namespaceResolver);
+        $namespaceResolver->resolve(Argument::cetera())->willReturn('someClass');
+        $namespaceResolver->analyse(Argument::any())->shouldNotBeCalled();
+
         $this->shouldHaveType('PhpSpec\CodeAnalysis\TypeHintRewriter');
     }
 

--- a/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
+++ b/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
@@ -9,6 +9,7 @@ class InvalidCollaboratorTypeExceptionSpec extends ObjectBehavior
 {
     function let(\ReflectionParameter $parameter, \ReflectionFunctionAbstract $function)
     {
+        $function->getName()->willReturn('bar');
         $this->beConstructedWith($parameter, $function);
     }
 

--- a/spec/PhpSpec/Formatter/DotFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/DotFormatterSpec.php
@@ -13,6 +13,8 @@ use PhpSpec\Exception\Example\PendingException;
 use PhpSpec\Loader\Node\SpecificationNode;
 use PhpSpec\Loader\Node\ExampleNode;
 use Prophecy\Argument;
+use Prophecy\Prophecy\MethodProphecy;
+use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionFunctionAbstract;
 
 class DotFormatterSpec extends ObjectBehavior
@@ -29,8 +31,12 @@ class DotFormatterSpec extends ObjectBehavior
         $presenter->presentException(Argument::cetera())->willReturn('presented exception');
         $io->isVerbose()->willReturn(false);
         $io->askConfirmation(Argument::any())->willReturn(false);
-        $io->write(Argument::any())->willReturn(null);
-        $io->writeln(Argument::cetera())->willReturn(null);
+        $io->write(Argument::any())->should(function() {
+            return;
+        });
+        $io->writeln(Argument::cetera())->should(function() {
+            return;
+        });
         $io->getBlockWidth()->willReturn(80);
         $event->getTime()->willReturn(10.0);
     }
@@ -46,6 +52,7 @@ class DotFormatterSpec extends ObjectBehavior
         StatisticsCollector $stats
     ) {
         $event->getResult()->willReturn(ExampleEvent::PASSED);
+        $stats->getEventsCount()->willReturn(1);
 
         $this->afterExample($event);
 
@@ -58,6 +65,7 @@ class DotFormatterSpec extends ObjectBehavior
         StatisticsCollector $stats
     ) {
         $event->getResult()->willReturn(ExampleEvent::PENDING);
+        $stats->getEventsCount()->willReturn(1);
 
         $this->afterExample($event);
 
@@ -70,6 +78,7 @@ class DotFormatterSpec extends ObjectBehavior
         StatisticsCollector $stats
     ) {
         $event->getResult()->willReturn(ExampleEvent::SKIPPED);
+        $stats->getEventsCount()->willReturn(1);
 
         $this->afterExample($event);
 
@@ -82,6 +91,7 @@ class DotFormatterSpec extends ObjectBehavior
         StatisticsCollector $stats
     ) {
         $event->getResult()->willReturn(ExampleEvent::FAILED);
+        $stats->getEventsCount()->willReturn(1);
 
         $this->afterExample($event);
 
@@ -94,6 +104,7 @@ class DotFormatterSpec extends ObjectBehavior
         StatisticsCollector $stats
     ) {
         $event->getResult()->willReturn(ExampleEvent::BROKEN);
+        $stats->getEventsCount()->willReturn(1);
 
         $this->afterExample($event);
 
@@ -139,8 +150,8 @@ class DotFormatterSpec extends ObjectBehavior
 
         $io->isVerbose()->willReturn(false);
         $io->getBlockWidth()->willReturn(10);
-        $io->write(Argument::type('string'))->willReturn();
-        $io->writeln(Argument::cetera())->willReturn();
+        $io->write(Argument::type('string'))->should(function () {});
+        $io->writeln(Argument::cetera())->should(function () {});
 
         $stats->getEventsCount()->willReturn(1);
         $stats->getFailedEvents()->willReturn(array());

--- a/spec/PhpSpec/Formatter/Presenter/Differ/StringEngineSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Differ/StringEngineSpec.php
@@ -30,7 +30,7 @@ DIFF;
         $this->compare('string1', 'string2')->shouldBeEqualRegardlessOfLineEndings($expected);
     }
 
-    public function getMatchers() : array
+    public function getMatchers(): array
     {
         return [
             'beEqualRegardlessOfLineEndings' => function ($actual, $expected) {

--- a/spec/PhpSpec/Formatter/ProgressFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/ProgressFormatterSpec.php
@@ -16,7 +16,7 @@ class ProgressFormatterSpec extends ObjectBehavior
         $this->beConstructedWith($presenter, $io, $stats);
         $io->getBlockWidth()->willReturn(80);
         $io->isDecorated()->willReturn(false);
-        $io->writeTemp(Argument::cetera())->willReturn();
+        $io->writeTemp(Argument::cetera())->should(function () {});
     }
 
     function it_is_an_event_subscriber()

--- a/spec/PhpSpec/Listener/ClassNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/ClassNotFoundListenerSpec.php
@@ -26,7 +26,7 @@ class ClassNotFoundListenerSpec extends ObjectBehavior
         Resource $resource
     )
     {
-        $io->writeln(Argument::any())->willReturn();
+        $io->writeln(Argument::any())->should(function () {});
         $io->askConfirmation(Argument::any())->willReturn(false);
 
         $exception->getClassname()->willReturn('SomeClass');

--- a/spec/PhpSpec/Listener/CollaboratorNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/CollaboratorNotFoundListenerSpec.php
@@ -29,7 +29,7 @@ class CollaboratorNotFoundListenerSpec extends ObjectBehavior
 
         $io->isCodeGenerationEnabled()->willReturn(true);
         $io->askConfirmation(Argument::any())->willReturn(false);
-        $io->writeln(Argument::any())->willReturn(null);
+        $io->writeln(Argument::any())->should(function() {});
     }
 
     function it_listens_to_afterexample_and_aftersuite_events()

--- a/spec/PhpSpec/Listener/MethodNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodNotFoundListenerSpec.php
@@ -25,7 +25,7 @@ class MethodNotFoundListenerSpec extends ObjectBehavior
         ExampleEvent $exampleEvent,
         NameChecker $nameChecker
     ) {
-        $io->writeln(Argument::any())->willReturn();
+        $io->writeln(Argument::any())->should(function() {});
         $io->askConfirmation(Argument::any())->willReturn(false);
 
         $this->beConstructedWith($io, $resourceManager, $generatorManager, $nameChecker);

--- a/spec/PhpSpec/Listener/NamedConstructorNotFoundListenerSpec.php
+++ b/spec/PhpSpec/Listener/NamedConstructorNotFoundListenerSpec.php
@@ -23,7 +23,7 @@ class NamedConstructorNotFoundListenerSpec extends ObjectBehavior
         ExampleEvent $exampleEvent,
         NamedConstructorNotFoundException $exception)
     {
-        $io->writeln(Argument::any())->willReturn();
+        $io->writeln(Argument::any())->should(function() {});;
         $io->askConfirmation(Argument::any())->willReturn(false);
 
         $this->beConstructedWith($io, $resourceManager, $generatorManager);

--- a/spec/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProviderSpec.php
+++ b/spec/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProviderSpec.php
@@ -30,7 +30,7 @@ class ComposerPsrNamespaceProviderSpec extends ObjectBehavior
         );
     }
 
-    public function getMatchers() : array
+    public function getMatchers(): array
     {
         return array(
             'haveNamespaceLocation' => function ($subject, $namespace, $location, $standard) {

--- a/spec/PhpSpec/Process/ReRunner/CompositeReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/CompositeReRunnerSpec.php
@@ -47,7 +47,7 @@ class CompositeReRunnerSpec extends ObjectBehavior
         $reRunner1->isSupported()->willReturn(false);
         $reRunner2->isSupported()->willReturn(true);
 
-        $reRunner2->reRunSuite()->willReturn();
+        $reRunner2->reRunSuite()->should(function() {});;
 
         $this->reRunSuite();
 

--- a/spec/PhpSpec/Runner/SuiteRunnerSpec.php
+++ b/spec/PhpSpec/Runner/SuiteRunnerSpec.php
@@ -19,11 +19,13 @@ class SuiteRunnerSpec extends ObjectBehavior
                  SpecificationNode $spec1, SpecificationNode $spec2)
     {
         $this->beConstructedWith($dispatcher, $specRunner);
-        $suite->getSpecifications()->willReturn( array($spec1, $spec2));
+        $suite->getSpecifications()->willReturn(array($spec1, $spec2));
     }
 
     function it_runs_all_specs_in_the_suite_through_the_specrunner($suite, $specRunner, $spec1, $spec2)
     {
+        $specRunner->run($spec1)->willReturn(ExampleEvent::PASSED);
+        $specRunner->run($spec2)->willReturn(ExampleEvent::PASSED);
         $this->run($suite);
 
         $specRunner->run($spec1)->shouldHaveBeenCalled();
@@ -63,8 +65,11 @@ class SuiteRunnerSpec extends ObjectBehavior
         $this->run($suite)->shouldReturn(ExampleEvent::FAILED);
     }
 
-    function it_dispatches_events_before_and_after_the_suite($suite, $dispatcher)
+    function it_dispatches_events_before_and_after_the_suite($suite, $specRunner, $spec1, $spec2, $dispatcher)
     {
+        $specRunner->run($spec1)->willReturn(ExampleEvent::PASSED);
+        $specRunner->run($spec2)->willReturn(ExampleEvent::PASSED);
+
         $this->run($suite);
 
         $dispatcher->dispatch('beforeSuite',

--- a/src/PhpSpec/CodeAnalysis/AccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/AccessInspector.php
@@ -18,15 +18,15 @@ interface AccessInspector
     /**
      * @param object $object
      */
-    public function isPropertyReadable($object, string $property) : bool;
+    public function isPropertyReadable($object, string $property): bool;
 
     /**
      * @param object $object
      */
-    public function isPropertyWritable($object, string $property) : bool;
+    public function isPropertyWritable($object, string $property): bool;
 
     /**
      * @param object $object
      */
-    public function isMethodCallable($object, string $method) : bool;
+    public function isMethodCallable($object, string $method): bool;
 }

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -31,7 +31,7 @@ final class MagicAwareAccessInspector implements AccessInspector
     /**
      * @param object $object
      */
-    public function isPropertyReadable($object, string $property) : bool
+    public function isPropertyReadable($object, string $property): bool
     {
         return method_exists($object, '__get') || $this->accessInspector->isPropertyReadable($object, $property);
     }
@@ -39,7 +39,7 @@ final class MagicAwareAccessInspector implements AccessInspector
     /**
      * @param object $object
      */
-    public function isPropertyWritable($object, string $property) : bool
+    public function isPropertyWritable($object, string $property): bool
     {
         return method_exists($object, '__set') || $this->accessInspector->isPropertyWritable($object, $property);
     }
@@ -47,7 +47,7 @@ final class MagicAwareAccessInspector implements AccessInspector
     /**
      * @param object $object
      */
-    public function isMethodCallable($object, string $method) : bool
+    public function isMethodCallable($object, string $method): bool
     {
         return method_exists($object, '__call') || $this->accessInspector->isMethodCallable($object, $method);
     }

--- a/src/PhpSpec/CodeAnalysis/NamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/NamespaceResolver.php
@@ -17,5 +17,5 @@ interface NamespaceResolver
 {
     public function analyse(string $code): void;
 
-    public function resolve(string $typeAlias) : string;
+    public function resolve(string $typeAlias): string;
 }

--- a/src/PhpSpec/CodeAnalysis/NamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/NamespaceResolver.php
@@ -15,7 +15,7 @@ namespace PhpSpec\CodeAnalysis;
 
 interface NamespaceResolver
 {
-    public function analyse(string $code);
+    public function analyse(string $code): void;
 
     public function resolve(string $typeAlias) : string;
 }

--- a/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
@@ -30,7 +30,7 @@ final class StaticRejectingNamespaceResolver implements NamespaceResolver
         $this->namespaceResolver->analyse($code);
     }
 
-    public function resolve(string $typeAlias) : string
+    public function resolve(string $typeAlias): string
     {
         $this->guardNonObjectTypeHints($typeAlias);
 

--- a/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
@@ -25,7 +25,7 @@ final class StaticRejectingNamespaceResolver implements NamespaceResolver
         $this->namespaceResolver = $namespaceResolver;
     }
 
-    public function analyse(string $code)
+    public function analyse(string $code): void
     {
         $this->namespaceResolver->analyse($code);
     }

--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -95,7 +95,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
         }
     }
 
-    public function resolve(string $typeAlias) : string
+    public function resolve(string $typeAlias): string
     {
         if (strpos($typeAlias, '\\') === 0) {
             return substr($typeAlias, 1);

--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -30,7 +30,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
     /**
      * @param string $code
      */
-    public function analyse(string $code)
+    public function analyse(string $code): void
     {
         $this->state = self::STATE_DEFAULT;
         $this->currentUse = null;

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -63,7 +63,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         return $tokensToString;
     }
 
-    private function reset()
+    private function reset(): void
     {
         $this->state = self::STATE_DEFAULT;
         $this->currentClass = '';
@@ -141,7 +141,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         }, $tokens));
     }
 
-    private function extractTypehints(array &$tokens, int $index, array $token)
+    private function extractTypehints(array &$tokens, int $index, array $token): void
     {
         $typehint = '';
         for ($i = $index - 1; \in_array($tokens[$i][0], $this->typehintTokens); $i--) {

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -52,7 +52,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         $this->namespaceResolver = $namespaceResolver;
     }
 
-    public function rewrite(string $classDefinition) : string
+    public function rewrite(string $classDefinition): string
     {
         $this->namespaceResolver->analyse($classDefinition);
 
@@ -70,7 +70,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         $this->currentFunction = '';
     }
 
-    private function stripTypeHints(array $tokens) : array
+    private function stripTypeHints(array $tokens): array
     {
         foreach ($tokens as $index => $token) {
             if ($this->isToken($token, '{')) {
@@ -134,7 +134,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
      * @param array $tokens
      * @return string
      */
-    private function tokensToString(array $tokens) : string
+    private function tokensToString(array $tokens): string
     {
         return join('', array_map(function ($token) {
             return \is_array($token) ? $token[1] : $token;
@@ -176,12 +176,12 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     /**
      * @param array|string $token
      */
-    private function tokenHasType($token, string $type) : bool
+    private function tokenHasType($token, string $type): bool
     {
         return \is_array($token) && $type == $token[0];
     }
 
-    private function shouldExtractTokensOfClass(string $className) : bool
+    private function shouldExtractTokensOfClass(string $className): bool
     {
         return substr($className, -4) == 'Spec';
     }
@@ -189,7 +189,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     /**
      * @param array|string $token
      */
-    private function isToken($token, string $string) : bool
+    private function isToken($token, string $string): bool
     {
         return $token == $string || (\is_array($token) && $token[1] == $string);
     }

--- a/src/PhpSpec/CodeAnalysis/TypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TypeHintRewriter.php
@@ -20,5 +20,5 @@ interface TypeHintRewriter
      *
      * @return string
      */
-    public function rewrite(string $classDefinition) : string;
+    public function rewrite(string $classDefinition): string;
 }

--- a/src/PhpSpec/CodeAnalysis/VisibilityAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/VisibilityAccessInspector.php
@@ -21,7 +21,7 @@ final class VisibilityAccessInspector implements AccessInspector
     /**
      * @param object $object
      */
-    public function isPropertyReadable($object, string $property) : bool
+    public function isPropertyReadable($object, string $property): bool
     {
         return $this->isExistingPublicProperty($object, $property);
     }
@@ -29,7 +29,7 @@ final class VisibilityAccessInspector implements AccessInspector
     /**
      * @param object $object
      */
-    public function isPropertyWritable($object, string $property) : bool
+    public function isPropertyWritable($object, string $property): bool
     {
         return $this->isExistingPublicProperty($object, $property);
     }
@@ -37,7 +37,7 @@ final class VisibilityAccessInspector implements AccessInspector
     /**
      * @param object $object
      */
-    private function isExistingPublicProperty($object, string $property) : bool
+    private function isExistingPublicProperty($object, string $property): bool
     {
         if (!property_exists($object, $property)) {
             return false;
@@ -51,7 +51,7 @@ final class VisibilityAccessInspector implements AccessInspector
     /**
      * @param object $object
      */
-    public function isMethodCallable($object, string $method) : bool
+    public function isMethodCallable($object, string $method): bool
     {
         return $this->isExistingPublicMethod($object, $method);
     }
@@ -59,7 +59,7 @@ final class VisibilityAccessInspector implements AccessInspector
     /**
      * @param object $object
      */
-    private function isExistingPublicMethod($object, string $method) : bool
+    private function isExistingPublicMethod($object, string $method): bool
     {
         if (!method_exists($object, $method)) {
             return false;

--- a/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
@@ -28,17 +28,17 @@ final class ClassGenerator extends PromptingGenerator
      *
      * @return bool
      */
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'class' === $generation;
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 0;
     }
 
-    protected function renderTemplate(Resource $resource, string $filepath) : string
+    protected function renderTemplate(Resource $resource, string $filepath): string
     {
         $values = array(
             '%filepath%'        => $filepath,
@@ -59,17 +59,17 @@ final class ClassGenerator extends PromptingGenerator
         return $content;
     }
 
-    protected function getTemplate() : string
+    protected function getTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/class.template');
     }
 
-    protected function getFilePath(Resource $resource) : string
+    protected function getFilePath(Resource $resource): string
     {
         return $resource->getSrcFilename();
     }
 
-    protected function getGeneratedMessage(Resource $resource, string $filepath) : string
+    protected function getGeneratedMessage(Resource $resource, string $filepath): string
     {
         return sprintf(
             "<info>Class <value>%s</value> created in <value>%s</value>.</info>\n",

--- a/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
@@ -48,7 +48,7 @@ final class ConfirmingGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(Resource $resource, array $data): void
     {
         if ($this->io->askConfirmation($this->composeMessage($resource))) {
             $this->generator->generate($resource, $data);

--- a/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
@@ -40,7 +40,7 @@ final class ConfirmingGenerator implements Generator
         $this->generator = $generator;
     }
 
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return $this->generator->supports($resource, $generation, $data);
     }
@@ -55,12 +55,12 @@ final class ConfirmingGenerator implements Generator
         }
     }
 
-    private function composeMessage(Resource $resource) : string
+    private function composeMessage(Resource $resource): string
     {
         return str_replace('{CLASSNAME}', $resource->getSrcClassname(), $this->message);
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return $this->generator->getPriority();
     }

--- a/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
@@ -44,7 +44,7 @@ class CreateObjectTemplate
         return $content;
     }
 
-    private function getTemplate() : string
+    private function getTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/named_constructor_create_object.template');
     }
@@ -52,7 +52,7 @@ class CreateObjectTemplate
     /**
      * @return string[]
      */
-    private function getValues() : array
+    private function getValues(): array
     {
         $argString = \count($this->arguments)
             ? '$argument'.implode(', $argument', range(1, \count($this->arguments)))

--- a/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
@@ -33,7 +33,7 @@ class ExistingConstructorTemplate
         $this->methodName = $methodName;
     }
 
-    public function getContent() : string
+    public function getContent(): string
     {
         if (!$this->numberOfConstructorArgumentsMatchMethod()) {
             return $this->getExceptionContent();
@@ -42,7 +42,7 @@ class ExistingConstructorTemplate
         return $this->getCreateObjectContent();
     }
 
-    private function numberOfConstructorArgumentsMatchMethod() : bool
+    private function numberOfConstructorArgumentsMatchMethod(): bool
     {
         $constructorArguments = 0;
 
@@ -58,7 +58,7 @@ class ExistingConstructorTemplate
         return $constructorArguments == \count($this->arguments);
     }
 
-    private function getExceptionContent() : string
+    private function getExceptionContent(): string
     {
         $values = $this->getValues();
 
@@ -72,7 +72,7 @@ class ExistingConstructorTemplate
         return $content;
     }
 
-    private function getCreateObjectContent() : string
+    private function getCreateObjectContent(): string
     {
         $values = $this->getValues(true);
 
@@ -89,7 +89,7 @@ class ExistingConstructorTemplate
     /**
      * @return string[]
      */
-    private function getValues(bool $constructorArguments = false) : array
+    private function getValues(bool $constructorArguments = false): array
     {
         $argString = \count($this->arguments)
             ? '$argument'.implode(', $argument', range(1, \count($this->arguments)))

--- a/src/PhpSpec/CodeGenerator/Generator/Generator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/Generator.php
@@ -22,7 +22,7 @@ interface Generator
 {
     public function supports(Resource $resource, string $generation, array $data) : bool;
 
-    public function generate(Resource $resource, array $data);
+    public function generate(Resource $resource, array $data) : void;
 
     public function getPriority() : int;
 }

--- a/src/PhpSpec/CodeGenerator/Generator/Generator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/Generator.php
@@ -20,9 +20,9 @@ use PhpSpec\Locator\Resource;
  */
 interface Generator
 {
-    public function supports(Resource $resource, string $generation, array $data) : bool;
+    public function supports(Resource $resource, string $generation, array $data): bool;
 
-    public function generate(Resource $resource, array $data) : void;
+    public function generate(Resource $resource, array $data): void;
 
-    public function getPriority() : int;
+    public function getPriority(): int;
 }

--- a/src/PhpSpec/CodeGenerator/Generator/InterfaceGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/InterfaceGenerator.php
@@ -21,17 +21,17 @@ use PhpSpec\Locator\Resource;
  */
 final class InterfaceGenerator extends PromptingGenerator
 {
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'interface' === $generation;
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 0;
     }
 
-    protected function renderTemplate(Resource $resource, string $filepath) : string
+    protected function renderTemplate(Resource $resource, string $filepath): string
     {
         $values = array(
             '%filepath%'        => $filepath,
@@ -51,17 +51,17 @@ final class InterfaceGenerator extends PromptingGenerator
         return $content;
     }
 
-    protected function getTemplate() : string
+    protected function getTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/interface.template');
     }
 
-    protected function getFilePath(Resource $resource) : string
+    protected function getFilePath(Resource $resource): string
     {
         return $resource->getSrcFilename();
     }
 
-    protected function getGeneratedMessage(Resource $resource, string $filepath) : string
+    protected function getGeneratedMessage(Resource $resource, string $filepath): string
     {
         return sprintf(
             "<info>Interface <value>%s</value> created in <value>%s</value>.</info>\n",

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -67,7 +67,7 @@ final class MethodGenerator implements Generator
      * @param Resource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array())
+    public function generate(Resource $resource, array $data = array()) : void
     {
         $filepath  = $resource->getSrcFilename();
         $name      = $data['name'];

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -58,7 +58,7 @@ final class MethodGenerator implements Generator
         $this->codeWriter = $codeWriter;
     }
 
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'method' === $generation;
     }
@@ -67,7 +67,7 @@ final class MethodGenerator implements Generator
      * @param Resource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array()) : void
+    public function generate(Resource $resource, array $data = array()): void
     {
         $filepath  = $resource->getSrcFilename();
         $name      = $data['name'];
@@ -96,17 +96,17 @@ final class MethodGenerator implements Generator
         ), 2);
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 0;
     }
 
-    protected function getTemplate() : string
+    protected function getTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/method.template');
     }
 
-    private function getUpdatedCode(string $methodName, string $snippetToInsert, string $code) : string
+    private function getUpdatedCode(string $methodName, string $snippetToInsert, string $code): string
     {
         if ('__construct' === $methodName) {
             return $this->codeWriter->insertMethodFirstInClass($code, $snippetToInsert);

--- a/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
@@ -50,12 +50,12 @@ final class MethodSignatureGenerator implements Generator
         $this->filesystem = $filesystem;
     }
 
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'method-signature' === $generation;
     }
 
-    public function generate(Resource $resource, array $data = array()) : void
+    public function generate(Resource $resource, array $data = array()): void
     {
         $filepath  = $resource->getSrcFilename();
         $name      = $data['name'];
@@ -78,12 +78,12 @@ final class MethodSignatureGenerator implements Generator
         ), 2);
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 0;
     }
 
-    protected function getTemplate() : string
+    protected function getTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/interface_method_signature.template');
     }
@@ -95,7 +95,7 @@ final class MethodSignatureGenerator implements Generator
         $this->filesystem->putFileContents($filepath, $code);
     }
 
-    private function buildArgumentString(array $arguments) : string
+    private function buildArgumentString(array $arguments): string
     {
         $argString = \count($arguments)
             ? '$argument' . implode(', $argument', range(1, \count($arguments)))

--- a/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
@@ -55,7 +55,7 @@ final class MethodSignatureGenerator implements Generator
         return 'method-signature' === $generation;
     }
 
-    public function generate(Resource $resource, array $data = array())
+    public function generate(Resource $resource, array $data = array()) : void
     {
         $filepath  = $resource->getSrcFilename();
         $name      = $data['name'];

--- a/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
@@ -64,7 +64,7 @@ final class NamedConstructorGenerator implements Generator
      * @param Resource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array())
+    public function generate(Resource $resource, array $data = array()) : void
     {
         $filepath   = $resource->getSrcFilename();
         $methodName = $data['name'];

--- a/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
@@ -55,7 +55,7 @@ final class NamedConstructorGenerator implements Generator
         $this->codeWriter = $codeWriter;
     }
 
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'named_constructor' === $generation;
     }
@@ -64,7 +64,7 @@ final class NamedConstructorGenerator implements Generator
      * @param Resource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array()) : void
+    public function generate(Resource $resource, array $data = array()): void
     {
         $filepath   = $resource->getSrcFilename();
         $methodName = $data['name'];
@@ -86,12 +86,12 @@ final class NamedConstructorGenerator implements Generator
         ), 2);
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 0;
     }
 
-    private function getContent(Resource $resource, string $methodName, array $arguments) : string
+    private function getContent(Resource $resource, string $methodName, array $arguments): string
     {
         $className = $resource->getName();
         $class = $resource->getSrcClassname();
@@ -111,7 +111,7 @@ final class NamedConstructorGenerator implements Generator
         return $template->getContent();
     }
 
-    private function appendMethodToCode(string $code, string $method) : string
+    private function appendMethodToCode(string $code, string $method): string
     {
         try {
             return $this->codeWriter->insertAfterMethod($code, '__construct', $method);

--- a/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
@@ -36,12 +36,12 @@ final class NewFileNotifyingGenerator implements Generator
         $this->filesystem = $filesystem;
     }
 
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return $this->generator->supports($resource, $generation, $data);
     }
 
-    public function generate(Resource $resource, array $data) : void
+    public function generate(Resource $resource, array $data): void
     {
         $filePath = $this->getFilePath($resource);
 
@@ -52,12 +52,12 @@ final class NewFileNotifyingGenerator implements Generator
         $this->dispatchEventIfFileWasCreated($fileExisted, $filePath);
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return $this->generator->getPriority();
     }
 
-    private function getFilePath(Resource $resource) : string
+    private function getFilePath(Resource $resource): string
     {
         if ($this->generator->supports($resource, 'specification', array())) {
             return $resource->getSpecFilename();
@@ -66,12 +66,12 @@ final class NewFileNotifyingGenerator implements Generator
         return $resource->getSrcFilename();
     }
 
-    private function fileExists(string $filePath) : bool
+    private function fileExists(string $filePath): bool
     {
         return $this->filesystem->pathExists($filePath);
     }
 
-    private function dispatchEventIfFileWasCreated(bool $fileExisted, string $filePath) : void
+    private function dispatchEventIfFileWasCreated(bool $fileExisted, string $filePath): void
     {
         if (!$fileExisted && $this->fileExists($filePath)) {
             $event = new FileCreationEvent($filePath);

--- a/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
@@ -41,7 +41,7 @@ final class NewFileNotifyingGenerator implements Generator
         return $this->generator->supports($resource, $generation, $data);
     }
 
-    public function generate(Resource $resource, array $data)
+    public function generate(Resource $resource, array $data) : void
     {
         $filePath = $this->getFilePath($resource);
 
@@ -71,7 +71,7 @@ final class NewFileNotifyingGenerator implements Generator
         return $this->filesystem->pathExists($filePath);
     }
 
-    private function dispatchEventIfFileWasCreated(bool $fileExisted, string $filePath)
+    private function dispatchEventIfFileWasCreated(bool $fileExisted, string $filePath) : void
     {
         if (!$fileExisted && $this->fileExists($filePath)) {
             $event = new FileCreationEvent($filePath);

--- a/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
@@ -35,7 +35,7 @@ final class OneTimeGenerator implements Generator
         $this->generator = $generator;
     }
 
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return $this->generator->supports($resource, $generation, $data);
     }
@@ -43,7 +43,7 @@ final class OneTimeGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(Resource $resource, array $data) : void
+    public function generate(Resource $resource, array $data): void
     {
         $classname = $resource->getSrcClassname();
         if (\in_array($classname, $this->alreadyGenerated)) {
@@ -54,7 +54,7 @@ final class OneTimeGenerator implements Generator
         $this->alreadyGenerated[] = $classname;
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return $this->generator->getPriority();
     }

--- a/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
@@ -43,7 +43,7 @@ final class OneTimeGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(Resource $resource, array $data) : void
     {
         $classname = $resource->getSrcClassname();
         if (\in_array($classname, $this->alreadyGenerated)) {

--- a/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
@@ -56,7 +56,7 @@ final class PrivateConstructorGenerator implements Generator
         $this->codeWriter = $codeWriter;
     }
 
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'private-constructor' === $generation;
     }
@@ -65,7 +65,7 @@ final class PrivateConstructorGenerator implements Generator
      * @param Resource $resource
      * @param array $data
      */
-    public function generate(Resource $resource, array $data) : void
+    public function generate(Resource $resource, array $data): void
     {
         $filepath  = $resource->getSrcFilename();
 
@@ -83,12 +83,12 @@ final class PrivateConstructorGenerator implements Generator
         $this->io->writeln("<info>Private constructor has been created.</info>\n", 2);
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 0;
     }
 
-    protected function getTemplate() : string
+    protected function getTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/private-constructor.template');
     }

--- a/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
@@ -65,7 +65,7 @@ final class PrivateConstructorGenerator implements Generator
      * @param Resource $resource
      * @param array $data
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(Resource $resource, array $data) : void
     {
         $filepath  = $resource->getSrcFilename();
 

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -62,7 +62,7 @@ abstract class PromptingGenerator implements Generator
      * @param Resource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array())
+    public function generate(Resource $resource, array $data = array()) : void
     {
         $filepath = $this->getFilePath($resource);
 

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -62,7 +62,7 @@ abstract class PromptingGenerator implements Generator
      * @param Resource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data = array()) : void
+    public function generate(Resource $resource, array $data = array()): void
     {
         $filepath = $this->getFilePath($resource);
 
@@ -79,14 +79,14 @@ abstract class PromptingGenerator implements Generator
         $this->executionContext->addGeneratedType($resource->getSrcClassname());
     }
 
-    protected function getTemplateRenderer() : TemplateRenderer
+    protected function getTemplateRenderer(): TemplateRenderer
     {
         return $this->templates;
     }
 
-    abstract protected function getFilePath(Resource $resource) : string;
+    abstract protected function getFilePath(Resource $resource): string;
 
-    abstract protected function renderTemplate(Resource $resource, string $filepath) : string;
+    abstract protected function renderTemplate(Resource $resource, string $filepath): string;
 
     /**
      * @param Resource $resource
@@ -94,14 +94,14 @@ abstract class PromptingGenerator implements Generator
      *
      * @return string
      */
-    abstract protected function getGeneratedMessage(Resource $resource, string $filepath) : string;
+    abstract protected function getGeneratedMessage(Resource $resource, string $filepath): string;
 
-    private function fileAlreadyExists(string $filepath) : bool
+    private function fileAlreadyExists(string $filepath): bool
     {
         return $this->filesystem->pathExists($filepath);
     }
 
-    private function userAborts(string $filepath) : bool
+    private function userAborts(string $filepath): bool
     {
         $message = sprintf('File "%s" already exists. Overwrite?', basename($filepath));
 

--- a/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
@@ -54,7 +54,7 @@ final class ReturnConstantGenerator implements Generator
      * @param Resource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data)
+    public function generate(Resource $resource, array $data) : void
     {
         $method = $data['method'];
         $expected = $data['expected'];

--- a/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
@@ -45,7 +45,7 @@ final class ReturnConstantGenerator implements Generator
         $this->filesystem = $filesystem;
     }
 
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'returnConstant' == $generation;
     }
@@ -54,7 +54,7 @@ final class ReturnConstantGenerator implements Generator
      * @param Resource $resource
      * @param array             $data
      */
-    public function generate(Resource $resource, array $data) : void
+    public function generate(Resource $resource, array $data): void
     {
         $method = $data['method'];
         $expected = $data['expected'];
@@ -83,12 +83,12 @@ final class ReturnConstantGenerator implements Generator
         ), 2);
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 0;
     }
 
-    protected function getTemplate() : string
+    protected function getTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/returnconstant.template');
     }

--- a/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
@@ -21,12 +21,12 @@ use PhpSpec\Locator\Resource;
  */
 final class SpecificationGenerator extends PromptingGenerator
 {
-    public function supports(Resource $resource, string $generation, array $data) : bool
+    public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'specification' === $generation;
     }
 
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 0;
     }
@@ -37,7 +37,7 @@ final class SpecificationGenerator extends PromptingGenerator
      *
      * @return string
      */
-    protected function renderTemplate(Resource $resource, string $filepath) : string
+    protected function renderTemplate(Resource $resource, string $filepath): string
     {
         $values = array(
             '%filepath%'      => $filepath,
@@ -54,17 +54,17 @@ final class SpecificationGenerator extends PromptingGenerator
         return $content;
     }
 
-    protected function getTemplate() : string
+    protected function getTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/specification.template');
     }
 
-    protected function getFilePath(Resource $resource) : string
+    protected function getFilePath(Resource $resource): string
     {
         return $resource->getSpecFilename();
     }
 
-    protected function getGeneratedMessage(Resource $resource, string $filepath) : string
+    protected function getGeneratedMessage(Resource $resource, string $filepath): string
     {
         return sprintf(
             "<info>Specification for <value>%s</value> created in <value>%s</value>.</info>\n",

--- a/src/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGenerator.php
@@ -37,7 +37,7 @@ final class ValidateClassNameSpecificationGenerator implements Generator
         return $this->originalGenerator->supports($resource, $generation, $data);
     }
 
-    public function generate(Resource $resource, array $data) : void
+    public function generate(Resource $resource, array $data): void
     {
         $className = $resource->getSrcClassname();
 
@@ -49,7 +49,7 @@ final class ValidateClassNameSpecificationGenerator implements Generator
         $this->originalGenerator->generate($resource, $data);
     }
 
-    private function writeInvalidClassNameError(string $className) : void
+    private function writeInvalidClassNameError(string $className): void
     {
         $error = "I cannot generate spec for '$className' because class name contains reserved keyword";
         $this->io->writeBrokenCodeBlock($error, 2);

--- a/src/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGenerator.php
@@ -37,7 +37,7 @@ final class ValidateClassNameSpecificationGenerator implements Generator
         return $this->originalGenerator->supports($resource, $generation, $data);
     }
 
-    public function generate(Resource $resource, array $data)
+    public function generate(Resource $resource, array $data) : void
     {
         $className = $resource->getSrcClassname();
 
@@ -49,7 +49,7 @@ final class ValidateClassNameSpecificationGenerator implements Generator
         $this->originalGenerator->generate($resource, $data);
     }
 
-    private function writeInvalidClassNameError(string $className)
+    private function writeInvalidClassNameError(string $className) : void
     {
         $error = "I cannot generate spec for '$className' because class name contains reserved keyword";
         $this->io->writeBrokenCodeBlock($error, 2);

--- a/src/PhpSpec/CodeGenerator/GeneratorManager.php
+++ b/src/PhpSpec/CodeGenerator/GeneratorManager.php
@@ -30,7 +30,7 @@ class GeneratorManager
     /**
      * @param Generator $generator
      */
-    public function registerGenerator(Generator $generator) : void
+    public function registerGenerator(Generator $generator): void
     {
         $this->generators[] = $generator;
         @usort($this->generators, function (Generator $generator1, Generator $generator2) {
@@ -42,7 +42,7 @@ class GeneratorManager
      * @return mixed
      * @throws \InvalidArgumentException
      */
-    public function generate(Resource $resource, string $name, array $data = array()) : void
+    public function generate(Resource $resource, string $name, array $data = array()): void
     {
         foreach ($this->generators as $generator) {
             if ($generator->supports($resource, $name, $data)) {

--- a/src/PhpSpec/CodeGenerator/GeneratorManager.php
+++ b/src/PhpSpec/CodeGenerator/GeneratorManager.php
@@ -30,7 +30,7 @@ class GeneratorManager
     /**
      * @param Generator $generator
      */
-    public function registerGenerator(Generator $generator)
+    public function registerGenerator(Generator $generator) : void
     {
         $this->generators[] = $generator;
         @usort($this->generators, function (Generator $generator1, Generator $generator2) {
@@ -42,11 +42,13 @@ class GeneratorManager
      * @return mixed
      * @throws \InvalidArgumentException
      */
-    public function generate(Resource $resource, string $name, array $data = array())
+    public function generate(Resource $resource, string $name, array $data = array()) : void
     {
         foreach ($this->generators as $generator) {
             if ($generator->supports($resource, $name, $data)) {
-                return $generator->generate($resource, $data);
+                $generator->generate($resource, $data);
+
+                return;
             }
         }
 

--- a/src/PhpSpec/CodeGenerator/TemplateRenderer.php
+++ b/src/PhpSpec/CodeGenerator/TemplateRenderer.php
@@ -42,27 +42,27 @@ class TemplateRenderer
     /**
      * @param array $locations
      */
-    public function setLocations(array $locations) : void
+    public function setLocations(array $locations): void
     {
         $this->locations = array_map(array($this, 'normalizeLocation'), $locations);
     }
 
-    public function prependLocation(string $location) : void
+    public function prependLocation(string $location): void
     {
         array_unshift($this->locations, $this->normalizeLocation($location));
     }
 
-    public function appendLocation(string $location) : void
+    public function appendLocation(string $location): void
     {
         array_push($this->locations, $this->normalizeLocation($location));
     }
 
-    public function getLocations() : array
+    public function getLocations(): array
     {
         return $this->locations;
     }
 
-    public function render(string $name, array $values = array()) : string
+    public function render(string $name, array $values = array()): string
     {
         foreach ($this->locations as $location) {
             $path = $location.DIRECTORY_SEPARATOR.$this->normalizeLocation($name, true).'.tpl';
@@ -74,12 +74,12 @@ class TemplateRenderer
         return '';
     }
 
-    public function renderString(string $template, array $values = array()) : string
+    public function renderString(string $template, array $values = array()): string
     {
         return strtr($template, $values);
     }
 
-    private function normalizeLocation(string $location, bool $trimLeft = false) : string
+    private function normalizeLocation(string $location, bool $trimLeft = false): string
     {
         $location = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $location);
         $location = rtrim($location, DIRECTORY_SEPARATOR);

--- a/src/PhpSpec/CodeGenerator/TemplateRenderer.php
+++ b/src/PhpSpec/CodeGenerator/TemplateRenderer.php
@@ -42,17 +42,17 @@ class TemplateRenderer
     /**
      * @param array $locations
      */
-    public function setLocations(array $locations)
+    public function setLocations(array $locations) : void
     {
         $this->locations = array_map(array($this, 'normalizeLocation'), $locations);
     }
 
-    public function prependLocation(string $location)
+    public function prependLocation(string $location) : void
     {
         array_unshift($this->locations, $this->normalizeLocation($location));
     }
 
-    public function appendLocation(string $location)
+    public function appendLocation(string $location) : void
     {
         array_push($this->locations, $this->normalizeLocation($location));
     }

--- a/src/PhpSpec/CodeGenerator/Writer/CodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/CodeWriter.php
@@ -15,9 +15,9 @@ namespace PhpSpec\CodeGenerator\Writer;
 
 interface CodeWriter
 {
-    public function insertMethodFirstInClass(string $class, string $method) : string;
+    public function insertMethodFirstInClass(string $class, string $method): string;
 
-    public function insertMethodLastInClass(string $class, string $method) : string;
+    public function insertMethodLastInClass(string $class, string $method): string;
 
-    public function insertAfterMethod(string $class, string $methodName, string $method) : string;
+    public function insertAfterMethod(string $class, string $methodName, string $method): string;
 }

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -30,7 +30,7 @@ final class TokenizedCodeWriter implements CodeWriter
         $this->analyser = $analyser;
     }
 
-    public function insertMethodFirstInClass(string $class, string $method) : string
+    public function insertMethodFirstInClass(string $class, string $method): string
     {
         if (!$this->analyser->classHasMethods($class)) {
             return $this->writeAtEndOfClass($class, $method);
@@ -41,7 +41,7 @@ final class TokenizedCodeWriter implements CodeWriter
         return $this->insertStringBeforeLine($class, $method, $line);
     }
 
-    public function insertMethodLastInClass(string $class, string $method) : string
+    public function insertMethodLastInClass(string $class, string $method): string
     {
         if ($this->analyser->classHasMethods($class)) {
             $line = $this->analyser->getEndLineOfLastMethod($class);
@@ -51,14 +51,14 @@ final class TokenizedCodeWriter implements CodeWriter
         return $this->writeAtEndOfClass($class, $method);
     }
 
-    public function insertAfterMethod(string $class, string $methodName, string $method) : string
+    public function insertAfterMethod(string $class, string $methodName, string $method): string
     {
         $line = $this->analyser->getEndLineOfNamedMethod($class, $methodName);
 
         return $this->insertStringAfterLine($class, $method, $line);
     }
 
-    private function insertStringAfterLine(string $target, string $toInsert, int $line, bool $leadingNewline = true) : string
+    private function insertStringAfterLine(string $target, string $toInsert, int $line, bool $leadingNewline = true): string
     {
         $lines = explode("\n", $target);
         $lastLines = \array_slice($lines, $line);
@@ -72,7 +72,7 @@ final class TokenizedCodeWriter implements CodeWriter
         return implode("\n", $lines);
     }
 
-    private function insertStringBeforeLine(string $target, string $toInsert, int $line) : string
+    private function insertStringBeforeLine(string $target, string $toInsert, int $line): string
     {
         $line--;
         $lines = explode("\n", $target);
@@ -83,7 +83,7 @@ final class TokenizedCodeWriter implements CodeWriter
         return implode("\n", $lines);
     }
 
-    private function writeAtEndOfClass(string $class, string $method, bool $prependNewLine = false) : string
+    private function writeAtEndOfClass(string $class, string $method, bool $prependNewLine = false): string
     {
         $tokens = token_get_all($class);
         $searching = false;
@@ -126,7 +126,7 @@ final class TokenizedCodeWriter implements CodeWriter
     /**
      * @param $token
      */
-    private function isWritePoint($token) : bool
+    private function isWritePoint($token): bool
     {
         return \is_array($token) && ($token[1] === "\n" || $token[0] === T_COMMENT);
     }

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -222,7 +222,7 @@ final class Application extends BaseApplication
         return $config;
     }
 
-    private function extractConfigFromFirstParsablePath(array $paths) : array
+    private function extractConfigFromFirstParsablePath(array $paths): array
     {
         foreach ($paths as $path) {
             if (!file_exists($path)) {
@@ -242,7 +242,7 @@ final class Application extends BaseApplication
      *
      * @return array
      */
-    private function parseConfigFromExistingPath(string $path) : array
+    private function parseConfigFromExistingPath(string $path): array
     {
         if (!file_exists($path)) {
             return array();
@@ -251,7 +251,7 @@ final class Application extends BaseApplication
         return Yaml::parse(file_get_contents($path)) ?: [];
     }
 
-    private function addPathsToEachSuiteConfig(string $configDir, array $config) : array
+    private function addPathsToEachSuiteConfig(string $configDir, array $config): array
     {
         if (isset($config['suites']) && \is_array($config['suites'])) {
             foreach ($config['suites'] as $suiteKey => $suiteConfig) {

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Question\Question;
  */
 final class DescribeCommand extends Command
 {
-    protected function configure()
+    protected function configure() : void
     {
         $this
             ->setName('describe')

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Question\Question;
  */
 final class DescribeCommand extends Command
 {
-    protected function configure() : void
+    protected function configure(): void
     {
         $this
             ->setName('describe')
@@ -93,7 +93,7 @@ EOF
     /**
      * Make path safe to echo to the terminal (to get around symfony/console issue #24652)
      */
-    private function escapePathForTerminal(string $path) : string
+    private function escapePathForTerminal(string $path): string
     {
         return str_replace('\\', '/', $path);
     }

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -74,17 +74,17 @@ class ConsoleIO implements IO
         $this->prompter = $prompter;
     }
 
-    public function isInteractive() : bool
+    public function isInteractive(): bool
     {
         return $this->input->isInteractive();
     }
 
-    public function isDecorated() : bool
+    public function isDecorated(): bool
     {
         return $this->output->isDecorated();
     }
 
-    public function isCodeGenerationEnabled() : bool
+    public function isCodeGenerationEnabled(): bool
     {
         if (!$this->isInteractive()) {
             return false;
@@ -94,28 +94,28 @@ class ConsoleIO implements IO
             && !$this->input->getOption('no-code-generation');
     }
 
-    public function isStopOnFailureEnabled() : bool
+    public function isStopOnFailureEnabled(): bool
     {
         return $this->config->isStopOnFailureEnabled()
             || $this->input->getOption('stop-on-failure');
     }
 
-    public function isVerbose() : bool
+    public function isVerbose(): bool
     {
         return OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity();
     }
 
-    public function getLastWrittenMessage() : string
+    public function getLastWrittenMessage(): string
     {
         return $this->lastMessage;
     }
 
-    public function writeln(string $message = '', int $indent = null) : void
+    public function writeln(string $message = '', int $indent = null): void
     {
         $this->write($message, $indent, true);
     }
 
-    public function writeTemp(string $message, int $indent = null) : void
+    public function writeTemp(string $message, int $indent = null): void
     {
         $this->write($message, $indent);
         $this->hasTempString = true;
@@ -144,12 +144,12 @@ class ConsoleIO implements IO
         return $message;
     }
 
-    public function freezeTemp() : void
+    public function freezeTemp(): void
     {
         $this->write($this->lastMessage);
     }
 
-    public function write(string $message, int $indent = null, bool $newline = false) : void
+    public function write(string $message, int $indent = null, bool $newline = false): void
     {
         if ($this->hasTempString) {
             $this->hasTempString = false;
@@ -166,12 +166,12 @@ class ConsoleIO implements IO
         $this->lastMessage = $message.($newline ? "\n" : '');
     }
 
-    public function overwriteln(string $message = '', int $indent = null) : void
+    public function overwriteln(string $message = '', int $indent = null): void
     {
         $this->overwrite($message, $indent, true);
     }
 
-    public function overwrite(string $message, int $indent = null, bool $newline = false) : void
+    public function overwrite(string $message, int $indent = null, bool $newline = false): void
     {
         if (null !== $indent) {
             $message = $this->indentText($message, $indent);
@@ -220,7 +220,7 @@ class ConsoleIO implements IO
         return $common;
     }
 
-    public function askConfirmation(string $question, bool $default = true) : bool
+    public function askConfirmation(string $question, bool $default = true): bool
     {
         $lines   = array();
         $lines[] = '<question>'.str_repeat(' ', $this->getBlockWidth())."</question>";
@@ -235,7 +235,7 @@ class ConsoleIO implements IO
         return $this->prompter->askConfirmation($formattedQuestion, $default);
     }
 
-    private function indentText(string $text, int $indent) : string
+    private function indentText(string $text, int $indent): string
     {
         return implode("\n", array_map(
             function ($line) use ($indent) {
@@ -245,12 +245,12 @@ class ConsoleIO implements IO
         ));
     }
 
-    public function isRerunEnabled() : bool
+    public function isRerunEnabled(): bool
     {
         return !$this->input->getOption('no-rerun') && $this->config->isReRunEnabled();
     }
 
-    public function isFakingEnabled() : bool
+    public function isFakingEnabled(): bool
     {
         return $this->input->getOption('fake') || $this->config->isFakingEnabled();
     }
@@ -270,12 +270,12 @@ class ConsoleIO implements IO
         return null;
     }
 
-    public function setConsoleWidth(int $width) : void
+    public function setConsoleWidth(int $width): void
     {
         $this->consoleWidth = $width;
     }
 
-    public function getBlockWidth() : int
+    public function getBlockWidth(): int
     {
         $width = self::COL_DEFAULT_WIDTH;
         if ($this->consoleWidth && ($this->consoleWidth - 10) > self::COL_MIN_WIDTH) {
@@ -291,7 +291,7 @@ class ConsoleIO implements IO
      * @param string $message
      * @param int $indent
      */
-    public function writeBrokenCodeBlock(string $message, int $indent = 0) : void
+    public function writeBrokenCodeBlock(string $message, int $indent = 0): void
     {
         $message = wordwrap($message, $this->getBlockWidth() - ($indent * 2), "\n", true);
 

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -110,12 +110,12 @@ class ConsoleIO implements IO
         return $this->lastMessage;
     }
 
-    public function writeln(string $message = '', int $indent = null)
+    public function writeln(string $message = '', int $indent = null) : void
     {
         $this->write($message, $indent, true);
     }
 
-    public function writeTemp(string $message, int $indent = null)
+    public function writeTemp(string $message, int $indent = null) : void
     {
         $this->write($message, $indent);
         $this->hasTempString = true;
@@ -144,12 +144,12 @@ class ConsoleIO implements IO
         return $message;
     }
 
-    public function freezeTemp()
+    public function freezeTemp() : void
     {
         $this->write($this->lastMessage);
     }
 
-    public function write(string $message, int $indent = null, bool $newline = false)
+    public function write(string $message, int $indent = null, bool $newline = false) : void
     {
         if ($this->hasTempString) {
             $this->hasTempString = false;
@@ -166,12 +166,12 @@ class ConsoleIO implements IO
         $this->lastMessage = $message.($newline ? "\n" : '');
     }
 
-    public function overwriteln(string $message = '', int $indent = null)
+    public function overwriteln(string $message = '', int $indent = null) : void
     {
         $this->overwrite($message, $indent, true);
     }
 
-    public function overwrite(string $message, int $indent = null, bool $newline = false)
+    public function overwrite(string $message, int $indent = null, bool $newline = false) : void
     {
         if (null !== $indent) {
             $message = $this->indentText($message, $indent);
@@ -270,7 +270,7 @@ class ConsoleIO implements IO
         return null;
     }
 
-    public function setConsoleWidth(int $width)
+    public function setConsoleWidth(int $width) : void
     {
         $this->consoleWidth = $width;
     }
@@ -291,7 +291,7 @@ class ConsoleIO implements IO
      * @param string $message
      * @param int $indent
      */
-    public function writeBrokenCodeBlock(string $message, int $indent = 0)
+    public function writeBrokenCodeBlock(string $message, int $indent = 0) : void
     {
         $message = wordwrap($message, $this->getBlockWidth() - ($indent * 2), "\n", true);
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -55,7 +55,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    public function build(IndexedServiceContainer $container) : void
+    public function build(IndexedServiceContainer $container): void
     {
         $this->setupParameters($container);
         $this->setupIO($container);
@@ -76,7 +76,7 @@ final class ContainerAssembler
         $this->setupShutdown($container);
     }
 
-    private function setupParameters(IndexedServiceContainer $container) : void
+    private function setupParameters(IndexedServiceContainer $container): void
     {
         $container->setParam(
             'generator.private-constructor.message',
@@ -84,7 +84,7 @@ final class ContainerAssembler
         );
     }
 
-    private function setupIO(IndexedServiceContainer $container) : void
+    private function setupIO(IndexedServiceContainer $container): void
     {
         if (!$container->has('console.prompter')) {
             $container->define('console.prompter', function ($c) {
@@ -120,14 +120,14 @@ final class ContainerAssembler
         });
     }
 
-    private function setupResultConverter(IndexedServiceContainer $container) : void
+    private function setupResultConverter(IndexedServiceContainer $container): void
     {
         $container->define('console.result_converter', function () {
             return new ResultConverter();
         });
     }
 
-    private function setupCommands(IndexedServiceContainer $container) : void
+    private function setupCommands(IndexedServiceContainer $container): void
     {
         $container->define('console.commands.run', function () {
             return new Command\RunCommand();
@@ -141,7 +141,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupConsoleEventDispatcher(IndexedServiceContainer $container) : void
+    private function setupConsoleEventDispatcher(IndexedServiceContainer $container): void
     {
         $container->define('console_event_dispatcher', function (IndexedServiceContainer $c) {
             $dispatcher = new EventDispatcher();
@@ -158,7 +158,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupEventDispatcher(IndexedServiceContainer $container) : void
+    private function setupEventDispatcher(IndexedServiceContainer $container): void
     {
         $container->define('event_dispatcher', function () {
             return new EventDispatcher();
@@ -252,7 +252,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupGenerators(IndexedServiceContainer $container) : void
+    private function setupGenerators(IndexedServiceContainer $container): void
     {
         $container->define('code_generator', function (IndexedServiceContainer $c) {
             $generator = new CodeGenerator\GeneratorManager();
@@ -388,7 +388,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupPresenter(IndexedServiceContainer $container) : void
+    private function setupPresenter(IndexedServiceContainer $container): void
     {
         $presenterAssembler = new PresenterAssembler();
         $presenterAssembler->assemble($container);
@@ -397,7 +397,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupLocator(IndexedServiceContainer $container) : void
+    private function setupLocator(IndexedServiceContainer $container): void
     {
         $container->define('locator.resource_manager', function (IndexedServiceContainer $c) {
             $manager = new Locator\PrioritizedResourceManager();
@@ -489,7 +489,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupLoader(IndexedServiceContainer $container) : void
+    private function setupLoader(IndexedServiceContainer $container): void
     {
         $container->define('loader.resource_loader', function (IndexedServiceContainer $c) {
             return new Loader\ResourceLoader(
@@ -524,7 +524,7 @@ final class ContainerAssembler
      *
      * @throws \RuntimeException
      */
-    protected function setupFormatter(IndexedServiceContainer $container) : void
+    protected function setupFormatter(IndexedServiceContainer $container): void
     {
         $container->define(
             'formatter.formatters.progress',
@@ -618,7 +618,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupRunner(IndexedServiceContainer $container) : void
+    private function setupRunner(IndexedServiceContainer $container): void
     {
         $container->define('runner.suite', function (IndexedServiceContainer $c) {
             return new Runner\SuiteRunner(
@@ -700,7 +700,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupMatchers(IndexedServiceContainer $container) : void
+    private function setupMatchers(IndexedServiceContainer $container): void
     {
         $container->define('matchers.identity', function (IndexedServiceContainer $c) {
             return new Matcher\IdentityMatcher($c->get('formatter.presenter'));
@@ -776,7 +776,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupRerunner(IndexedServiceContainer $container) : void
+    private function setupRerunner(IndexedServiceContainer $container): void
     {
         $container->define('process.rerunner', function (IndexedServiceContainer $c) {
             return new ReRunner\OptionalReRunner(
@@ -820,7 +820,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupSubscribers(IndexedServiceContainer $container) : void
+    private function setupSubscribers(IndexedServiceContainer $container): void
     {
         $container->addConfigurator(function (IndexedServiceContainer $c) {
             array_map(
@@ -833,7 +833,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupCurrentExample(IndexedServiceContainer $container) : void
+    private function setupCurrentExample(IndexedServiceContainer $container): void
     {
         $container->define('current_example', function () {
             return new CurrentExampleTracker();
@@ -843,7 +843,7 @@ final class ContainerAssembler
   /**
    * @param IndexedServiceContainer $container
    */
-    private function setupShutdown(IndexedServiceContainer $container) : void
+    private function setupShutdown(IndexedServiceContainer $container): void
     {
         $container->define('process.shutdown', function () {
             return new Shutdown();

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -55,7 +55,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    public function build(IndexedServiceContainer $container)
+    public function build(IndexedServiceContainer $container) : void
     {
         $this->setupParameters($container);
         $this->setupIO($container);
@@ -76,7 +76,7 @@ final class ContainerAssembler
         $this->setupShutdown($container);
     }
 
-    private function setupParameters(IndexedServiceContainer $container)
+    private function setupParameters(IndexedServiceContainer $container) : void
     {
         $container->setParam(
             'generator.private-constructor.message',
@@ -84,7 +84,7 @@ final class ContainerAssembler
         );
     }
 
-    private function setupIO(IndexedServiceContainer $container)
+    private function setupIO(IndexedServiceContainer $container) : void
     {
         if (!$container->has('console.prompter')) {
             $container->define('console.prompter', function ($c) {
@@ -120,14 +120,14 @@ final class ContainerAssembler
         });
     }
 
-    private function setupResultConverter(IndexedServiceContainer $container)
+    private function setupResultConverter(IndexedServiceContainer $container) : void
     {
         $container->define('console.result_converter', function () {
             return new ResultConverter();
         });
     }
 
-    private function setupCommands(IndexedServiceContainer $container)
+    private function setupCommands(IndexedServiceContainer $container) : void
     {
         $container->define('console.commands.run', function () {
             return new Command\RunCommand();
@@ -141,7 +141,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupConsoleEventDispatcher(IndexedServiceContainer $container)
+    private function setupConsoleEventDispatcher(IndexedServiceContainer $container) : void
     {
         $container->define('console_event_dispatcher', function (IndexedServiceContainer $c) {
             $dispatcher = new EventDispatcher();
@@ -158,7 +158,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupEventDispatcher(IndexedServiceContainer $container)
+    private function setupEventDispatcher(IndexedServiceContainer $container) : void
     {
         $container->define('event_dispatcher', function () {
             return new EventDispatcher();
@@ -252,7 +252,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupGenerators(IndexedServiceContainer $container)
+    private function setupGenerators(IndexedServiceContainer $container) : void
     {
         $container->define('code_generator', function (IndexedServiceContainer $c) {
             $generator = new CodeGenerator\GeneratorManager();
@@ -388,7 +388,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupPresenter(IndexedServiceContainer $container)
+    private function setupPresenter(IndexedServiceContainer $container) : void
     {
         $presenterAssembler = new PresenterAssembler();
         $presenterAssembler->assemble($container);
@@ -397,7 +397,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupLocator(IndexedServiceContainer $container)
+    private function setupLocator(IndexedServiceContainer $container) : void
     {
         $container->define('locator.resource_manager', function (IndexedServiceContainer $c) {
             $manager = new Locator\PrioritizedResourceManager();
@@ -489,7 +489,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupLoader(IndexedServiceContainer $container)
+    private function setupLoader(IndexedServiceContainer $container) : void
     {
         $container->define('loader.resource_loader', function (IndexedServiceContainer $c) {
             return new Loader\ResourceLoader(
@@ -524,7 +524,7 @@ final class ContainerAssembler
      *
      * @throws \RuntimeException
      */
-    protected function setupFormatter(IndexedServiceContainer $container)
+    protected function setupFormatter(IndexedServiceContainer $container) : void
     {
         $container->define(
             'formatter.formatters.progress',
@@ -618,7 +618,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupRunner(IndexedServiceContainer $container)
+    private function setupRunner(IndexedServiceContainer $container) : void
     {
         $container->define('runner.suite', function (IndexedServiceContainer $c) {
             return new Runner\SuiteRunner(
@@ -700,7 +700,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupMatchers(IndexedServiceContainer $container)
+    private function setupMatchers(IndexedServiceContainer $container) : void
     {
         $container->define('matchers.identity', function (IndexedServiceContainer $c) {
             return new Matcher\IdentityMatcher($c->get('formatter.presenter'));
@@ -776,7 +776,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupRerunner(IndexedServiceContainer $container)
+    private function setupRerunner(IndexedServiceContainer $container) : void
     {
         $container->define('process.rerunner', function (IndexedServiceContainer $c) {
             return new ReRunner\OptionalReRunner(
@@ -820,7 +820,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupSubscribers(IndexedServiceContainer $container)
+    private function setupSubscribers(IndexedServiceContainer $container) : void
     {
         $container->addConfigurator(function (IndexedServiceContainer $c) {
             array_map(
@@ -833,7 +833,7 @@ final class ContainerAssembler
     /**
      * @param IndexedServiceContainer $container
      */
-    private function setupCurrentExample(IndexedServiceContainer $container)
+    private function setupCurrentExample(IndexedServiceContainer $container) : void
     {
         $container->define('current_example', function () {
             return new CurrentExampleTracker();
@@ -843,7 +843,7 @@ final class ContainerAssembler
   /**
    * @param IndexedServiceContainer $container
    */
-    private function setupShutdown(IndexedServiceContainer $container)
+    private function setupShutdown(IndexedServiceContainer $container) : void
     {
         $container->define('process.shutdown', function () {
             return new Shutdown();

--- a/src/PhpSpec/Console/Prompter.php
+++ b/src/PhpSpec/Console/Prompter.php
@@ -15,5 +15,5 @@ namespace PhpSpec\Console;
 
 interface Prompter
 {
-    public function askConfirmation(string $question, bool $default = true) : bool;
+    public function askConfirmation(string $question, bool $default = true): bool;
 }

--- a/src/PhpSpec/Console/Prompter/Question.php
+++ b/src/PhpSpec/Console/Prompter/Question.php
@@ -48,7 +48,7 @@ final class Question implements Prompter
      * @param boolean $default
      * @return boolean
      */
-    public function askConfirmation(string $question, bool $default = true) : bool
+    public function askConfirmation(string $question, bool $default = true): bool
     {
         return (bool)$this->helper->ask($this->input, $this->output, new ConfirmationQuestion($question, $default));
     }

--- a/src/PhpSpec/Event/SuiteEvent.php
+++ b/src/PhpSpec/Event/SuiteEvent.php
@@ -85,12 +85,12 @@ class SuiteEvent extends Event implements PhpSpecEvent
         return $this->worthRerunning;
     }
 
-    public function markAsWorthRerunning()
+    public function markAsWorthRerunning() : void
     {
         $this->worthRerunning = true;
     }
 
-    public function markAsNotWorthRerunning()
+    public function markAsNotWorthRerunning() : void
     {
         $this->worthRerunning = false;
     }

--- a/src/PhpSpec/Event/SuiteEvent.php
+++ b/src/PhpSpec/Event/SuiteEvent.php
@@ -85,12 +85,12 @@ class SuiteEvent extends Event implements PhpSpecEvent
         return $this->worthRerunning;
     }
 
-    public function markAsWorthRerunning() : void
+    public function markAsWorthRerunning(): void
     {
         $this->worthRerunning = true;
     }
 
-    public function markAsNotWorthRerunning() : void
+    public function markAsNotWorthRerunning(): void
     {
         $this->worthRerunning = false;
     }

--- a/src/PhpSpec/Exception/Exception.php
+++ b/src/PhpSpec/Exception/Exception.php
@@ -36,7 +36,7 @@ class Exception extends \Exception
     /**
      * @param ReflectionFunctionAbstract $cause
      */
-    public function setCause(ReflectionFunctionAbstract $cause) : void
+    public function setCause(ReflectionFunctionAbstract $cause): void
     {
         $this->cause = $cause;
     }

--- a/src/PhpSpec/Exception/Exception.php
+++ b/src/PhpSpec/Exception/Exception.php
@@ -36,7 +36,7 @@ class Exception extends \Exception
     /**
      * @param ReflectionFunctionAbstract $cause
      */
-    public function setCause(ReflectionFunctionAbstract $cause)
+    public function setCause(ReflectionFunctionAbstract $cause) : void
     {
         $this->cause = $cause;
     }

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -51,7 +51,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
     /**
      * @param ExampleEvent $event
      */
-    protected function printException(ExampleEvent $event)
+    protected function printException(ExampleEvent $event) : void
     {
         if (null === $exception = $event->getException()) {
             return;
@@ -74,7 +74,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
      * @param ExampleEvent $event
      * @param string $type
      */
-    protected function printSpecificException(ExampleEvent $event, string $type)
+    protected function printSpecificException(ExampleEvent $event, string $type) : void
     {
         $title = str_replace('\\', DIRECTORY_SEPARATOR, $event->getSpecification()->getTitle());
         $message = $this->getPresenter()->presentException($event->getException(), $this->io->isVerbose());
@@ -94,7 +94,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
         $this->io->writeln();
     }
 
-    public function displayFatal(CurrentExampleTracker $currentExample, $error)
+    public function displayFatal(CurrentExampleTracker $currentExample, $error) : void
     {
         if (
             (null !== $error && ($currentExample->getCurrentExample() || $error['type'] == E_ERROR)) ||

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -51,7 +51,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
     /**
      * @param ExampleEvent $event
      */
-    protected function printException(ExampleEvent $event) : void
+    protected function printException(ExampleEvent $event): void
     {
         if (null === $exception = $event->getException()) {
             return;
@@ -74,7 +74,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
      * @param ExampleEvent $event
      * @param string $type
      */
-    protected function printSpecificException(ExampleEvent $event, string $type) : void
+    protected function printSpecificException(ExampleEvent $event, string $type): void
     {
         $title = str_replace('\\', DIRECTORY_SEPARATOR, $event->getSpecification()->getTitle());
         $message = $this->getPresenter()->presentException($event->getException(), $this->io->isVerbose());
@@ -94,7 +94,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
         $this->io->writeln();
     }
 
-    public function displayFatal(CurrentExampleTracker $currentExample, $error) : void
+    public function displayFatal(CurrentExampleTracker $currentExample, $error): void
     {
         if (
             (null !== $error && ($currentExample->getCurrentExample() || $error['type'] == E_ERROR)) ||

--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -92,7 +92,7 @@ final class DotFormatter extends ConsoleFormatter
         $this->outputSuiteSummary($event);
     }
 
-    private function outputExceptions()
+    private function outputExceptions() : void
     {
         $stats = $this->getStatisticsCollector();
         $notPassed = array_filter(array(
@@ -107,7 +107,7 @@ final class DotFormatter extends ConsoleFormatter
         }
     }
 
-    private function outputSuiteSummary(SuiteEvent $event)
+    private function outputSuiteSummary(SuiteEvent $event) : void
     {
         $this->outputTotalSpecCount();
         $this->outputTotalExamplesCount();
@@ -121,19 +121,19 @@ final class DotFormatter extends ConsoleFormatter
         return $count !== 1 ? 's' : '';
     }
 
-    private function outputTotalSpecCount()
+    private function outputTotalSpecCount() : void
     {
         $count = $this->getStatisticsCollector()->getTotalSpecs();
         $this->getIO()->writeln(sprintf("%d spec%s", $count, $this->plural($count)));
     }
 
-    private function outputTotalExamplesCount()
+    private function outputTotalExamplesCount() : void
     {
         $count = $this->getStatisticsCollector()->getEventsCount();
         $this->getIO()->write(sprintf("%d example%s ", $count, $this->plural($count)));
     }
 
-    private function outputSpecificExamplesCount()
+    private function outputSpecificExamplesCount() : void
     {
         $typesWithEvents = array_filter($this->getStatisticsCollector()->getCountsHash());
 

--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -92,7 +92,7 @@ final class DotFormatter extends ConsoleFormatter
         $this->outputSuiteSummary($event);
     }
 
-    private function outputExceptions() : void
+    private function outputExceptions(): void
     {
         $stats = $this->getStatisticsCollector();
         $notPassed = array_filter(array(
@@ -107,7 +107,7 @@ final class DotFormatter extends ConsoleFormatter
         }
     }
 
-    private function outputSuiteSummary(SuiteEvent $event) : void
+    private function outputSuiteSummary(SuiteEvent $event): void
     {
         $this->outputTotalSpecCount();
         $this->outputTotalExamplesCount();
@@ -121,19 +121,19 @@ final class DotFormatter extends ConsoleFormatter
         return $count !== 1 ? 's' : '';
     }
 
-    private function outputTotalSpecCount() : void
+    private function outputTotalSpecCount(): void
     {
         $count = $this->getStatisticsCollector()->getTotalSpecs();
         $this->getIO()->writeln(sprintf("%d spec%s", $count, $this->plural($count)));
     }
 
-    private function outputTotalExamplesCount() : void
+    private function outputTotalExamplesCount(): void
     {
         $count = $this->getStatisticsCollector()->getEventsCount();
         $this->getIO()->write(sprintf("%d example%s ", $count, $this->plural($count)));
     }
 
-    private function outputSpecificExamplesCount() : void
+    private function outputSpecificExamplesCount(): void
     {
         $typesWithEvents = array_filter($this->getStatisticsCollector()->getCountsHash());
 

--- a/src/PhpSpec/Formatter/FatalPresenter.php
+++ b/src/PhpSpec/Formatter/FatalPresenter.php
@@ -17,5 +17,5 @@ use PhpSpec\Message\CurrentExampleTracker;
 
 interface FatalPresenter
 {
-    public function displayFatal(CurrentExampleTracker $currentExample, $error);
+    public function displayFatal(CurrentExampleTracker $currentExample, $error) : void;
 }

--- a/src/PhpSpec/Formatter/FatalPresenter.php
+++ b/src/PhpSpec/Formatter/FatalPresenter.php
@@ -17,5 +17,5 @@ use PhpSpec\Message\CurrentExampleTracker;
 
 interface FatalPresenter
 {
-    public function displayFatal(CurrentExampleTracker $currentExample, $error) : void;
+    public function displayFatal(CurrentExampleTracker $currentExample, $error): void;
 }

--- a/src/PhpSpec/Formatter/Html/HtmlIO.php
+++ b/src/PhpSpec/Formatter/Html/HtmlIO.php
@@ -20,7 +20,7 @@ final class HtmlIO implements IO
     /**
      * @param $message
      */
-    public function write($message)
+    public function write(string $message) : void
     {
         echo $message;
     }

--- a/src/PhpSpec/Formatter/Html/HtmlIO.php
+++ b/src/PhpSpec/Formatter/Html/HtmlIO.php
@@ -20,7 +20,7 @@ final class HtmlIO implements IO
     /**
      * @param $message
      */
-    public function write(string $message) : void
+    public function write(string $message): void
     {
         echo $message;
     }

--- a/src/PhpSpec/Formatter/Html/ReportFailedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportFailedItem.php
@@ -51,7 +51,7 @@ class ReportFailedItem
     /**
      * @param int $index
      */
-    public function write(int $index) : void
+    public function write(int $index): void
     {
         $code = $this->presenter->presentException($this->event->getException(), true);
         $this->template->render(

--- a/src/PhpSpec/Formatter/Html/ReportFailedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportFailedItem.php
@@ -51,7 +51,7 @@ class ReportFailedItem
     /**
      * @param int $index
      */
-    public function write(int $index)
+    public function write(int $index) : void
     {
         $code = $this->presenter->presentException($this->event->getException(), true);
         $this->template->render(

--- a/src/PhpSpec/Formatter/Html/ReportItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportItem.php
@@ -16,7 +16,7 @@ namespace PhpSpec\Formatter\Html;
 interface ReportItem
 {
     /**
-     * @return mixed
+     * @return void
      */
-    public function write();
+    public function write() : void;
 }

--- a/src/PhpSpec/Formatter/Html/ReportItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportItem.php
@@ -18,5 +18,5 @@ interface ReportItem
     /**
      * @return void
      */
-    public function write() : void;
+    public function write(): void;
 }

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -60,7 +60,7 @@ class ReportItemFactory
      *
      * @throws InvalidExampleResultException
      */
-    private function invalidResultException(int $result)
+    private function invalidResultException(int $result) : void
     {
         throw new InvalidExampleResultException(
             "Unrecognised example result $result"

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -60,7 +60,7 @@ class ReportItemFactory
      *
      * @throws InvalidExampleResultException
      */
-    private function invalidResultException(int $result) : void
+    private function invalidResultException(int $result): void
     {
         throw new InvalidExampleResultException(
             "Unrecognised example result $result"

--- a/src/PhpSpec/Formatter/Html/ReportPassedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPassedItem.php
@@ -37,7 +37,7 @@ class ReportPassedItem
         $this->event = $event;
     }
 
-    public function write() : void
+    public function write(): void
     {
         $this->template->render(Template::DIR.'/Template/ReportPass.html', array(
             'title' => $this->event->getTitle()

--- a/src/PhpSpec/Formatter/Html/ReportPassedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPassedItem.php
@@ -37,10 +37,7 @@ class ReportPassedItem
         $this->event = $event;
     }
 
-    /**
-     *
-     */
-    public function write()
+    public function write() : void
     {
         $this->template->render(Template::DIR.'/Template/ReportPass.html', array(
             'title' => $this->event->getTitle()

--- a/src/PhpSpec/Formatter/Html/ReportPendingItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPendingItem.php
@@ -41,10 +41,7 @@ class ReportPendingItem
         $this->event = $event;
     }
 
-    /**
-     *
-     */
-    public function write()
+    public function write() : void
     {
         $this->template->render(Template::DIR.'/Template/ReportPending.html', array(
             'title' => $this->event->getTitle(),

--- a/src/PhpSpec/Formatter/Html/ReportPendingItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPendingItem.php
@@ -41,7 +41,7 @@ class ReportPendingItem
         $this->event = $event;
     }
 
-    public function write() : void
+    public function write(): void
     {
         $this->template->render(Template::DIR.'/Template/ReportPending.html', array(
             'title' => $this->event->getTitle(),

--- a/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
@@ -37,7 +37,7 @@ class ReportSkippedItem
         $this->event    = $event;
     }
 
-    public function write() : void
+    public function write(): void
     {
         $this->template->render(Template::DIR.'/Template/ReportSkipped.html', array(
             'title' => htmlentities(strip_tags($this->event->getTitle())),

--- a/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
@@ -37,10 +37,7 @@ class ReportSkippedItem
         $this->event    = $event;
     }
 
-    /**
-     *
-     */
-    public function write()
+    public function write() : void
     {
         $this->template->render(Template::DIR.'/Template/ReportSkipped.html', array(
             'title' => htmlentities(strip_tags($this->event->getTitle())),

--- a/src/PhpSpec/Formatter/Html/Template.php
+++ b/src/PhpSpec/Formatter/Html/Template.php
@@ -37,7 +37,7 @@ final class Template implements TemplateInterface
      * @param string $text
      * @param array  $templateVars
      */
-    public function render(string $text, array $templateVars = array())
+    public function render(string $text, array $templateVars = array()) : void
     {
         if (file_exists($text)) {
             $text = file_get_contents($text);

--- a/src/PhpSpec/Formatter/Html/Template.php
+++ b/src/PhpSpec/Formatter/Html/Template.php
@@ -37,7 +37,7 @@ final class Template implements TemplateInterface
      * @param string $text
      * @param array  $templateVars
      */
-    public function render(string $text, array $templateVars = array()) : void
+    public function render(string $text, array $templateVars = array()): void
     {
         if (file_exists($text)) {
             $text = file_get_contents($text);

--- a/src/PhpSpec/Formatter/JUnitFormatter.php
+++ b/src/PhpSpec/Formatter/JUnitFormatter.php
@@ -64,7 +64,7 @@ final class JUnitFormatter extends BasicFormatter
      *
      * @param array $testCaseNodes
      */
-    public function setTestCaseNodes(array $testCaseNodes) : void
+    public function setTestCaseNodes(array $testCaseNodes): void
     {
         $this->testCaseNodes = $testCaseNodes;
     }
@@ -210,7 +210,7 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Initialize test case nodes and example status counts
      */
-    protected function initTestCaseNodes() : void
+    protected function initTestCaseNodes(): void
     {
         $this->testCaseNodes       = array();
         $this->exampleStatusCounts = array(

--- a/src/PhpSpec/Formatter/JUnitFormatter.php
+++ b/src/PhpSpec/Formatter/JUnitFormatter.php
@@ -64,7 +64,7 @@ final class JUnitFormatter extends BasicFormatter
      *
      * @param array $testCaseNodes
      */
-    public function setTestCaseNodes(array $testCaseNodes)
+    public function setTestCaseNodes(array $testCaseNodes) : void
     {
         $this->testCaseNodes = $testCaseNodes;
     }
@@ -210,7 +210,7 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Initialize test case nodes and example status counts
      */
-    protected function initTestCaseNodes()
+    protected function initTestCaseNodes() : void
     {
         $this->testCaseNodes       = array();
         $this->exampleStatusCounts = array(

--- a/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
@@ -28,7 +28,7 @@ final class ArrayEngine extends StringEngine
         return parent::compare($expectedString, $actualString);
     }
 
-    private function convertArrayToString(array $a, $pad = 2)
+    private function convertArrayToString(array $a, $pad = 2) : string
     {
         $str = str_pad('', $pad, ' ').'[';
         foreach ($a as $key => $val) {

--- a/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
@@ -15,12 +15,12 @@ namespace PhpSpec\Formatter\Presenter\Differ;
 
 final class ArrayEngine extends StringEngine
 {
-    public function supports($expected, $actual) : bool
+    public function supports($expected, $actual): bool
     {
         return \is_array($expected) && \is_array($actual);
     }
 
-    public function compare($expected, $actual) : string
+    public function compare($expected, $actual): string
     {
         $expectedString = $this->convertArrayToString($expected);
         $actualString   = $this->convertArrayToString($actual);
@@ -28,7 +28,7 @@ final class ArrayEngine extends StringEngine
         return parent::compare($expectedString, $actualString);
     }
 
-    private function convertArrayToString(array $a, $pad = 2) : string
+    private function convertArrayToString(array $a, $pad = 2): string
     {
         $str = str_pad('', $pad, ' ').'[';
         foreach ($a as $key => $val) {

--- a/src/PhpSpec/Formatter/Presenter/Differ/Differ.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/Differ.php
@@ -22,7 +22,7 @@ class Differ
         $this->engines = $engines;
     }
 
-    public function addEngine(DifferEngine $engine) : void
+    public function addEngine(DifferEngine $engine): void
     {
         $this->engines[] = $engine;
     }

--- a/src/PhpSpec/Formatter/Presenter/Differ/Differ.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/Differ.php
@@ -22,7 +22,7 @@ class Differ
         $this->engines = $engines;
     }
 
-    public function addEngine(DifferEngine $engine)
+    public function addEngine(DifferEngine $engine) : void
     {
         $this->engines[] = $engine;
     }

--- a/src/PhpSpec/Formatter/PrettyFormatter.php
+++ b/src/PhpSpec/Formatter/PrettyFormatter.php
@@ -109,7 +109,7 @@ final class PrettyFormatter extends ConsoleFormatter
         }
     }
 
-    protected function printException(ExampleEvent $event, $depth = null) : void
+    protected function printException(ExampleEvent $event, $depth = null): void
     {
         $io = $this->getIO();
 

--- a/src/PhpSpec/Formatter/PrettyFormatter.php
+++ b/src/PhpSpec/Formatter/PrettyFormatter.php
@@ -109,7 +109,7 @@ final class PrettyFormatter extends ConsoleFormatter
         }
     }
 
-    protected function printException(ExampleEvent $event, $depth = null)
+    protected function printException(ExampleEvent $event, $depth = null) : void
     {
         $io = $this->getIO();
 

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -146,7 +146,7 @@ final class ProgressFormatter extends ConsoleFormatter
      * @param array     $progress
      * @param int       $total
      */
-    private function updateProgressBar(ConsoleIO $io, array $progress, int $total)
+    private function updateProgressBar(ConsoleIO $io, array $progress, int $total) : void
     {
         if ($io->isDecorated()) {
             $progressBar = implode('', $progress);
@@ -157,7 +157,7 @@ final class ProgressFormatter extends ConsoleFormatter
         }
     }
 
-    private function drawStats()
+    private function drawStats() : void
     {
         $io = $this->getIO();
         $stats = $this->getStatisticsCollector();

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -146,7 +146,7 @@ final class ProgressFormatter extends ConsoleFormatter
      * @param array     $progress
      * @param int       $total
      */
-    private function updateProgressBar(ConsoleIO $io, array $progress, int $total) : void
+    private function updateProgressBar(ConsoleIO $io, array $progress, int $total): void
     {
         if ($io->isDecorated()) {
             $progressBar = implode('', $progress);
@@ -157,7 +157,7 @@ final class ProgressFormatter extends ConsoleFormatter
         }
     }
 
-    private function drawStats() : void
+    private function drawStats(): void
     {
         $io = $this->getIO();
         $stats = $this->getStatisticsCollector();

--- a/src/PhpSpec/Formatter/Template.php
+++ b/src/PhpSpec/Formatter/Template.php
@@ -19,5 +19,5 @@ interface Template
      * @param string $text
      * @param array  $templateVars
      */
-    public function render(string $text, array $templateVars = array());
+    public function render(string $text, array $templateVars = array()) : void;
 }

--- a/src/PhpSpec/Formatter/Template.php
+++ b/src/PhpSpec/Formatter/Template.php
@@ -19,5 +19,5 @@ interface Template
      * @param string $text
      * @param array  $templateVars
      */
-    public function render(string $text, array $templateVars = array()) : void;
+    public function render(string $text, array $templateVars = array()): void;
 }

--- a/src/PhpSpec/IO/IO.php
+++ b/src/PhpSpec/IO/IO.php
@@ -15,7 +15,7 @@ namespace PhpSpec\IO;
 
 interface IO
 {
-    public function write(string $message);
+    public function write(string $message) : void;
 
     public function isVerbose() : bool;
 }

--- a/src/PhpSpec/IO/IO.php
+++ b/src/PhpSpec/IO/IO.php
@@ -15,7 +15,7 @@ namespace PhpSpec\IO;
 
 interface IO
 {
-    public function write(string $message) : void;
+    public function write(string $message): void;
 
-    public function isVerbose() : bool;
+    public function isVerbose(): bool;
 }

--- a/src/PhpSpec/Listener/BootstrapListener.php
+++ b/src/PhpSpec/Listener/BootstrapListener.php
@@ -22,7 +22,7 @@ final class BootstrapListener implements EventSubscriberInterface
         return array('beforeSuite' => array('beforeSuite', 1100));
     }
 
-    public function beforeSuite() : void
+    public function beforeSuite(): void
     {
         if ($bootstrap = $this->io->getBootstrapPath()) {
             if (!is_file($bootstrap)) {

--- a/src/PhpSpec/Listener/BootstrapListener.php
+++ b/src/PhpSpec/Listener/BootstrapListener.php
@@ -22,7 +22,7 @@ final class BootstrapListener implements EventSubscriberInterface
         return array('beforeSuite' => array('beforeSuite', 1100));
     }
 
-    public function beforeSuite()
+    public function beforeSuite() : void
     {
         if ($bootstrap = $this->io->getBootstrapPath()) {
             if (!is_file($bootstrap)) {

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -90,7 +90,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
     /**
      * @param ExampleEvent $event
      */
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         if (!$exception = $this->getMethodNotFoundException($event)) {
             return;
@@ -135,7 +135,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
     /**
      * @param SuiteEvent $event
      */
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         foreach ($this->interfaces as $interface => $methods) {
             try {
@@ -195,14 +195,14 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         }
     }
 
-    private function checkIfMethodNameAllowed($methodName)
+    private function checkIfMethodNameAllowed($methodName) : void
     {
         if (!$this->nameChecker->isNameValid($methodName)) {
             $this->wrongMethodNames[] = $methodName;
         }
     }
 
-    private function writeErrorMessage()
+    private function writeErrorMessage() : void
     {
         foreach ($this->wrongMethodNames as $methodName) {
             $message = sprintf("I cannot generate the method '%s' for you because it is a reserved keyword", $methodName);

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -90,7 +90,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
     /**
      * @param ExampleEvent $event
      */
-    public function afterExample(ExampleEvent $event) : void
+    public function afterExample(ExampleEvent $event): void
     {
         if (!$exception = $this->getMethodNotFoundException($event)) {
             return;
@@ -135,7 +135,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
     /**
      * @param SuiteEvent $event
      */
-    public function afterSuite(SuiteEvent $event) : void
+    public function afterSuite(SuiteEvent $event): void
     {
         foreach ($this->interfaces as $interface => $methods) {
             try {
@@ -195,14 +195,14 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         }
     }
 
-    private function checkIfMethodNameAllowed($methodName) : void
+    private function checkIfMethodNameAllowed($methodName): void
     {
         if (!$this->nameChecker->isNameValid($methodName)) {
             $this->wrongMethodNames[] = $methodName;
         }
     }
 
-    private function writeErrorMessage() : void
+    private function writeErrorMessage(): void
     {
         foreach ($this->wrongMethodNames as $methodName) {
             $message = sprintf("I cannot generate the method '%s' for you because it is a reserved keyword", $methodName);

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -70,7 +70,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
     /**
      * @param ExampleEvent $event
      */
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         if (($exception = $event->getException()) &&
             ($exception instanceof CollaboratorNotFoundException)) {
@@ -81,7 +81,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
     /**
      * @param SuiteEvent $event
      */
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -70,7 +70,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
     /**
      * @param ExampleEvent $event
      */
-    public function afterExample(ExampleEvent $event) : void
+    public function afterExample(ExampleEvent $event): void
     {
         if (($exception = $event->getException()) &&
             ($exception instanceof CollaboratorNotFoundException)) {
@@ -81,7 +81,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
     /**
      * @param SuiteEvent $event
      */
-    public function afterSuite(SuiteEvent $event) : void
+    public function afterSuite(SuiteEvent $event): void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;

--- a/src/PhpSpec/Listener/CurrentExampleListener.php
+++ b/src/PhpSpec/Listener/CurrentExampleListener.php
@@ -39,17 +39,17 @@ final class CurrentExampleListener implements EventSubscriberInterface {
         $this->currentExample = $currentExample;
     }
 
-    public function beforeCurrentExample(ExampleEvent $event)
+    public function beforeCurrentExample(ExampleEvent $event) : void
     {
         $this->currentExample->setCurrentExample($event->getTitle());
     }
 
-    public function afterCurrentExample()
+    public function afterCurrentExample() : void
     {
         $this->currentExample->setCurrentExample(null);
     }
 
-    public function afterSuiteEvent(SuiteEvent $event)
+    public function afterSuiteEvent(SuiteEvent $event) : void
     {
         $this->currentExample->setCurrentExample('Exited with code: ' . $event->getResult());
     }

--- a/src/PhpSpec/Listener/CurrentExampleListener.php
+++ b/src/PhpSpec/Listener/CurrentExampleListener.php
@@ -39,17 +39,17 @@ final class CurrentExampleListener implements EventSubscriberInterface {
         $this->currentExample = $currentExample;
     }
 
-    public function beforeCurrentExample(ExampleEvent $event) : void
+    public function beforeCurrentExample(ExampleEvent $event): void
     {
         $this->currentExample->setCurrentExample($event->getTitle());
     }
 
-    public function afterCurrentExample() : void
+    public function afterCurrentExample(): void
     {
         $this->currentExample->setCurrentExample(null);
     }
 
-    public function afterSuiteEvent(SuiteEvent $event) : void
+    public function afterSuiteEvent(SuiteEvent $event): void
     {
         $this->currentExample->setCurrentExample('Exited with code: ' . $event->getResult());
     }

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -60,7 +60,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         );
     }
 
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         if (null === $exception = $event->getException()) {
             return;
@@ -76,7 +76,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         $this->checkIfMethodNameAllowed($methodName);
     }
 
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;
@@ -112,14 +112,14 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         }
     }
 
-    private function checkIfMethodNameAllowed($methodName)
+    private function checkIfMethodNameAllowed($methodName) : void
     {
         if (!$this->nameChecker->isNameValid($methodName)) {
             $this->wrongMethodNames[] = $methodName;
         }
     }
 
-    private function writeWrongMethodNameMessage()
+    private function writeWrongMethodNameMessage() : void
     {
         foreach ($this->wrongMethodNames as $methodName) {
             $message = sprintf("I cannot generate the method '%s' for you because it is a reserved keyword", $methodName);

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -60,7 +60,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         );
     }
 
-    public function afterExample(ExampleEvent $event) : void
+    public function afterExample(ExampleEvent $event): void
     {
         if (null === $exception = $event->getException()) {
             return;
@@ -76,7 +76,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         $this->checkIfMethodNameAllowed($methodName);
     }
 
-    public function afterSuite(SuiteEvent $event) : void
+    public function afterSuite(SuiteEvent $event): void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;
@@ -112,14 +112,14 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         }
     }
 
-    private function checkIfMethodNameAllowed($methodName) : void
+    private function checkIfMethodNameAllowed($methodName): void
     {
         if (!$this->nameChecker->isNameValid($methodName)) {
             $this->wrongMethodNames[] = $methodName;
         }
     }
 
-    private function writeWrongMethodNameMessage() : void
+    private function writeWrongMethodNameMessage(): void
     {
         foreach ($this->wrongMethodNames as $methodName) {
             $message = sprintf("I cannot generate the method '%s' for you because it is a reserved keyword", $methodName);

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -82,12 +82,12 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
         );
     }
 
-    public function afterMethodCall(MethodCallEvent $methodCallEvent)
+    public function afterMethodCall(MethodCallEvent $methodCallEvent) : void
     {
         $this->lastMethodCallEvent = $methodCallEvent;
     }
 
-    public function afterExample(ExampleEvent $exampleEvent)
+    public function afterExample(ExampleEvent $exampleEvent) : void
     {
         $exception = $exampleEvent->getException();
 
@@ -130,7 +130,7 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
         $this->nullMethods[$key]['expected'][] = $exception->getExpected();
     }
 
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -82,12 +82,12 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
         );
     }
 
-    public function afterMethodCall(MethodCallEvent $methodCallEvent) : void
+    public function afterMethodCall(MethodCallEvent $methodCallEvent): void
     {
         $this->lastMethodCallEvent = $methodCallEvent;
     }
 
-    public function afterExample(ExampleEvent $exampleEvent) : void
+    public function afterExample(ExampleEvent $exampleEvent): void
     {
         $exception = $exampleEvent->getException();
 
@@ -130,7 +130,7 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
         $this->nullMethods[$key]['expected'][] = $exception->getExpected();
     }
 
-    public function afterSuite(SuiteEvent $event) : void
+    public function afterSuite(SuiteEvent $event): void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -43,7 +43,7 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
         );
     }
 
-    public function afterExample(ExampleEvent $event) : void
+    public function afterExample(ExampleEvent $event): void
     {
         if (null === $exception = $event->getException()) {
             return;
@@ -57,7 +57,7 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
         $this->methods[$className .'::'.$exception->getMethodName()] = $exception->getArguments();
     }
 
-    public function afterSuite(SuiteEvent $event) : void
+    public function afterSuite(SuiteEvent $event): void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -43,7 +43,7 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
         );
     }
 
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         if (null === $exception = $event->getException()) {
             return;
@@ -57,7 +57,7 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
         $this->methods[$className .'::'.$exception->getMethodName()] = $exception->getArguments();
     }
 
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;

--- a/src/PhpSpec/Listener/RerunListener.php
+++ b/src/PhpSpec/Listener/RerunListener.php
@@ -54,7 +54,7 @@ final class RerunListener implements EventSubscriberInterface
     /**
      * @param SuiteEvent $suiteEvent
      */
-    public function beforeSuite(SuiteEvent $suiteEvent)
+    public function beforeSuite(SuiteEvent $suiteEvent) : void
     {
         $this->suitePrerequisites->guardPrerequisites();
     }
@@ -62,7 +62,7 @@ final class RerunListener implements EventSubscriberInterface
     /**
      * @param SuiteEvent $suiteEvent
      */
-    public function afterSuite(SuiteEvent $suiteEvent)
+    public function afterSuite(SuiteEvent $suiteEvent) : void
     {
         if ($suiteEvent->isWorthRerunning()) {
             $this->reRunner->reRunSuite();

--- a/src/PhpSpec/Listener/RerunListener.php
+++ b/src/PhpSpec/Listener/RerunListener.php
@@ -54,7 +54,7 @@ final class RerunListener implements EventSubscriberInterface
     /**
      * @param SuiteEvent $suiteEvent
      */
-    public function beforeSuite(SuiteEvent $suiteEvent) : void
+    public function beforeSuite(SuiteEvent $suiteEvent): void
     {
         $this->suitePrerequisites->guardPrerequisites();
     }
@@ -62,7 +62,7 @@ final class RerunListener implements EventSubscriberInterface
     /**
      * @param SuiteEvent $suiteEvent
      */
-    public function afterSuite(SuiteEvent $suiteEvent) : void
+    public function afterSuite(SuiteEvent $suiteEvent): void
     {
         if ($suiteEvent->isWorthRerunning()) {
             $this->reRunner->reRunSuite();

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -40,12 +40,12 @@ class StatisticsCollector implements EventSubscriberInterface
         );
     }
 
-    public function afterSpecification(SpecificationEvent $event)
+    public function afterSpecification(SpecificationEvent $event) : void
     {
         $this->totalSpecs++;
     }
 
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         $this->globalResult = max($this->globalResult, $event->getResult());
 
@@ -68,7 +68,7 @@ class StatisticsCollector implements EventSubscriberInterface
         }
     }
 
-    public function beforeSuite(SuiteEvent $suiteEvent)
+    public function beforeSuite(SuiteEvent $suiteEvent) : void
     {
         $this->totalSpecsCount = \count($suiteEvent->getSuite()->getSpecifications());
     }

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -40,12 +40,12 @@ class StatisticsCollector implements EventSubscriberInterface
         );
     }
 
-    public function afterSpecification(SpecificationEvent $event) : void
+    public function afterSpecification(SpecificationEvent $event): void
     {
         $this->totalSpecs++;
     }
 
-    public function afterExample(ExampleEvent $event) : void
+    public function afterExample(ExampleEvent $event): void
     {
         $this->globalResult = max($this->globalResult, $event->getResult());
 
@@ -68,7 +68,7 @@ class StatisticsCollector implements EventSubscriberInterface
         }
     }
 
-    public function beforeSuite(SuiteEvent $suiteEvent) : void
+    public function beforeSuite(SuiteEvent $suiteEvent): void
     {
         $this->totalSpecsCount = \count($suiteEvent->getSuite()->getSpecifications());
     }

--- a/src/PhpSpec/Listener/StopOnFailureListener.php
+++ b/src/PhpSpec/Listener/StopOnFailureListener.php
@@ -48,7 +48,7 @@ final class StopOnFailureListener implements EventSubscriberInterface
      *
      * @throws \PhpSpec\Exception\Example\StopOnFailureException
      */
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         if (!$this->io->isStopOnFailureEnabled()) {
             return;

--- a/src/PhpSpec/Listener/StopOnFailureListener.php
+++ b/src/PhpSpec/Listener/StopOnFailureListener.php
@@ -48,7 +48,7 @@ final class StopOnFailureListener implements EventSubscriberInterface
      *
      * @throws \PhpSpec\Exception\Example\StopOnFailureException
      */
-    public function afterExample(ExampleEvent $event) : void
+    public function afterExample(ExampleEvent $event): void
     {
         if (!$this->io->isStopOnFailureEnabled()) {
             return;

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -55,7 +55,7 @@ class ExampleNode
     /**
      * @param bool $isPending
      */
-    public function markAsPending(bool $isPending = true) : void
+    public function markAsPending(bool $isPending = true): void
     {
         $this->isPending = $isPending;
     }
@@ -79,7 +79,7 @@ class ExampleNode
     /**
      * @param SpecificationNode $specification
      */
-    public function setSpecification(SpecificationNode $specification) : void
+    public function setSpecification(SpecificationNode $specification): void
     {
         $this->specification = $specification;
     }

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -55,7 +55,7 @@ class ExampleNode
     /**
      * @param bool $isPending
      */
-    public function markAsPending(bool $isPending = true)
+    public function markAsPending(bool $isPending = true) : void
     {
         $this->isPending = $isPending;
     }
@@ -79,7 +79,7 @@ class ExampleNode
     /**
      * @param SpecificationNode $specification
      */
-    public function setSpecification(SpecificationNode $specification)
+    public function setSpecification(SpecificationNode $specification) : void
     {
         $this->specification = $specification;
     }

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -79,7 +79,7 @@ class SpecificationNode implements \Countable
     /**
      * @param ExampleNode $example
      */
-    public function addExample(ExampleNode $example) : void
+    public function addExample(ExampleNode $example): void
     {
         $this->examples[] = $example;
         $example->setSpecification($this);

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -79,7 +79,7 @@ class SpecificationNode implements \Countable
     /**
      * @param ExampleNode $example
      */
-    public function addExample(ExampleNode $example)
+    public function addExample(ExampleNode $example) : void
     {
         $this->examples[] = $example;
         $example->setSpecification($this);

--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -20,7 +20,7 @@ class StreamWrapper
 
     private static $specTransformers = array();
 
-    public static function register()
+    public static function register() : void
     {
         if (\in_array('phpspec', stream_get_wrappers())) {
             stream_wrapper_unregister('phpspec');
@@ -28,12 +28,12 @@ class StreamWrapper
         stream_wrapper_register('phpspec', 'PhpSpec\Loader\StreamWrapper');
     }
 
-    public static function reset()
+    public static function reset() : void
     {
         static::$specTransformers = array();
     }
 
-    public static function addTransformer(SpecTransformer $specTransformer)
+    public static function addTransformer(SpecTransformer $specTransformer) : void
     {
         static::$specTransformers[] = $specTransformer;
     }

--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -20,7 +20,7 @@ class StreamWrapper
 
     private static $specTransformers = array();
 
-    public static function register() : void
+    public static function register(): void
     {
         if (\in_array('phpspec', stream_get_wrappers())) {
             stream_wrapper_unregister('phpspec');
@@ -28,12 +28,12 @@ class StreamWrapper
         stream_wrapper_register('phpspec', 'PhpSpec\Loader\StreamWrapper');
     }
 
-    public static function reset() : void
+    public static function reset(): void
     {
         static::$specTransformers = array();
     }
 
-    public static function addTransformer(SpecTransformer $specTransformer) : void
+    public static function addTransformer(SpecTransformer $specTransformer): void
     {
         static::$specTransformers[] = $specTransformer;
     }

--- a/src/PhpSpec/Loader/Suite.php
+++ b/src/PhpSpec/Loader/Suite.php
@@ -23,7 +23,7 @@ class Suite implements \Countable
     /**
      * @param Node\SpecificationNode $spec
      */
-    public function addSpecification(Node\SpecificationNode $spec)
+    public function addSpecification(Node\SpecificationNode $spec) : void
     {
         $this->specs[] = $spec;
         $spec->setSuite($this);

--- a/src/PhpSpec/Loader/Suite.php
+++ b/src/PhpSpec/Loader/Suite.php
@@ -23,7 +23,7 @@ class Suite implements \Countable
     /**
      * @param Node\SpecificationNode $spec
      */
-    public function addSpecification(Node\SpecificationNode $spec) : void
+    public function addSpecification(Node\SpecificationNode $spec): void
     {
         $this->specs[] = $spec;
         $spec->setSuite($this);

--- a/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
@@ -26,7 +26,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param string $typehint
      */
-    public function add(string $class, string $method, string $argument, string $typehint) : void
+    public function add(string $class, string $method, string $argument, string $typehint): void
     {
         $this->store($class, $method, $argument, $typehint);
     }
@@ -37,7 +37,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param \Exception $exception
      */
-    public function addInvalid(string $class, string $method, string $argument, \Exception $exception) : void
+    public function addInvalid(string $class, string $method, string $argument, \Exception $exception): void
     {
         $this->store($class, $method, $argument, $exception);
     }
@@ -48,7 +48,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param mixed $typehint
      */
-    private function store(string $class, string $method, string $argument, $typehint) : void
+    private function store(string $class, string $method, string $argument, $typehint): void
     {
         $class = strtolower($class);
         $method = strtolower($method);

--- a/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
@@ -26,7 +26,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param string $typehint
      */
-    public function add(string $class, string $method, string $argument, string $typehint)
+    public function add(string $class, string $method, string $argument, string $typehint) : void
     {
         $this->store($class, $method, $argument, $typehint);
     }
@@ -37,7 +37,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param \Exception $exception
      */
-    public function addInvalid(string $class, string $method, string $argument, \Exception $exception)
+    public function addInvalid(string $class, string $method, string $argument, \Exception $exception) : void
     {
         $this->store($class, $method, $argument, $exception);
     }
@@ -48,7 +48,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      * @param string $argument
      * @param mixed $typehint
      */
-    private function store(string $class, string $method, string $argument, $typehint)
+    private function store(string $class, string $method, string $argument, $typehint) : void
     {
         $class = strtolower($class);
         $method = strtolower($method);

--- a/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
@@ -21,7 +21,7 @@ interface TypeHintIndex
      * @param string $argument
      * @param string $typehint
      */
-    public function add(string $class, string $method, string $argument, string $typehint);
+    public function add(string $class, string $method, string $argument, string $typehint) : void;
 
     /**
      * @param string $class
@@ -29,7 +29,7 @@ interface TypeHintIndex
      * @param string $argument
      * @param \Exception $exception
      */
-    public function addInvalid(string $class, string $method, string $argument, \Exception $exception);
+    public function addInvalid(string $class, string $method, string $argument, \Exception $exception) : void;
 
     /**
      * @param string $class

--- a/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
@@ -21,7 +21,7 @@ interface TypeHintIndex
      * @param string $argument
      * @param string $typehint
      */
-    public function add(string $class, string $method, string $argument, string $typehint) : void;
+    public function add(string $class, string $method, string $argument, string $typehint): void;
 
     /**
      * @param string $class
@@ -29,7 +29,7 @@ interface TypeHintIndex
      * @param string $argument
      * @param \Exception $exception
      */
-    public function addInvalid(string $class, string $method, string $argument, \Exception $exception) : void;
+    public function addInvalid(string $class, string $method, string $argument, \Exception $exception): void;
 
     /**
      * @param string $class

--- a/src/PhpSpec/Locator/PSR0/PSR0Resource.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Resource.php
@@ -39,7 +39,7 @@ final class PSR0Resource implements Resource
     /**
      * @return string
      */
-    public function getName() : string
+    public function getName(): string
     {
         return end($this->parts);
     }

--- a/src/PhpSpec/Matcher/ApproximatelyMatcher.php
+++ b/src/PhpSpec/Matcher/ApproximatelyMatcher.php
@@ -68,7 +68,7 @@ final class ApproximatelyMatcher extends BasicMatcher
     }
 
 
-    protected function getFailureException(string $name, $subject, array $arguments) : FailureException
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected an approximated value of %s, but got %s',

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -29,7 +29,7 @@ final class IterablesMatcher
      * @throws SubjectHasFewerElementsException
      * @throws SubjectHasMoreElementsException
      */
-    public function match($subject, $expected, bool $strict = true) : void
+    public function match($subject, $expected, bool $strict = true): void
     {
         if (!$this->isIterable($subject)) {
             throw new \InvalidArgumentException('Subject value should be an array or implement \Traversable.');
@@ -93,7 +93,7 @@ final class IterablesMatcher
         return $iterator;
     }
 
-    private function valueIsEqual($expected, $value, bool $strict) : bool
+    private function valueIsEqual($expected, $value, bool $strict): bool
     {
         return $strict ? $expected === $value : $expected == $value;
     }

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -29,7 +29,7 @@ final class IterablesMatcher
      * @throws SubjectHasFewerElementsException
      * @throws SubjectHasMoreElementsException
      */
-    public function match($subject, $expected, bool $strict = true)
+    public function match($subject, $expected, bool $strict = true) : void
     {
         if (!$this->isIterable($subject)) {
             throw new \InvalidArgumentException('Subject value should be an array or implement \Traversable.');

--- a/src/PhpSpec/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Matcher/IterateAsMatcher.php
@@ -75,7 +75,7 @@ final class IterateAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 100;
     }

--- a/src/PhpSpec/Matcher/IterateLikeMatcher.php
+++ b/src/PhpSpec/Matcher/IterateLikeMatcher.php
@@ -75,7 +75,7 @@ final class IterateLikeMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 100;
     }

--- a/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
@@ -75,7 +75,7 @@ final class StartIteratingAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 100;
     }

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -34,7 +34,7 @@ final class StringContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    public function supports(string $name, $subject, array $arguments) : bool
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'contain' === $name
             && \is_string($subject)
@@ -45,7 +45,7 @@ final class StringContainMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function matches($subject, array $arguments) : bool
+    protected function matches($subject, array $arguments): bool
     {
         return false !== strpos($subject, $arguments[0]);
     }

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -86,7 +86,7 @@ final class TraversableCountMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function getPriority() : int
+    public function getPriority(): int
     {
         return 100;
     }

--- a/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
@@ -35,7 +35,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    public function supports(string $name, $subject, array $arguments) : bool
+    public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveKeyWithValue' === $name
             && 2 === \count($arguments)
@@ -46,7 +46,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
     /**
      * {@inheritdoc}
      */
-    protected function matches($subject, array $arguments) : bool
+    protected function matches($subject, array $arguments): bool
     {
         foreach ($subject as $key => $value) {
             if ($key === $arguments[0] && $value === $arguments[1]) {

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -32,7 +32,7 @@ class ComposerPsrNamespaceProvider
      *                      'My\PSR0Namespace' => '',
      *                  ]
      */
-    public function getNamespaces() : array
+    public function getNamespaces(): array
     {
         $vendors = array();
         foreach (get_declared_classes() as $class) {

--- a/src/PhpSpec/NamespaceProvider/NamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/NamespaceProvider.php
@@ -18,5 +18,5 @@ interface NamespaceProvider
      *                     NamespaceProvider::SUPPORTED_AUTOLOADING_STANDARD
      *                  )]
      */
-    public function getNamespaces() : array;
+    public function getNamespaces(): array;
 }

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -82,7 +82,7 @@ abstract class ObjectBehavior implements
      *
      * @param Subject $subject
      */
-    public function setSpecificationSubject(Subject $subject)
+    public function setSpecificationSubject(Subject $subject) : void
     {
         $this->object = $subject;
     }

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -70,7 +70,7 @@ abstract class ObjectBehavior implements
      * @link http://phpspec.net/cookbook/matchers.html Matchers cookbook
      * @return array a list of inline matchers
      */
-    public function getMatchers() : array
+    public function getMatchers(): array
     {
         return array();
     }
@@ -82,7 +82,7 @@ abstract class ObjectBehavior implements
      *
      * @param Subject $subject
      */
-    public function setSpecificationSubject(Subject $subject) : void
+    public function setSpecificationSubject(Subject $subject): void
     {
         $this->object = $subject;
     }

--- a/src/PhpSpec/Process/Prerequisites/PrerequisiteTester.php
+++ b/src/PhpSpec/Process/Prerequisites/PrerequisiteTester.php
@@ -18,5 +18,5 @@ interface PrerequisiteTester
     /**
      * @throws PrerequisiteFailedException
      */
-    public function guardPrerequisites() : void;
+    public function guardPrerequisites(): void;
 }

--- a/src/PhpSpec/Process/Prerequisites/PrerequisiteTester.php
+++ b/src/PhpSpec/Process/Prerequisites/PrerequisiteTester.php
@@ -18,5 +18,5 @@ interface PrerequisiteTester
     /**
      * @throws PrerequisiteFailedException
      */
-    public function guardPrerequisites();
+    public function guardPrerequisites() : void;
 }

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
@@ -33,7 +33,7 @@ final class SuitePrerequisites implements PrerequisiteTester
     /**
      * @throws PrerequisiteFailedException
      */
-    public function guardPrerequisites() : void
+    public function guardPrerequisites(): void
     {
         $undefinedTypes = array();
 

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
@@ -33,7 +33,7 @@ final class SuitePrerequisites implements PrerequisiteTester
     /**
      * @throws PrerequisiteFailedException
      */
-    public function guardPrerequisites()
+    public function guardPrerequisites() : void
     {
         $undefinedTypes = array();
 

--- a/src/PhpSpec/Process/ReRunner.php
+++ b/src/PhpSpec/Process/ReRunner.php
@@ -15,5 +15,5 @@ namespace PhpSpec\Process;
 
 interface ReRunner
 {
-    public function reRunSuite() : void;
+    public function reRunSuite(): void;
 }

--- a/src/PhpSpec/Process/ReRunner.php
+++ b/src/PhpSpec/Process/ReRunner.php
@@ -15,5 +15,5 @@ namespace PhpSpec\Process;
 
 interface ReRunner
 {
-    public function reRunSuite();
+    public function reRunSuite() : void;
 }

--- a/src/PhpSpec/Process/ReRunner/CompositeReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/CompositeReRunner.php
@@ -35,7 +35,7 @@ final class CompositeReRunner implements ReRunner
         }
     }
 
-    public function reRunSuite()
+    public function reRunSuite() : void
     {
         $this->reRunner->reRunSuite();
     }

--- a/src/PhpSpec/Process/ReRunner/CompositeReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/CompositeReRunner.php
@@ -35,7 +35,7 @@ final class CompositeReRunner implements ReRunner
         }
     }
 
-    public function reRunSuite() : void
+    public function reRunSuite(): void
     {
         $this->reRunner->reRunSuite();
     }

--- a/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
@@ -36,7 +36,7 @@ final class OptionalReRunner implements ReRunner
         $this->decoratedRerunner = $decoratedRerunner;
     }
 
-    public function reRunSuite() : void
+    public function reRunSuite(): void
     {
         if ($this->io->isRerunEnabled()) {
             $this->decoratedRerunner->reRunSuite();

--- a/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
@@ -36,7 +36,7 @@ final class OptionalReRunner implements ReRunner
         $this->decoratedRerunner = $decoratedRerunner;
     }
 
-    public function reRunSuite()
+    public function reRunSuite() : void
     {
         if ($this->io->isRerunEnabled()) {
             $this->decoratedRerunner->reRunSuite();

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -50,7 +50,7 @@ final class PcntlReRunner extends PhpExecutableReRunner
     /**
      * Kills the current process and starts a new one
      */
-    public function reRunSuite() : void
+    public function reRunSuite(): void
     {
         $args = $_SERVER['argv'];
         $env = $this->executionContext ? $this->executionContext->asEnv() : array();

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -50,7 +50,7 @@ final class PcntlReRunner extends PhpExecutableReRunner
     /**
      * Kills the current process and starts a new one
      */
-    public function reRunSuite()
+    public function reRunSuite() : void
     {
         $args = $_SERVER['argv'];
         $env = $this->executionContext ? $this->executionContext->asEnv() : array();

--- a/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
@@ -47,7 +47,7 @@ final class ProcOpenReRunner extends PhpExecutableReRunner
             && (stripos(PHP_OS, "win") !== 0);
     }
 
-    public function reRunSuite() : void
+    public function reRunSuite(): void
     {
         $args = $_SERVER['argv'];
         $command = $this->buildArgString() . escapeshellcmd($this->getExecutablePath()).' '.join(' ', array_map('escapeshellarg', $args)) . ' 2>&1';

--- a/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
@@ -47,7 +47,7 @@ final class ProcOpenReRunner extends PhpExecutableReRunner
             && (stripos(PHP_OS, "win") !== 0);
     }
 
-    public function reRunSuite()
+    public function reRunSuite() : void
     {
         $args = $_SERVER['argv'];
         $command = $this->buildArgString() . escapeshellcmd($this->getExecutablePath()).' '.join(' ', array_map('escapeshellarg', $args)) . ' 2>&1';

--- a/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
@@ -47,7 +47,7 @@ final class WindowsPassthruReRunner extends PhpExecutableReRunner
             && (stripos(PHP_OS, "win") === 0);
     }
 
-    public function reRunSuite() : void
+    public function reRunSuite(): void
     {
         $args = $_SERVER['argv'];
         $command = $this->buildArgString() . escapeshellarg($this->getExecutablePath()) . ' ' . join(' ', array_map('escapeshellarg', $args));

--- a/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
@@ -47,7 +47,7 @@ final class WindowsPassthruReRunner extends PhpExecutableReRunner
             && (stripos(PHP_OS, "win") === 0);
     }
 
-    public function reRunSuite()
+    public function reRunSuite() : void
     {
         $args = $_SERVER['argv'];
         $command = $this->buildArgString() . escapeshellarg($this->getExecutablePath()) . ' ' . join(' ', array_map('escapeshellarg', $args));

--- a/src/PhpSpec/Process/Shutdown/Shutdown.php
+++ b/src/PhpSpec/Process/Shutdown/Shutdown.php
@@ -22,18 +22,18 @@ final class Shutdown
         $this->actions = array();
     }
 
-    public function registerShutdown()
+    public function registerShutdown() : void
     {
         error_reporting(error_reporting() & ~E_ERROR);
         register_shutdown_function(array($this, 'runShutdown'));
     }
 
-    public function registerAction(ShutdownAction $action)
+    public function registerAction(ShutdownAction $action) : void
     {
         $this->actions[] = $action;
     }
 
-    public function runShutdown()
+    public function runShutdown() : void
     {
         $error = $this->getFatalError();
 

--- a/src/PhpSpec/Process/Shutdown/Shutdown.php
+++ b/src/PhpSpec/Process/Shutdown/Shutdown.php
@@ -22,18 +22,18 @@ final class Shutdown
         $this->actions = array();
     }
 
-    public function registerShutdown() : void
+    public function registerShutdown(): void
     {
         error_reporting(error_reporting() & ~E_ERROR);
         register_shutdown_function(array($this, 'runShutdown'));
     }
 
-    public function registerAction(ShutdownAction $action) : void
+    public function registerAction(ShutdownAction $action): void
     {
         $this->actions[] = $action;
     }
 
-    public function runShutdown() : void
+    public function runShutdown(): void
     {
         $error = $this->getFatalError();
 

--- a/src/PhpSpec/Process/Shutdown/ShutdownAction.php
+++ b/src/PhpSpec/Process/Shutdown/ShutdownAction.php
@@ -15,5 +15,5 @@ namespace PhpSpec\Process\Shutdown;
 
 interface ShutdownAction
 {
-    public function runAction($error);
+    public function runAction($error) : void;
 }

--- a/src/PhpSpec/Process/Shutdown/ShutdownAction.php
+++ b/src/PhpSpec/Process/Shutdown/ShutdownAction.php
@@ -15,5 +15,5 @@ namespace PhpSpec\Process\Shutdown;
 
 interface ShutdownAction
 {
-    public function runAction($error) : void;
+    public function runAction($error): void;
 }

--- a/src/PhpSpec/Process/Shutdown/UpdateConsoleAction.php
+++ b/src/PhpSpec/Process/Shutdown/UpdateConsoleAction.php
@@ -34,7 +34,7 @@ final class UpdateConsoleAction implements ShutdownAction
         $this->currentExampleWriter = $currentExampleWriter;
     }
 
-    public function runAction($error) : void
+    public function runAction($error): void
     {
         $this->currentExampleWriter->displayFatal($this->currentExample, $error);
     }

--- a/src/PhpSpec/Process/Shutdown/UpdateConsoleAction.php
+++ b/src/PhpSpec/Process/Shutdown/UpdateConsoleAction.php
@@ -34,7 +34,7 @@ final class UpdateConsoleAction implements ShutdownAction
         $this->currentExampleWriter = $currentExampleWriter;
     }
 
-    public function runAction($error)
+    public function runAction($error) : void
     {
         $this->currentExampleWriter->displayFatal($this->currentExample, $error);
     }

--- a/src/PhpSpec/Runner/CollaboratorManager.php
+++ b/src/PhpSpec/Runner/CollaboratorManager.php
@@ -41,7 +41,7 @@ class CollaboratorManager
      * @param string       $name
      * @param object $collaborator
      */
-    public function set(string $name, $collaborator)
+    public function set(string $name, $collaborator) : void
     {
         $this->collaborators[$name] = $collaborator;
     }

--- a/src/PhpSpec/Runner/CollaboratorManager.php
+++ b/src/PhpSpec/Runner/CollaboratorManager.php
@@ -41,7 +41,7 @@ class CollaboratorManager
      * @param string       $name
      * @param object $collaborator
      */
-    public function set(string $name, $collaborator) : void
+    public function set(string $name, $collaborator): void
     {
         $this->collaborators[$name] = $collaborator;
     }

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -55,7 +55,7 @@ class ExampleRunner
     /**
      * @param Maintainer $maintainer
      */
-    public function registerMaintainer(Maintainer $maintainer)
+    public function registerMaintainer(Maintainer $maintainer): void
     {
         $this->maintainers[] = $maintainer;
 
@@ -125,7 +125,7 @@ class ExampleRunner
      * @throws \PhpSpec\Exception\Example\PendingException
      * @throws \Exception
      */
-    protected function executeExample(Specification $context, ExampleNode $example)
+    protected function executeExample(Specification $context, ExampleNode $example): void
     {
         if ($example->isPending()) {
             throw new ExampleException\PendingException();
@@ -179,7 +179,7 @@ class ExampleRunner
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
         foreach (array_reverse($maintainers) as $maintainer) {
             $maintainer->teardown($example, $context, $matchers, $collaborators);
         }

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -78,7 +78,7 @@ final class CollaboratorsMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
         $this->prophet = new Prophet(null, $this->unwrapper, null);
 
         $classRefl = $example->getSpecification()->getClassReflection();
@@ -101,7 +101,7 @@ final class CollaboratorsMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
         $this->prophet->checkPredictions();
     }
 
@@ -118,7 +118,7 @@ final class CollaboratorsMaintainer implements Maintainer
      * @param \ReflectionFunctionAbstract $function
      * @param \ReflectionClass            $classRefl
      */
-    private function generateCollaborators(CollaboratorManager $collaborators, \ReflectionFunctionAbstract $function, \ReflectionClass $classRefl)
+    private function generateCollaborators(CollaboratorManager $collaborators, \ReflectionFunctionAbstract $function, \ReflectionClass $classRefl): void
     {
         foreach ($function->getParameters() as $parameter) {
 
@@ -141,7 +141,7 @@ final class CollaboratorsMaintainer implements Maintainer
         }
     }
 
-    private function isUnsupportedTypeHinting(\ReflectionParameter $parameter)
+    private function isUnsupportedTypeHinting(\ReflectionParameter $parameter): bool
     {
         return $parameter->isArray() || $parameter->isCallable();
     }
@@ -168,7 +168,7 @@ final class CollaboratorsMaintainer implements Maintainer
      * @param string $className
      * @throws CollaboratorNotFoundException
      */
-    private function throwCollaboratorNotFound(\Exception $e, \ReflectionParameter $parameter = null, string $className = null)
+    private function throwCollaboratorNotFound(\Exception $e, \ReflectionParameter $parameter = null, string $className = null): void
     {
         throw new CollaboratorNotFoundException(
             sprintf('Collaborator does not exist '),

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -59,7 +59,7 @@ final class ErrorMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
         $this->errorHandler = set_error_handler(array($this, 'errorHandler'), $this->errorLevel);
     }
 
@@ -74,7 +74,7 @@ final class ErrorMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
         if (null !== $this->errorHandler) {
             set_error_handler($this->errorHandler);
         }

--- a/src/PhpSpec/Runner/Maintainer/LetAndLetgoMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/LetAndLetgoMaintainer.php
@@ -43,7 +43,7 @@ class LetAndLetgoMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
         if (!$example->getSpecification()->getClassReflection()->hasMethod('let')) {
             return;
         }
@@ -63,7 +63,7 @@ class LetAndLetgoMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
         if (!$example->getSpecification()->getClassReflection()->hasMethod('letgo')) {
             return;
         }

--- a/src/PhpSpec/Runner/Maintainer/Maintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/Maintainer.php
@@ -38,7 +38,7 @@ interface Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    );
+    ) : void;
 
     /**
      * @param ExampleNode            $example
@@ -51,7 +51,7 @@ interface Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    );
+    ) : void;
 
     /**
      * @return integer

--- a/src/PhpSpec/Runner/Maintainer/Maintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/Maintainer.php
@@ -38,7 +38,7 @@ interface Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) : void;
+    ): void;
 
     /**
      * @param ExampleNode            $example
@@ -51,7 +51,7 @@ interface Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) : void;
+    ): void;
 
     /**
      * @return integer

--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -68,7 +68,7 @@ final class MatchersMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) : void {
+    ): void {
 
         $matchers->replace($this->defaultMatchers);
 
@@ -100,7 +100,7 @@ final class MatchersMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) : void {
+    ): void {
     }
 
     /**

--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -68,7 +68,7 @@ final class MatchersMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ) : void {
 
         $matchers->replace($this->defaultMatchers);
 
@@ -100,7 +100,7 @@ final class MatchersMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ) : void {
     }
 
     /**

--- a/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
@@ -82,7 +82,7 @@ final class SubjectMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) : void {
+    ): void {
         $subjectFactory = new Wrapper($matchers, $this->presenter, $this->dispatcher, $example, $this->accessInspector);
         $subject = $subjectFactory->wrap(null);
         $subject->beAnInstanceOf(
@@ -103,7 +103,7 @@ final class SubjectMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) : void {
+    ): void {
     }
 
     /**

--- a/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
@@ -82,7 +82,7 @@ final class SubjectMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ) : void {
         $subjectFactory = new Wrapper($matchers, $this->presenter, $this->dispatcher, $example, $this->accessInspector);
         $subject = $subjectFactory->wrap(null);
         $subject->beAnInstanceOf(
@@ -103,7 +103,7 @@ final class SubjectMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ) : void {
     }
 
     /**

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -39,7 +39,7 @@ class MatcherManager
     /**
      * @param Matcher $matcher
      */
-    public function add(Matcher $matcher)
+    public function add(Matcher $matcher) : void
     {
         $this->matchers[] = $matcher;
         @usort($this->matchers, function (Matcher $matcher1, Matcher $matcher2) {
@@ -52,7 +52,7 @@ class MatcherManager
      *
      * @param Matcher[] $matchers
      */
-    public function replace(array $matchers)
+    public function replace(array $matchers) : void
     {
         $this->matchers = $matchers;
     }

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -39,7 +39,7 @@ class MatcherManager
     /**
      * @param Matcher $matcher
      */
-    public function add(Matcher $matcher) : void
+    public function add(Matcher $matcher): void
     {
         $this->matchers[] = $matcher;
         @usort($this->matchers, function (Matcher $matcher1, Matcher $matcher2) {
@@ -52,7 +52,7 @@ class MatcherManager
      *
      * @param Matcher[] $matchers
      */
-    public function replace(array $matchers) : void
+    public function replace(array $matchers): void
     {
         $this->matchers = $matchers;
     }

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -14,7 +14,7 @@ interface ServiceContainer
      * @param string $id
      * @param mixed $value
      */
-    public function setParam(string $id, $value);
+    public function setParam(string $id, $value) : void;
 
     /**
      * Gets a param from the container or a default value.
@@ -35,7 +35,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set(string $id, $service, array $tags = []);
+    public function set(string $id, $service, array $tags = []) : void;
 
     /**
      * Sets a factory for the service creation. The same service will
@@ -47,7 +47,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
-    public function define(string $id, callable $definition, array $tags = []);
+    public function define(string $id, callable $definition, array $tags = []) : void;
 
     /**
      * Retrieves a service from the container
@@ -75,7 +75,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function remove(string $id);
+    public function remove(string $id) : void;
 
     /**
      * Finds all services tagged with a particular string

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -14,7 +14,7 @@ interface ServiceContainer
      * @param string $id
      * @param mixed $value
      */
-    public function setParam(string $id, $value) : void;
+    public function setParam(string $id, $value): void;
 
     /**
      * Gets a param from the container or a default value.
@@ -35,7 +35,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set(string $id, $service, array $tags = []) : void;
+    public function set(string $id, $service, array $tags = []): void;
 
     /**
      * Sets a factory for the service creation. The same service will
@@ -47,7 +47,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
-    public function define(string $id, callable $definition, array $tags = []) : void;
+    public function define(string $id, callable $definition, array $tags = []): void;
 
     /**
      * Retrieves a service from the container
@@ -75,7 +75,7 @@ interface ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function remove(string $id) : void;
+    public function remove(string $id): void;
 
     /**
      * Finds all services tagged with a particular string

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -53,7 +53,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param string $id
      * @param mixed  $value
      */
-    public function setParam(string $id, $value)
+    public function setParam(string $id, $value) : void
     {
         $this->parameters[$id] = $value;
     }
@@ -80,7 +80,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set(string $id, $service, array $tags = [])
+    public function set(string $id, $service, array $tags = []) : void
     {
         if (!\is_object($service)) {
             throw new InvalidArgumentException(sprintf(
@@ -103,7 +103,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param callable $definition
      * @param array    $tags
      */
-    public function define(string $id, callable $definition, array $tags = [])
+    public function define(string $id, callable $definition, array $tags = []) : void
     {
         $this->definitions[$id] = $definition;
         unset($this->services[$id]);
@@ -151,7 +151,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function remove(string $id)
+    public function remove(string $id) : void
     {
         if (!$this->has($id)) {
             throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
@@ -166,7 +166,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param string $id
      * @param array  $tags
      */
-    private function indexTags(string $id, array $tags)
+    private function indexTags(string $id, array $tags) : void
     {
         foreach ($tags as $tag) {
             $this->tags[$tag][] = $id;
@@ -194,7 +194,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if configurator is not a value
      */
-    public function addConfigurator(callable $configurator)
+    public function addConfigurator(callable $configurator) : void
     {
         $this->configurators[] = $configurator;
     }
@@ -204,7 +204,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @internal
      */
-    public function configure()
+    public function configure() : void
     {
         foreach ($this->configurators as $configurator) {
             \call_user_func($configurator, $this);

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -53,7 +53,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param string $id
      * @param mixed  $value
      */
-    public function setParam(string $id, $value) : void
+    public function setParam(string $id, $value): void
     {
         $this->parameters[$id] = $value;
     }
@@ -80,7 +80,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set(string $id, $service, array $tags = []) : void
+    public function set(string $id, $service, array $tags = []): void
     {
         if (!\is_object($service)) {
             throw new InvalidArgumentException(sprintf(
@@ -103,7 +103,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param callable $definition
      * @param array    $tags
      */
-    public function define(string $id, callable $definition, array $tags = []) : void
+    public function define(string $id, callable $definition, array $tags = []): void
     {
         $this->definitions[$id] = $definition;
         unset($this->services[$id]);
@@ -151,7 +151,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function remove(string $id) : void
+    public function remove(string $id): void
     {
         if (!$this->has($id)) {
             throw new InvalidArgumentException(sprintf('Service "%s" is not defined.', $id));
@@ -166,7 +166,7 @@ final class IndexedServiceContainer implements ServiceContainer
      * @param string $id
      * @param array  $tags
      */
-    private function indexTags(string $id, array $tags) : void
+    private function indexTags(string $id, array $tags): void
     {
         foreach ($tags as $tag) {
             $this->tags[$tag][] = $id;
@@ -194,7 +194,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @throws \InvalidArgumentException if configurator is not a value
      */
-    public function addConfigurator(callable $configurator) : void
+    public function addConfigurator(callable $configurator): void
     {
         $this->configurators[] = $configurator;
     }
@@ -204,7 +204,7 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @internal
      */
-    public function configure() : void
+    public function configure(): void
     {
         foreach ($this->configurators as $configurator) {
             \call_user_func($configurator, $this);

--- a/src/PhpSpec/Util/Filesystem.php
+++ b/src/PhpSpec/Util/Filesystem.php
@@ -59,7 +59,7 @@ class Filesystem
     /**
      * @param string $path
      */
-    public function makeDirectory(string $path)
+    public function makeDirectory(string $path) : void
     {
         mkdir($path, 0777, true);
     }

--- a/src/PhpSpec/Util/Filesystem.php
+++ b/src/PhpSpec/Util/Filesystem.php
@@ -59,7 +59,7 @@ class Filesystem
     /**
      * @param string $path
      */
-    public function makeDirectory(string $path) : void
+    public function makeDirectory(string $path): void
     {
         mkdir($path, 0777, true);
     }

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -33,7 +33,7 @@ final class Collaborator implements ObjectWrapper
     /**
      * @param string $classOrInterface
      */
-    public function beADoubleOf(string $classOrInterface)
+    public function beADoubleOf(string $classOrInterface) : void
     {
         if (interface_exists($classOrInterface)) {
             $this->prophecy->willImplement($classOrInterface);
@@ -45,7 +45,7 @@ final class Collaborator implements ObjectWrapper
     /**
      * @param array $arguments
      */
-    public function beConstructedWith(array $arguments = null)
+    public function beConstructedWith(array $arguments = null) : void
     {
         $this->prophecy->willBeConstructedWith($arguments);
     }
@@ -53,7 +53,7 @@ final class Collaborator implements ObjectWrapper
     /**
      * @param string $interface
      */
-    public function implement(string $interface)
+    public function implement(string $interface) : void
     {
         $this->prophecy->willImplement($interface);
     }

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -33,7 +33,7 @@ final class Collaborator implements ObjectWrapper
     /**
      * @param string $classOrInterface
      */
-    public function beADoubleOf(string $classOrInterface) : void
+    public function beADoubleOf(string $classOrInterface): void
     {
         if (interface_exists($classOrInterface)) {
             $this->prophecy->willImplement($classOrInterface);
@@ -45,7 +45,7 @@ final class Collaborator implements ObjectWrapper
     /**
      * @param array $arguments
      */
-    public function beConstructedWith(array $arguments = null) : void
+    public function beConstructedWith(array $arguments = null): void
     {
         $this->prophecy->willBeConstructedWith($arguments);
     }
@@ -53,7 +53,7 @@ final class Collaborator implements ObjectWrapper
     /**
      * @param string $interface
      */
-    public function implement(string $interface) : void
+    public function implement(string $interface): void
     {
         $this->prophecy->willImplement($interface);
     }

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -174,7 +174,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      * @param string $className
      * @param array  $arguments
      */
-    public function beAnInstanceOf(string $className, array $arguments = array()) : void
+    public function beAnInstanceOf(string $className, array $arguments = array()): void
     {
         $this->wrappedObject->beAnInstanceOf($className, $arguments);
     }
@@ -182,7 +182,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     /**
      * @param ...$arguments
      */
-    public function beConstructedWith() : void
+    public function beConstructedWith(): void
     {
         $this->wrappedObject->beConstructedWith(\func_get_args());
     }
@@ -191,7 +191,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      * @param array|string $factoryMethod
      * @param array        $arguments
      */
-    public function beConstructedThrough($factoryMethod, array $arguments = array()) : void
+    public function beConstructedThrough($factoryMethod, array $arguments = array()): void
     {
         $this->wrappedObject->beConstructedThrough($factoryMethod, $arguments);
     }
@@ -264,7 +264,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      * @param string|integer $key
      * @param mixed          $value
      */
-    public function offsetSet($key, $value) : void
+    public function offsetSet($key, $value): void
     {
         $this->arrayAccess->offsetSet($key, $value);
     }
@@ -272,7 +272,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     /**
      * @param string|integer $key
      */
-    public function offsetUnset($key) : void
+    public function offsetUnset($key): void
     {
         $this->arrayAccess->offsetUnset($key);
     }
@@ -334,7 +334,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      *
      * @return Subject
      */
-    private function wrap($value) : Subject
+    private function wrap($value): Subject
     {
         return $this->wrapper->wrap($value);
     }

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -174,7 +174,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      * @param string $className
      * @param array  $arguments
      */
-    public function beAnInstanceOf(string $className, array $arguments = array())
+    public function beAnInstanceOf(string $className, array $arguments = array()) : void
     {
         $this->wrappedObject->beAnInstanceOf($className, $arguments);
     }
@@ -182,7 +182,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     /**
      * @param ...$arguments
      */
-    public function beConstructedWith()
+    public function beConstructedWith() : void
     {
         $this->wrappedObject->beConstructedWith(\func_get_args());
     }
@@ -191,7 +191,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      * @param array|string $factoryMethod
      * @param array        $arguments
      */
-    public function beConstructedThrough($factoryMethod, array $arguments = array())
+    public function beConstructedThrough($factoryMethod, array $arguments = array()) : void
     {
         $this->wrappedObject->beConstructedThrough($factoryMethod, $arguments);
     }
@@ -264,7 +264,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      * @param string|integer $key
      * @param mixed          $value
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value) : void
     {
         $this->arrayAccess->offsetSet($key, $value);
     }
@@ -272,7 +272,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     /**
      * @param string|integer $key
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key) : void
     {
         $this->arrayAccess->offsetUnset($key);
     }

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -111,7 +111,7 @@ class Caller
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      * @throws \PhpSpec\Exception\Fracture\PropertyNotFoundException
      */
-    public function set(string $property, $value = null) : void
+    public function set(string $property, $value = null): void
     {
         if (null === $this->getWrappedObject()) {
             throw $this->settingPropertyOnNonObject($property);

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -111,7 +111,7 @@ class Caller
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      * @throws \PhpSpec\Exception\Fracture\PropertyNotFoundException
      */
-    public function set(string $property, $value = null)
+    public function set(string $property, $value = null) : void
     {
         if (null === $this->getWrappedObject()) {
             throw $this->settingPropertyOnNonObject($property);
@@ -121,7 +121,9 @@ class Caller
         $value = $unwrapper->unwrapOne($value);
 
         if ($this->isObjectPropertyWritable($property)) {
-            return $this->getWrappedObject()->$property = $value;
+            $this->getWrappedObject()->$property = $value;
+
+            return;
         }
 
         throw $this->propertyNotFound($property);

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
@@ -39,7 +39,7 @@ abstract class Decorator implements Expectation
     /**
      * @param Expectation $expectation
      */
-    protected function setExpectation(Expectation $expectation)
+    protected function setExpectation(Expectation $expectation) : void
     {
         $this->expectation = $expectation;
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
@@ -39,7 +39,7 @@ abstract class Decorator implements Expectation
     /**
      * @param Expectation $expectation
      */
-    protected function setExpectation(Expectation $expectation) : void
+    protected function setExpectation(Expectation $expectation): void
     {
         $this->expectation = $expectation;
     }

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -85,7 +85,7 @@ class SubjectWithArrayAccess
      * @param string|integer $key
      * @param mixed          $value
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value) : void
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -100,7 +100,7 @@ class SubjectWithArrayAccess
     /**
      * @param string|integer $key
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key) : void
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -117,7 +117,7 @@ class SubjectWithArrayAccess
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      * @throws \PhpSpec\Exception\Fracture\InterfaceNotImplementedException
      */
-    private function checkIfSubjectImplementsArrayAccess($subject)
+    private function checkIfSubjectImplementsArrayAccess($subject) : void
     {
         if (\is_object($subject) && !($subject instanceof \ArrayAccess)) {
             throw $this->interfaceNotImplemented();

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -85,7 +85,7 @@ class SubjectWithArrayAccess
      * @param string|integer $key
      * @param mixed          $value
      */
-    public function offsetSet($key, $value) : void
+    public function offsetSet($key, $value): void
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -100,7 +100,7 @@ class SubjectWithArrayAccess
     /**
      * @param string|integer $key
      */
-    public function offsetUnset($key) : void
+    public function offsetUnset($key): void
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -117,7 +117,7 @@ class SubjectWithArrayAccess
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      * @throws \PhpSpec\Exception\Fracture\InterfaceNotImplementedException
      */
-    private function checkIfSubjectImplementsArrayAccess($subject) : void
+    private function checkIfSubjectImplementsArrayAccess($subject): void
     {
         if (\is_object($subject) && !($subject instanceof \ArrayAccess)) {
             throw $this->interfaceNotImplemented();

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -65,7 +65,7 @@ class WrappedObject
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
-    public function beAnInstanceOf(string $classname, array $arguments = array())
+    public function beAnInstanceOf(string $classname, array $arguments = array()) : void
     {
         if (!\is_string($classname)) {
             throw new SubjectException(sprintf(
@@ -86,7 +86,7 @@ class WrappedObject
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
-    public function beConstructedWith(array $args)
+    public function beConstructedWith(array $args) : void
     {
         if (null === $this->classname) {
             throw new SubjectException(sprintf(
@@ -106,7 +106,7 @@ class WrappedObject
      * @param callable|string|null $factoryMethod
      * @param array                $arguments
      */
-    public function beConstructedThrough($factoryMethod, array $arguments = array())
+    public function beConstructedThrough($factoryMethod, array $arguments = array()) : void
     {
         if (\is_string($factoryMethod) &&
             false === strpos($factoryMethod, '::') &&
@@ -143,7 +143,7 @@ class WrappedObject
     /**
      * @param boolean $instantiated
      */
-    public function setInstantiated(bool $instantiated)
+    public function setInstantiated(bool $instantiated) : void
     {
         $this->isInstantiated = $instantiated;
     }
@@ -159,7 +159,7 @@ class WrappedObject
     /**
      * @param string $classname
      */
-    public function setClassName(string $classname)
+    public function setClassName(string $classname) : void
     {
         $this->classname = $classname;
     }
@@ -183,7 +183,7 @@ class WrappedObject
     /**
      * @param object $instance
      */
-    public function setInstance($instance)
+    public function setInstance($instance) : void
     {
         $this->instance = $instance;
     }

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -65,7 +65,7 @@ class WrappedObject
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
-    public function beAnInstanceOf(string $classname, array $arguments = array()) : void
+    public function beAnInstanceOf(string $classname, array $arguments = array()): void
     {
         if (!\is_string($classname)) {
             throw new SubjectException(sprintf(
@@ -86,7 +86,7 @@ class WrappedObject
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
-    public function beConstructedWith(array $args) : void
+    public function beConstructedWith(array $args): void
     {
         if (null === $this->classname) {
             throw new SubjectException(sprintf(
@@ -106,7 +106,7 @@ class WrappedObject
      * @param callable|string|null $factoryMethod
      * @param array                $arguments
      */
-    public function beConstructedThrough($factoryMethod, array $arguments = array()) : void
+    public function beConstructedThrough($factoryMethod, array $arguments = array()): void
     {
         if (\is_string($factoryMethod) &&
             false === strpos($factoryMethod, '::') &&
@@ -143,7 +143,7 @@ class WrappedObject
     /**
      * @param boolean $instantiated
      */
-    public function setInstantiated(bool $instantiated) : void
+    public function setInstantiated(bool $instantiated): void
     {
         $this->isInstantiated = $instantiated;
     }
@@ -159,7 +159,7 @@ class WrappedObject
     /**
      * @param string $classname
      */
-    public function setClassName(string $classname) : void
+    public function setClassName(string $classname): void
     {
         $this->classname = $classname;
     }
@@ -183,7 +183,7 @@ class WrappedObject
     /**
      * @param object $instance
      */
-    public function setInstance($instance) : void
+    public function setInstance($instance): void
     {
         $this->instance = $instance;
     }

--- a/src/PhpSpec/Wrapper/SubjectContainer.php
+++ b/src/PhpSpec/Wrapper/SubjectContainer.php
@@ -18,5 +18,5 @@ interface SubjectContainer
     /**
      * @param Subject $subject
      */
-    public function setSpecificationSubject(Subject $subject) : void;
+    public function setSpecificationSubject(Subject $subject): void;
 }

--- a/src/PhpSpec/Wrapper/SubjectContainer.php
+++ b/src/PhpSpec/Wrapper/SubjectContainer.php
@@ -18,5 +18,5 @@ interface SubjectContainer
     /**
      * @param Subject $subject
      */
-    public function setSpecificationSubject(Subject $subject);
+    public function setSpecificationSubject(Subject $subject) : void;
 }


### PR DESCRIPTION
This required some changes for the specs to pass, e.g. `->willReturn();` → `->should(function() {})`.
Also, the codestyle is not consistent: sometimes it has a space before the colon, sometimes it doesn't. I've added spaces where the typehints were added.