### PR TITLE
Move PHAR build to makefile and use newer version of box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 behat.yml
 vendor
 composer.lock
-phpspec.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,7 @@ script:
    - ./vendor/bin/behat --format=progress
 
 before_deploy:
-  - curl -LSs https://box-project.github.io/box2/installer.php | php
-  - export PATH=.:$PATH
-  - rm -Rf ./vendor
-  - composer install --no-dev -o
-  - box.phar build
+  - make phpspec.phar
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - php: 7.2
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.2
+      env: BUILD_PHAR='yes'
     - php: 7.3
     - php: 7.3
       env: DEPENDENCIES='dev'
@@ -33,9 +34,7 @@ script:
    - bin/phpspec run --format=dot
    - ./vendor/bin/phpunit -v
    - ./vendor/bin/behat --format=progress
-
-before_deploy:
-  - make phpspec.phar
+   - if [ "$BUILD_PHAR" == "yes" ]; then make phpspec.phar; fi;
 
 deploy:
   provider: releases
@@ -45,5 +44,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    php: 7.2
-    condition: COMPOSER_FLAGS != "--prefer-lowest"
+    condition: BUILD_PHAR == "yes"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ box.phar:
 
 phpspec.phar: box.phar vendor
 	./box.phar compile
+	vendor/bin/behat --profile=phar --format=progress || rm phpspec.phar
 
 vendor: composer.phar
 	./composer.phar install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+box.phar:
+	curl -Lls https://github.com/humbug/box/releases/download/3.8.4/box.phar -o box.phar
+	chmod +x box.phar
+
+phpspec.phar: box.phar vendor
+	./box.phar compile
+
+vendor: composer.phar
+	./composer.phar install
+
+composer.phar:
+	curl -Lls https://getcomposer.org/installer | php
+
+.PHONY: clean
+clean:
+	rm -f phpspec.phar box.phar composer.phar

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -10,6 +10,3 @@ default:
       contexts: [ IsolatedProcessContext, FilesystemContext ]
       filters: { tags: "@smoke && ~@isolated" }
 
-no-smoke:
-  suites:
-    smoke: ~

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -10,3 +10,10 @@ default:
       contexts: [ IsolatedProcessContext, FilesystemContext ]
       filters: { tags: "@smoke && ~@isolated" }
 
+phar:
+  suites:
+    application: false
+    isolated:
+      contexts: [ PharProcessContext, FilesystemContext ]
+    smoke:
+      contexts: [ PharProcessContext, FilesystemContext ]

--- a/box.json
+++ b/box.json
@@ -1,5 +1,4 @@
 {
-    "chmod": "0755",
     "directories": [
         "src"
     ],
@@ -13,7 +12,5 @@
             "in": "vendor"
         }
     ],
-    "main": "bin/phpspec",
-    "output": "phpspec.phar",
-    "stub": true
+    "output": "phpspec.phar"
 }

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -16,6 +16,8 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
 
     private $lastOutput;
 
+    protected $executablePath = __DIR__ . '/../../bin/phpspec';
+
     /**
      * @Given I have started describing the :class class
      */
@@ -57,8 +59,12 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
      */
     protected function buildPhpSpecCmd()
     {
+        if (!file_exists($this->executablePath)) {
+            throw new \RuntimeException('Could not find phpspec executable at ' . $this->executablePath);
+        }
+
         $isWindows = DIRECTORY_SEPARATOR === '\\';
-        $cmd = escapeshellcmd('' . __DIR__ . '/../../bin/phpspec');
+        $cmd = escapeshellcmd($this->executablePath);
         if ($isWindows) {
             $cmd = 'php ' . $cmd;
         }

--- a/features/bootstrap/PharProcessContext.php
+++ b/features/bootstrap/PharProcessContext.php
@@ -1,0 +1,6 @@
+<?php
+
+final class PharProcessContext extends \IsolatedProcessContext
+{
+    protected $executablePath = __DIR__ . '/../../phpspec.phar';
+}


### PR DESCRIPTION
Moving to the newer version of box with a view to scoping the dependencies in future

It struck me this isn't adequately tested so I've executed some of the behat tests against the PHAR - we could add more via a `@phar` tag