### PR TITLE
Better fatal error example in test suite

### DIFF
--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -116,7 +116,7 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
     public function iShouldSee($message)
     {
         if (strpos($this->lastOutput, $message) === false) {
-            throw new \Exception("Missing message: $message");
+            throw new \Exception("Missing message: $message\nActual: {$this->lastOutput}");
         }
     }
 

--- a/features/exception_handling/developer_defines_supporting_spec.feature
+++ b/features/exception_handling/developer_defines_supporting_spec.feature
@@ -4,7 +4,7 @@ Feature: Developer has defined a supporting class and should not see a silent er
   So that I can better trace where my changes caused a fatal error
 
   @isolated
-  Scenario: Spec attempts to run a class with an undeclared interface, outputs to stdout
+  Scenario: Spec attempts to run a class with trying to implement throwable, outputs to stdout
     Given the spec file "spec/SomethingSpec.php" contains:
       """
       <?php
@@ -20,7 +20,7 @@ Feature: Developer has defined a supporting class and should not see a silent er
             }
         }
 
-        class ExampleClass implements NotDefinedInterface
+        class ExampleClass implements \Throwable
         {
         }
 


### PR DESCRIPTION
The example we had previously stopped being a hard fatal in PHP 7.4, this different example still triggers the fatal error handling

Fixes 1/4 errors on master