### PR TITLE
#1183 Potentially undefined variable

### DIFF
--- a/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
@@ -47,7 +47,7 @@ class ConstructorDecoratorSpec extends ObjectBehavior
 
         $subject->__call('getWrappedObject', [])->willThrow(new Error());
         $wrapped->getClassName()->willReturn(\stdClass::class);
-        $expectation->match($alias, Argument::type('object'), $arguments)->shouldBeCalledOnce()->willReturn($match);
+        $expectation->match($alias, Argument::type('object'), $arguments)->shouldBeCalledTimes(1)->willReturn($match);
 
         $this->beConstructedWith($expectation);
 

--- a/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
@@ -2,11 +2,16 @@
 
 namespace spec\PhpSpec\Wrapper\Subject\Expectation;
 
+use Error;
+use Exception;
+use PhpSpec\Exception\ErrorException;
+use PhpSpec\Exception\Fracture\FractureException;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Wrapper\Subject;
-use PhpSpec\Wrapper\Subject\WrappedObject;
-
 use PhpSpec\Wrapper\Subject\Expectation\Expectation;
+use PhpSpec\Wrapper\Subject\WrappedObject;
+use Prophecy\Argument;
+use stdClass;
 
 class ConstructorDecoratorSpec extends ObjectBehavior
 {
@@ -17,20 +22,35 @@ class ConstructorDecoratorSpec extends ObjectBehavior
 
     function it_rethrows_php_errors_as_phpspec_error_exceptions(Subject $subject, WrappedObject $wrapped)
     {
-        $subject->callOnWrappedObject('getWrappedObject', array())->willThrow('PhpSpec\Exception\Example\ErrorException');
-        $this->shouldThrow('PhpSpec\Exception\Example\ErrorException')->duringMatch('be', $subject, array(), $wrapped);
+        $subject->__call('getWrappedObject', [])->willThrow(new Error());
+        $this->shouldThrow(ErrorException::class)->duringMatch('be', $subject, array(), $wrapped);
     }
 
-    function it_rethrows_fracture_errors_as_phpspec_error_exceptions(Subject $subject, WrappedObject $wrapped)
+    function it_rethrows_fracture_errors(Subject $subject, WrappedObject $wrapped)
     {
-        $subject->__call('getWrappedObject', array())->willThrow('PhpSpec\Exception\Fracture\FractureException');
-        $this->shouldThrow('PhpSpec\Exception\Fracture\FractureException')->duringMatch('be', $subject, array(), $wrapped);
+        $subject->__call('getWrappedObject', [])->willThrow(FractureException::class);
+        $this->shouldThrow(FractureException::class)->duringMatch('be', $subject, array(), $wrapped);
     }
 
-    function it_ignores_any_other_exception(Subject $subject, WrappedObject $wrapped)
+    function it_throws_phpspec_error_exception_when_wrapped_object_not_provided(Subject $subject)
     {
-        $subject->callOnWrappedObject('getWrappedObject', array())->willThrow('\Exception');
-        $wrapped->getClassName()->willReturn('\stdClass');
-        $this->shouldNotThrow('\Exception')->duringMatch('be', $subject, array(), $wrapped);
+        $exception = new Exception();
+        $subject->__call('getWrappedObject', array())->willThrow($exception);
+        $this->shouldThrow($exception)->duringMatch('be', $subject);
+    }
+
+    function it_returns_match_from_expectation_when_subject_throws_error(Expectation $expectation, Subject $subject, WrappedObject $wrapped)
+    {
+        $alias = 'alias';
+        $match = new \stdClass();
+        $arguments = ['arg1'];
+
+        $subject->__call('getWrappedObject', [])->willThrow(new Error());
+        $wrapped->getClassName()->willReturn(\stdClass::class);
+        $expectation->match($alias, Argument::type('object'), $arguments)->shouldBeCalledOnce()->willReturn($match);
+
+        $this->beConstructedWith($expectation);
+
+        $this->match($alias, $subject, $arguments, $wrapped)->shouldReturn($match);
     }
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -13,9 +13,6 @@
 
 namespace PhpSpec\Wrapper\Subject\Expectation;
 
-use Exception;
-use PhpSpec\Exception\Example\ErrorException;
-use PhpSpec\Exception\Fracture\FractureException;
 use PhpSpec\Util\Instantiator;
 use PhpSpec\Wrapper\Subject\WrappedObject;
 
@@ -30,31 +27,34 @@ final class ConstructorDecorator extends Decorator implements Expectation
     }
 
     /**
-     * @param string        $alias
-     * @param mixed         $subject
-     * @param array         $arguments
-     * @param WrappedObject $wrappedObject
+     * @param string             $alias
+     * @param mixed              $subject
+     * @param array              $arguments
+     * @param WrappedObject|null $wrappedObject
      *
      * @return mixed
      *
-     * @throws \Exception
+     * @throws \PhpSpec\Exception\ErrorException
      * @throws \PhpSpec\Exception\Example\ErrorException
-     * @throws \Exception
      * @throws \PhpSpec\Exception\Fracture\FractureException
      */
-    public function match(string $alias, $subject, array $arguments = array(), WrappedObject $wrappedObject = null)
+    public function match(string $alias, $subject, array $arguments = [], WrappedObject $wrappedObject = null)
     {
         try {
             $wrapped = $subject->getWrappedObject();
-        } catch (ErrorException $e) {
+        } catch (\PhpSpec\Exception\Example\ErrorException $e) {
             throw $e;
-        } catch (FractureException $e) {
+        } catch (\PhpSpec\Exception\Fracture\FractureException $e) {
             throw $e;
-        } catch (Exception $e) {
-            if (null !== $wrappedObject && $wrappedObject->getClassName()) {
-                $instantiator = new Instantiator();
-                $wrapped = $instantiator->instantiate($wrappedObject->getClassName());
+        } catch (\Error $e) {
+            if ($wrappedObject === null || $wrappedObject->getClassName() === null) {
+                throw new \PhpSpec\Exception\ErrorException($e);
             }
+
+            $instantiator = new Instantiator();
+            $wrapped = $instantiator->instantiate(
+                $wrappedObject->getClassName()
+            );
         }
 
         return $this->getExpectation()->match($alias, $wrapped, $arguments);


### PR DESCRIPTION
Make sure that the variable is defined to prevent raw php errors.

Thix fixes #1183