### PR TITLE
Assume people are using PSR-4

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Create a ``composer.json`` file:
         "config": {
             "bin-dir": "bin"
         },
-        "autoload": {"psr-0": {"": "src"}}
+        "autoload": {"psr-4": {"App\\": "src"}}
     }
 
 Follow the instructions on this page to install composer: `<https://getcomposer.org/download/>`_.  

--- a/docs/manual/installation.rst
+++ b/docs/manual/installation.rst
@@ -23,8 +23,8 @@ this:
 .. code-block:: json
 
     "autoload": {
-        "psr-0": {
-            "": "src/"
+        "psr-4": {
+            "App\\": "src/"
         }
     }
 
@@ -53,8 +53,8 @@ If you prefer editing your ``composer.json`` file manually, add phpspec to your
             "bin-dir": "bin"
         },
         "autoload": {
-            "psr-0": {
-                "": "src/"
+            "psr-4": {
+                "App\\": "src/"
             }
         }
     }


### PR DESCRIPTION
PSR-0 is deprecated (see https://www.php-fig.org/psr/psr-0), and as a
result PSR-4 is more likely to be seen in a beginner's composer.json
file, so let us not confuse them with PSR-0.
Fixes #1230