### PR TITLE
Remove the requirement for an error context in error handler

### DIFF
--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -82,7 +82,7 @@ final class TriggerMatcher implements Matcher
     {
         $triggered = 0;
 
-        $prevHandler = set_error_handler(function ($type, $str, $file, $line, $context) use (&$prevHandler, $level, $message, &$triggered) {
+        $prevHandler = set_error_handler(function ($type, $str, $file, $line, $context=[]) use (&$prevHandler, $level, $message, &$triggered) {
             if (null !== $level && $level !== $type) {
                 return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }


### PR DESCRIPTION
Since PHP8 error handlers are only called with 4 arguments so this causes an ArgumentCountError to be thrown