### PR TITLE
Use new PHP8 tokens when stripping out type hints

### DIFF
--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -51,7 +51,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         $this->typeHintIndex = $typeHintIndex;
         $this->namespaceResolver = $namespaceResolver;
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             $this->typehintTokens[] = T_NAME_FULLY_QUALIFIED;
             $this->typehintTokens[] = T_NAME_QUALIFIED;
         }

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -50,6 +50,11 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     {
         $this->typeHintIndex = $typeHintIndex;
         $this->namespaceResolver = $namespaceResolver;
+
+        if (PHP_VERSION_ID >= 80000) {
+            $this->typehintTokens[] = T_NAME_FULLY_QUALIFIED;
+            $this->typehintTokens[] = T_NAME_QUALIFIED;
+        }
     }
 
     public function rewrite(string $classDefinition): string


### PR DESCRIPTION
Similar to #1325 this fixes the type hint rewriting by using the new tokens in PHP8