### PR TITLE
[PHPUnit 9] Allow sebastian/exporter 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php":                      "^7.2, <7.5",
         "phpspec/prophecy":         "^1.9",
         "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "^1.0 || ^2.0 || ^3.0",
+        "sebastian/exporter":       "^1.0 || ^2.0 || ^3.0 || ^4.0",
         "symfony/console":          "^3.4 || ^4.0 || ^5.0",
         "symfony/event-dispatcher": "^3.4 || ^4.0 || ^5.0",
         "symfony/process":          "^3.4 || ^4.0 || ^5.0",


### PR DESCRIPTION
`sebastian/exporter` 4.0 got released, the only difference with v3 is that [it drops support for PHP <7.3](https://github.com/sebastianbergmann/exporter/blob/master/ChangeLog.md#400---2020-02-07)

This is a requirement for some to upgrade to PHPUnit 9.