### PR TITLE
Removed `Prophecy\Argument;` from templates and everywhere it wasn't used

### DIFF
--- a/docs/manual/getting-started.rst
+++ b/docs/manual/getting-started.rst
@@ -34,7 +34,6 @@ navigate to the spec folder and see the spec there:
 
     use Markdown;
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MarkdownSpec extends ObjectBehavior
     {

--- a/features/code_generation/developer_generates_class.feature
+++ b/features/code_generation/developer_generates_class.feature
@@ -111,7 +111,6 @@ Feature: Developer generates a class
     use CodeGeneration\MethodExample2\UserRepository;
     use CodeGeneration\MethodExample2\User;
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class ForgotPasswordSpec extends ObjectBehavior
     {

--- a/features/code_generation/developer_generates_collaborator.feature
+++ b/features/code_generation/developer_generates_collaborator.feature
@@ -11,7 +11,6 @@ Feature: Developer generates a collaborator
       namespace spec\CodeGeneration\CollaboratorExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorExample1\Parser;
 
       class MarkdownSpec extends ObjectBehavior
@@ -50,7 +49,6 @@ Feature: Developer generates a collaborator
       namespace spec\CodeGeneration\CollaboratorExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorExample2\Parser;
 
       class MarkdownSpec extends ObjectBehavior
@@ -94,7 +92,6 @@ Feature: Developer generates a collaborator
       namespace spec\CodeGeneration\CollaboratorExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {

--- a/features/code_generation/developer_generates_collaborator_from_use_group.feature
+++ b/features/code_generation/developer_generates_collaborator_from_use_group.feature
@@ -11,7 +11,6 @@ Feature: Developer generates a collaborator
       namespace spec\CodeGeneration\CollaboratorExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorExample1\{Tokenizer, Parser};
 
       class Markdown1Spec extends ObjectBehavior
@@ -50,7 +49,6 @@ Feature: Developer generates a collaborator
       namespace spec\CodeGeneration\CollaboratorExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorExample2\{Tokenizer, Parser};
 
       class Markdown1Spec extends ObjectBehavior
@@ -94,7 +92,6 @@ Feature: Developer generates a collaborator
       namespace spec\CodeGeneration\CollaboratorExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorExample3\{Tokenizer, Parser};
 
       class Markdown1Spec extends ObjectBehavior

--- a/features/code_generation/developer_generates_collaborator_method.feature
+++ b/features/code_generation/developer_generates_collaborator_method.feature
@@ -11,7 +11,6 @@ Feature: Developer generates a collaborator's method
       namespace spec\CodeGeneration\CollaboratorMethodExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorMethodExample1\Parser;
 
       class MarkdownSpec extends ObjectBehavior
@@ -61,7 +60,6 @@ Feature: Developer generates a collaborator's method
       namespace spec\CodeGeneration\CollaboratorMethodExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorMethodExample3\Parser;
 
       class MarkdownSpec extends ObjectBehavior
@@ -118,7 +116,6 @@ Feature: Developer generates a collaborator's method
       namespace spec\CodeGeneration\CollaboratorMethodExample4;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorMethodExample4\Parser;
 
       class MarkdownSpec extends ObjectBehavior
@@ -175,7 +172,6 @@ Feature: Developer generates a collaborator's method
       namespace spec\CodeGeneration\CollaboratorMethodExample5;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use CodeGeneration\CollaboratorMethodExample5\Parser;
 
       class MarkdownSpec extends ObjectBehavior

--- a/features/code_generation/developer_generates_method.feature
+++ b/features/code_generation/developer_generates_method.feature
@@ -11,7 +11,6 @@ Feature: Developer generates a method
       namespace spec\CodeGeneration\MethodExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -57,7 +56,6 @@ Feature: Developer generates a method
       namespace spec\Behat\Tests\MyNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class PrefixSpec extends ObjectBehavior
       {
@@ -110,7 +108,6 @@ Feature: Developer generates a method
       namespace spec\MyNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ConstructorSpec extends ObjectBehavior
       {
@@ -166,7 +163,6 @@ Feature: Developer generates a method
       namespace spec\MyNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ConstructorFirstSpec extends ObjectBehavior
       {
@@ -213,7 +209,6 @@ Feature: Developer generates a method
       namespace spec\MyNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ExistingMethodSpec extends ObjectBehavior
       {
@@ -270,7 +265,6 @@ Feature: Developer generates a method
       namespace spec\MyNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ExistingMethodAnonymousFunctionSpec extends ObjectBehavior
       {
@@ -331,7 +325,6 @@ Feature: Developer generates a method
       namespace spec\MyNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CommentMethodSpec extends ObjectBehavior
       {
@@ -381,7 +374,6 @@ Feature: Developer generates a method
       namespace spec\MyNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class KeywordMethodSpec extends ObjectBehavior
       {

--- a/features/code_generation/developer_generates_named_constructor.feature
+++ b/features/code_generation/developer_generates_named_constructor.feature
@@ -11,7 +11,6 @@ Feature: Developer generates a named constructor
     namespace spec\CodeGeneration\NamedConstructor;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class UserSpec extends ObjectBehavior
     {
@@ -63,7 +62,6 @@ Feature: Developer generates a named constructor
     namespace spec\CodeGeneration\NamedConstructor\TooManyArguments;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class UserSpec extends ObjectBehavior
     {
@@ -118,7 +116,6 @@ Feature: Developer generates a named constructor
     namespace spec\CodeGeneration\NamedConstructor\TooFewArguments;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class UserSpec extends ObjectBehavior
     {
@@ -173,7 +170,6 @@ Feature: Developer generates a named constructor
     namespace spec\CodeGeneration\NamedConstructor\EqualArguments;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class UserSpec extends ObjectBehavior
     {
@@ -232,7 +228,6 @@ Feature: Developer generates a named constructor
     namespace spec\CodeGeneration\NamedConstructor\OptionalArguments;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class UserSpec extends ObjectBehavior
     {
@@ -291,7 +286,6 @@ Feature: Developer generates a named constructor
       namespace spec\CodeGeneration\ShortSyntax;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class UserSpec extends ObjectBehavior
       {
@@ -343,7 +337,6 @@ Feature: Developer generates a named constructor
       namespace spec\CodeGeneration\ShortSyntax2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class UserSpec extends ObjectBehavior
       {
@@ -395,7 +388,6 @@ Feature: Developer generates a named constructor
       namespace spec\CodeGeneration\PrivateConstructor;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class UserSpec extends ObjectBehavior
       {
@@ -451,7 +443,6 @@ Feature: Developer generates a named constructor
       namespace spec\CodeGeneration\PrivateConstructor;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class AgeSpec extends ObjectBehavior
       {

--- a/features/code_generation/developer_generates_return_constant.feature
+++ b/features/code_generation/developer_generates_return_constant.feature
@@ -11,7 +11,6 @@ Feature: Developer generates a method returning a constant
       namespace spec\CodeGeneration\ConstantExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -60,7 +59,6 @@ Feature: Developer generates a method returning a constant
       namespace spec\CodeGeneration\ConstantExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -114,7 +112,6 @@ Feature: Developer generates a method returning a constant
       namespace spec\CodeGeneration\ConstantExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -151,7 +148,6 @@ Feature: Developer generates a method returning a constant
       namespace spec\CodeGeneration\ConstantExample4;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -192,7 +188,6 @@ Feature: Developer generates a method returning a constant
       namespace spec\CodeGeneration\ConstantExample5;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -228,7 +223,6 @@ Feature: Developer generates a method returning a constant
       namespace spec\CodeGeneration\ConstantExample6;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -268,7 +262,6 @@ Feature: Developer generates a method returning a constant
       namespace spec\CodeGeneration\ConstantExample7;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {

--- a/features/code_generation/developer_generates_spec.feature
+++ b/features/code_generation/developer_generates_spec.feature
@@ -13,7 +13,6 @@ Feature: Developer generates a spec
 
       use CodeGeneration\SpecExample1\Markdown;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -35,7 +34,6 @@ Feature: Developer generates a spec
       namespace spec\Zyzzyva\SpecExample;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use Zyzzyva\SpecExample\Example;
 
       class ExampleSpec extends ObjectBehavior
@@ -68,7 +66,6 @@ Feature: Developer generates a spec
 
     use CodeGeneration\SpecExample2\Markdown;
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MarkdownSpec extends ObjectBehavior
     {
@@ -101,7 +98,6 @@ Feature: Developer generates a spec
 
     use CodeGeneration\SpecExample2\Markdown;
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MarkdownSpec extends ObjectBehavior
     {
@@ -124,7 +120,6 @@ Feature: Developer generates a spec
 
       use CodeGeneration\SpecExample1\Text_Markdown;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class Text_MarkdownSpec extends ObjectBehavior
       {
@@ -147,7 +142,6 @@ Feature: Developer generates a spec
 
       use CodeGeneration\Spec_Example2\Text_Markdown;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class Text_MarkdownSpec extends ObjectBehavior
       {
@@ -176,7 +170,6 @@ Feature: Developer generates a spec
 
       use Behat\CodeGeneration\Markdown;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {

--- a/features/code_generation/developer_reruns_features.feature
+++ b/features/code_generation/developer_reruns_features.feature
@@ -17,7 +17,6 @@ Feature: Developer generates a class
       namespace spec\CodeGeneration\RerunExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {

--- a/features/config/developer_can_use_composer_to_create_suites.feature
+++ b/features/config/developer_can_use_composer_to_create_suites.feature
@@ -19,7 +19,6 @@ Feature: Composer can be leveraged to create suites
 
       use Andromeda\N4S4Arm\Gazorpazorp;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class GazorpazorpSpec extends ObjectBehavior
       {
@@ -46,7 +45,6 @@ Feature: Composer can be leveraged to create suites
 
       use MilkyWay\OrionCygnusArm\LocalBubble;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class LocalBubbleSpec extends ObjectBehavior
       {

--- a/features/config/developer_can_use_config_dir_in_paths.feature
+++ b/features/config/developer_can_use_config_dir_in_paths.feature
@@ -20,7 +20,6 @@ Feature: Config directory can be used in spec and src paths
 
       use MilkyWay\OrionCygnusArm\LocalBubble;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class LocalBubbleSpec extends ObjectBehavior
       {
@@ -48,7 +47,6 @@ Feature: Config directory can be used in spec and src paths
 
       use MilkyWay\OrionCygnusArm\ButterflyCluster;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ButterflyClusterSpec extends ObjectBehavior
       {

--- a/features/construction/developer_specifies_object_construction.feature
+++ b/features/construction/developer_specifies_object_construction.feature
@@ -11,7 +11,6 @@ Feature: Developer specifies object construction
       namespace spec\Runner\ConstructorExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithConstructorSpec extends ObjectBehavior
       {
@@ -55,7 +54,6 @@ Feature: Developer specifies object construction
       namespace spec\Runner\ConstructorExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithStaticFactoryMethodSpec extends ObjectBehavior
       {
@@ -104,7 +102,6 @@ Feature: Developer specifies object construction
       namespace spec\Runner\ConstructorExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithConstructorSpec extends ObjectBehavior
       {
@@ -155,7 +152,6 @@ Feature: Developer specifies object construction
       namespace spec\Runner\ConstructorExample4;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithStaticFactoryMethodSpec extends ObjectBehavior
       {
@@ -210,7 +206,6 @@ Feature: Developer specifies object construction
     namespace spec\Runner\ConstructorExample7;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class ClassWithStaticFactoryMethodAndConstructorSpec extends ObjectBehavior
     {
@@ -275,7 +270,6 @@ Feature: Developer specifies object construction
     namespace spec\Runner\ConstructorExample8;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class ClassWithStaticFactoryMethodAndConstructorSpec extends ObjectBehavior
     {
@@ -341,7 +335,6 @@ Feature: Developer specifies object construction
     namespace spec\Runner\ConstructorExample9;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class ClassConstructorSpec extends ObjectBehavior
     {
@@ -387,7 +380,6 @@ Feature: Developer specifies object construction
     namespace spec\Runner\ConstructorExample10;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class ClassWithFactoryMethodSpec extends ObjectBehavior
     {

--- a/features/exception_handling/developer_defines_supporting_spec.feature
+++ b/features/exception_handling/developer_defines_supporting_spec.feature
@@ -11,7 +11,6 @@ Feature: Developer has defined a supporting class and should not see a silent er
         namespace spec;
 
         use PhpSpec\ObjectBehavior;
-        use Prophecy\Argument;
 
         class SomethingSpec extends ObjectBehavior
         {

--- a/features/exception_handling/developer_is_shown_a_parse_error.feature
+++ b/features/exception_handling/developer_is_shown_a_parse_error.feature
@@ -12,7 +12,6 @@ Feature: Developer is shown a parse error
 
       use Parse;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ParseSpec extends ObjectBehavior
       {
@@ -50,7 +49,6 @@ Feature: Developer is shown a parse error
 
       use Parse;
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ParseSpec extends ObjectBehavior
       {

--- a/features/exception_handling/developer_specifies_exceptions.feature
+++ b/features/exception_handling/developer_specifies_exceptions.feature
@@ -11,7 +11,6 @@ Feature: Developer specifies exception behaviour
       namespace spec\Runner\ExceptionExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {

--- a/features/extensions/developer_uses_bootstrap_config_key_in_any_place.feature
+++ b/features/extensions/developer_uses_bootstrap_config_key_in_any_place.feature
@@ -35,7 +35,6 @@ Feature: Developer uses bootstrap config key in any place
     namespace spec\Example1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class TestConfigSpec extends ObjectBehavior
     {

--- a/features/extensions/developer_uses_extension.feature
+++ b/features/extensions/developer_uses_extension.feature
@@ -118,7 +118,6 @@ Feature: Developer uses extension
     namespace spec\Example1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class DummySpec extends ObjectBehavior
     {
@@ -220,7 +219,6 @@ Feature: Developer uses extension
     namespace spec\Example2;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
     use Example2\Dummy;
 
     class DummySpec extends ObjectBehavior

--- a/features/formatter/developer_is_shown_diffs.feature
+++ b/features/formatter/developer_is_shown_diffs.feature
@@ -11,7 +11,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithStringsSpec extends ObjectBehavior
       {
@@ -53,7 +52,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithArraysSpec extends ObjectBehavior
       {
@@ -105,7 +103,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithArraysOfObjectsSpec extends ObjectBehavior
       {
@@ -159,7 +156,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithObjectsSpec extends ObjectBehavior
       {
@@ -214,7 +210,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample4;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use Diffs\DiffExample4\ClassBeingMocked;
 
       class ClassUnderSpecificationSpec extends ObjectBehavior
@@ -270,7 +265,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample5;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use Diffs\DiffExample5\ClassBeingMocked;
 
       class ClassUnderSpecificationSpec extends ObjectBehavior
@@ -334,7 +328,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample6;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use Diffs\DiffExample6\ClassBeingMocked;
 
       class ClassUnderSpecificationSpec extends ObjectBehavior
@@ -401,7 +394,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample7;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use Diffs\DiffExample7\ClassBeingMocked;
 
       class ClassUnderSpecificationSpec extends ObjectBehavior
@@ -456,7 +448,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample8;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use Diffs\DiffExample8\ClassBeingMocked;
 
       class ClassUnderSpecificationSpec extends ObjectBehavior
@@ -514,7 +505,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample9;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithArraysSpec extends ObjectBehavior
       {
@@ -562,7 +552,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample10;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ClassWithArraysSpec extends ObjectBehavior
       {
@@ -614,7 +603,6 @@ Feature: Developer is shown diffs
       namespace spec\Diffs\DiffExample11;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {

--- a/features/formatter/use_the_junit_formatter.feature
+++ b/features/formatter/use_the_junit_formatter.feature
@@ -11,7 +11,6 @@ Feature: Use the JUnit formatter
       namespace spec\Formatter\SpecExample;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {

--- a/features/invalid_usage/developer_uses_unsupported_collaborator_type_hinting.feature
+++ b/features/invalid_usage/developer_uses_unsupported_collaborator_type_hinting.feature
@@ -10,7 +10,6 @@ Feature: Developer uses unsupported collaborator type hinting
       namespace spec\InvalidUsage\InvalidUsageExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class StorageSpec extends ObjectBehavior
       {
@@ -51,7 +50,6 @@ Feature: Developer uses unsupported collaborator type hinting
       namespace spec\InvalidUsage\InvalidUsageExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class InvokerSpec extends ObjectBehavior
       {
@@ -92,7 +90,6 @@ Feature: Developer uses unsupported collaborator type hinting
       namespace spec\InvalidUsage\InvalidUsageExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class StorageSpec extends ObjectBehavior
       {

--- a/features/matchers/developer_uses_approximately_matcher.feature
+++ b/features/matchers/developer_uses_approximately_matcher.feature
@@ -12,7 +12,6 @@ Feature: Developer uses approximately matcher
     namespace spec\Matchers\FloatApproximatelyExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class GeoCoordSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_array_contain_matcher.feature
+++ b/features/matchers/developer_uses_array_contain_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses array-contain matcher
     namespace spec\Matchers\ArrayContainExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_array_count_matcher.feature
+++ b/features/matchers/developer_uses_array_count_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses array-count matcher
     namespace spec\Matchers\ArrayCountExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_array_key_matcher.feature
+++ b/features/matchers/developer_uses_array_key_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses array-key matcher
     namespace spec\Matchers\ArrayKeyExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_array_key_value_matcher.feature
+++ b/features/matchers/developer_uses_array_key_value_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses array-key-value matcher
     namespace spec\Matchers\ArrayKeyValueExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_comparison_matcher.feature
+++ b/features/matchers/developer_uses_comparison_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses comparison matcher
     namespace spec\Matchers\ComparisonExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class StringCalculatorSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_custom_matcher.feature
+++ b/features/matchers/developer_uses_custom_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses custom matcher
     namespace spec\Matchers\Custom;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_identity_matcher.feature
+++ b/features/matchers/developer_uses_identity_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -48,7 +47,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -85,7 +83,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -122,7 +119,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample4;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -159,7 +155,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample5;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -196,7 +191,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample6;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -233,7 +227,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample7;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -270,7 +263,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample8;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -307,7 +299,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample9;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -344,7 +335,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample10;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -381,7 +371,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample11;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -418,7 +407,6 @@ Feature: Developer uses identity matcher
       namespace spec\Matchers\IdentityExample12;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {

--- a/features/matchers/developer_uses_inline_matcher.feature
+++ b/features/matchers/developer_uses_inline_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses inline matcher
       namespace spec\Matchers\InlineExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -64,7 +63,6 @@ Feature: Developer uses inline matcher
       namespace spec\Matchers\InlineExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {
@@ -117,7 +115,6 @@ Feature: Developer uses inline matcher
       namespace spec\Matchers\InlineExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use PhpSpec\Exception\Example\FailureException;
 
       class CalculatorSpec extends ObjectBehavior

--- a/features/matchers/developer_uses_iterate_as_matcher.feature
+++ b/features/matchers/developer_uses_iterate_as_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses iterate-as matcher
     namespace spec\Matchers\IterateExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_iterate_like_matcher.feature
+++ b/features/matchers/developer_uses_iterate_like_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses iterate-as matcher
     namespace spec\Matchers\IterateLikeExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class IterSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_object_state_matcher.feature
+++ b/features/matchers/developer_uses_object_state_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses object-state matcher
     namespace spec\Matchers\ObjectStateExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {
@@ -48,7 +47,6 @@ Feature: Developer uses object-state matcher
     namespace spec\Matchers\ObjectStateExample2;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_scalar_matcher.feature
+++ b/features/matchers/developer_uses_scalar_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses scalar matcher
     namespace spec\Matchers\ScalarExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_start_iterating_as_matcher.feature
+++ b/features/matchers/developer_uses_start_iterating_as_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses start-iterate-as matcher
     namespace spec\Matchers\StartIteratingExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_string_contain_matcher.feature
+++ b/features/matchers/developer_uses_string_contain_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses string-contain matcher
     namespace spec\Matchers\StringContainExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_string_end_matcher.feature
+++ b/features/matchers/developer_uses_string_end_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses string-end matcher
     namespace spec\Matchers\StringEndExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_string_regex_matcher.feature
+++ b/features/matchers/developer_uses_string_regex_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses string-regex matcher
     namespace spec\Matchers\StringRegexExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_string_start_matcher.feature
+++ b/features/matchers/developer_uses_string_start_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses string-start matcher
     namespace spec\Matchers\StringStartExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_throw_matcher.feature
+++ b/features/matchers/developer_uses_throw_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses throw matcher
     namespace spec\Matchers\ThrowExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class EmployeeSpec extends ObjectBehavior
     {
@@ -50,7 +49,6 @@ Feature: Developer uses throw matcher
     namespace spec\Matchers\ThrowExample2;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class EmployeeSpec extends ObjectBehavior
     {
@@ -90,7 +88,6 @@ Feature: Developer uses throw matcher
     namespace spec\Matchers\ThrowExample3;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class EmployeeSpec extends ObjectBehavior
     {
@@ -130,7 +127,6 @@ Feature: Developer uses throw matcher
     namespace spec\Runner\ThrowExample4;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MarkdownSpec extends ObjectBehavior
     {
@@ -173,7 +169,6 @@ Feature: Developer uses throw matcher
       namespace spec\Runner\ThrowExample5;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -222,7 +217,6 @@ Feature: Developer uses throw matcher
       namespace spec\Runner\ThrowExample6;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class CalculatorSpec extends ObjectBehavior
       {

--- a/features/matchers/developer_uses_traversable_contain_matcher.feature
+++ b/features/matchers/developer_uses_traversable_contain_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses traversable-contain matcher
     namespace spec\Matchers\TraversableContainExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_traversable_count_matcher.feature
+++ b/features/matchers/developer_uses_traversable_count_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses traversable-count matcher
     namespace spec\Matchers\TraversableCountExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_traversable_key_matcher.feature
+++ b/features/matchers/developer_uses_traversable_key_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses traversable-key matcher
     namespace spec\Matchers\TraversableKeyExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_traversable_key_value_matcher.feature
+++ b/features/matchers/developer_uses_traversable_key_value_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses traversable-key-value matcher
     namespace spec\Matchers\TraversableKeyValueExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class MovieSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_trigger_matcher.feature
+++ b/features/matchers/developer_uses_trigger_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses trigger matcher
     namespace spec\Matchers\TriggerExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class FooSpec extends ObjectBehavior
     {
@@ -46,7 +45,6 @@ Feature: Developer uses trigger matcher
     namespace spec\Matchers\TriggerExample3;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class FooSpec extends ObjectBehavior
     {
@@ -81,7 +79,6 @@ Feature: Developer uses trigger matcher
     namespace spec\Matchers\TriggerExample3;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class FooSpec extends ObjectBehavior
     {

--- a/features/matchers/developer_uses_type_matcher.feature
+++ b/features/matchers/developer_uses_type_matcher.feature
@@ -11,7 +11,6 @@ Feature: Developer uses type matcher
     namespace spec\Matchers\TypeExample1;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {
@@ -45,7 +44,6 @@ Feature: Developer uses type matcher
     namespace spec\Matchers\TypeExample2;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {
@@ -82,7 +80,6 @@ Feature: Developer uses type matcher
     namespace spec\Matchers\TypeExample3;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {
@@ -119,7 +116,6 @@ Feature: Developer uses type matcher
     namespace spec\Matchers\TypeExample4;
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class CarSpec extends ObjectBehavior
     {

--- a/features/options/developer_chooses_no_code_generation.feature
+++ b/features/options/developer_chooses_no_code_generation.feature
@@ -12,7 +12,6 @@ Feature: Developer chooses no code generation
       namespace spec\NoCodeGeneration\SpecExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class NewClassSpec extends ObjectBehavior
       {
@@ -39,7 +38,6 @@ Feature: Developer chooses no code generation
       namespace spec\NoCodeGeneration\SpecExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class NewClassSpec extends ObjectBehavior
       {
@@ -66,7 +64,6 @@ Feature: Developer chooses no code generation
       namespace spec\NoCodeGeneration\SpecExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class NewClassSpec extends ObjectBehavior
       {

--- a/features/options/developer_chooses_stop_on_failure.feature
+++ b/features/options/developer_chooses_stop_on_failure.feature
@@ -12,7 +12,6 @@ Feature: Developer chooses stop on failure
       namespace spec\SkipOnFailure\SpecExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class FirstFailSpec extends ObjectBehavior
       {
@@ -59,7 +58,6 @@ Feature: Developer chooses stop on failure
       namespace spec\SkipOnFailure\SpecExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class FirstFailSpec extends ObjectBehavior
       {
@@ -107,7 +105,6 @@ Feature: Developer chooses stop on failure
       namespace spec\SkipOnFailure\SpecExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class FirstFailSpec extends ObjectBehavior
       {

--- a/features/options/developer_chooses_verbose_output.feature
+++ b/features/options/developer_chooses_verbose_output.feature
@@ -15,7 +15,6 @@ Feature: Developer chooses verbosity output
       namespace spec\Verbose\SpecExample1;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ConfigVerbosityConsoleNotSetSpec extends ObjectBehavior
       {
@@ -60,7 +59,6 @@ Feature: Developer chooses verbosity output
       namespace spec\Verbose\SpecExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ConfigVerbosityNotSetConsoleNotSetSpec extends ObjectBehavior
       {
@@ -109,7 +107,6 @@ Feature: Developer chooses verbosity output
       namespace spec\Verbose\SpecExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ConsoleQuietVerbosityOverrideConfigVerbositySpec extends ObjectBehavior
       {
@@ -150,7 +147,6 @@ Feature: Developer chooses verbosity output
       namespace spec\Verbose\SpecExample4;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class ConsoleVerbosityOverrideConfigVerbosityFalseSpec extends ObjectBehavior
       {

--- a/features/runner/developer_runs_specs.feature
+++ b/features/runner/developer_runs_specs.feature
@@ -16,7 +16,6 @@ Feature: Developer runs the specs
       namespace spec\Runner\SpecExample2;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -54,7 +53,6 @@ Feature: Developer runs the specs
       namespace spec\Runner\SpecExample3;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -97,7 +95,6 @@ Feature: Developer runs the specs
       namespace spec\Runner\SpecExample4;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {
@@ -139,7 +136,6 @@ Feature: Developer runs the specs
       namespace spec\Runner\TestNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class Example1Spec extends ObjectBehavior
       {
@@ -171,7 +167,6 @@ Feature: Developer runs the specs
       namespace spec\Psr4\Runner\TestNamespace;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class Example2Spec extends ObjectBehavior
       {

--- a/features/runner/developer_runs_specs_with_spec_path.feature
+++ b/features/runner/developer_runs_specs_with_spec_path.feature
@@ -21,7 +21,6 @@ Feature: Developer runs specs with the given specs path configured to be the sam
       namespace spec\Runner\SpecPathExample;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
 
       class MarkdownSpec extends ObjectBehavior
       {

--- a/features/runner/developer_skips_specs.feature
+++ b/features/runner/developer_skips_specs.feature
@@ -11,7 +11,6 @@ Feature: Developer skips examples
       namespace spec\Runner\SpecExample;
 
       use PhpSpec\ObjectBehavior;
-      use Prophecy\Argument;
       use PhpSpec\Exception\Example\SkippingException;
 
       class MarkdownSpec extends ObjectBehavior

--- a/spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\CodeAnalysis;
 
 use Phpspec\CodeAnalysis\AccessInspector;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class MagicAwareAccessInspectorSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolverSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolverSpec.php
@@ -5,7 +5,6 @@ namespace spec\PhpSpec\CodeAnalysis;
 use PhpSpec\CodeAnalysis\DisallowedNonObjectTypehintException;
 use PhpSpec\CodeAnalysis\NamespaceResolver;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class StaticRejectingNamespaceResolverSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/CodeAnalysis/TokenizedNamespaceResolverSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/TokenizedNamespaceResolverSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\CodeAnalysis;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class TokenizedNamespaceResolverSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/CodeAnalysis/VisibilityAccessInspectorSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/VisibilityAccessInspectorSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\CodeAnalysis;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class VisibilityAccessInspectorSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/CodeGenerator/Generator/ReturnConstantGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ReturnConstantGeneratorSpec.php
@@ -6,7 +6,6 @@ use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\Filesystem;
-use Prophecy\Argument;
 use PhpSpec\Locator\Resource;
 
 class ReturnConstantGeneratorSpec extends ObjectBehavior

--- a/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
@@ -51,7 +51,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
             '%filepath%'  => '/project/spec/Acme/AppSpec.php',
             '%name%'      => 'AppSpec',
             '%namespace%' => 'spec\Acme',
-            '%imports%'   => "use Acme\App;\nuse PhpSpec\ObjectBehavior;\nuse Prophecy\Argument;",
+            '%imports%'   => "use Acme\App;\nuse PhpSpec\ObjectBehavior;",
             '%subject%'   => 'Acme\App',
             '%subject_class%'  => 'App',
         );
@@ -79,7 +79,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
             '%filepath%'  => '/project/spec/Acme/AppSpec.php',
             '%name%'      => 'AppSpec',
             '%namespace%' => 'spec\Acme',
-            '%imports%'   => "use Acme\App;\nuse PhpSpec\ObjectBehavior;\nuse Prophecy\Argument;",
+            '%imports%'   => "use Acme\App;\nuse PhpSpec\ObjectBehavior;",
             '%subject%'   => 'Acme\App',
             '%subject_class%'  => 'App',
         );

--- a/spec/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGeneratorSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\CodeGenerator\Generator\ValidateClassNameSpecificationGenerator;
 use PhpSpec\CodeGenerator\Generator\Generator;
-use PhpSpec\CodeGenerator\Generator\SpecificationGenerator;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Locator\Resource;
 use PhpSpec\ObjectBehavior;

--- a/spec/PhpSpec/CodeGenerator/GeneratorManagerSpec.php
+++ b/spec/PhpSpec/CodeGenerator/GeneratorManagerSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\CodeGenerator;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\CodeGenerator\Generator\Generator;
 use PhpSpec\Locator\Resource;

--- a/spec/PhpSpec/CodeGenerator/TemplateRendererSpec.php
+++ b/spec/PhpSpec/CodeGenerator/TemplateRendererSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\CodeGenerator;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Util\Filesystem;
 

--- a/spec/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriterSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriterSpec.php
@@ -5,7 +5,6 @@ namespace spec\PhpSpec\CodeGenerator\Writer;
 use PhpSpec\Exception\Generator\NamedMethodNotFoundException;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\ClassFileAnalyser;
-use Prophecy\Argument;
 
 class TokenizedCodeWriterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Console/ApplicationSpec.php
+++ b/spec/PhpSpec/Console/ApplicationSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Console;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ApplicationSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Console/ConsoleIOSpec.php
+++ b/spec/PhpSpec/Console/ConsoleIOSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Console;
 
 use PhpSpec\Console\Prompter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use PhpSpec\Config\OptionsConfig;
 
 use Symfony\Component\Console\Helper\DialogHelper;

--- a/spec/PhpSpec/Console/Provider/NamespacesAutocompleteProviderSpec.php
+++ b/spec/PhpSpec/Console/Provider/NamespacesAutocompleteProviderSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Console\Provider;
 
 use PhpSpec\Locator\SrcPathLocator;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 

--- a/spec/PhpSpec/Console/ResultConverterSpec.php
+++ b/spec/PhpSpec/Console/ResultConverterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Console;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use PhpSpec\Event\ExampleEvent;
 
 class ResultConverterSpec extends ObjectBehavior

--- a/spec/PhpSpec/Event/ExpectationEventSpec.php
+++ b/spec/PhpSpec/Event/ExpectationEventSpec.php
@@ -7,7 +7,6 @@ use PhpSpec\Loader\Suite;
 use PhpSpec\Loader\Node\SpecificationNode;
 use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\Matcher\Matcher;
-use Prophecy\Argument;
 use Exception;
 
 class ExpectationEventSpec extends ObjectBehavior

--- a/spec/PhpSpec/Event/FileCreationEventSpec.php
+++ b/spec/PhpSpec/Event/FileCreationEventSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Event;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class FileCreationEventSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Event/MethodCallEventSpec.php
+++ b/spec/PhpSpec/Event/MethodCallEventSpec.php
@@ -3,11 +3,9 @@
 namespace spec\PhpSpec\Event;
 
 use PhpSpec\ObjectBehavior;
-use PhpSpec\Wrapper\Subject;
 use PhpSpec\Loader\Suite;
 use PhpSpec\Loader\Node\SpecificationNode;
 use PhpSpec\Loader\Node\ExampleNode;
-use Prophecy\Argument;
 
 class MethodCallEventSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Exception/ErrorExceptionSpec.php
+++ b/spec/PhpSpec/Exception/ErrorExceptionSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Exception;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ErrorExceptionSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Exception/Example/StopOnFailureExceptionSpec.php
+++ b/spec/PhpSpec/Exception/Example/StopOnFailureExceptionSpec.php
@@ -2,9 +2,7 @@
 
 namespace spec\PhpSpec\Exception\Example;
 
-use PhpSpec\Event\ExampleEvent;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class StopOnFailureExceptionSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Exception/ExceptionFactorySpec.php
+++ b/spec/PhpSpec/Exception/ExceptionFactorySpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Exception;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 

--- a/spec/PhpSpec/Exception/Fracture/MethodNotVisibleExceptionSpec.php
+++ b/spec/PhpSpec/Exception/Fracture/MethodNotVisibleExceptionSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Exception\Fracture;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class MethodNotVisibleExceptionSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Exception/Fracture/NamedConstructorNotFoundExceptionSpec.php
+++ b/spec/PhpSpec/Exception/Fracture/NamedConstructorNotFoundExceptionSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Exception\Fracture;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class NamedConstructorNotFoundExceptionSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
+++ b/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Exception\Wrapper;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class InvalidCollaboratorTypeExceptionSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/BasicFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/BasicFormatterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Formatter\BasicFormatter;
 use PhpSpec\Formatter\Presenter\Presenter;

--- a/spec/PhpSpec/Formatter/Html/HtmlIOSpec.php
+++ b/spec/PhpSpec/Formatter/Html/HtmlIOSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Html;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use Symfony\Component\Console\Input\InputInterface;
 

--- a/spec/PhpSpec/Formatter/Html/ReportItemFactorySpec.php
+++ b/spec/PhpSpec/Formatter/Html/ReportItemFactorySpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Html;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Formatter\Template;

--- a/spec/PhpSpec/Formatter/Html/ReportPassedItemSpec.php
+++ b/spec/PhpSpec/Formatter/Html/ReportPassedItemSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Html;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Formatter\Html\Template as HtmlTemplate;

--- a/spec/PhpSpec/Formatter/Html/ReportPendingItemSpec.php
+++ b/spec/PhpSpec/Formatter/Html/ReportPendingItemSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Html;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Formatter\Html\Template as HtmlTemplate;

--- a/spec/PhpSpec/Formatter/Html/TemplateSpec.php
+++ b/spec/PhpSpec/Formatter/Html/TemplateSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Html;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\IO\IO;
 

--- a/spec/PhpSpec/Formatter/JUnitFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/JUnitFormatterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\IO\IO;
 use PhpSpec\Listener\StatisticsCollector;

--- a/spec/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenterSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Formatter\Presenter\Exception;
 
 use PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class GenericPhpSpecExceptionPresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Presenter\Exception;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class HtmlPhpSpecExceptionPresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenterSpec.php
@@ -5,7 +5,6 @@ namespace spec\PhpSpec\Formatter\Presenter\Exception;
 use PhpSpec\Formatter\Presenter\Value\ExceptionTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class SimpleExceptionElementPresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenterSpec.php
@@ -7,7 +7,6 @@ use PhpSpec\Formatter\Presenter\Exception\CallArgumentsPresenter;
 use PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter;
 use PhpSpec\Formatter\Presenter\Exception\PhpSpecExceptionPresenter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class SimpleExceptionPresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenterSpec.php
@@ -2,11 +2,9 @@
 
 namespace spec\PhpSpec\Formatter\Presenter\Exception;
 
-use PhpSpec\Formatter\Presenter\Exception\ExceptionElementPresenter;
 use PhpSpec\Formatter\Presenter\Value\ExceptionTypePresenter;
 use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class TaggingExceptionElementPresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/SimplePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/SimplePresenterSpec.php
@@ -16,7 +16,6 @@ namespace spec\PhpSpec\Formatter\Presenter;
 use PhpSpec\Formatter\Presenter\Exception\ExceptionPresenter;
 use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class SimplePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/TaggingPresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/TaggingPresenterSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Formatter\Presenter;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class TaggingPresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ArrayTypePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\Exception\ErrorException;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class BaseExceptionTypePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class BooleanTypePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Value/CallableTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/CallableTypePresenterSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class CallableTypePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Value/NullTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/NullTypePresenterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class NullTypePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ObjectTypePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenterSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class QuotingStringTypePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenterSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Formatter\Presenter\Value;
 
 use PhpSpec\Formatter\Presenter\Value\StringTypePresenter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class TruncatingStringTypePresenterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Formatter/TapFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/TapFormatterSpec.php
@@ -11,7 +11,6 @@ use PhpSpec\Loader\Node\SpecificationNode;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Listener\StatisticsCollector;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class TapFormatterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Listener/CurrentExampleListenerSpec.php
+++ b/spec/PhpSpec/Listener/CurrentExampleListenerSpec.php
@@ -6,7 +6,6 @@ use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Message\CurrentExampleTracker;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class CurrentExampleListenerSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Listener/RerunListenerSpec.php
+++ b/spec/PhpSpec/Listener/RerunListenerSpec.php
@@ -6,7 +6,6 @@ use PhpSpec\Event\SuiteEvent;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Process\Prerequisites\PrerequisiteTester;
 use PhpSpec\Process\ReRunner;
-use Prophecy\Argument;
 
 class RerunListenerSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Listener/StatisticsCollectorSpec.php
+++ b/spec/PhpSpec/Listener/StatisticsCollectorSpec.php
@@ -8,7 +8,6 @@ use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Loader\Node\SpecificationNode;
 use PhpSpec\Loader\Suite;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class StatisticsCollectorSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Listener/StopOnFailureListenerSpec.php
+++ b/spec/PhpSpec/Listener/StopOnFailureListenerSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Listener;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Console\ConsoleIO;

--- a/spec/PhpSpec/Loader/Node/ExampleNodeSpec.php
+++ b/spec/PhpSpec/Loader/Node/ExampleNodeSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Loader\Node;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Loader\Node\SpecificationNode;
 

--- a/spec/PhpSpec/Loader/Node/SpecificationNodeSpec.php
+++ b/spec/PhpSpec/Loader/Node/SpecificationNodeSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Loader\Node;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Locator\Resource;
 use PhpSpec\Loader\Node\ExampleNode;

--- a/spec/PhpSpec/Loader/Transformer/InMemoryTypeHintIndexSpec.php
+++ b/spec/PhpSpec/Loader/Transformer/InMemoryTypeHintIndexSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Loader\Transformer;
 
 use PhpSpec\CodeAnalysis\DisallowedNonObjectTypehintException;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class InMemoryTypeHintIndexSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Loader/Transformer/TypeHintRewriterSpec.php
+++ b/spec/PhpSpec/Loader/Transformer/TypeHintRewriterSpec.php
@@ -3,9 +3,7 @@
 namespace spec\PhpSpec\Loader\Transformer;
 
 use PhpSpec\CodeAnalysis\TypeHintRewriter;
-use PhpSpec\Loader\Transformer\TypeHintIndex;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class TypeHintRewriterSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Matcher/Iterate/SubjectHasFewerElementsExceptionSpec.php
+++ b/spec/PhpSpec/Matcher/Iterate/SubjectHasFewerElementsExceptionSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Matcher\Iterate;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 final class SubjectHasFewerElementsExceptionSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Matcher/Iterate/SubjectHasMoreElementsExceptionSpec.php
+++ b/spec/PhpSpec/Matcher/Iterate/SubjectHasMoreElementsExceptionSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Matcher\Iterate;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 final class SubjectHasMoreElementsExceptionSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Matcher/IterateLikeMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/IterateLikeMatcherSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\PhpSpec\Matcher;
 
-use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Matcher\Iterate\SubjectElementDoesNotMatchException;
 use PhpSpec\Matcher\Matcher;

--- a/spec/PhpSpec/Message/CurrentExampleTrackerSpec.php
+++ b/spec/PhpSpec/Message/CurrentExampleTrackerSpec.php
@@ -2,9 +2,7 @@
 
 namespace spec\PhpSpec\Message;
 
-use PhpSpec\Message\CurrentExampleTracker;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class CurrentExampleTrackerSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProviderSpec.php
+++ b/spec/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProviderSpec.php
@@ -6,7 +6,6 @@ use PhpSpec\NamespaceProvider\ComposerPsrNamespaceProvider;
 use PhpSpec\NamespaceProvider\NamespaceLocation;
 use PhpSpec\NamespaceProvider\NamespaceProvider;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ComposerPsrNamespaceProviderSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Process/Context/JsonExecutionContextSpec.php
+++ b/spec/PhpSpec/Process/Context/JsonExecutionContextSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Process\Context;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class JsonExecutionContextSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Process/Prerequisites/SuitePrerequisitesSpec.php
+++ b/spec/PhpSpec/Process/Prerequisites/SuitePrerequisitesSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Process\Prerequisites;
 
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Process\Context\ExecutionContext;
-use Prophecy\Argument;
 
 class SuitePrerequisitesSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Process/ReRunner/CompositeReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/CompositeReRunnerSpec.php
@@ -3,9 +3,7 @@
 namespace spec\PhpSpec\Process\ReRunner;
 
 use PhpSpec\ObjectBehavior;
-use PhpSpec\Process\ReRunner;
 use PhpSpec\Process\ReRunner\PlatformSpecificReRunner;
-use Prophecy\Argument;
 
 class CompositeReRunnerSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Process/ReRunner/OptionalReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/OptionalReRunnerSpec.php
@@ -5,7 +5,6 @@ namespace spec\PhpSpec\Process\ReRunner;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Process\ReRunner;
-use Prophecy\Argument;
 
 class OptionalReRunnerSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Process/ReRunner/PcntlReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/PcntlReRunnerSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Process\ReRunner;
 
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Process\Context\ExecutionContext;
-use Prophecy\Argument;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class PcntlReRunnerSpec extends ObjectBehavior

--- a/spec/PhpSpec/Process/ReRunner/ProcOpenReRunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/ProcOpenReRunnerSpec.php
@@ -15,7 +15,6 @@ namespace spec\PhpSpec\Process\ReRunner;
 
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Process\Context\ExecutionContext;
-use Prophecy\Argument;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class ProcOpenReRunnerSpec extends ObjectBehavior

--- a/spec/PhpSpec/Process/ReRunner/WindowsPassthruRerunnerSpec.php
+++ b/spec/PhpSpec/Process/ReRunner/WindowsPassthruRerunnerSpec.php
@@ -15,7 +15,6 @@ namespace spec\PhpSpec\Process\ReRunner;
 
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Process\Context\ExecutionContext;
-use Prophecy\Argument;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class WindowsPassthruRerunnerSpec extends ObjectBehavior

--- a/spec/PhpSpec/Process/Shutdown/ShutdownSpec.php
+++ b/spec/PhpSpec/Process/Shutdown/ShutdownSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Process\Shutdown;
 
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Process\Shutdown\ShutdownAction;
-use Prophecy\Argument;
 
 class ShutdownSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Process/Shutdown/UpdateConsoleActionSpec.php
+++ b/spec/PhpSpec/Process/Shutdown/UpdateConsoleActionSpec.php
@@ -5,7 +5,6 @@ namespace spec\PhpSpec\Process\Shutdown;
 use PhpSpec\Formatter\FatalPresenter;
 use PhpSpec\Message\CurrentExampleTracker;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class UpdateConsoleActionSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Runner/Maintainer/MatchersMaintainerSpec.php
+++ b/spec/PhpSpec/Runner/Maintainer/MatchersMaintainerSpec.php
@@ -9,7 +9,6 @@ use PhpSpec\ObjectBehavior;
 use PhpSpec\Runner\CollaboratorManager;
 use PhpSpec\Runner\MatcherManager;
 use PhpSpec\Specification;
-use Prophecy\Argument;
 
 class MatchersMaintainerSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Specification/ErrorSpecificationSpec.php
+++ b/spec/PhpSpec/Specification/ErrorSpecificationSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Specification;
 
 use PhpSpec\Specification;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ErrorSpecificationSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Util/ClassFileAnalyserSpec.php
+++ b/spec/PhpSpec/Util/ClassFileAnalyserSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Util;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ClassFileAnalyserSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Util/ClassNameCheckerSpec.php
+++ b/spec/PhpSpec/Util/ClassNameCheckerSpec.php
@@ -2,10 +2,8 @@
 
 namespace spec\PhpSpec\Util;
 
-use PhpSpec\Util\ClassNameChecker;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\NameChecker;
-use Prophecy\Argument;
 
 class ClassNameCheckerSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Util/InstantiatorSpec.php
+++ b/spec/PhpSpec/Util/InstantiatorSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Util;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class InstantiatorSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Util/MethodAnalyserSpec.php
+++ b/spec/PhpSpec/Util/MethodAnalyserSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Util;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class MethodAnalyserSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
@@ -5,7 +5,6 @@ namespace spec\PhpSpec\Wrapper\Subject\Expectation;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Wrapper\Subject;
 use PhpSpec\Wrapper\Subject\WrappedObject;
-use Prophecy\Argument;
 
 use PhpSpec\Wrapper\Subject\Expectation\Expectation;
 

--- a/spec/PhpSpec/Wrapper/Subject/Expectation/DecoratorSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/DecoratorSpec.php
@@ -3,7 +3,6 @@
 namespace spec\PhpSpec\Wrapper\Subject\Expectation;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Wrapper\Subject\Expectation\Decorator as AbstractDecorator;
 use PhpSpec\Wrapper\Subject\Expectation\Expectation;

--- a/spec/PhpSpec/Wrapper/Subject/Expectation/NegativeSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/NegativeSpec.php
@@ -3,8 +3,6 @@
 namespace spec\PhpSpec\Wrapper\Subject\Expectation;
 
 use PhpSpec\ObjectBehavior;
-use PhpSpec\Wrapper\Subject;
-use Prophecy\Argument;
 
 use PhpSpec\Matcher\Matcher;
 

--- a/spec/PhpSpec/Wrapper/Subject/Expectation/PositiveSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/PositiveSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Wrapper\Subject\Expectation;
 
 use PhpSpec\Matcher\Matcher;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class PositiveSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Wrapper/Subject/WrappedObjectSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/WrappedObjectSpec.php
@@ -4,7 +4,6 @@ namespace spec\PhpSpec\Wrapper\Subject;
 
 use PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 use PhpSpec\Formatter\Presenter\Presenter;
 

--- a/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
@@ -15,7 +15,6 @@ namespace PhpSpec\CodeGenerator\Generator;
 
 use PhpSpec\Locator\Resource;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 /**
  * Generates spec classes from resources and puts them into the appropriate
@@ -78,7 +77,7 @@ final class SpecificationGenerator extends PromptingGenerator
 
     protected function getImports(Resource $resource): string
     {
-        $imports = [$resource->getSrcClassname(), ObjectBehavior::class, Argument::class];
+        $imports = [$resource->getSrcClassname(), ObjectBehavior::class];
         asort($imports);
 
         foreach ($imports as &$import) {


### PR DESCRIPTION
`Prophecy\Argument;` is no longer used in this template so we can safely remove it from `use` import