### PR TITLE
Re-enable PHAR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    php: 7.0
+    php: 7.1
     condition: COMPOSER_FLAGS != "--prefer-lowest"


### PR DESCRIPTION
This silently turned off when we dropped 7.0 support and I only recently noticed