### PR TITLE
Implement stream_set_option() to avoid warnings when running with php…

### DIFF
--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -88,4 +88,9 @@ class StreamWrapper
     {
         return feof($this->fileResource);
     }
+
+    public function stream_set_option($option, $arg1, $arg2)
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
Implement stream_set_option() to avoid warnings when running with php >= 7.4 version