### PR TITLE
always fire `afterSpecification`

### DIFF
--- a/src/PhpSpec/Runner/SpecificationRunner.php
+++ b/src/PhpSpec/Runner/SpecificationRunner.php
@@ -51,14 +51,17 @@ class SpecificationRunner
         );
 
         $result = Event\ExampleEvent::PASSED;
-        foreach ($specification->getExamples() as $example) {
-            $result = max($result, $this->exampleRunner->run($example));
+        
+        try {
+            foreach ($specification->getExamples() as $example) {
+                $result = max($result, $this->exampleRunner->run($example));
+            }
+        } finally {
+            $this->dispatcher->dispatch(
+                'afterSpecification',
+                new Event\SpecificationEvent($specification, microtime(true) - $startTime, $result)
+            );
         }
-
-        $this->dispatcher->dispatch(
-            'afterSpecification',
-            new Event\SpecificationEvent($specification, microtime(true) - $startTime, $result)
-        );
 
         return $result;
     }


### PR DESCRIPTION
this will allow formatters to add 'closing' output