### PR TITLE
Quick Start snippet updated to latest release

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Create a ``composer.json`` file:
 
     {
         "require-dev": {
-            "phpspec/phpspec": "^4.0"
+            "phpspec/phpspec": "^5.1"
         },
         "config": {
             "bin-dir": "bin"


### PR DESCRIPTION
I was installing phpspec on a new project following the Quick Start procedure and i end up installing an old version so I updated the docs/index.rst updating the lib versione from 4.0 to 5.1