### PR TITLE
Filter out non-strings from the envs array when re-running phpspec

### DIFF
--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -55,6 +55,11 @@ final class PcntlReRunner extends PhpExecutableReRunner
         $args = $_SERVER['argv'];
         $env = $this->executionContext ? $this->executionContext->asEnv() : array();
 
-        pcntl_exec($this->getExecutablePath(), $args, array_merge($env, $_SERVER));
+        $env = array_filter(
+            array_merge($env, $_SERVER),
+            function($x): bool { return !is_array($x); }
+        );
+
+        pcntl_exec($this->getExecutablePath(), $args, $env);
     }
 }


### PR DESCRIPTION
PHP 7.4 is stricter about array->string and emits a notice