### PR TITLE
Augments parse error output with file and line

### DIFF
--- a/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenterSpec.php
@@ -28,4 +28,17 @@ class BaseExceptionTypePresenterSpec extends ObjectBehavior
         $this->present(new ErrorException(new \Error('foo')))
             ->shouldReturn('[err:Error("foo")]');
     }
+
+    function it_should_present_a_parse_error_with_file_and_line_number()
+    {
+        $this->present(new ErrorException(new class() extends \ParseError {
+            public function __construct()
+            {
+                $this->message = 'Something is not correct';
+                $this->file = '/app/some/file.php';
+                $this->line = 42;
+            }
+        }))
+            ->shouldContain('Something is not correct in "/app/some/file.php" on line 42');
+    }
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
@@ -33,17 +33,27 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
     public function present($value): string
     {
         $label = 'exc';
+        $message = $value->getMessage();
 
         if ($value instanceof ErrorException) {
             $value = $value->getPrevious();
             $label = 'err';
         }
 
+        if ($value instanceof \ParseError) {
+            $message = sprintf(
+                '%s in "%s" on line %d',
+                $value->getMessage(),
+                $value->getFile(),
+                $value->getLine()
+            );
+        }
+
         return sprintf(
             '[%s:%s("%s")]',
             $label,
             \get_class($value),
-            $value->getMessage()
+            $message
         );
     }
 


### PR DESCRIPTION
See https://github.com/phpspec/phpspec/issues/1217

I believe that it enhances DX to always (not only with verbosity on) display file and line number in case of a parsing error.

WDYT?