### PR TITLE
Cannot pass BaseEvent using symfony/event-dispatcher 3.4.*

### DIFF
--- a/src/PhpSpec/Event/BaseEvent.php
+++ b/src/PhpSpec/Event/BaseEvent.php
@@ -2,10 +2,12 @@
 
 namespace PhpSpec\Event;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event as OldEvent;
 use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 
-if (class_exists(ContractEvent::class)) {
+if (\is_subclass_of(EventDispatcher::class, EventDispatcherInterface::class)) {
     class BaseEvent extends ContractEvent
     {
     }


### PR DESCRIPTION
Currently on v3.4.42

```
✘ Fatal error happened while executing the following 
     
    Uncaught TypeError: Argument 2 passed to Symfony\Component\EventDispatcher\EventDispatcher::dispatch() must be an instance of Symfony\Component\EventDispatcher\Event or null, instance of PhpSpec\Event\SuiteEvent given, called in /var/www/vendor/phpspec/phpspec/src/PhpSpec/Util/DispatchTrait.php on line 24 and defined in /var/www/vendor/symfony/event-dispatcher/EventDispatcher.php:37
Stack trace:
#0 /var/www/vendor/phpspec/phpspec/src/PhpSpec/Util/DispatchTrait.php(24): Symfony\Component\EventDispatcher\EventDispatcher->dispatch('beforeSuite', Object(PhpSpec\Event\SuiteEvent))
#1 /var/www/vendor/phpspec/phpspec/src/PhpSpec/Runner/SuiteRunner.php(52): PhpSpec\Runner\SuiteRunner->dispatch(Object(Symfony\Component\EventDispatcher\EventDispatcher), Object(PhpSpec\Event\SuiteEvent), 'beforeSuite')
#2 /var/www/vendor/phpspec/phpspec/src/PhpSpec/Console/Command/RunCommand.php(178): PhpSpec\Runner\SuiteRunner->run(Object(PhpSpec\Loader\Suite))
#3 /var/www/vendor/symfony/console/Command/Command.php(255): PhpSpec\Consol in /var/www/vendor/symfony/event-dispatcher/EventDispatcher.php on line 37 
```