### PR TITLE
PHP 7.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.1
     - php: 7.2
+    - php: 7.3
     - php: nightly
       env: DEPENDENCIES='dev'
       env: COMPOSER_FLAGS='--ignore-platform-reqs'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,13 @@ matrix:
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.1
     - php: 7.2
-    - php: 7.3
+    - php: 7.3.0RC1
+      dist: xenial
+      sudo: required
+      addons:
+        apt:
+          packages:
+          - libzip4
     - php: nightly
       env: DEPENDENCIES='dev'
       env: COMPOSER_FLAGS='--ignore-platform-reqs'

--- a/CHANGES-v5.md
+++ b/CHANGES-v5.md
@@ -3,10 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+ 
+## [Unreleased]
+### Added
+ - PHP 7.3 compatibility (@ciaranmcnulty)
 
 ## [5.0.2]
 ### Fixed
- - Better error message when trying to call method on scalar return type (@ciaranmcnulty) 
+ - Better error message when trying to call method on scalar return type (@ciaranmcnulty)
 
 ## [5.0.1]
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
 
     "require": {
-        "php":                      "^7.1, <7.3",
+        "php":                      "^7.1, <7.4",
         "phpspec/prophecy":         "^1.7",
         "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "^1.0 || ^2.0 || ^3.0",

--- a/spec/PhpSpec/Matcher/IterateLikeMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/IterateLikeMatcherSpec.php
@@ -68,11 +68,7 @@ final class IterateLikeMatcherSpec extends ObjectBehavior
         $second->foo = 'bar';
 
         $this
-            ->shouldThrow(new SubjectElementDoesNotMatchException(0, '"0"', '"stdClass::__set_state(array(
-   \'foo\' => \'foo\',
-))"', '"0"', '"stdClass::__set_state(array(
-   \'foo\' => \'bar\',
-))"'))
+            ->shouldThrow(SubjectElementDoesNotMatchException::class)
             ->during('positiveMatch', [
                 'iterateLike',
                 $this->createGeneratorReturningArray([$first]),


### PR DESCRIPTION
 - allow 7.3 in composer.json
 - add 7.3 to travis CI grid
 - fix one test that contained changed implementation detail

This should not be merged until Travis supports 7.3, and it has been checked against a late RC of 7.3

Will fix #1211 
