### PR TITLE
Don't allow prophecy 1.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 
     "require": {
         "php":                      "^7.2, <7.5",
-        "phpspec/prophecy":         "^1.9",
+        "phpspec/prophecy":         "~1.9.0",
         "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "^1.0 || ^2.0 || ^3.0",
         "symfony/console":          "^3.4 || ^4.0 || ^5.0",


### PR DESCRIPTION
Prophecy 1.10.0 breaks the tests, as we can see from the travis run of the 6.1.1 release commit. The commit just before it ran with 1.9.0, and the tests passed.

I propose that we disallow 1.10+ for now, until it's established what the issue is, and what fixes are required.

---

See https://github.com/phpspec/phpspec/pull/1290#issuecomment-568295565 where this was pointed out.