### PR TITLE
Configure the build on github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,90 @@
+name: Build
+
+on:
+    push:
+        branches: [main, next, master, 2.5, 3.4, 4.3, 5.1, 6.2]
+    pull_request:
+    release:
+        types: [created]
+
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+        name: Build and test
+        strategy:
+            matrix:
+                php: [7.3, 7.4]
+                composer-flags: [""]
+                composer-extras: [""]
+                stability: ["stable"]
+                include:
+                    -   php: 7.3
+                        publish-phar: true
+                    -   php: 7.3
+                        composer-flags: --prefer-lowest
+                    -   php: 7.3
+                        composer-extras: "symfony/event-dispatcher ^3.4 symfony/contracts ^2.0"
+                    -   php: 7.4
+                        stability: "dev"
+
+        env:
+            COMPOSER_ROOT_VERSION: dev-master
+
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: "${{ matrix.php }}"
+                    ini-values: "phar.readonly=0"
+
+            -   name: Install composer extras
+                if: matrix.composer-extras != ''
+                run: composer require ${{ matrix.composer-extras }} --no-update
+
+            -   name: Update the minimum stability
+                if: matrix.stability == 'dev'
+                run: composer config minimum-stability ${{ matrix.stability }}
+
+            -   name: Install dependencies
+                run: composer update ${{ matrix.composer-flags }}
+
+            -   name: Run tests (phpspec)
+                run: bin/phpspec run --format=dot
+
+            -   name: Run tests (phpunit)
+                run: ./vendor/bin/phpunit -v
+
+            -   name: Build the PHAR
+                run: |
+                    composer config platform.php 7.3.0 &&
+                    ln -s `which composer` composer.phar &&
+                    make phpspec.phar
+
+            -   uses: actions/upload-artifact@v1
+                name: Publish the PHAR
+                if: matrix.publish-phar
+                with:
+                    name: phpspec.phar
+                    path: phpspec.phar
+
+    publish-phar:
+        runs-on: ubuntu-latest
+        name: Publish the PHAR
+        needs: tests
+        if: github.event_name == 'release'
+        steps:
+            -   uses: actions/download-artifact@v1
+                with:
+                    name: phpspec.phar
+                    path: .
+            -   name: Upload phpspec.phar
+                uses: actions/upload-release-asset@v1
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                with:
+                    upload_url: ${{ github.event.release.upload_url }}
+                    asset_path: phpspec.phar
+                    asset_name: phpspec.phar
+                    asset_content_type: application/zip


### PR DESCRIPTION
To start I only aimed to reproduce what's currently done on Travis.

# Matrix

| PHP | Composer flags | Composer extras | Stability |
|--|--|--|--|
| 7.3 |  | | stable |
| 7.3 | --prefer-lowest | | stable |
| 7.3 |  | symfony/event-dispatcher ^3.4 symfony/contracts ^2.0 | stable |
| 7.4 | | | stable |
| 7.4 | | | dev |

<img width="296" alt="image" src="https://user-images.githubusercontent.com/190447/97290564-9ca58980-1840-11eb-8d18-c14b116cf891.png">

# Notes

* The PHAR is built on each job, but it's only published as a build artifact on PHP 7.3 stable (so it's only published once).
* The PHAR is attached to a release if the build is triggered by a release.
* The only thing I couldn't get to work is "allow failures". It's documented here, but doesn't seem to work: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
* Behat tests are currently disabled as they're failing.

# Example builds

Example build: https://github.com/jakzal/phpspec/actions/runs/331115517
Example build for a release: https://github.com/jakzal/phpspec/actions/runs/331116603
Example release: https://github.com/jakzal/phpspec/releases/tag/0.0.1-test

# Build times

## Github Actions

<img width="861" alt="image" src="https://user-images.githubusercontent.com/190447/97291744-3ae61f00-1842-11eb-9d78-60194027814d.png">

## Travis CI

<img width="809" alt="image" src="https://user-images.githubusercontent.com/190447/97291793-49ccd180-1842-11eb-9c7a-3c648fc5593d.png">
