### PR TITLE
Fix Prophecy error message bug

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -193,6 +193,24 @@ class ApplicationContext implements Context
     }
 
     /**
+     * @Then I should see the error that :methodCall was not expected on :class
+     */
+    public function iShouldSeeTheErrorThatWasNotExpectedOn($methodCall, $class)
+    {
+        $this->checkApplicationOutput((string)$methodCall);
+        $this->checkApplicationOutput((string)$this->normalize($class));
+
+        $output = $this->tester->getDisplay();
+
+        $containsOldProphecyMessage = strpos($output, 'was not expected') !== false;
+        $containsNewProphecyMessage = strpos($output, 'Unexpected method call') !== false;
+
+        if (!$containsOldProphecyMessage && !$containsNewProphecyMessage) {
+            throw new \Exception('Was expecting error message about an unexpected method call');
+        }
+    }
+
+    /**
      * @Then I should not be prompted for code generation
      */
     public function iShouldNotBePromptedForCodeGeneration()

--- a/features/formatter/developer_is_shown_diffs.feature
+++ b/features/formatter/developer_is_shown_diffs.feature
@@ -392,13 +392,7 @@ Feature: Developer is shown diffs
       }
       """
     When I run phpspec with the "verbose" option
-    Then I should see:
-      """
-            method call:
-              - methodTwo("value")
-            on Double\Diffs\DiffExample7\ClassBeingMocked\P13 was not expected, expected calls were:
-              - methodOne(exact("value"))
-      """
+    Then I should see the error that 'methodTwo("value")' was not expected on "Double\Diffs\DiffExample7\ClassBeingMocked\P13"
 
   Scenario: Unexpected method call when another prophecy for that call with not matching arguments exists
     Given the spec file "spec/Diffs/DiffExample8/ClassUnderSpecificationSpec.php" contains:
@@ -456,14 +450,7 @@ Feature: Developer is shown diffs
       }
       """
     When I run phpspec with the "verbose" option
-    Then I should see:
-      """
-            method call:
-              - methodTwo("another value")
-            on Double\Diffs\DiffExample8\ClassBeingMocked\P14 was not expected, expected calls were:
-              - methodTwo(exact("value"))
-              - methodOne(exact("another value"))
-      """
+    Then I should see the error that 'methodTwo("another value")' was not expected on "Double\Diffs\DiffExample8\ClassBeingMocked\P14"
 
   Scenario: Array diffing with long strings
     Given the spec file "spec/Diffs/DiffExample9/ClassWithArraysSpec.php" contains:


### PR DESCRIPTION
Prophecy 1.8 rephrases an error message. This makes two tests fail in all branches of Behat. This PR makes the tests less closely coupled to the wording of the expected error message.