### PR TITLE
add official JSON formatter

### DIFF
--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -558,6 +558,16 @@ final class ContainerAssembler
             }
         );
         $container->define(
+            'formatter.formatters.json',
+            function (IndexedServiceContainer $c) {
+                return new SpecFormatter\JsonFormatter(
+                    $c->get('formatter.presenter'),
+                    $c->get('console.io'),
+                    $c->get('event_dispatcher.listeners.stats')
+                );
+            }
+        );
+        $container->define(
             'formatter.formatters.dot',
             function (IndexedServiceContainer $c) {
                 return new SpecFormatter\DotFormatter(

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -73,7 +73,7 @@ final class JsonFormatter extends BasicFormatter
 
     public function afterSuite(SuiteEvent $event)
     {
-        $this->data['satus'] = self::STATUS_NAME[$event->getResult()];
+        $this->data['status'] = self::STATUS_NAME[$event->getResult()];
         $this->data['time'] = $event->getTime();
 
         $this->getIO()->write(json_encode($this->data));

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -18,7 +18,11 @@ use PhpSpec\Event\SuiteEvent;
 
 final class JsonFormatter extends BasicFormatter
 {
-    private $data = [];
+    private $data = [
+        'status' => '',
+        'time' => 0,
+        'specifications' => [],
+    ];
 
     private const STATUS_NAME = [
         ExampleEvent::PASSED  => 'passed',
@@ -30,7 +34,11 @@ final class JsonFormatter extends BasicFormatter
 
     public function beforeSpecification(SpecificationEvent $event)
     {
-        $this->data[$event->getSpecification()->getTitle()] = [];
+        $this->data['specifications'][$event->getSpecification()->getTitle()] = [
+            'status' => '',
+            'time' => 0,
+            'examples' => [],
+        ];
     }
 
     public function afterExample(ExampleEvent $event)
@@ -38,7 +46,7 @@ final class JsonFormatter extends BasicFormatter
         $specification = $event->getSpecification()->getTitle();
         $example = $event->getTitle();
 
-        $this->data[$specification][$example] = [
+        $this->data['specifications'][$specification]['examples'][$example] = [
             'status' => self::STATUS_NAME[$event->getResult()],
             'time' => $event->getTime(),
         ];
@@ -57,18 +65,16 @@ final class JsonFormatter extends BasicFormatter
 
     public function afterSpecification(SpecificationEvent $event)
     {
-        $this->data[$event->getSpecification()->getTitle()]['@meta'] = [
-            'status' => self::STATUS_NAME[$event->getResult()],
-            'time' => $event->getTime(),
-        ];
+        $specification = $event->getSpecification()->getTitle();
+        
+        $this->data['specifications'][$specification]['satus'] = self::STATUS_NAME[$event->getResult()];
+        $this->data['specifications'][$specification]['time'] = $event->getTime();
     }
 
     public function afterSuite(SuiteEvent $event)
     {
-        $this->data['@meta'] = [
-            'result' => self::STATUS_NAME[$event->getResult()],
-            'time' => $event->getTime(),
-        ];
+        $this->data['satus'] = self::STATUS_NAME[$event->getResult()];
+        $this->data['time'] = $event->getTime();
 
         $this->getIO()->write(json_encode($this->data));
     }

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Chris Kruining <chrise@keruining.eu>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
+namespace PhpSpec\Formatter
+{
+    use PhpSpec\Event\ExampleEvent;
+    use PhpSpec\Event\SpecificationEvent;
+    use PhpSpec\Event\SuiteEvent;
+
+    final class JsonFormatter extends ConsoleFormatter
+    {
+        private $data = [];
+
+        private const STATUS_NAME = [
+            ExampleEvent::PASSED  => 'passed',
+            ExampleEvent::PENDING => 'pending',
+            ExampleEvent::SKIPPED => 'skipped',
+            ExampleEvent::FAILED  => 'failed',
+            ExampleEvent::BROKEN  => 'broken',
+        ];
+
+        public function beforeSpecification(SpecificationEvent $event)
+        {
+            $this->data[$event->getSpecification()->getTitle()] = [];
+        }
+
+        public function afterExample(ExampleEvent $event)
+        {
+            $specification = $event->getSpecification()->getTitle();
+            $example = $event->getTitle();
+
+            $this->data[$specification][$example] = [
+                'status' => static::STATUS_NAME[$event->getResult()],
+                'time' => $event->getTime(),
+            ];
+
+            $exception = $event->getException();
+
+            if($exception === null)
+            {
+                return;
+            }
+
+            $this->data[$specification][$example]['@exception'] = [
+                'message' => $exception->getMessage(),
+                'trace' => $exception->getTrace(),
+            ];
+        }
+
+        public function afterSpecification(SpecificationEvent $event)
+        {
+            $this->data[$event->getSpecification()->getTitle()]['@meta'] = [
+                'status' => static::STATUS_NAME[$event->getResult()],
+                'time' => $event->getTime(),
+            ];
+        }
+
+        public function afterSuite(SuiteEvent $event)
+        {
+            $this->data['@meta'] = [
+                'result' => static::STATUS_NAME[$event->getResult()],
+                'time' => $event->getTime(),
+            ];
+
+            $this->getIO()->write(json_encode($this->data));
+        }
+    }
+}

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -67,7 +67,7 @@ final class JsonFormatter extends BasicFormatter
     {
         $specification = $event->getSpecification()->getTitle();
         
-        $this->data['specifications'][$specification]['satus'] = self::STATUS_NAME[$event->getResult()];
+        $this->data['specifications'][$specification]['status'] = self::STATUS_NAME[$event->getResult()];
         $this->data['specifications'][$specification]['time'] = $event->getTime();
     }
 

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -4,7 +4,7 @@
  * This file is part of PhpSpec, A php toolset to drive emergent
  * design by specification.
  *
- * (c) Chris Kruining <chrise@keruining.eu>
+ * (c) Chris Kruining <chrise@kruining.eu>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -57,7 +57,7 @@ final class JsonFormatter extends BasicFormatter
             return;
         }
 
-        $this->data[$specification][$example]['@exception'] = [
+        $this->data['specifications'][$specification]['examples'][$example]['@exception'] = [
             'message' => $exception->getMessage(),
             'trace' => $exception->getTrace(),
         ];

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -16,7 +16,7 @@ use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SpecificationEvent;
 use PhpSpec\Event\SuiteEvent;
 
-final class JsonFormatter extends ConsoleFormatter
+final class JsonFormatter extends BasicFormatter
 {
     private $data = [];
 


### PR DESCRIPTION
I have used this formatter(https://github.com/chris-kruining/phpspec-json) as a personal extension for a while now and I think it could be beneficial to others.

antoher argument would be that the help lists json as a format, yet there is none

this implementation does require https://github.com/phpspec/phpspec/pull/1253 to work!