### PR TITLE
Fix break when union double is type hinted and show sensible message

### DIFF
--- a/features/doubles/union_doubles.feature
+++ b/features/doubles/union_doubles.feature
@@ -1,0 +1,23 @@
+Feature: Union Doubles
+
+  Currently these are not supported so we show an appropriate message
+
+  Scenario: Error when using a union double
+    Given the spec file "spec/Doubles/UnionDoublesSpec.php" contains:
+       """
+       <?php
+
+       namespace spec\Doubles;
+
+       use PhpSpec\ObjectBehavior;
+
+       class UnionDoublesSpec extends ObjectBehavior
+       {
+            function it_does_something_with_a_double(\stdClass|\ArrayObject $double)
+            {
+                return;
+            }
+       }
+       """
+    When I run phpspec
+    Then I should see "union type \stdClass|\ArrayObject cannot be used to create a double"

--- a/src/PhpSpec/CodeAnalysis/DisallowedUnionTypehintException.php
+++ b/src/PhpSpec/CodeAnalysis/DisallowedUnionTypehintException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\CodeAnalysis;
+
+class DisallowedUnionTypehintException extends \Exception
+{
+}

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -149,8 +149,8 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     private function extractTypehints(array &$tokens, int $index, array $token): void
     {
         $typehint = '';
-        for ($i = $index - 1; \in_array($tokens[$i][0], $this->typehintTokens); $i--) {
-            $typehint = $tokens[$i][1] . $typehint;
+        for ($i = $index - 1; !$this->haveNotReachedEndOfTypeHint($tokens[$i]); $i--) {
+            $typehint = (is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i]) . $typehint;
 
             if (T_WHITESPACE !== $tokens[$i][0]) {
                 unset($tokens[$i]);
@@ -158,7 +158,20 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         }
 
         if ($typehint = trim($typehint)) {
+
             $class = $this->namespaceResolver->resolve($this->currentClass);
+
+            if (\strpos($typehint, '|') !== false) {
+                $this->typeHintIndex->addInvalid(
+                    $class,
+                    trim($this->currentFunction),
+                    $token[1],
+                    new DisallowedUnionTypehintException("Union type $typehint cannot be used to create a double")
+                );
+
+                return;
+            }
+
             try {
                 $typehintFcqn = $this->namespaceResolver->resolve($typehint);
                 $this->typeHintIndex->add(
@@ -176,6 +189,15 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                 );
             }
         }
+    }
+
+    private function haveNotReachedEndOfTypeHint($token) : bool
+    {
+        if ($token == '|') {
+            return false;
+        }
+
+        return !\in_array($token[0], $this->typehintTokens);
     }
 
     /**

--- a/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
+++ b/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
@@ -17,11 +17,19 @@ namespace PhpSpec\Exception\Wrapper;
 class InvalidCollaboratorTypeException extends CollaboratorException
 {
 
-    public function __construct(\ReflectionParameter $parameter, \ReflectionFunctionAbstract $function)
+    public function __construct(
+        \ReflectionParameter $parameter,
+        \ReflectionFunctionAbstract $function,
+        ?string $reason = null,
+        ?string $prompt = null
+    )
     {
+        $reason = $reason ?? 'Collaborator must be an object';
+        $prompt = $prompt ?? 'You can create non-object values manually.';
+
         $message = sprintf(
-            'Collaborator must be an object: argument %s defined in %s. ' .
-            'You can create non-object values manually.',
+            $reason . ': argument %s defined in %s. ' .
+            $prompt,
             $parameter->getPosition(),
             $this->fetchFunctionIdentifier($function)
         );

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -14,6 +14,7 @@
 namespace PhpSpec\Runner\Maintainer;
 
 use PhpSpec\CodeAnalysis\DisallowedNonObjectTypehintException;
+use PhpSpec\CodeAnalysis\DisallowedUnionTypehintException;
 use PhpSpec\Exception\Fracture\CollaboratorNotFoundException;
 use PhpSpec\Exception\Wrapper\InvalidCollaboratorTypeException;
 use PhpSpec\Loader\Node\ExampleNode;
@@ -134,6 +135,9 @@ final class CollaboratorsMaintainer implements Maintainer
             }
             catch (ClassNotFoundException $e) {
                 $this->throwCollaboratorNotFound($e, null, $e->getClassname());
+            }
+            catch (DisallowedUnionTypehintException $e) {
+                throw new InvalidCollaboratorTypeException($parameter, $function, $e->getMessage(), 'Use a specific type');
             }
             catch (DisallowedNonObjectTypehintException $e) {
                 throw new InvalidCollaboratorTypeException($parameter, $function);


### PR DESCRIPTION
PhpSpec handled a union collaborator type hint badly. This fixes the hard crash and shows a sensible error message

Closes #1314 