### PR TITLE
Don't allow prophecy 1.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 
     "require": {
         "php":                      "^7.2, <7.5",
-        "phpspec/prophecy":         "^1.9",
+        "phpspec/prophecy":         "~1.9.0 || ^1.10.1",
         "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "^1.0 || ^2.0 || ^3.0",
         "symfony/console":          "^3.4 || ^4.0 || ^5.0",


### PR DESCRIPTION
1.9.x and 1.10.1+ should be fine, but not 1.10.0.