### PR TITLE
[WIP][docs] Update code coverage extension repository

### DIFF
--- a/docs/cookbook/extensions.rst
+++ b/docs/cookbook/extensions.rst
@@ -59,7 +59,7 @@ Additional Formatters
 Metrics
 ~~~~~~~
 
- * `Code coverage <https://github.com/henrikbjorn/PhpSpecCodeCoverageExtension>`_
+ * `Code coverage <https://github.com/<maintainer_missing>/phpspec-code-coverage>`_
 
 Matchers
 ~~~~~~~~


### PR DESCRIPTION
## Description

The repository https://github.com/lhenrikbjorn/PhpSpecCodeCoverageExtension is linked as code coverage extension in the docs. This repository was deprecated by the author 2 years ago, but the repo was picked up and maintained by https://github.com/leanphp/phpspec-code-coverage for over a year. Sadly, the repo seems to be abandoned yet again, since the maintainer hasn't been active on GitHub for almost a year. 

Since you released phpspec 5.x, the code-coverage-extension can't be installed anymore, because of this version constraint:
https://github.com/leanphp/phpspec-code-coverage/blob/9dc509ed354f64ea9f4be6748bd1efcb32d1630b/composer.json#L28

This is reflected in the PR https://github.com/leanphp/phpspec-code-coverage/pull/35, https://github.com/leanphp/phpspec-code-coverage/pull/38 and in issue https://github.com/leanphp/phpspec-code-coverage/issues/36.

## Possible solutions

I think it would be worth a thought to ingest the leanphp/phpspec-code-coverage repository into the phpspec organization, so it can be maintained. (This is obviously your call, but I would be willing to triage issues and PRs, also @shulard and @Dragonrun1 seem interested.)   
The second option would be to wait for someone to pick up the repo and maintain it.
The third option would be to simply delete the extension from the docs.

### Why does someone even use this extension?

I am aware why the extension was discontinued:

> CodeCoverage should not be used with spec testing in order to see how good your tests are.

But I use it nevertheless to make sure I covered all the code with tests.

It would be nice to have your input on this. Thanks!