### PR TITLE
Improve diff of array of objects

### DIFF
--- a/features/formatter/developer_is_shown_diffs.feature
+++ b/features/formatter/developer_is_shown_diffs.feature
@@ -97,6 +97,60 @@ Feature: Developer is shown diffs
                ]
       """
 
+  Scenario: Array of object diffing
+    Given the spec file "spec/Diffs/DiffExample2/ClassWithArraysOfObjectsSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Diffs\DiffExample2;
+
+      use PhpSpec\ObjectBehavior;
+      use Prophecy\Argument;
+
+      class ClassWithArraysOfObjectsSpec extends ObjectBehavior
+      {
+          function it_is_equal()
+          {
+              $std = new \stdClass;
+              $std->test = 'anotherProperty';
+              $this->getArray()->shouldBeLike([$std]);
+          }
+      }
+
+      """
+    And the class file "src/Diffs/DiffExample2/ClassWithArraysOfObjects.php" contains:
+      """
+      <?php
+
+      namespace Diffs\DiffExample2;
+
+      class ClassWithArraysOfObjects
+      {
+          public function getArray()
+          {
+              $std = new \stdClass;
+              $std->property = 'testValue';
+              $std->hash = 'fooHash';
+
+              return [$std];
+          }
+      }
+
+      """
+    When I run phpspec with the "verbose" option
+    Then I should see:
+      """
+          -        'test' => 'anotherProperty'
+      """
+    And I should see:
+      """
+          +        'property' => 'testValue'
+      """
+    And I should see:
+      """
+          +        'hash' => 'fooHash'
+      """
+
   Scenario: Object diffing
     Given the spec file "spec/Diffs/DiffExample3/ClassWithObjectsSpec.php" contains:
       """

--- a/spec/PhpSpec/Formatter/Presenter/Differ/ArrayEngineSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Differ/ArrayEngineSpec.php
@@ -2,23 +2,52 @@
 
 namespace spec\PhpSpec\Formatter\Presenter\Differ;
 
+use PhpSpec\Formatter\Presenter\Differ\DifferEngine;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
+use SebastianBergmann\Exporter\Exporter;
+use stdClass;
+use function var_dump;
 
 class ArrayEngineSpec extends ObjectBehavior
 {
+    function let()
+    {
+        $this->beConstructedWith(new Exporter());
+    }
+
     function it_is_a_diff_engine()
     {
-        $this->shouldBeAnInstanceOf('PhpSpec\Formatter\Presenter\Differ\DifferEngine');
+        $this->shouldBeAnInstanceOf(DifferEngine::class);
     }
 
     function it_supports_arrays()
     {
-        $this->supports(array(), array(1, 2, 3))->shouldReturn(true);
+        $this->supports([], [ 1, 2, 3 ])->shouldReturn(true);
     }
 
     function it_does_not_support_anything_else()
     {
         $this->supports('str', 2)->shouldReturn(false);
+    }
+
+    function it_compare_equal_arrays()
+    {
+        $result = $this->compare([ 1 ], [ 1 ]);
+        $result->shouldBeString();
+        $result->shouldNotContain('1');
+    }
+
+    function it_compare_array_of_objects_to_and_displays_its_properties()
+    {
+        $obj1 = new stdClass();
+        $obj1->hash = '123#';
+        $obj2 = new stdClass();
+        $obj2->trash = '12345f';
+
+        $diff = $this->compare([ $obj1 ], [ $obj2 ]);
+        $diff->shouldContain('hash');
+        $diff->shouldContain('123#');
+        $diff->shouldContain('trash');
+        $diff->shouldContain('12345f');
     }
 }

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -72,7 +72,7 @@ final class PresenterAssembler
         }, ['formatter.presenter.differ.engines']);
 
         $container->define('formatter.presenter.differ.engines.array', function () {
-            return new ArrayEngine();
+            return new ArrayEngine(new Exporter());
         }, ['formatter.presenter.differ.engines']);
 
         $container->define('formatter.presenter.differ.engines.object', function (IndexedServiceContainer $c) {

--- a/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
@@ -13,8 +13,21 @@
 
 namespace PhpSpec\Formatter\Presenter\Differ;
 
+use SebastianBergmann\Exporter\Exporter;
+
 final class ArrayEngine extends StringEngine
 {
+    private const PAD_SIZE = 2;
+
+    private const PAD_STRING = ' ';
+
+    private $exporter;
+
+    public function __construct(Exporter $exporter)
+    {
+        $this->exporter = $exporter;
+    }
+
     public function supports($expected, $actual): bool
     {
         return \is_array($expected) && \is_array($actual);
@@ -23,21 +36,21 @@ final class ArrayEngine extends StringEngine
     public function compare($expected, $actual): string
     {
         $expectedString = $this->convertArrayToString($expected);
-        $actualString   = $this->convertArrayToString($actual);
+        $actualString = $this->convertArrayToString($actual);
 
         return parent::compare($expectedString, $actualString);
     }
 
-    private function convertArrayToString(array $a, $pad = 2): string
+    private function convertArrayToString(array $a, $pad = 1): string
     {
-        $str = str_pad('', $pad, ' ').'[';
+        $str = str_pad('', $pad * self::PAD_SIZE, self::PAD_STRING) . '[';
         foreach ($a as $key => $val) {
             switch ($type = strtolower(\gettype($val))) {
                 case 'array':
                     $line = sprintf(
                         '%s => %s,',
                         $key,
-                        ltrim($this->convertArrayToString($val, $pad+2))
+                        ltrim($this->convertArrayToString($val, $pad + 1))
                     );
                     break;
                 case 'null':
@@ -47,11 +60,12 @@ final class ArrayEngine extends StringEngine
                     $line = sprintf('%s => %s,', $key, $val ? 'true' : 'false');
                     break;
                 case 'object':
+                    $exporterPadSize = 4;
+                    $padCorrection = self::PAD_SIZE / $exporterPadSize;
                     $line = sprintf(
-                        '%s => %s#%s,',
+                        '%s => %s,',
                         $key,
-                        \get_class($val),
-                        spl_object_hash($val)
+                        $this->exporter->export($val, ($pad + 1) * $padCorrection)
                     );
                     break;
                 case 'string':
@@ -65,9 +79,9 @@ final class ArrayEngine extends StringEngine
                 default:
                     $line = sprintf('%s => %s:%s,', $key, $type, $val);
             }
-            $str .= PHP_EOL.str_pad('', $pad+2, ' ').$line;
+            $str .= PHP_EOL . str_pad('', ($pad + 1) * self::PAD_SIZE, self::PAD_STRING) . $line;
         }
-        $str .= PHP_EOL.str_pad('', $pad, ' ').']';
+        $str .= PHP_EOL . str_pad('', $pad * self::PAD_SIZE, self::PAD_STRING) . ']';
 
         return $str;
     }


### PR DESCRIPTION
When devoloping TDD you always try to start with simplest of possible solutions as conseqence you  can implement collections or other future objects as array of objects or tuple of objects. Diff of this type of arrays is not very useful in phpspec. Let`s consider example output for test like
```php
    function it_ruturn_net_cash_flow_by_month()
    {
        $balances = [
            MonthlyBalance::zero(Month::fromDate('01.01.2017'))
                          ->withCashFlow(MonthlyNewIncome::fromMoneyAndType(Money::fromRubles(100), Type::iptv()))
                          ->withOperationalExpenditure(OperationalExpenditure::fromMoney(Money::fromRubles(50)))
                          ->withAmortization(Money::fromRubles(5))
                          ->withPropertyTax(Money::fromRubles(5)),
            MonthlyBalance::zero(Month::fromDate('01.02.2017'))
                          ->withCashFlow(MonthlyNewIncome::fromMoneyAndType(Money::fromRubles(100), Type::iptv()))
                          ->withOperationalExpenditure(OperationalExpenditure::fromMoney(Money::fromRubles(60)))
                          ->withAmortization(Money::fromRubles(5))
                          ->withPropertyTax(Money::fromRubles(5)),
            MonthlyBalance::zero(Month::fromDate('01.03.2017'))
                          ->withCashFlow(MonthlyNewIncome::fromMoneyAndType(Money::fromRubles(100), Type::iptv()))
                          ->withOperationalExpenditure(OperationalExpenditure::fromMoney(Money::fromRubles(50)))
                          ->withAmortization(Money::fromRubles(5))
                          ->withPropertyTax(Money::fromRubles(5)),
            MonthlyBalance::zero(Month::fromDate('01.04.2017'))
                          ->withCashFlow(MonthlyNewIncome::fromMoneyAndType(Money::fromRubles(100), Type::iptv()))
                          ->withOperationalExpenditure(OperationalExpenditure::fromMoney(Money::fromRubles(50)))
                          ->withAmortization(Money::fromRubles(6))
                          ->withPropertyTax(Money::fromRubles(5)),

        ];
        $this->beConstructedFromMonthlyBalances($balances);
        $this->netCashFlow(IncomeTaxRate::fromPercent(10))
             ->shouldBeLike(
                 [
                     [ Month::fromDate('01.01.2017'), Money::fromRubles(0) ],
                     [ Month::fromDate('01.02.2017'), Money::fromRubles(90) ],
                     [ Month::fromDate('01.03.2017'), Money::fromRubles(40) ],
                     [ Month::fromDate('01.04.2017'), Money::fromRubles(29) ],
                 ]
             );
    }
```
phpspec run -v gives us:
![screenshot_20180819_163503](https://user-images.githubusercontent.com/2681887/44309333-d9a6a380-a3cd-11e8-9f72-88721d1493d1.png)

Damn it, var_dump ftw.

Proposed PR makes output like this:
![screenshot_20180819_163657](https://user-images.githubusercontent.com/2681887/44309354-183c5e00-a3ce-11e8-801a-d7ede2fcca03.png)

Huh, now one knows whats going on.
What do you think about it?

