### PR TITLE
Remove deprecated Reflection method calls

### DIFF
--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -143,7 +143,7 @@ final class CollaboratorsMaintainer implements Maintainer
 
     private function isUnsupportedTypeHinting(\ReflectionParameter $parameter): bool
     {
-        return $parameter->isArray() || $parameter->isCallable();
+        return $parameter->getType() && in_array($parameter->getType()->getName(), ['array', 'callable']);
     }
 
     /**
@@ -201,7 +201,7 @@ final class CollaboratorsMaintainer implements Maintainer
     private function getParameterTypeFromReflection(\ReflectionParameter $parameter): string
     {
         try {
-            if (null === $class = $parameter->getClass()) {
+            if (null === $class = $parameter->getType()) {
                 return '';
             }
 


### PR DESCRIPTION
PHP8 deprecates some of the reflection API

there are similar issues in dependent libraries (like Prophecy) so we won't be compatible until those are fixed too