### PR TITLE
Test PHAR against all php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - php: 7.2
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.2
-      env: BUILD_PHAR='yes'
+      env: DEPLOY_PHAR='yes'
     - php: 7.3
     - php: 7.3
       env: DEPENDENCIES='dev'
@@ -35,7 +35,7 @@ script:
    - ./vendor/bin/phpunit -v
    - ./vendor/bin/behat --format=progress
    - ln -s `which composer` composer.phar
-   - if [ "$BUILD_PHAR" == "yes" ]; then make phpspec.phar; fi;
+   - make phpspec.phar
 
 deploy:
   provider: releases
@@ -45,4 +45,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    condition: BUILD_PHAR == "yes"
+    condition: DEPLOY_PHAR == "yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
    - bin/phpspec run --format=dot
    - ./vendor/bin/phpunit -v
    - ./vendor/bin/behat --format=progress
+   - composer config platform.php 7.2.0
    - ln -s `which composer` composer.phar
    - make phpspec.phar
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
    - bin/phpspec run --format=dot
    - ./vendor/bin/phpunit -v
    - ./vendor/bin/behat --format=progress
+   - ln -s `which composer` composer.phar
    - if [ "$BUILD_PHAR" == "yes" ]; then make phpspec.phar; fi;
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ box.phar:
 
 phpspec.phar: box.phar vendor
 	./box.phar compile
-	vendor/bin/behat --profile=phar --format=progress || rm phpspec.phar
+	vendor/bin/behat --profile=phar --format=progress
 
 vendor: composer.phar
 	./composer.phar install

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 box.phar:
-	curl -Lls https://github.com/humbug/box/releases/download/3.8.4/box.phar -o box.phar
+	curl -Ll https://github.com/humbug/box/releases/download/3.8.4/box.phar -o box.phar
 	chmod +x box.phar
 
 phpspec.phar: box.phar vendor


### PR DESCRIPTION
We currently only build the PHAR in 7.2 and attach it to the release.

This builds it with the 7.2 dependencies and ensures it runs against all supported PHP versions