### PR TITLE
Update install instructions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Install **phpspec** with composer:
 
 .. code-block:: bash
 
-    php composer.phar install
+    composer require --dev phpspec/phpspec
 
 Start writing specs:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Install **phpspec** with composer:
 
 .. code-block:: bash
 
-    composer require --dev phpspec/phpspec
+    composer install
 
 Start writing specs:
 


### PR DESCRIPTION
The current instructions detail how to install Composer which is already explained right before it. It seems this is just an oversight as this line should explain how PhpSpec itself is installed through Composer. I also updated the Composer binary to the global one as that's the default when installing Composer.