### PR TITLE
Split latest-deps vs next-PHP builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,13 @@ matrix:
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.2
     - php: 7.3
-    - php: nightly
+    - php: 7.3
       env: DEPENDENCIES='dev'
+    - php: 7.4snapshot
       env: COMPOSER_FLAGS='--ignore-platform-reqs'
   allow_failures:
-    - php: nightly
+    - php: 7.4snapshot
+    - env: DEPENDENCIES='dev'
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
We currently test nightly builds + dev builds of dependencies, and it's showing a lot of failures

This splits next-PHP tests from next-dependencies tests. If the latter gets too fuzzy we should also look at splitting out e.g. next-symfony tests
