### PR TITLE
Fix regression around triggering instantiation during type checks

### DIFF
--- a/features/construction/developer_specifies_object_construction.feature
+++ b/features/construction/developer_specifies_object_construction.feature
@@ -426,3 +426,38 @@ Feature: Developer specifies object construction
     """
     When I run phpspec
     Then I should see "you can not change object construction method when it is already instantiated"
+
+  Scenario: Type checking does not trigger construction
+    Given the spec file "spec/Runner/ConstructorExample12/ClassWithPrivateConstructorSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\ConstructorExample12;
+
+      use PhpSpec\ObjectBehavior;
+
+      class ClassWithPrivateConstructorSpec extends ObjectBehavior
+      {
+          function it_is_initializable()
+          {
+              $this->shouldHaveType('Runner\ConstructorExample12\ClassWithPrivateConstructor');
+          }
+      }
+
+      """
+    And the class file "src/Runner/ConstructorExample12/ClassWithPrivateConstructor.php" contains:
+      """
+      <?php
+
+      namespace Runner\ConstructorExample12;
+
+      class ClassWithPrivateConstructor
+      {
+          private function __construct()
+          {
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass

--- a/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecoratorSpec.php
@@ -22,35 +22,20 @@ class ConstructorDecoratorSpec extends ObjectBehavior
 
     function it_rethrows_php_errors_as_phpspec_error_exceptions(Subject $subject, WrappedObject $wrapped)
     {
-        $subject->__call('getWrappedObject', [])->willThrow(new Error());
-        $this->shouldThrow(ErrorException::class)->duringMatch('be', $subject, array(), $wrapped);
+        $subject->__call('getWrappedObject', array())->willThrow('PhpSpec\Exception\Example\ErrorException');
+        $this->shouldThrow('PhpSpec\Exception\Example\ErrorException')->duringMatch('be', $subject, array(), $wrapped);
     }
 
-    function it_rethrows_fracture_errors(Subject $subject, WrappedObject $wrapped)
+    function it_rethrows_fracture_errors_as_phpspec_error_exceptions(Subject $subject, WrappedObject $wrapped)
     {
-        $subject->__call('getWrappedObject', [])->willThrow(FractureException::class);
-        $this->shouldThrow(FractureException::class)->duringMatch('be', $subject, array(), $wrapped);
+        $subject->__call('getWrappedObject', array())->willThrow('PhpSpec\Exception\Fracture\FractureException');
+        $this->shouldThrow('PhpSpec\Exception\Fracture\FractureException')->duringMatch('be', $subject, array(), $wrapped);
     }
 
-    function it_throws_phpspec_error_exception_when_wrapped_object_not_provided(Subject $subject)
+    function it_ignores_any_other_exception(Subject $subject, WrappedObject $wrapped)
     {
-        $exception = new Exception();
-        $subject->__call('getWrappedObject', array())->willThrow($exception);
-        $this->shouldThrow($exception)->duringMatch('be', $subject);
-    }
-
-    function it_returns_match_from_expectation_when_subject_throws_error(Expectation $expectation, Subject $subject, WrappedObject $wrapped)
-    {
-        $alias = 'alias';
-        $match = new \stdClass();
-        $arguments = ['arg1'];
-
-        $subject->__call('getWrappedObject', [])->willThrow(new Error());
-        $wrapped->getClassName()->willReturn(\stdClass::class);
-        $expectation->match($alias, Argument::type('object'), $arguments)->shouldBeCalledTimes(1)->willReturn($match);
-
-        $this->beConstructedWith($expectation);
-
-        $this->match($alias, $subject, $arguments, $wrapped)->shouldReturn($match);
+        $subject->__call('getWrappedObject', array())->willThrow('\Exception');
+        $wrapped->getClassName()->willReturn('\stdClass');
+        $this->shouldNotThrow('\Exception')->duringMatch('be', $subject, array(), $wrapped);
     }
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -46,9 +46,9 @@ final class ConstructorDecorator extends Decorator implements Expectation
             throw $e;
         } catch (\PhpSpec\Exception\Fracture\FractureException $e) {
             throw $e;
-        } catch (\Error $e) {
+        } catch (\Exception $e) {
             if ($wrappedObject === null || $wrappedObject->getClassName() === null) {
-                throw new \PhpSpec\Exception\ErrorException($e);
+                throw $e;
             }
 
             $instantiator = new Instantiator();


### PR DESCRIPTION
Changing the catch from Exception to Error in #1267 seems to have broken this behaviour, see discussion in #1284 

Possibly it should be Throwable?

Added an acceptance test around the behaviour that should be preserved and reverted the key change