### PR TITLE
Promote 7.4 into CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ matrix:
     - php: 7.3
       env: DEPENDENCIES='dev'
     - php: 7.4snapshot
-      env: COMPOSER_FLAGS='--ignore-platform-reqs'
   allow_failures:
-    - php: 7.4snapshot
     - env: DEPENDENCIES='dev'
   fast_finish: true
 


### PR DESCRIPTION
ok `master` currently says that 7.4 works but it doesn't, so I'm adding 7.4 to the proper build grid and we can work towards fixing things