### PR TITLE
Avoid segmentation fault when calling getEventsCount

### DIFF
--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -132,7 +132,7 @@ class StatisticsCollector implements EventSubscriberInterface
 
     public function getEventsCount() : int
     {
-        return \count($this->getAllEvents());
+        return array_sum($this->getCountsHash());
     }
 
     public function getTotalSpecsCount() : int


### PR DESCRIPTION
This avoids segmentation fault caused by `DotFormatter` when reaching a certain amount of collected events, instead of doing an `array_merge` over all event arrays and doing a count, this change sums the count of all those events separately.

After this change looks like `getAllEvents` would only be used by the `StatisticsCollectorSpec` so I don't know if it would be safe just to delete it or we should deprecate it if some external libs or extensions are still using it.

Before:

![image](https://user-images.githubusercontent.com/3073746/62290086-bf3fcb80-b460-11e9-8f2a-2534836897f5.png)

After:

![image](https://user-images.githubusercontent.com/3073746/62290129-e0082100-b460-11e9-96ac-2e09cce107bf.png)