### PR TITLE
fix composer dependencies for 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/process":          "^2.6|~3.0",
         "symfony/finder":           "~2.1|~3.0",
         "symfony/yaml":             "~2.1|~3.0",
-        "doctrine/instantiator":    "^1.0.1",
+        "doctrine/instantiator":    "~1.0.5",
         "ext-tokenizer":            "*"
     },
 


### PR DESCRIPTION
`^1.0.1` translates to `>=1.0.1, <2.0.0` - which is correct. But unfortunately the upstream-package did not version according to semver and introduced a breaking change in a minor version bump, meaning their version `1.1.0` now requires `php7.1+`, see:

* https://github.com/doctrine/instantiator/issues/46
* https://github.com/doctrine/instantiator/releases/tag/1.1.0

The changes below will make sure that only `>=1.05, <1.1.0` version will be installed.

Workaround until this is merged + released is to manually require the correct version in your project:

```
$ composer require "doctrine/instantiator" "~1.0.5"
```