### PR TITLE
use parsed psr4Prefix in match

### DIFF
--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -77,7 +77,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         $this->specPath      = rtrim(realpath($specPath), '/\\').$sepr;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\').'\\', '\\');
         $this->psr4Prefix    = (null === $psr4Prefix) ? null : ltrim(trim($psr4Prefix, ' \\').'\\', '\\');
-        if (null !== $this->psr4Prefix  && substr($this->srcNamespace, 0, \strlen($psr4Prefix)) !== $psr4Prefix) {
+        if (null !== $this->psr4Prefix  && substr($this->srcNamespace, 0, \strlen($this->psr4Prefix)) !== $this->psr4Prefix) {
             throw new InvalidArgumentException('PSR4 prefix doesn\'t match given class namespace.'.PHP_EOL);
         }
         $srcNamespacePath = null === $this->psr4Prefix ?


### PR DESCRIPTION
I have no clue if the choice to use the 'unparsed' psr4Prefix for this check was deliberate, bu I do know that this change fixes my error with the following phpspec.yml ::
```yml
bootstrap: ./Bootstrap.php
formatter.name: pretty
stop_on_failure: true
suites:
    Core-Company:
        namespace: \Core\Company
        psr4_prefix: \Core\Company
        src_path: "%paths.config%/apps/Core/Company/src"
        spec_path: "%paths.config%/apps/Core/Company/"

    Core-Customer:
        namespace: \Core\Customer
        psr4_prefix: \Core\Customer
        src_path: "%paths.config%/apps/Core/Customer/src"
        spec_path: "%paths.config%/apps/Core/Customer/"

    Core-News:
        namespace: \Core\News
        psr4_prefix: \Core\News
        src_path: "%paths.config%/apps/Core/News/src"
        spec_path: "%paths.config%/apps/Core/News/"

    Core-Page:
        namespace: \Core\Page
        psr4_prefix: \Core\Page
        src_path: "%paths.config%/apps/Core/Page/src"
        spec_path: "%paths.config%/apps/Core/Page/"

    Core-Shop:
        namespace: \Core\Shop
        psr4_prefix: \Core\Shop
        src_path: "%paths.config%/apps/Core/Shop/src"
        spec_path: "%paths.config%/apps/Core/Shop/"

    Core-Utility:
        namespace: \Core\Utility
        psr4_prefix: \Core\Utility
        src_path: "%paths.config%/apps/Core/Utility/src"
        spec_path: "%paths.config%/apps/Core/Utility/"

    Core-WhiteLabel:
        namespace: \Core\WhiteLabel
        psr4_prefix: \Core\WhiteLabel
        src_path: "%paths.config%/apps/Core/WhiteLabel/src"
        spec_path: "%paths.config%/apps/Core/WhiteLabel/"


    Kiosk-Main:
        namespace: \Kiosk\Main
        psr4_prefix: \Kiosk\Main
        src_path: "%paths.config%/apps/Kiosk/Main/src"
        spec_path: "%paths.config%/apps/Kiosk/Main/"

    Kiosk-Shop:
        namespace: \Kiosk\Shop
        psr4_prefix: \Kiosk\Shop
        src_path: "%paths.config%/apps/Kiosk/Shop/src"
        spec_path: "%paths.config%/apps/Kiosk/Shop/"


    Site-Company:
        namespace: \Site\Company
        psr4_prefix: \Site\Company
        src_path: "%paths.config%/apps/Site/Company/src"
        spec_path: "%paths.config%/apps/Site/Company/"

    Site-Customer:
        namespace: \Site\Customer
        psr4_prefix: \Site\Customer
        src_path: "%paths.config%/apps/Site/Customer/src"
        spec_path: "%paths.config%/apps/Site/Customer/"

    Site-Form:
        namespace: \Site\Form
        psr4_prefix: \Site\Form
        src_path: "%paths.config%/apps/Site/Form/src"
        spec_path: "%paths.config%/apps/Site/Form/"

    Site-Link:
        namespace: \Site\Link
        psr4_prefix: \Site\Link
        src_path: "%paths.config%/apps/Site/Link/src"
        spec_path: "%paths.config%/apps/Site/Link/"

    Site-News:
        namespace: \Site\News
        psr4_prefix: \Site\News
        src_path: "%paths.config%/apps/Site/News/src"
        spec_path: "%paths.config%/apps/Site/News/"

    Site-Page:
        namespace: \Site\Page
        psr4_prefix: \Site\Page
        src_path: "%paths.config%/apps/Site/Page/src"
        spec_path: "%paths.config%/apps/Site/Page/"

    Site-Shop:
        namespace: \Site\Shop
        psr4_prefix: \Site\Shop
        src_path: "%paths.config%/apps/Site/Shop/src"
        spec_path: "%paths.config%/apps/Site/Shop/"

    Site-Utility:
        namespace: \Site\Utility
        psr4_prefix: \Site\Utility
        src_path: "%paths.config%/apps/Site/Utility/src"
        spec_path: "%paths.config%/apps/Site/Utility/"

```