### PR TITLE
5.0 add more typehints

### DIFF
--- a/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
@@ -30,7 +30,7 @@ class CreateObjectTemplate
         $this->className  = $className;
     }
 
-    public function getContent()
+    public function getContent(): string
     {
         $values = $this->getValues();
 

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -76,12 +76,12 @@ class OptionsConfig
         return $this->codeGenerationEnabled;
     }
 
-    public function isReRunEnabled() : bool
+    public function isReRunEnabled(): bool
     {
         return $this->reRunEnabled;
     }
 
-    public function isFakingEnabled() : bool
+    public function isFakingEnabled(): bool
     {
         return $this->fakingEnabled;
     }

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -76,12 +76,12 @@ class OptionsConfig
         return $this->codeGenerationEnabled;
     }
 
-    public function isReRunEnabled()
+    public function isReRunEnabled() : bool
     {
         return $this->reRunEnabled;
     }
 
-    public function isFakingEnabled()
+    public function isFakingEnabled() : bool
     {
         return $this->fakingEnabled;
     }

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -195,7 +195,7 @@ class ConsoleIO implements IO
         $this->lastMessage = $message.($newline ? "\n" : '');
     }
 
-    private function getCommonPrefix(string $stringA, string $stringB) : string
+    private function getCommonPrefix(string $stringA, string $stringB): string
     {
         for ($i = 0, $len = min(\strlen($stringA), \strlen($stringB)); $i<$len; $i++) {
             if ($stringA[$i] != $stringB[$i]) {
@@ -250,7 +250,7 @@ class ConsoleIO implements IO
     /**
      * @return ?string
      */
-    public function getBootstrapPath() : ?string
+    public function getBootstrapPath(): ?string
     {
         if ($path = $this->input->getOption('bootstrap')) {
             return $path;

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -122,15 +122,7 @@ class ConsoleIO implements IO
     }
 
     /**
-<<<<<<< HEAD
      * @return ?string
-=======
-<<<<<<< HEAD
-     * @return null|string
-=======
-     * @return ?string
->>>>>>> ef380ca0... Make phpdoc more accurate
->>>>>>> 3.4
      */
     public function cutTemp()
     {
@@ -203,7 +195,7 @@ class ConsoleIO implements IO
         $this->lastMessage = $message.($newline ? "\n" : '');
     }
 
-    private function getCommonPrefix(string $stringA, string $stringB)
+    private function getCommonPrefix(string $stringA, string $stringB) : string
     {
         for ($i = 0, $len = min(\strlen($stringA), \strlen($stringB)); $i<$len; $i++) {
             if ($stringA[$i] != $stringB[$i]) {
@@ -256,9 +248,9 @@ class ConsoleIO implements IO
     }
 
     /**
-     * @return string|null
+     * @return ?string
      */
-    public function getBootstrapPath()
+    public function getBootstrapPath() : ?string
     {
         if ($path = $this->input->getOption('bootstrap')) {
             return $path;

--- a/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
+++ b/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
@@ -30,7 +30,7 @@ class InvalidCollaboratorTypeException extends CollaboratorException
         parent::__construct($message);
     }
 
-    private function fetchFunctionIdentifier(\ReflectionFunctionAbstract $function)
+    private function fetchFunctionIdentifier(\ReflectionFunctionAbstract $function) : string
     {
         $functionIdentifier = $function->getName();
         if ($function instanceof \ReflectionMethod) {

--- a/src/PhpSpec/Formatter/Html/ReportFailedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportFailedItem.php
@@ -70,7 +70,7 @@ class ReportFailedItem
     /**
      * @return string
      */
-    private function formatBacktrace(): string
+    private function formatBacktrace() : string
     {
         $backtrace = '';
         foreach ($this->event->getBacktrace() as $step) {

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -73,12 +73,12 @@ class StatisticsCollector implements EventSubscriberInterface
         $this->totalSpecsCount = \count($suiteEvent->getSuite()->getSpecifications());
     }
 
-    public function getGlobalResult()
+    public function getGlobalResult() : int
     {
         return $this->globalResult;
     }
 
-    public function getAllEvents()
+    public function getAllEvents() : array
     {
         return array_merge(
             $this->passedEvents,
@@ -89,32 +89,32 @@ class StatisticsCollector implements EventSubscriberInterface
         );
     }
 
-    public function getPassedEvents()
+    public function getPassedEvents() : array
     {
         return $this->passedEvents;
     }
 
-    public function getPendingEvents()
+    public function getPendingEvents() : array
     {
         return $this->pendingEvents;
     }
 
-    public function getSkippedEvents()
+    public function getSkippedEvents() : array
     {
         return $this->skippedEvents;
     }
 
-    public function getFailedEvents()
+    public function getFailedEvents() : array
     {
         return $this->failedEvents;
     }
 
-    public function getBrokenEvents()
+    public function getBrokenEvents() : array
     {
         return $this->brokenEvents;
     }
 
-    public function getCountsHash()
+    public function getCountsHash() : array
     {
         return array(
             'passed'  => \count($this->getPassedEvents()),
@@ -125,17 +125,17 @@ class StatisticsCollector implements EventSubscriberInterface
         );
     }
 
-    public function getTotalSpecs()
+    public function getTotalSpecs() : int
     {
         return $this->totalSpecs;
     }
 
-    public function getEventsCount()
+    public function getEventsCount() : int
     {
         return \count($this->getAllEvents());
     }
 
-    public function getTotalSpecsCount()
+    public function getTotalSpecsCount() : int
     {
         return $this->totalSpecsCount;
     }

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -88,7 +88,7 @@ class SpecificationNode implements \Countable
     /**
      * @return ExampleNode[]
      */
-    public function getExamples() : array
+    public function getExamples(): array
     {
         return $this->examples;
     }

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -88,7 +88,7 @@ class SpecificationNode implements \Countable
     /**
      * @return ExampleNode[]
      */
-    public function getExamples()
+    public function getExamples() : array
     {
         return $this->examples;
     }

--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -38,7 +38,7 @@ class StreamWrapper
         static::$specTransformers[] = $specTransformer;
     }
 
-    public static function wrapPath($path)
+    public static function wrapPath($path) : string
     {
         if (!\defined('HHVM_VERSION'))
         {
@@ -48,7 +48,7 @@ class StreamWrapper
         return $path;
     }
 
-    public function stream_open($path, $mode, $options, &$opened_path)
+    public function stream_open($path, $mode, $options, &$opened_path) : bool
     {
         if ($mode != 'rb') {
             throw new \RuntimeException('Cannot open phpspec url in mode "$mode"');
@@ -74,7 +74,7 @@ class StreamWrapper
         return true;
     }
 
-    public function stream_stat()
+    public function stream_stat() : array
     {
         return stat($this->realPath);
     }
@@ -84,7 +84,7 @@ class StreamWrapper
         return fread($this->fileResource, $count);
     }
 
-    public function stream_eof()
+    public function stream_eof() : bool
     {
         return feof($this->fileResource);
     }

--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -38,7 +38,7 @@ class StreamWrapper
         static::$specTransformers[] = $specTransformer;
     }
 
-    public static function wrapPath($path) : string
+    public static function wrapPath($path): string
     {
         if (!\defined('HHVM_VERSION'))
         {
@@ -48,7 +48,7 @@ class StreamWrapper
         return $path;
     }
 
-    public function stream_open($path, $mode, $options, &$opened_path) : bool
+    public function stream_open($path, $mode, $options, &$opened_path): bool
     {
         if ($mode != 'rb') {
             throw new \RuntimeException('Cannot open phpspec url in mode "$mode"');
@@ -74,7 +74,7 @@ class StreamWrapper
         return true;
     }
 
-    public function stream_stat() : array
+    public function stream_stat(): array
     {
         return stat($this->realPath);
     }
@@ -84,7 +84,7 @@ class StreamWrapper
         return fread($this->fileResource, $count);
     }
 
-    public function stream_eof() : bool
+    public function stream_eof(): bool
     {
         return feof($this->fileResource);
     }

--- a/src/PhpSpec/Loader/Suite.php
+++ b/src/PhpSpec/Loader/Suite.php
@@ -32,7 +32,7 @@ class Suite implements \Countable
     /**
      * @return Node\SpecificationNode[]
      */
-    public function getSpecifications()
+    public function getSpecifications() : array
     {
         return $this->specs;
     }

--- a/src/PhpSpec/Loader/Suite.php
+++ b/src/PhpSpec/Loader/Suite.php
@@ -32,7 +32,7 @@ class Suite implements \Countable
     /**
      * @return Node\SpecificationNode[]
      */
-    public function getSpecifications() : array
+    public function getSpecifications(): array
     {
         return $this->specs;
     }

--- a/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
@@ -36,7 +36,7 @@ final class TypeHintRewriter implements SpecTransformer
      *
      * @return string
      */
-    function transform(string $spec): string
+    public function transform(string $spec): string
     {
         return $this->rewriter->rewrite($spec);
     }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -143,7 +143,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     /**
      * @return Resource[]
      */
-    public function getAllResources()
+    public function getAllResources() : array
     {
         return $this->findSpecResources($this->fullSpecPath);
     }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -143,7 +143,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     /**
      * @return Resource[]
      */
-    public function getAllResources() : array
+    public function getAllResources(): array
     {
         return $this->findSpecResources($this->fullSpecPath);
     }

--- a/src/PhpSpec/Locator/PrioritizedResourceManager.php
+++ b/src/PhpSpec/Locator/PrioritizedResourceManager.php
@@ -39,7 +39,7 @@ final class PrioritizedResourceManager implements ResourceManager
      *
      * @return Resource[]
      */
-    public function locateResources(string $query)
+    public function locateResources(string $query) : array
     {
         $resources = array();
         foreach ($this->locators as $locator) {
@@ -86,7 +86,7 @@ final class PrioritizedResourceManager implements ResourceManager
      *
      * @return Resource[]
      */
-    private function removeDuplicateResources(array $resources)
+    private function removeDuplicateResources(array $resources) : array
     {
         $filteredResources = array();
 

--- a/src/PhpSpec/Locator/PrioritizedResourceManager.php
+++ b/src/PhpSpec/Locator/PrioritizedResourceManager.php
@@ -39,7 +39,7 @@ final class PrioritizedResourceManager implements ResourceManager
      *
      * @return Resource[]
      */
-    public function locateResources(string $query) : array
+    public function locateResources(string $query): array
     {
         $resources = array();
         foreach ($this->locators as $locator) {
@@ -86,7 +86,7 @@ final class PrioritizedResourceManager implements ResourceManager
      *
      * @return Resource[]
      */
-    private function removeDuplicateResources(array $resources) : array
+    private function removeDuplicateResources(array $resources): array
     {
         $filteredResources = array();
 

--- a/src/PhpSpec/Locator/ResourceLocator.php
+++ b/src/PhpSpec/Locator/ResourceLocator.php
@@ -18,7 +18,7 @@ interface ResourceLocator
     /**
      * @return Resource[]
      */
-    public function getAllResources() : array;
+    public function getAllResources(): array;
 
     /**
      * @param string $query

--- a/src/PhpSpec/Locator/ResourceLocator.php
+++ b/src/PhpSpec/Locator/ResourceLocator.php
@@ -18,7 +18,7 @@ interface ResourceLocator
     /**
      * @return Resource[]
      */
-    public function getAllResources();
+    public function getAllResources() : array;
 
     /**
      * @param string $query

--- a/src/PhpSpec/Locator/ResourceManager.php
+++ b/src/PhpSpec/Locator/ResourceManager.php
@@ -20,7 +20,7 @@ interface ResourceManager
      *
      * @return \PhpSpec\Locator\Resource[]
      */
-    public function locateResources(string $query);
+    public function locateResources(string $query) : array ;
 
     /**
      * @param string $classname

--- a/src/PhpSpec/Locator/ResourceManager.php
+++ b/src/PhpSpec/Locator/ResourceManager.php
@@ -20,7 +20,7 @@ interface ResourceManager
      *
      * @return \PhpSpec\Locator\Resource[]
      */
-    public function locateResources(string $query) : array ;
+    public function locateResources(string $query): array;
 
     /**
      * @param string $classname

--- a/src/PhpSpec/Matcher/BasicMatcher.php
+++ b/src/PhpSpec/Matcher/BasicMatcher.php
@@ -27,7 +27,7 @@ abstract class BasicMatcher implements Matcher
      *
      * @throws FailureException
      */
-    final public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    final public function positiveMatch(string $name, $subject, array $arguments): ?DelayedCall
     {
         if (false === $this->matches($subject, $arguments)) {
             throw $this->getFailureException($name, $subject, $arguments);
@@ -45,7 +45,7 @@ abstract class BasicMatcher implements Matcher
      *
      * @throws FailureException
      */
-    final public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    final public function negativeMatch(string $name, $subject, array $arguments): ?DelayedCall
     {
         if (true === $this->matches($subject, $arguments)) {
             throw $this->getNegativeFailureException($name, $subject, $arguments);

--- a/src/PhpSpec/Matcher/BasicMatcher.php
+++ b/src/PhpSpec/Matcher/BasicMatcher.php
@@ -14,6 +14,7 @@
 namespace PhpSpec\Matcher;
 
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Wrapper\DelayedCall;
 
 abstract class BasicMatcher implements Matcher
 {
@@ -22,17 +23,17 @@ abstract class BasicMatcher implements Matcher
      * @param mixed  $subject
      * @param array  $arguments
      *
-     * @return mixed
+     * @return void
      *
-     *   @throws FailureException
+     * @throws FailureException
      */
-    final public function positiveMatch(string $name, $subject, array $arguments)
+    final public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         if (false === $this->matches($subject, $arguments)) {
             throw $this->getFailureException($name, $subject, $arguments);
         }
 
-        return $subject;
+        return null;
     }
 
     /**
@@ -40,17 +41,17 @@ abstract class BasicMatcher implements Matcher
      * @param mixed  $subject
      * @param array  $arguments
      *
-     * @return mixed
+     * @return void
      *
      * @throws FailureException
      */
-    final public function negativeMatch(string $name, $subject, array $arguments)
+    final public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         if (true === $this->matches($subject, $arguments)) {
             throw $this->getNegativeFailureException($name, $subject, $arguments);
         }
 
-        return $subject;
+        return null;
     }
 
     /**

--- a/src/PhpSpec/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Matcher/IterateAsMatcher.php
@@ -16,6 +16,7 @@ namespace PhpSpec\Matcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Matcher\Iterate\IterablesMatcher;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class IterateAsMatcher implements Matcher
 {
@@ -47,7 +48,7 @@ final class IterateAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function positiveMatch(string $name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0]);
@@ -56,17 +57,19 @@ final class IterateAsMatcher implements Matcher
         } catch (Iterate\SubjectHasMoreElementsException $exception) {
             throw new FailureException('Expected subject to have the same number of elements than matched value, but it has more.', 0, $exception);
         }
+
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function negativeMatch(string $name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
         } catch (FailureException $exception) {
-            return;
+            return null;
         }
 
         throw new FailureException('Expected subject not to iterate the same as matched value, but it does.');

--- a/src/PhpSpec/Matcher/IterateLikeMatcher.php
+++ b/src/PhpSpec/Matcher/IterateLikeMatcher.php
@@ -16,6 +16,7 @@ namespace PhpSpec\Matcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Matcher\Iterate\IterablesMatcher;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class IterateLikeMatcher implements Matcher
 {
@@ -47,7 +48,7 @@ final class IterateLikeMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function positiveMatch(string $name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0], false);
@@ -56,17 +57,19 @@ final class IterateLikeMatcher implements Matcher
         } catch (Iterate\SubjectHasMoreElementsException $exception) {
             throw new FailureException('Expected subject to have the same number of elements than matched value, but it has more.', 0, $exception);
         }
+
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function negativeMatch(string $name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
         } catch (FailureException $exception) {
-            return;
+            return null;
         }
 
         throw new FailureException('Expected subject not to iterate the same as matched value, but it does.');

--- a/src/PhpSpec/Matcher/Matcher.php
+++ b/src/PhpSpec/Matcher/Matcher.php
@@ -13,6 +13,8 @@
 
 namespace PhpSpec\Matcher;
 
+use PhpSpec\Wrapper\DelayedCall;
+
 interface Matcher
 {
     /**
@@ -33,7 +35,7 @@ interface Matcher
      * @param mixed  $subject
      * @param array  $arguments
      */
-    public function positiveMatch(string $name, $subject, array $arguments);
+    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall;
 
     /**
      * Evaluates negative match.
@@ -42,7 +44,7 @@ interface Matcher
      * @param mixed  $subject
      * @param array  $arguments
      */
-    public function negativeMatch(string $name, $subject, array $arguments);
+    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall;
 
     /**
      * Returns matcher priority.

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -16,6 +16,7 @@ namespace PhpSpec\Matcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Fracture\MethodNotFoundException;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class ObjectStateMatcher implements Matcher
 {
@@ -58,7 +59,7 @@ final class ObjectStateMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      */
-    public function positiveMatch(string $name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         preg_match(self::$regex, $name, $matches);
         $method   = ('be' === $matches[1] ? 'is' : 'has').ucfirst($matches[2]);
@@ -74,6 +75,8 @@ final class ObjectStateMatcher implements Matcher
         if (true !== $result = \call_user_func_array($callable, $arguments)) {
             throw $this->getFailureExceptionFor($callable, true, $result);
         }
+
+        return null;
     }
 
     /**
@@ -84,7 +87,7 @@ final class ObjectStateMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      */
-    public function negativeMatch(string $name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         preg_match(self::$regex, $name, $matches);
         $method   = ('be' === $matches[1] ? 'is' : 'has').ucfirst($matches[2]);

--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -15,6 +15,7 @@ namespace PhpSpec\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class ScalarMatcher implements Matcher
 {
@@ -57,7 +58,7 @@ final class ScalarMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @return boolean
      */
-    public function positiveMatch(string $name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         $checker = $this->getCheckerName($name);
 
@@ -72,6 +73,8 @@ final class ScalarMatcher implements Matcher
                 $this->presenter->presentValue(true)
             ));
         }
+
+        return null;
     }
 
     /**
@@ -84,7 +87,7 @@ final class ScalarMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @return boolean
      */
-    public function negativeMatch(string $name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         $checker = $this->getCheckerName($name);
 

--- a/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
@@ -16,6 +16,7 @@ namespace PhpSpec\Matcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Matcher\Iterate\IterablesMatcher;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class StartIteratingAsMatcher implements Matcher
 {
@@ -47,7 +48,7 @@ final class StartIteratingAsMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function positiveMatch(string $name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0]);
@@ -56,17 +57,19 @@ final class StartIteratingAsMatcher implements Matcher
         } catch (Iterate\SubjectHasFewerElementsException $exception) {
             throw new FailureException('Expected subject to have the same or more elements than matched value, but it has fewer.', 0, $exception);
         }
+
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function negativeMatch(string $name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
         } catch (FailureException $exception) {
-            return;
+            return null;
         }
 
         throw new FailureException('Expected subject not to start iterating the same as matched value, but it does.');

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -15,6 +15,7 @@ namespace PhpSpec\Matcher;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class TraversableCountMatcher implements Matcher
 {
@@ -49,7 +50,7 @@ final class TraversableCountMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function positiveMatch(string $name, $subject, array $arguments)
+    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         $countDifference = $this->countDifference($subject, (int) $arguments[0]);
 
@@ -62,13 +63,13 @@ final class TraversableCountMatcher implements Matcher
             ));
         }
 
-        return $subject;
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function negativeMatch(string $name, $subject, array $arguments)
+    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
         $count = $this->countDifference($subject, (int) $arguments[0]);
 
@@ -80,7 +81,7 @@ final class TraversableCountMatcher implements Matcher
             ));
         }
 
-        return $subject;
+        return null;
     }
 
     /**

--- a/src/PhpSpec/Message/CurrentExampleTracker.php
+++ b/src/PhpSpec/Message/CurrentExampleTracker.php
@@ -17,12 +17,12 @@ final class CurrentExampleTracker
 {
     private $currentExample;
 
-    public function setCurrentExample($currentExample)
+    public function setCurrentExample(string $currentExample = null)
     {
         $this->currentExample = $currentExample;
     }
 
-    public function getCurrentExample()
+    public function getCurrentExample() : ?string
     {
         return $this->currentExample;
     }

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -61,7 +61,7 @@ class ComposerPsrNamespaceProvider
         return $namespaces;
     }
 
-    private function getNamespacesFromPrefixes(array $prefixes, array $vendors, $standard)
+    private function getNamespacesFromPrefixes(array $prefixes, array $vendors, $standard) : array
     {
         $namespaces = array();
         foreach ($prefixes as $namespace => $psrPrefix) {

--- a/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
@@ -67,7 +67,7 @@ final class ProcOpenReRunner extends PhpExecutableReRunner
         exit($status['exitcode']);
     }
 
-    private function buildArgString()
+    private function buildArgString() : string
     {
         $argstring = '';
 

--- a/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
@@ -56,7 +56,7 @@ final class WindowsPassthruReRunner extends PhpExecutableReRunner
         exit($exitCode);
     }
 
-    private function buildArgString()
+    private function buildArgString() : string
     {
         $argstring = '';
 

--- a/src/PhpSpec/Runner/SpecificationRunner.php
+++ b/src/PhpSpec/Runner/SpecificationRunner.php
@@ -42,7 +42,7 @@ class SpecificationRunner
      * @param  SpecificationNode $specification
      * @return int|mixed
      */
-    public function run(SpecificationNode $specification)
+    public function run(SpecificationNode $specification) : int
     {
         $startTime = microtime(true);
         $this->dispatcher->dispatch(

--- a/src/PhpSpec/Runner/SpecificationRunner.php
+++ b/src/PhpSpec/Runner/SpecificationRunner.php
@@ -42,7 +42,7 @@ class SpecificationRunner
      * @param  SpecificationNode $specification
      * @return int|mixed
      */
-    public function run(SpecificationNode $specification) : int
+    public function run(SpecificationNode $specification): int
     {
         $startTime = microtime(true);
         $this->dispatcher->dispatch(

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -212,7 +212,7 @@ final class ClassFileAnalyser
         }
     }
 
-    private function isSpecialBraceToken($token) : bool
+    private function isSpecialBraceToken($token): bool
     {
         if (!\is_array($token)) {
             return false;

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -212,7 +212,7 @@ final class ClassFileAnalyser
         }
     }
 
-    private function isSpecialBraceToken($token)
+    private function isSpecialBraceToken($token) : bool
     {
         if (!\is_array($token)) {
             return false;

--- a/src/PhpSpec/Util/Filesystem.php
+++ b/src/PhpSpec/Util/Filesystem.php
@@ -69,7 +69,7 @@ class Filesystem
      *
      * @return \SplFileInfo[]
      */
-    public function findSpecFilesIn(string $path) : array
+    public function findSpecFilesIn(string $path): array
     {
         $finder = Finder::create()
             ->files()

--- a/src/PhpSpec/Util/Filesystem.php
+++ b/src/PhpSpec/Util/Filesystem.php
@@ -69,7 +69,7 @@ class Filesystem
      *
      * @return \SplFileInfo[]
      */
-    public function findSpecFilesIn(string $path)
+    public function findSpecFilesIn(string $path) : array
     {
         $finder = Finder::create()
             ->files()

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -104,7 +104,7 @@ class MethodAnalyser
      *
      * @return null|\ReflectionClass
      */
-    private function getDeclaringTrait(array $traits, string $file, int $start, int $end) : ?\ReflectionClass
+    private function getDeclaringTrait(array $traits, string $file, int $start, int $end): ?\ReflectionClass
     {
         foreach ($traits as $trait) {
             if ($trait->getFileName() == $file && $trait->getStartLine() <= $start && $trait->getEndLine() >= $end) {

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -104,7 +104,7 @@ class MethodAnalyser
      *
      * @return null|\ReflectionClass
      */
-    private function getDeclaringTrait(array $traits, string $file, int $start, int $end)
+    private function getDeclaringTrait(array $traits, string $file, int $start, int $end) : ?\ReflectionClass
     {
         foreach ($traits as $trait) {
             if ($trait->getFileName() == $file && $trait->getStartLine() <= $start && $trait->getEndLine() >= $end) {

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -15,6 +15,7 @@ namespace PhpSpec\Wrapper\Subject;
 
 use PhpSpec\CodeAnalysis\AccessInspector;
 use PhpSpec\Exception\ExceptionFactory;
+use PhpSpec\Exception\Fracture\NamedConstructorNotFoundException;
 use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\Wrapper\Subject;
 use PhpSpec\Wrapper\Wrapper;
@@ -339,13 +340,7 @@ class Caller
         return $this->exceptionFactory->classNotFound($this->wrappedObject->getClassName());
     }
 
-    /**
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return \PhpSpec\Exception\Fracture\MethodNotFoundException|\PhpSpec\Exception\Fracture\MethodNotVisibleException
-     */
-    private function namedConstructorNotFound(string $method, array $arguments = array())
+    private function namedConstructorNotFound(string $method, array $arguments = array()) : NamedConstructorNotFoundException
     {
         $className = $this->wrappedObject->getClassName();
 


### PR DESCRIPTION
While working on #1206, I've also found several methods that could have return type hints. Also, CS fixed so that return typehints all have no space before colons.

`ConsoleIO` had a merge conflict in it; resolved to `@return ?string` instead of `@return string|null`