### PR TITLE
Implement stream_set_option in StreamWrapper to avoid warning with PHP 7.4

### DIFF
--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -91,6 +91,6 @@ class StreamWrapper
 
     public function stream_set_option ( int $option , int $arg1 , int $arg2 ) : bool
     {
-        return true;
+        return false;
     }
 }

--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -88,4 +88,9 @@ class StreamWrapper
     {
         return feof($this->fileResource);
     }
+
+    public function stream_set_option ( int $option , int $arg1 , int $arg2 ) : bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This is now called by require_once since php 7.4

AFAIK is the only phpspec blocker on PHP 7.4 but there is a Prophecy issue that needs to be addressed.