### PR TITLE
Remove superfluous PHPDoc tags.

### DIFF
--- a/features/bootstrap/Fake/ReRunner.php
+++ b/features/bootstrap/Fake/ReRunner.php
@@ -8,10 +8,7 @@ class ReRunner implements BaseReRunner
 {
     private $hasBeenReRun = false;
 
-    /**
-     * @return boolean
-     */
-    public function isSupported()
+    public function isSupported(): bool
     {
         return true;
     }

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -20,9 +20,7 @@ final class MagicAwareAccessInspector implements AccessInspector
      */
     private $accessInspector;
 
-    /**
-     * @param AccessInspector $accessInspector
-     */
+    
     public function __construct(AccessInspector $accessInspector)
     {
         $this->accessInspector = $accessInspector;

--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -27,9 +27,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
     private $currentUse;
     private $uses = array();
 
-    /**
-     * @param string $code
-     */
+    
     public function analyse(string $code): void
     {
         $this->state = self::STATE_DEFAULT;

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -42,10 +42,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
      */
     private $namespaceResolver;
 
-    /**
-     * @param TypeHintIndex $typeHintIndex
-     * @param NamespaceResolver $namespaceResolver
-     */
+    
     public function __construct(TypeHintIndex $typeHintIndex, NamespaceResolver $namespaceResolver)
     {
         $this->typeHintIndex = $typeHintIndex;
@@ -135,10 +132,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         return $tokens;
     }
 
-    /**
-     * @param array $tokens
-     * @return string
-     */
+    
     private function tokensToString(array $tokens): string
     {
         return join('', array_map(function ($token) {

--- a/src/PhpSpec/CodeAnalysis/TypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TypeHintRewriter.php
@@ -15,10 +15,6 @@ namespace PhpSpec\CodeAnalysis;
 
 interface TypeHintRewriter
 {
-    /**
-     * @param string $classDefinition
-     *
-     * @return string
-     */
+    
     public function rewrite(string $classDefinition): string;
 }

--- a/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php
@@ -21,13 +21,7 @@ use PhpSpec\Locator\Resource;
  */
 final class ClassGenerator extends PromptingGenerator
 {
-    /**
-     * @param Resource $resource
-     * @param string            $generation
-     * @param array             $data
-     *
-     * @return bool
-     */
+    
     public function supports(Resource $resource, string $generation, array $data): bool
     {
         return 'class' === $generation;

--- a/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
@@ -105,17 +105,13 @@ class ExistingConstructorTemplate
         );
     }
 
-    /**
-     * @return string
-     */
+    
     private function getCreateObjectTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/named_constructor_create_object.template');
     }
 
-    /**
-     * @return string
-     */
+    
     private function getExceptionTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/named_constructor_exception.template');

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -44,12 +44,7 @@ final class MethodGenerator implements Generator
      */
     private $codeWriter;
 
-    /**
-     * @param ConsoleIO $io
-     * @param TemplateRenderer $templates
-     * @param Filesystem $filesystem
-     * @param CodeWriter $codeWriter
-     */
+    
     public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
     {
         $this->io         = $io;
@@ -63,10 +58,7 @@ final class MethodGenerator implements Generator
         return 'method' === $generation;
     }
 
-    /**
-     * @param Resource $resource
-     * @param array             $data
-     */
+    
     public function generate(Resource $resource, array $data = array()): void
     {
         $filepath  = $resource->getSrcFilename();

--- a/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
@@ -38,11 +38,7 @@ final class MethodSignatureGenerator implements Generator
      */
     private $filesystem;
 
-    /**
-     * @param ConsoleIO               $io
-     * @param TemplateRenderer $templates
-     * @param Filesystem       $filesystem
-     */
+    
     public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
     {
         $this->io         = $io;

--- a/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
@@ -41,12 +41,7 @@ final class NamedConstructorGenerator implements Generator
      */
     private $codeWriter;
 
-    /**
-     * @param ConsoleIO $io
-     * @param TemplateRenderer $templates
-     * @param Filesystem $filesystem
-     * @param CodeWriter $codeWriter
-     */
+    
     public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
     {
         $this->io         = $io;
@@ -60,10 +55,7 @@ final class NamedConstructorGenerator implements Generator
         return 'named_constructor' === $generation;
     }
 
-    /**
-     * @param Resource $resource
-     * @param array             $data
-     */
+    
     public function generate(Resource $resource, array $data = array()): void
     {
         $filepath   = $resource->getSrcFilename();

--- a/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
@@ -27,11 +27,7 @@ final class NewFileNotifyingGenerator implements Generator
      */
     private $filesystem;
 
-    /**
-     * @param Generator $generator
-     * @param EventDispatcherInterface $dispatcher
-     * @param Filesystem $filesystem
-     */
+    
     public function __construct(Generator $generator, EventDispatcherInterface $dispatcher, Filesystem $filesystem)
     {
         $this->generator = $generator;

--- a/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
@@ -27,9 +27,7 @@ final class OneTimeGenerator implements Generator
      */
     private $alreadyGenerated = array();
 
-    /**
-     * @param Generator $generator
-     */
+    
     public function __construct(Generator $generator)
     {
         $this->generator = $generator;

--- a/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
@@ -42,12 +42,7 @@ final class PrivateConstructorGenerator implements Generator
      */
     private $codeWriter;
 
-    /**
-     * @param ConsoleIO $io
-     * @param TemplateRenderer $templates
-     * @param Filesystem $filesystem
-     * @param CodeWriter $codeWriter
-     */
+    
     public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
     {
         $this->io         = $io;
@@ -61,10 +56,7 @@ final class PrivateConstructorGenerator implements Generator
         return 'private-constructor' === $generation;
     }
 
-    /**
-     * @param Resource $resource
-     * @param array $data
-     */
+    
     public function generate(Resource $resource, array $data): void
     {
         $filepath  = $resource->getSrcFilename();

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -44,12 +44,7 @@ abstract class PromptingGenerator implements Generator
      */
     private $executionContext;
 
-    /**
-     * @param ConsoleIO $io
-     * @param TemplateRenderer $templates
-     * @param Filesystem $filesystem
-     * @param ExecutionContext $executionContext
-     */
+    
     public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, ExecutionContext $executionContext)
     {
         $this->io         = $io;
@@ -58,10 +53,7 @@ abstract class PromptingGenerator implements Generator
         $this->executionContext = $executionContext;
     }
 
-    /**
-     * @param Resource $resource
-     * @param array             $data
-     */
+    
     public function generate(Resource $resource, array $data = array()): void
     {
         $filepath = $this->getFilePath($resource);
@@ -88,12 +80,7 @@ abstract class PromptingGenerator implements Generator
 
     abstract protected function renderTemplate(Resource $resource, string $filepath): string;
 
-    /**
-     * @param Resource $resource
-     * @param string            $filepath
-     *
-     * @return string
-     */
+    
     abstract protected function getGeneratedMessage(Resource $resource, string $filepath): string;
 
     private function fileAlreadyExists(string $filepath): bool

--- a/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
@@ -33,11 +33,7 @@ final class ReturnConstantGenerator implements Generator
      */
     private $filesystem;
 
-    /**
-     * @param ConsoleIO        $io
-     * @param TemplateRenderer $templates
-     * @param Filesystem       $filesystem
-     */
+    
     public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
     {
         $this->io = $io;
@@ -50,10 +46,7 @@ final class ReturnConstantGenerator implements Generator
         return 'returnConstant' == $generation;
     }
 
-    /**
-     * @param Resource $resource
-     * @param array             $data
-     */
+    
     public function generate(Resource $resource, array $data): void
     {
         $method = $data['method'];

--- a/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
@@ -32,12 +32,7 @@ final class SpecificationGenerator extends PromptingGenerator
         return 0;
     }
 
-    /**
-     * @param Resource $resource
-     * @param string            $filepath
-     *
-     * @return string
-     */
+    
     protected function renderTemplate(Resource $resource, string $filepath): string
     {
         $values = array(

--- a/src/PhpSpec/CodeGenerator/GeneratorManager.php
+++ b/src/PhpSpec/CodeGenerator/GeneratorManager.php
@@ -27,9 +27,7 @@ class GeneratorManager
      */
     private $generators = array();
 
-    /**
-     * @param Generator $generator
-     */
+    
     public function registerGenerator(Generator $generator): void
     {
         $this->generators[] = $generator;

--- a/src/PhpSpec/CodeGenerator/TemplateRenderer.php
+++ b/src/PhpSpec/CodeGenerator/TemplateRenderer.php
@@ -31,17 +31,13 @@ class TemplateRenderer
      */
     private $filesystem;
 
-    /**
-     * @param Filesystem $filesystem
-     */
+    
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
     }
 
-    /**
-     * @param array $locations
-     */
+    
     public function setLocations(array $locations): void
     {
         $this->locations = array_map(array($this, 'normalizeLocation'), $locations);

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -22,9 +22,7 @@ final class TokenizedCodeWriter implements CodeWriter
      */
     private $analyser;
 
-    /**
-     * @param ClassFileAnalyser $analyser
-     */
+    
     public function __construct(ClassFileAnalyser $analyser)
     {
         $this->analyser = $analyser;

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -48,10 +48,6 @@ class OptionsConfig
     private $isVerbose;
 
     /**
-     * @param bool $stopOnFailureEnabled
-     * @param bool $codeGenerationEnabled
-     * @param bool $reRunEnabled
-     * @param bool $fakingEnabled
      * @param string|bool $bootstrapPath
      * @param bool $isVerbose
      */
@@ -71,17 +67,13 @@ class OptionsConfig
         $this->isVerbose = $isVerbose;
     }
 
-    /**
-     * @return bool
-     */
+    
     public function isStopOnFailureEnabled(): bool
     {
         return $this->stopOnFailureEnabled;
     }
 
-    /**
-     * @return bool
-     */
+    
     public function isCodeGenerationEnabled(): bool
     {
         return $this->codeGenerationEnabled;

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -51,9 +51,7 @@ final class Application extends BaseApplication
         return $this->container;
     }
 
-    /**
-     * @return int
-     */
+    
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
         $helperSet = $this->getHelperSet();
@@ -196,9 +194,7 @@ final class Application extends BaseApplication
     }
 
     /**
-     * @param InputInterface $input
      *
-     * @return array
      *
      * @throws \RuntimeException
      */
@@ -237,11 +233,7 @@ final class Application extends BaseApplication
         return array();
     }
 
-    /**
-     * @param string $path
-     *
-     * @return array
-     */
+    
     private function parseConfigFromExistingPath(string $path): array
     {
         if (!file_exists($path)) {

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -55,8 +55,6 @@ EOF
     }
 
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
      *
      * @return int
      */

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -130,12 +130,7 @@ EOF
         ;
     }
 
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return mixed
-     */
+    
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $container = $this->getApplication()->getContainer();

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -280,10 +280,7 @@ class ConsoleIO implements IO
         return $width;
     }
 
-    /**
-     * @param string $message
-     * @param int $indent
-     */
+    
     public function writeBrokenCodeBlock(string $message, int $indent = 0): void
     {
         $message = wordwrap($message, $this->getBlockWidth() - ($indent * 2), "\n", true);

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -52,9 +52,7 @@ use PhpSpec\Process\Shutdown\Shutdown;
  */
 final class ContainerAssembler
 {
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     public function build(IndexedServiceContainer $container): void
     {
         $this->setupParameters($container);
@@ -139,9 +137,7 @@ final class ContainerAssembler
         }, ['console.commands']);
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupConsoleEventDispatcher(IndexedServiceContainer $container): void
     {
         $container->define('console_event_dispatcher', function (IndexedServiceContainer $c) {
@@ -156,9 +152,7 @@ final class ContainerAssembler
         });
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupEventDispatcher(IndexedServiceContainer $container): void
     {
         $container->define('event_dispatcher', function () {
@@ -250,9 +244,7 @@ final class ContainerAssembler
         }, ['event_dispatcher.listeners']);
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupGenerators(IndexedServiceContainer $container): void
     {
         $container->define('code_generator', function (IndexedServiceContainer $c) {
@@ -386,18 +378,14 @@ final class ContainerAssembler
         ));
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupPresenter(IndexedServiceContainer $container): void
     {
         $presenterAssembler = new PresenterAssembler();
         $presenterAssembler->assemble($container);
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupLocator(IndexedServiceContainer $container): void
     {
         $container->define('locator.resource_manager', function (IndexedServiceContainer $c) {
@@ -487,9 +475,7 @@ final class ContainerAssembler
         });
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupLoader(IndexedServiceContainer $container): void
     {
         $container->define('loader.resource_loader', function (IndexedServiceContainer $c) {
@@ -521,7 +507,6 @@ final class ContainerAssembler
     }
 
     /**
-     * @param IndexedServiceContainer $container
      *
      * @throws \RuntimeException
      */
@@ -626,9 +611,7 @@ final class ContainerAssembler
         });
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupRunner(IndexedServiceContainer $container): void
     {
         $container->define('runner.suite', function (IndexedServiceContainer $c) {
@@ -708,9 +691,7 @@ final class ContainerAssembler
         });
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupMatchers(IndexedServiceContainer $container): void
     {
         $container->define('matchers.identity', function (IndexedServiceContainer $c) {
@@ -784,9 +765,7 @@ final class ContainerAssembler
         }, ['matchers']);
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupRerunner(IndexedServiceContainer $container): void
     {
         $container->define('process.rerunner', function (IndexedServiceContainer $c) {
@@ -828,9 +807,7 @@ final class ContainerAssembler
         });
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupSubscribers(IndexedServiceContainer $container): void
     {
         $container->addConfigurator(function (IndexedServiceContainer $c) {
@@ -841,9 +818,7 @@ final class ContainerAssembler
         });
     }
 
-    /**
-     * @param IndexedServiceContainer $container
-     */
+    
     private function setupCurrentExample(IndexedServiceContainer $container): void
     {
         $container->define('current_example', function () {
@@ -851,9 +826,7 @@ final class ContainerAssembler
         });
     }
 
-  /**
-   * @param IndexedServiceContainer $container
-   */
+  
     private function setupShutdown(IndexedServiceContainer $container): void
     {
         $container->define('process.shutdown', function () {

--- a/src/PhpSpec/Console/Formatter.php
+++ b/src/PhpSpec/Console/Formatter.php
@@ -25,7 +25,6 @@ class Formatter extends OutputFormatter
     /**
      * @param boolean $decorated
      *
-     * @param array $styles
      */
     public function __construct(bool $decorated = false, array $styles = array())
     {

--- a/src/PhpSpec/Console/Prompter/Question.php
+++ b/src/PhpSpec/Console/Prompter/Question.php
@@ -44,9 +44,7 @@ final class Question implements Prompter
     }
 
     /**
-     * @param string  $question
      * @param boolean $default
-     * @return boolean
      */
     public function askConfirmation(string $question, bool $default = true): bool
     {

--- a/src/PhpSpec/Console/ResultConverter.php
+++ b/src/PhpSpec/Console/ResultConverter.php
@@ -23,9 +23,7 @@ class ResultConverter
     /**
      * Convert Example result into exit code
      *
-     * @param mixed $result
      *
-     * @return int
      */
     public function convert($result): int
     {

--- a/src/PhpSpec/Event/ExampleEvent.php
+++ b/src/PhpSpec/Event/ExampleEvent.php
@@ -68,7 +68,6 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
     private $exception;
 
     /**
-     * @param ExampleNode  $example
      * @param float|null   $time
      * @param integer|null $result
      * @param \Exception   $exception
@@ -85,57 +84,43 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
         $this->exception = $exception;
     }
 
-    /**
-     * @return ExampleNode
-     */
+    
     public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
-    /**
-     * @return SpecificationNode
-     */
+    
     public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
-    /**
-     * @return Suite
-     */
+    
     public function getSuite(): Suite
     {
         return $this->getSpecification()->getSuite();
     }
 
-    /**
-     * @return string
-     */
+    
     public function getTitle(): string
     {
         return $this->example->getTitle();
     }
 
-    /**
-     * @return string
-     */
+    
     public function getMessage(): string
     {
         return $this->exception->getMessage();
     }
 
-    /**
-     * @return array
-     */
+    
     public function getBacktrace(): array
     {
         return $this->exception->getTrace();
     }
 
-    /**
-     * @return float
-     */
+    
     public function getTime(): float
     {
         return $this->time;

--- a/src/PhpSpec/Event/ExpectationEvent.php
+++ b/src/PhpSpec/Event/ExpectationEvent.php
@@ -48,9 +48,7 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
      */
     private $matcher;
 
-    /**
-     * @var mixed
-     */
+    
     private $subject;
 
     /**
@@ -74,9 +72,6 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
     private $exception;
 
     /**
-     * @param ExampleNode      $example
-     * @param Matcher $matcher
-     * @param mixed            $subject
      * @param string           $method
      * @param array            $arguments
      * @param integer          $result
@@ -100,57 +95,43 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
         $this->exception = $exception;
     }
 
-    /**
-     * @return Matcher
-     */
+    
     public function getMatcher(): Matcher
     {
         return $this->matcher;
     }
 
-    /**
-     * @return ExampleNode
-     */
+    
     public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
-    /**
-     * @return SpecificationNode
-     */
+    
     public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
-    /**
-     * @return Suite
-     */
+    
     public function getSuite(): Suite
     {
         return $this->example->getSpecification()->getSuite();
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getSubject()
     {
         return $this->subject;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getMethod(): string
     {
         return $this->method;
     }
 
-    /**
-     * @return array
-     */
+    
     public function getArguments(): array
     {
         return $this->arguments;

--- a/src/PhpSpec/Event/FileCreationEvent.php
+++ b/src/PhpSpec/Event/FileCreationEvent.php
@@ -26,9 +26,7 @@ final class FileCreationEvent extends BaseEvent implements PhpSpecEvent
         $this->filepath = $filepath;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getFilePath(): string
     {
         return $this->filepath;

--- a/src/PhpSpec/Event/MethodCallEvent.php
+++ b/src/PhpSpec/Event/MethodCallEvent.php
@@ -27,9 +27,7 @@ class MethodCallEvent extends BaseEvent implements PhpSpecEvent
      */
     private $example;
 
-    /**
-     * @var mixed
-     */
+    
     private $subject;
 
     /**
@@ -42,17 +40,12 @@ class MethodCallEvent extends BaseEvent implements PhpSpecEvent
      */
     private $arguments;
 
-    /**
-     * @var mixed
-     */
+    
     private $returnValue;
 
     /**
-     * @param ExampleNode $example
-     * @param mixed       $subject
      * @param string      $method
      * @param array       $arguments
-     * @param mixed       $returnValue
      */
     public function __construct(ExampleNode $example, $subject, $method, $arguments, $returnValue = null)
     {
@@ -63,57 +56,43 @@ class MethodCallEvent extends BaseEvent implements PhpSpecEvent
         $this->returnValue = $returnValue;
     }
 
-    /**
-     * @return ExampleNode
-     */
+    
     public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
-    /**
-     * @return SpecificationNode
-     */
+    
     public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
-    /**
-     * @return Suite
-     */
+    
     public function getSuite(): Suite
     {
         return $this->example->getSpecification()->getSuite();
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getSubject()
     {
         return $this->subject;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getMethod(): string
     {
         return $this->method;
     }
 
-    /**
-     * @return array
-     */
+    
     public function getArguments(): array
     {
         return $this->arguments;
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getReturnValue()
     {
         return $this->returnValue;

--- a/src/PhpSpec/Event/SpecificationEvent.php
+++ b/src/PhpSpec/Event/SpecificationEvent.php
@@ -37,8 +37,6 @@ class SpecificationEvent extends BaseEvent implements PhpSpecEvent
     private $result;
 
     /**
-     * @param SpecificationNode $specification
-     * @param float             $time
      * @param integer           $result
      */
     public function __construct(SpecificationNode $specification, float $time = 0.0, int $result = 0)
@@ -48,33 +46,25 @@ class SpecificationEvent extends BaseEvent implements PhpSpecEvent
         $this->result        = $result;
     }
 
-    /**
-     * @return SpecificationNode
-     */
+    
     public function getSpecification(): SpecificationNode
     {
         return $this->specification;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getTitle(): string
     {
         return $this->specification->getTitle();
     }
 
-    /**
-     * @return Suite
-     */
+    
     public function getSuite(): Suite
     {
         return $this->specification->getSuite();
     }
 
-    /**
-     * @return float
-     */
+    
     public function getTime(): float
     {
         return $this->time;

--- a/src/PhpSpec/Event/SuiteEvent.php
+++ b/src/PhpSpec/Event/SuiteEvent.php
@@ -41,8 +41,6 @@ class SuiteEvent extends BaseEvent implements PhpSpecEvent
     private $worthRerunning = false;
 
     /**
-     * @param Suite   $suite
-     * @param float   $time
      * @param integer $result
      */
     public function __construct(Suite $suite, float $time = 0.0, int $result = 0)
@@ -52,17 +50,13 @@ class SuiteEvent extends BaseEvent implements PhpSpecEvent
         $this->result = $result;
     }
 
-    /**
-     * @return Suite
-     */
+    
     public function getSuite(): Suite
     {
         return $this->suite;
     }
 
-    /**
-     * @return float
-     */
+    
     public function getTime(): float
     {
         return $this->time;
@@ -76,9 +70,7 @@ class SuiteEvent extends BaseEvent implements PhpSpecEvent
         return $this->result;
     }
 
-    /**
-     * @return bool
-     */
+    
     public function isWorthRerunning(): bool
     {
         return $this->worthRerunning;

--- a/src/PhpSpec/Exception/Example/NotEqualException.php
+++ b/src/PhpSpec/Exception/Example/NotEqualException.php
@@ -18,21 +18,13 @@ namespace PhpSpec\Exception\Example;
  */
 class NotEqualException extends FailureException
 {
-    /**
-     * @var mixed
-     */
+    
     private $expected;
 
-    /**
-     * @var mixed
-     */
+    
     private $actual;
 
-    /**
-     * @param string $message
-     * @param mixed  $expected
-     * @param mixed  $actual
-     */
+    
     public function __construct(string $message, $expected, $actual)
     {
         parent::__construct($message);
@@ -41,25 +33,19 @@ class NotEqualException extends FailureException
         $this->actual   = $actual;
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getExpected()
     {
         return $this->expected;
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getActual()
     {
         return $this->actual;
     }
 
-    /**
-     * @return string
-     */
+    
     public function __toString(): string
     {
         return var_export(array($this->expected, $this->actual), true);

--- a/src/PhpSpec/Exception/Example/PendingException.php
+++ b/src/PhpSpec/Exception/Example/PendingException.php
@@ -18,9 +18,7 @@ namespace PhpSpec\Exception\Example;
  */
 class PendingException extends ExampleException
 {
-    /**
-     * @param string $text
-     */
+    
     public function __construct(string $text = 'write pending example')
     {
         parent::__construct(sprintf('todo: %s', $text));

--- a/src/PhpSpec/Exception/Example/SkippingException.php
+++ b/src/PhpSpec/Exception/Example/SkippingException.php
@@ -15,9 +15,7 @@ namespace PhpSpec\Exception\Example;
 
 class SkippingException extends ExampleException
 {
-    /**
-     * @param string $text
-     */
+    
     public function __construct(string $text)
     {
         parent::__construct(sprintf('skipped: %s', $text));

--- a/src/PhpSpec/Exception/Exception.php
+++ b/src/PhpSpec/Exception/Exception.php
@@ -25,17 +25,13 @@ class Exception extends \Exception
      */
     private $cause;
 
-    /**
-     * @return ReflectionFunctionAbstract
-     */
+    
     public function getCause(): ReflectionFunctionAbstract
     {
         return $this->cause;
     }
 
-    /**
-     * @param ReflectionFunctionAbstract $cause
-     */
+    
     public function setCause(ReflectionFunctionAbstract $cause): void
     {
         $this->cause = $cause;

--- a/src/PhpSpec/Exception/ExceptionFactory.php
+++ b/src/PhpSpec/Exception/ExceptionFactory.php
@@ -27,21 +27,13 @@ class ExceptionFactory
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $classname
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return Fracture\NamedConstructorNotFoundException
-     */
+    
     public function namedConstructorNotFound(string $classname, string $method, array $arguments = array()): Fracture\NamedConstructorNotFoundException
     {
         $instantiator = new Instantiator();
@@ -57,13 +49,7 @@ class ExceptionFactory
         );
     }
 
-    /**
-     * @param string $classname
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return Fracture\MethodNotFoundException
-     */
+    
     public function methodNotFound(string $classname, string $method, array $arguments = array()): Fracture\MethodNotFoundException
     {
         $instantiator = new Instantiator();
@@ -78,13 +64,7 @@ class ExceptionFactory
         );
     }
 
-    /**
-     * @param string $classname
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return Fracture\MethodNotVisibleException
-     */
+    
     public function methodNotVisible(string $classname, string $method, array $arguments = array()): Fracture\MethodNotVisibleException
     {
         $instantiator = new Instantiator();
@@ -99,11 +79,7 @@ class ExceptionFactory
         );
     }
 
-    /**
-     * @param string $classname
-     *
-     * @return Fracture\ClassNotFoundException
-     */
+    
     public function classNotFound(string $classname): Fracture\ClassNotFoundException
     {
         $message = sprintf('Class %s does not exist.', $this->presenter->presentString($classname));
@@ -112,10 +88,8 @@ class ExceptionFactory
     }
 
     /**
-     * @param mixed  $subject
      * @param string $property
      *
-     * @return Fracture\PropertyNotFoundException
      */
     public function propertyNotFound($subject, $property): Fracture\PropertyNotFoundException
     {
@@ -124,11 +98,7 @@ class ExceptionFactory
         return new Fracture\PropertyNotFoundException($message, $subject, $property);
     }
 
-    /**
-     * @param string $method
-     *
-     * @return SubjectException
-     */
+    
     public function callingMethodOnNonObject(string $method): SubjectException
     {
         return new SubjectException(sprintf(
@@ -137,11 +107,7 @@ class ExceptionFactory
         ));
     }
 
-    /**
-     * @param string $property
-     *
-     * @return SubjectException
-     */
+    
     public function settingPropertyOnNonObject(string $property): SubjectException
     {
         return new SubjectException(sprintf(
@@ -150,11 +116,7 @@ class ExceptionFactory
         ));
     }
 
-    /**
-     * @param string $property
-     *
-     * @return SubjectException
-     */
+    
     public function gettingPropertyOnNonObject(string $property): SubjectException
     {
         return new SubjectException(sprintf(

--- a/src/PhpSpec/Exception/Fracture/ClassNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/ClassNotFoundException.php
@@ -23,10 +23,7 @@ class ClassNotFoundException extends FractureException
      */
     private $classname;
 
-    /**
-     * @param string $message
-     * @param string $classname
-     */
+    
     public function __construct(string $message, string $classname)
     {
         parent::__construct($message);
@@ -34,9 +31,7 @@ class ClassNotFoundException extends FractureException
         $this->classname = $classname;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getClassname(): string
     {
         return $this->classname;

--- a/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
@@ -26,11 +26,8 @@ class CollaboratorNotFoundException extends FractureException
     private $collaboratorName;
 
     /**
-     * @param string $message
      * @param integer $code
      * @param Exception $previous
-     * @param ReflectionParameter|null $reflectionParameter
-     * @param string|null $className
      */
     public function __construct(
         string $message,
@@ -49,19 +46,13 @@ class CollaboratorNotFoundException extends FractureException
         parent::__construct($message . ': ' . $this->collaboratorName, $code, $previous);
     }
 
-    /**
-     * @return string
-     */
+    
     public function getCollaboratorName(): string
     {
         return $this->collaboratorName;
     }
 
-    /**
-     * @param ReflectionParameter $parameter
-     *
-     * @return string
-     */
+    
     private function extractCollaboratorName(ReflectionParameter $parameter): string
     {
         if (preg_match(self::CLASSNAME_REGEX, (string)$parameter, $matches)) {

--- a/src/PhpSpec/Exception/Fracture/InterfaceNotImplementedException.php
+++ b/src/PhpSpec/Exception/Fracture/InterfaceNotImplementedException.php
@@ -19,9 +19,7 @@ namespace PhpSpec\Exception\Fracture;
  */
 class InterfaceNotImplementedException extends FractureException
 {
-    /**
-     * @var mixed
-     */
+    
     private $subject;
 
     /**
@@ -30,8 +28,6 @@ class InterfaceNotImplementedException extends FractureException
     private $interface;
 
     /**
-     * @param string $message
-     * @param mixed  $subject
      * @param string $interface
      */
     public function __construct(string $message, $subject, $interface)
@@ -42,17 +38,13 @@ class InterfaceNotImplementedException extends FractureException
         $this->interface = $interface;
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getSubject()
     {
         return $this->subject;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getInterface(): string
     {
         return $this->interface;

--- a/src/PhpSpec/Exception/Fracture/MethodInvocationException.php
+++ b/src/PhpSpec/Exception/Fracture/MethodInvocationException.php
@@ -19,9 +19,7 @@ namespace PhpSpec\Exception\Fracture;
  */
 abstract class MethodInvocationException extends FractureException
 {
-    /**
-     * @var mixed
-     */
+    
     private $subject;
 
     /**
@@ -35,10 +33,7 @@ abstract class MethodInvocationException extends FractureException
     private $arguments;
 
     /**
-     * @param string $message
-     * @param mixed  $subject
      * @param string $method
-     * @param array  $arguments
      */
     public function __construct(string $message, $subject, $method, array $arguments = array())
     {
@@ -49,25 +44,19 @@ abstract class MethodInvocationException extends FractureException
         $this->arguments = $arguments;
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getSubject()
     {
         return $this->subject;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getMethodName(): string
     {
         return $this->method;
     }
 
-    /**
-     * @return array
-     */
+    
     public function getArguments(): array
     {
         return $this->arguments;

--- a/src/PhpSpec/Exception/Fracture/PropertyNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/PropertyNotFoundException.php
@@ -19,9 +19,7 @@ namespace PhpSpec\Exception\Fracture;
  */
 class PropertyNotFoundException extends FractureException
 {
-    /**
-     * @var mixed
-     */
+    
     private $subject;
 
     /**
@@ -30,8 +28,6 @@ class PropertyNotFoundException extends FractureException
     private $property;
 
     /**
-     * @param string $message
-     * @param mixed  $subject
      * @param string $property
      */
     public function __construct(string $message, $subject, $property)
@@ -42,17 +38,13 @@ class PropertyNotFoundException extends FractureException
         $this->property  = $property;
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getSubject()
     {
         return $this->subject;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getProperty(): string
     {
         return $this->property;

--- a/src/PhpSpec/Exception/Wrapper/MatcherNotFoundException.php
+++ b/src/PhpSpec/Exception/Wrapper/MatcherNotFoundException.php
@@ -26,9 +26,7 @@ class MatcherNotFoundException extends Exception
      */
     private $keyword;
 
-    /**
-     * @var mixed
-     */
+    
     private $subject;
 
     /**
@@ -36,12 +34,7 @@ class MatcherNotFoundException extends Exception
      */
     private $arguments;
 
-    /**
-     * @param string $message
-     * @param string $keyword
-     * @param mixed  $subject
-     * @param array  $arguments
-     */
+    
     public function __construct(string $message, string $keyword, $subject, array $arguments)
     {
         parent::__construct($message);
@@ -51,25 +44,19 @@ class MatcherNotFoundException extends Exception
         $this->arguments = $arguments;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getKeyword(): string
     {
         return $this->keyword;
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getSubject()
     {
         return $this->subject;
     }
 
-    /**
-     * @return array
-     */
+    
     public function getArguments(): array
     {
         return $this->arguments;

--- a/src/PhpSpec/Extension.php
+++ b/src/PhpSpec/Extension.php
@@ -19,9 +19,6 @@ namespace PhpSpec;
  */
 interface Extension
 {
-    /**
-     * @param ServiceContainer $container
-     * @param array            $params
-     */
+    
     public function load(ServiceContainer $container, array $params);
 }

--- a/src/PhpSpec/Factory/ReflectionFactory.php
+++ b/src/PhpSpec/Factory/ReflectionFactory.php
@@ -21,7 +21,6 @@ class ReflectionFactory
 {
     /**
      * @param $class
-     * @return \ReflectionClass
      */
     public function create($class): \ReflectionClass
     {

--- a/src/PhpSpec/Formatter/BasicFormatter.php
+++ b/src/PhpSpec/Formatter/BasicFormatter.php
@@ -45,9 +45,7 @@ abstract class BasicFormatter implements EventSubscriberInterface
         $this->stats = $stats;
     }
 
-    /**
-     * @return array
-     */
+    
     public static function getSubscribedEvents(): array
     {
         $events = array(
@@ -59,68 +57,50 @@ abstract class BasicFormatter implements EventSubscriberInterface
         return array_combine($events, $events);
     }
 
-    /**
-     * @return IO
-     */
+    
     protected function getIO(): IO
     {
         return $this->io;
     }
 
-    /**
-     * @return Presenter
-     */
+    
     protected function getPresenter(): Presenter
     {
         return $this->presenter;
     }
 
-    /**
-     * @return StatisticsCollector
-     */
+    
     protected function getStatisticsCollector(): StatisticsCollector
     {
         return $this->stats;
     }
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function beforeSuite(SuiteEvent $event)
     {
     }
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function afterSuite(SuiteEvent $event)
     {
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     public function beforeExample(ExampleEvent $event)
     {
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     public function afterExample(ExampleEvent $event)
     {
     }
 
-    /**
-     * @param SpecificationEvent $event
-     */
+    
     public function beforeSpecification(SpecificationEvent $event)
     {
     }
 
-    /**
-     * @param SpecificationEvent $event
-     */
+    
     public function afterSpecification(SpecificationEvent $event)
     {
     }

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -29,28 +29,20 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
      */
     private $io;
 
-    /**
-     * @param Presenter           $presenter
-     * @param ConsoleIO           $io
-     * @param StatisticsCollector $stats
-     */
+    
     public function __construct(Presenter $presenter, ConsoleIO $io, StatisticsCollector $stats)
     {
         parent::__construct($presenter, $io, $stats);
         $this->io = $io;
     }
 
-    /**
-     * @return IO
-     */
+    
     protected function getIO(): IO
     {
         return $this->io;
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     protected function printException(ExampleEvent $event): void
     {
         if (null === $exception = $event->getException()) {
@@ -70,10 +62,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
         }
     }
 
-    /**
-     * @param ExampleEvent $event
-     * @param string $type
-     */
+    
     protected function printSpecificException(ExampleEvent $event, string $type): void
     {
         $title = str_replace('\\', DIRECTORY_SEPARATOR, $event->getSpecification()->getTitle());

--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -23,17 +23,13 @@ final class DotFormatter extends ConsoleFormatter
      */
     private $examplesCount = 0;
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function beforeSuite(SuiteEvent $event)
     {
         $this->examplesCount = \count($event->getSuite());
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     public function afterExample(ExampleEvent $event)
     {
         $io = $this->getIO();
@@ -81,9 +77,7 @@ final class DotFormatter extends ConsoleFormatter
         }
     }
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function afterSuite(SuiteEvent $event)
     {
         $this->getIO()->writeln("\n");

--- a/src/PhpSpec/Formatter/Html/HtmlIO.php
+++ b/src/PhpSpec/Formatter/Html/HtmlIO.php
@@ -25,9 +25,7 @@ final class HtmlIO implements IO
         echo $message;
     }
 
-    /**
-     * @return bool
-     */
+    
     public function isVerbose(): bool
     {
         return true;

--- a/src/PhpSpec/Formatter/Html/ReportFailedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportFailedItem.php
@@ -36,11 +36,7 @@ class ReportFailedItem
      */
     private $presenter;
 
-    /**
-     * @param TemplateInterface $template
-     * @param ExampleEvent      $event
-     * @param Presenter         $presenter
-     */
+    
     public function __construct(TemplateInterface $template, ExampleEvent $event, Presenter $presenter)
     {
         $this->template = $template;
@@ -48,9 +44,7 @@ class ReportFailedItem
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param int $index
-     */
+    
     public function write(int $index): void
     {
         $code = $this->presenter->presentException($this->event->getException(), true);
@@ -67,9 +61,7 @@ class ReportFailedItem
         );
     }
 
-    /**
-     * @return string
-     */
+    
     private function formatBacktrace() : string
     {
         $backtrace = '';

--- a/src/PhpSpec/Formatter/Html/ReportItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportItem.php
@@ -15,8 +15,6 @@ namespace PhpSpec\Formatter\Html;
 
 interface ReportItem
 {
-    /**
-     * @return void
-     */
+    
     public function write(): void;
 }

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -24,17 +24,13 @@ class ReportItemFactory
      */
     private $template;
 
-    /**
-     * @param TemplateInterface $template
-     */
+    
     public function __construct(TemplateInterface $template)
     {
         $this->template = $template;
     }
 
     /**
-     * @param ExampleEvent $event
-     * @param Presenter    $presenter
      *
      * @return ReportFailedItem|ReportPassedItem|ReportPendingItem|ReportSkippedItem
      */

--- a/src/PhpSpec/Formatter/Html/ReportPassedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPassedItem.php
@@ -27,10 +27,7 @@ class ReportPassedItem
      */
     private $event;
 
-    /**
-     * @param TemplateInterface $template
-     * @param ExampleEvent      $event
-     */
+    
     public function __construct(TemplateInterface $template, ExampleEvent $event)
     {
         $this->template = $template;

--- a/src/PhpSpec/Formatter/Html/ReportPendingItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPendingItem.php
@@ -31,10 +31,7 @@ class ReportPendingItem
      */
     private static $pendingExamplesCount = 1;
 
-    /**
-     * @param TemplateInterface $template
-     * @param ExampleEvent      $event
-     */
+    
     public function __construct(TemplateInterface $template, ExampleEvent $event)
     {
         $this->template = $template;

--- a/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
@@ -27,10 +27,7 @@ class ReportSkippedItem
      */
     private $event;
 
-    /**
-     * @param TemplateInterface $template
-     * @param ExampleEvent      $event
-     */
+    
     public function __construct(TemplateInterface $template, ExampleEvent $event)
     {
         $this->template = $template;

--- a/src/PhpSpec/Formatter/Html/Template.php
+++ b/src/PhpSpec/Formatter/Html/Template.php
@@ -25,18 +25,13 @@ final class Template implements TemplateInterface
      */
     private $io;
 
-    /**
-     * @param IO $io
-     */
+    
     public function __construct(IO $io)
     {
         $this->io = $io;
     }
 
-    /**
-     * @param string $text
-     * @param array  $templateVars
-     */
+    
     public function render(string $text, array $templateVars = array()): void
     {
         if (file_exists($text)) {
@@ -47,11 +42,7 @@ final class Template implements TemplateInterface
         $this->io->write($output);
     }
 
-    /**
-     * @param array $templateVars
-     *
-     * @return array
-     */
+    
     private function extractKeys(array $templateVars): array
     {
         return array_map(function ($e) {

--- a/src/PhpSpec/Formatter/HtmlFormatter.php
+++ b/src/PhpSpec/Formatter/HtmlFormatter.php
@@ -43,17 +43,13 @@ final class HtmlFormatter extends BasicFormatter
         parent::__construct($presenter, $io, $stats);
     }
 
-    /**
-     * @param SuiteEvent $suite
-     */
+    
     public function beforeSuite(SuiteEvent $suite)
     {
         include __DIR__."/Html/Template/ReportHeader.html";
     }
 
-    /**
-     * @param SpecificationEvent $specification
-     */
+    
     public function beforeSpecification(SpecificationEvent $specification)
     {
         $index = $this->index++;
@@ -61,17 +57,13 @@ final class HtmlFormatter extends BasicFormatter
         include __DIR__."/Html/Template/ReportSpecificationStarts.html";
     }
 
-    /**
-     * @param SpecificationEvent $specification
-     */
+    
     public function afterSpecification(SpecificationEvent $specification)
     {
         include __DIR__."/Html/Template/ReportSpecificationEnds.html";
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     public function afterExample(ExampleEvent $event)
     {
         $reportLine = $this->reportItemFactory->create($event, $this->getPresenter());
@@ -79,9 +71,7 @@ final class HtmlFormatter extends BasicFormatter
         $this->getIO()->write(PHP_EOL);
     }
 
-    /**
-     * @param SuiteEvent $suite
-     */
+    
     public function afterSuite(SuiteEvent $suite)
     {
         include __DIR__."/Html/Template/ReportSummary.html";

--- a/src/PhpSpec/Formatter/JUnitFormatter.php
+++ b/src/PhpSpec/Formatter/JUnitFormatter.php
@@ -62,7 +62,6 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Set testcase nodes
      *
-     * @param array $testCaseNodes
      */
     public function setTestCaseNodes(array $testCaseNodes): void
     {
@@ -72,7 +71,6 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Get testcase nodes
      *
-     * @return array
      */
     public function getTestCaseNodes(): array
     {
@@ -82,7 +80,6 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Set testsuite nodes
      *
-     * @param array $testSuiteNodes
      */
     public function setTestSuiteNodes(array $testSuiteNodes)
     {
@@ -92,7 +89,6 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Get testsuite nodes
      *
-     * @return array
      */
     public function getTestSuiteNodes(): array
     {
@@ -102,7 +98,6 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Set example status counts
      *
-     * @param array $exampleStatusCounts
      */
     public function setExampleStatusCounts(array $exampleStatusCounts)
     {
@@ -112,7 +107,6 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Get example status counts
      *
-     * @return array
      */
     public function getExampleStatusCounts(): array
     {

--- a/src/PhpSpec/Formatter/Presenter/Differ/DifferEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/DifferEngine.php
@@ -15,19 +15,9 @@ namespace PhpSpec\Formatter\Presenter\Differ;
 
 interface DifferEngine
 {
-    /**
-     * @param mixed $expected
-     * @param mixed $actual
-     *
-     * @return bool
-     */
+    
     public function supports($expected, $actual): bool;
 
-    /**
-     * @param mixed $expected
-     * @param mixed $actual
-     *
-     * @return string
-     */
+    
     public function compare($expected, $actual): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
@@ -26,22 +26,14 @@ final class ObjectEngine implements DifferEngine
      */
     private $stringDiffer;
 
-    /**
-     * @param Exporter     $exporter
-     * @param StringEngine $stringDiffer
-     */
+    
     public function __construct(Exporter $exporter, StringEngine $stringDiffer)
     {
         $this->exporter = $exporter;
         $this->stringDiffer = $stringDiffer;
     }
 
-    /**
-     * @param mixed $expected
-     * @param mixed $actual
-     *
-     * @return bool
-     */
+    
     public function supports($expected, $actual): bool
     {
         return \is_object($expected) && \is_object($actual);
@@ -51,7 +43,6 @@ final class ObjectEngine implements DifferEngine
      * @param object $expected
      * @param object $actual
      *
-     * @return string
      */
     public function compare($expected, $actual): string
     {

--- a/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
@@ -17,10 +17,7 @@ use PhpSpec\Exception\Exception;
 
 abstract class AbstractPhpSpecExceptionPresenter
 {
-    /**
-     * @param Exception $exception
-     * @return string
-     */
+    
     public function presentException(Exception $exception): string
     {
         list($file, $line) = $this->getExceptionExamplePosition($exception);
@@ -28,10 +25,7 @@ abstract class AbstractPhpSpecExceptionPresenter
         return $this->presentFileCode($file, $line);
     }
 
-    /**
-     * @param Exception $exception
-     * @return array
-     */
+    
     private function getExceptionExamplePosition(Exception $exception): array
     {
         $cause = $exception->getCause();
@@ -50,11 +44,9 @@ abstract class AbstractPhpSpecExceptionPresenter
     }
 
     /**
-     * @param string  $file
      * @param integer $lineno
      * @param integer $context
      *
-     * @return string
      */
     abstract protected function presentFileCode(string $file, int $lineno, int $context = 6): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
@@ -25,18 +25,13 @@ class CallArgumentsPresenter
      */
     private $differ;
 
-    /**
-     * @param Differ $differ
-     */
+    
     public function __construct(Differ $differ)
     {
         $this->differ = $differ;
     }
 
-    /**
-     * @param UnexpectedCallException $exception
-     * @return string
-     */
+    
     public function presentDifference(UnexpectedCallException $exception): string
     {
         $actualArguments = $exception->getArguments();
@@ -64,7 +59,6 @@ class CallArgumentsPresenter
 
     /**
      * @param MethodProphecy[] $methodProphecies
-     * @return bool
      */
     private function noMethodPropheciesForUnexpectedCall(array $methodProphecies): bool
     {
@@ -73,7 +67,6 @@ class CallArgumentsPresenter
 
     /**
      * @param MethodProphecy[] $methodProphecies
-     * @param UnexpectedCallException $exception
      *
      * @return MethodProphecy|null
      */
@@ -99,22 +92,13 @@ class CallArgumentsPresenter
         return null;
     }
 
-    /**
-     * @param array $expectedTokens
-     * @param array $actualArguments
-     *
-     * @return bool
-     */
+    
     private function parametersCountMismatch(array $expectedTokens, array $actualArguments): bool
     {
         return \count($expectedTokens) !== \count($actualArguments);
     }
 
-    /**
-     * @param array $tokens
-     *
-     * @return array
-     */
+    
     private function convertArgumentTokensToDiffableValues(array $tokens): array
     {
         $values = array();
@@ -129,12 +113,7 @@ class CallArgumentsPresenter
         return $values;
     }
 
-    /**
-     * @param array $actualArguments
-     * @param array $expectedArguments
-     *
-     * @return string
-     */
+    
     private function generateArgumentsDifferenceText(array $actualArguments, array $expectedArguments): string
     {
         $text = '';

--- a/src/PhpSpec/Formatter/Presenter/Exception/ExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/ExceptionElementPresenter.php
@@ -16,44 +16,21 @@ namespace PhpSpec\Formatter\Presenter\Exception;
 
 interface ExceptionElementPresenter
 {
-    /**
-     * @param \Exception $exception
-     * @return string
-     */
+    
     public function presentExceptionThrownMessage(\Exception $exception): string;
 
-    /**
-     * @param string $number
-     * @param string $line
-     * @return string
-     */
+    
     public function presentCodeLine(string $number, string $line): string;
 
-    /**
-     * @param string $line
-     * @return string
-     */
+    
     public function presentHighlight(string $line): string;
 
-    /**
-     * @param string $header
-     * @return string
-     */
+    
     public function presentExceptionTraceHeader(string $header): string;
 
-    /**
-     * @param string $class
-     * @param string $type
-     * @param string $method
-     * @param array $args
-     * @return string
-     */
+    
     public function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string;
 
-    /**
-     * @param string $function
-     * @param array $args
-     * @return string
-     */
+    
     public function presentExceptionTraceFunction(string $function, array $args): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/ExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/ExceptionPresenter.php
@@ -15,10 +15,6 @@ namespace PhpSpec\Formatter\Presenter\Exception;
 
 interface ExceptionPresenter
 {
-    /**
-     * @param \Exception $exception
-     * @param bool $verbose
-     * @return string
-     */
+    
     public function presentException(\Exception $exception, bool $verbose = false): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
@@ -20,20 +20,16 @@ final class GenericPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPre
      */
     private $exceptionElementPresenter;
 
-    /**
-     * @param ExceptionElementPresenter $exceptionElementPresenter
-     */
+    
     public function __construct(ExceptionElementPresenter $exceptionElementPresenter)
     {
         $this->exceptionElementPresenter = $exceptionElementPresenter;
     }
 
     /**
-     * @param string  $file
      * @param integer $lineno
      * @param integer $context
      *
-     * @return string
      */
     protected function presentFileCode(string $file, int $lineno, int $context = 6): string
     {

--- a/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
@@ -16,11 +16,9 @@ namespace PhpSpec\Formatter\Presenter\Exception;
 final class HtmlPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresenter implements PhpSpecExceptionPresenter
 {
     /**
-     * @param string  $file
      * @param integer $lineno
      * @param integer $context
      *
-     * @return string
      */
     protected function presentFileCode(string $file, int $lineno, int $context = 6): string
     {

--- a/src/PhpSpec/Formatter/Presenter/Exception/PhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/PhpSpecExceptionPresenter.php
@@ -18,9 +18,6 @@ use PhpSpec\Exception\Exception;
 
 interface PhpSpecExceptionPresenter
 {
-    /**
-     * @param Exception $exception
-     * @return string
-     */
+    
     public function presentException(Exception $exception): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
@@ -28,20 +28,14 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
      */
     private $valuePresenter;
 
-    /**
-     * @param ExceptionTypePresenter $exceptionTypePresenter
-     * @param ValuePresenter $valuePresenter
-     */
+    
     public function __construct(ExceptionTypePresenter $exceptionTypePresenter, ValuePresenter $valuePresenter)
     {
         $this->exceptionTypePresenter = $exceptionTypePresenter;
         $this->valuePresenter = $valuePresenter;
     }
 
-    /**
-     * @param \Exception $exception
-     * @return string
-     */
+    
     public function presentExceptionThrownMessage(\Exception $exception): string
     {
         return sprintf(
@@ -50,60 +44,37 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
         );
     }
 
-    /**
-     * @param string $number
-     * @param string $line
-     * @return string
-     */
+    
     public function presentCodeLine(string $number, string $line): string
     {
         return sprintf('%s %s', $number, $line);
     }
 
-    /**
-     * @param string $line
-     * @return string
-     */
+    
     public function presentHighlight(string $line): string
     {
         return $line;
     }
 
-    /**
-     * @param string $header
-     * @return string
-     */
+    
     public function presentExceptionTraceHeader(string $header): string
     {
         return $header;
     }
 
-    /**
-     * @param string $class
-     * @param string $type
-     * @param string $method
-     * @param array $args
-     * @return string
-     */
+    
     public function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         return sprintf('   %s%s%s(%s)', $class, $type, $method, $this->presentExceptionTraceArguments($args));
     }
 
-    /**
-     * @param string $function
-     * @param array $args
-     * @return string
-     */
+    
     public function presentExceptionTraceFunction(string $function, array $args): string
     {
         return sprintf('   %s(%s)', $function, $this->presentExceptionTraceArguments($args));
     }
 
-    /**
-     * @param array $args
-     * @return string
-     */
+    
     private function presentExceptionTraceArguments(array $args): string
     {
         return implode(', ', array_map(array($this->valuePresenter, 'presentValue'), $args));

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -53,12 +53,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
      */
     private $phpspecExceptionPresenter;
 
-    /**
-     * @param Differ $differ
-     * @param ExceptionElementPresenter $exceptionElementPresenter
-     * @param CallArgumentsPresenter $callArgumentsPresenter
-     * @param PhpSpecExceptionPresenter $phpspecExceptionPresenter
-     */
+    
     public function __construct(
         Differ $differ,
         ExceptionElementPresenter $exceptionElementPresenter,
@@ -74,11 +69,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         $this->runnerPath  = $this->phpspecPath.DIRECTORY_SEPARATOR.'Runner';
     }
 
-    /**
-     * @param \Exception $exception
-     * @param bool $verbose
-     * @return string
-     */
+    
     public function presentException(\Exception $exception, bool $verbose = false): string
     {
         if ($exception instanceof PhpSpecException) {
@@ -96,11 +87,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return $this->getVerbosePresentation($exception, $presentation);
     }
 
-    /**
-     * @param \Exception $exception
-     * @param string $presentation
-     * @return string
-     */
+    
     private function getVerbosePresentation(\Exception $exception, string $presentation): string
     {
         if ($exception instanceof NotEqualException) {
@@ -120,11 +107,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return $presentation . $this->presentExceptionStackTrace($exception);
     }
 
-    /**
-     * @param NotEqualException $exception
-     *
-     * @return string
-     */
+    
     private function presentExceptionDifference(NotEqualException $exception): string
     {
         $diff = $this->differ->compare($exception->getExpected(), $exception->getActual());
@@ -132,11 +115,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return $diff === null ? '' : $diff;
     }
 
-    /**
-     * @param \Exception $exception
-     *
-     * @return string
-     */
+    
     private function presentExceptionStackTrace(\Exception $exception): string
     {
         $offset = 0;
@@ -163,47 +142,25 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return empty($text) ? $text : PHP_EOL . $text;
     }
 
-    /**
-     * @param string $header
-     *
-     * @return string
-     */
+    
     private function presentExceptionTraceHeader(string $header): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceHeader($header) . PHP_EOL;
     }
 
-    /**
-     * @param string $class
-     * @param string $type
-     * @param string $method
-     * @param array  $args
-     *
-     * @return string
-     */
+    
     private function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceMethod($class, $type, $method, $args) . PHP_EOL;
     }
 
-    /**
-     * @param string $function
-     * @param array  $args
-     *
-     * @return string
-     */
+    
     private function presentExceptionTraceFunction(string $function, array $args): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceFunction($function, $args) . PHP_EOL;
     }
 
-    /**
-     * @param int    $offset
-     * @param string $file
-     * @param int    $line
-     *
-     * @return string
-     */
+    
     private function presentExceptionTraceLocation(int $offset, string $file, int $line): string
     {
         return $this->presentExceptionTraceHeader(sprintf(
@@ -214,19 +171,13 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         ));
     }
 
-    /**
-     * @param array $call
-     * @return bool
-     */
+    
     private function shouldStopTracePresentation(array $call): bool
     {
         return isset($call['file']) && false !== strpos($call['file'], $this->runnerPath);
     }
 
-    /**
-     * @param array $call
-     * @return bool
-     */
+    
     private function shouldSkipTracePresentation(array $call): bool
     {
         if (isset($call['file']) && 0 === strpos($call['file'], $this->phpspecPath)) {
@@ -236,11 +187,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return isset($call['class']) && 0 === strpos($call['class'], "PhpSpec\\");
     }
 
-    /**
-     * @param array $call
-     * @param int $offset
-     * @return string
-     */
+    
     private function presentExceptionTraceDetails(array $call, int $offset): string
     {
         $text = '';

--- a/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
@@ -28,20 +28,14 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
      */
     private $valuePresenter;
 
-    /**
-     * @param ExceptionTypePresenter $exceptionTypePresenter
-     * @param ValuePresenter $valuePresenter
-     */
+    
     public function __construct(ExceptionTypePresenter $exceptionTypePresenter, ValuePresenter $valuePresenter)
     {
         $this->exceptionTypePresenter = $exceptionTypePresenter;
         $this->valuePresenter = $valuePresenter;
     }
 
-    /**
-     * @param \Exception $exception
-     * @return string
-     */
+    
     public function presentExceptionThrownMessage(\Exception $exception): string
     {
         return sprintf(
@@ -50,41 +44,25 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
         );
     }
 
-    /**
-     * @param string $number
-     * @param string $line
-     * @return string
-     */
+    
     public function presentCodeLine(string $number, string $line): string
     {
         return sprintf('<lineno>%s</lineno> <code>%s</code>', $number, $line);
     }
 
-    /**
-     * @param string $line
-     * @return string
-     */
+    
     public function presentHighlight(string $line): string
     {
         return sprintf('<hl>%s</hl>', $line);
     }
 
-    /**
-     * @param string $header
-     * @return string
-     */
+    
     public function presentExceptionTraceHeader(string $header): string
     {
         return sprintf('<trace>%s</trace>', $header);
     }
 
-    /**
-     * @param string $class
-     * @param string $type
-     * @param string $method
-     * @param array $args
-     * @return string
-     */
+    
     public function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         $template = '   <trace><trace-class>%s</trace-class><trace-type>%s</trace-type>'.
@@ -93,11 +71,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
         return sprintf($template, $class, $type, $method, $this->presentExceptionTraceArguments($args));
     }
 
-    /**
-     * @param string $function
-     * @param array $args
-     * @return string
-     */
+    
     public function presentExceptionTraceFunction(string $function, array $args): string
     {
         $template = '   <trace><trace-func>%s</trace-func>(<trace-args>%s</trace-args>)</trace>';
@@ -105,10 +79,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
         return sprintf($template, $function, $this->presentExceptionTraceArguments($args));
     }
 
-    /**
-     * @param array $args
-     * @return string
-     */
+    
     private function presentExceptionTraceArguments(array $args): string
     {
         $valuePresenter = $this->valuePresenter;

--- a/src/PhpSpec/Formatter/Presenter/Presenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Presenter.php
@@ -18,10 +18,6 @@ use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 interface Presenter extends ExceptionPresenter, ValuePresenter
 {
-    /**
-     * @param string $string
-     *
-     * @return string
-     */
+    
     public function presentString(string $string): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
@@ -28,42 +28,26 @@ final class SimplePresenter implements Presenter
      */
     private $exceptionPresenter;
 
-    /**
-     * @param ValuePresenter $valuePresenter
-     * @param ExceptionPresenter $exceptionPresenter
-     */
+    
     public function __construct(ValuePresenter $valuePresenter, ExceptionPresenter $exceptionPresenter)
     {
         $this->valuePresenter = $valuePresenter;
         $this->exceptionPresenter = $exceptionPresenter;
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @return string
-     */
+    
     public function presentValue($value): string
     {
         return $this->valuePresenter->presentValue($value);
     }
 
-    /**
-     * @param \Exception $exception
-     * @param bool $verbose
-     *
-     * @return string
-     */
+    
     public function presentException(\Exception $exception, bool $verbose = false): string
     {
         return $this->exceptionPresenter->presentException($exception, $verbose);
     }
 
-    /**
-     * @param string $string
-     *
-     * @return string
-     */
+    
     public function presentString(string $string): string
     {
         return $string;

--- a/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
@@ -20,38 +20,25 @@ final class TaggingPresenter implements Presenter
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param \Exception $exception
-     * @param bool $verbose
-     * @return string
-     */
+    
     public function presentException(\Exception $exception, bool $verbose = false): string
     {
         return $this->presenter->presentException($exception, $verbose);
     }
 
-    /**
-     * @param string $string
-     *
-     * @return string
-     */
+    
     public function presentString(string $string): string
     {
         return sprintf('<value>%s</value>', $string);
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function presentValue($value): string
     {
         return $this->presentString($this->presenter->presentValue($value));

--- a/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
@@ -15,27 +15,19 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class ArrayTypePresenter implements TypePresenter
 {
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool
     {
         return 'array' === strtolower(\gettype($value));
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string
     {
         return sprintf('[array:%d]', \count($value));
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 20;

--- a/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
@@ -17,19 +17,13 @@ use PhpSpec\Exception\ErrorException;
 
 final class BaseExceptionTypePresenter implements ExceptionTypePresenter
 {
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool
     {
         return $value instanceof \Exception;
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string
     {
         $label = 'exc';
@@ -57,9 +51,7 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
         );
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 60;

--- a/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
@@ -15,27 +15,19 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class BooleanTypePresenter implements TypePresenter
 {
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool
     {
         return 'boolean' === strtolower(\gettype($value));
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string
     {
         return $value ? 'true' : 'false';
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 40;

--- a/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
@@ -22,27 +22,19 @@ final class CallableTypePresenter implements TypePresenter
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool
     {
         return is_callable($value);
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string
     {
         if (\is_array($value)) {
@@ -61,9 +53,7 @@ final class CallableTypePresenter implements TypePresenter
         return sprintf('[%s()]', $value);
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 70;

--- a/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
@@ -20,9 +20,7 @@ final class ComposedValuePresenter implements ValuePresenter
      */
     private $typePresenters = array();
 
-    /**
-     * @param TypePresenter $typePresenter
-     */
+    
     public function addTypePresenter(TypePresenter $typePresenter)
     {
         $this->typePresenters[] = $typePresenter;
@@ -32,10 +30,7 @@ final class ComposedValuePresenter implements ValuePresenter
         });
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function presentValue($value): string
     {
         foreach ($this->typePresenters as $typePresenter) {

--- a/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
@@ -15,27 +15,19 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class NullTypePresenter implements TypePresenter
 {
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool
     {
         return null === $value;
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string
     {
         return 'null';
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 50;

--- a/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
@@ -15,27 +15,19 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class ObjectTypePresenter implements TypePresenter
 {
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool
     {
         return 'object' === strtolower(\gettype($value));
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string
     {
         return sprintf('[obj:%s]', \get_class($value));
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 30;

--- a/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
@@ -15,27 +15,19 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class QuotingStringTypePresenter implements StringTypePresenter
 {
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool
     {
         return 'string' === strtolower(\gettype($value));
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string
     {
         return sprintf('"%s"', $value);
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 10;

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -25,19 +25,13 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
         $this->stringTypePresenter = $stringTypePresenter;
     }
 
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool
     {
         return $this->stringTypePresenter->supports($value);
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string
     {
         if (25 > \strlen($value) && false === strpos($value, "\n")) {
@@ -48,9 +42,7 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
         return $this->stringTypePresenter->present(sprintf('%s...', substr($lines[0], 0, 25)));
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return $this->stringTypePresenter->getPriority();

--- a/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
@@ -16,20 +16,12 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 interface TypePresenter
 {
-    /**
-     * @param mixed $value
-     * @return bool
-     */
+    
     public function supports($value): bool;
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function present($value): string;
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int;
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
@@ -16,9 +16,6 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 interface ValuePresenter
 {
-    /**
-     * @param mixed $value
-     * @return string
-     */
+    
     public function presentValue($value): string;
 }

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -66,7 +66,6 @@ final class ProgressFormatter extends ConsoleFormatter
     /**
      * @param $total
      * @param $counts
-     * @return array
      */
     private function getPercentages($total, $counts): array
     {
@@ -84,10 +83,7 @@ final class ProgressFormatter extends ConsoleFormatter
         );
     }
 
-    /**
-     * @param array $counts
-     * @return array
-     */
+    
     private function getBarLengths(array $counts): array
     {
         $stats = $this->getStatisticsCollector();
@@ -104,10 +100,7 @@ final class ProgressFormatter extends ConsoleFormatter
     }
 
     /**
-     * @param  array   $barLengths
-     * @param  array   $percents
      * @param  boolean $isDecorated
-     * @return array
      */
     private function formatProgressOutput(array $barLengths, array $percents, bool $isDecorated): array
     {
@@ -141,11 +134,7 @@ final class ProgressFormatter extends ConsoleFormatter
         return $progress;
     }
 
-    /**
-     * @param ConsoleIO $io
-     * @param array     $progress
-     * @param int       $total
-     */
+    
     private function updateProgressBar(ConsoleIO $io, array $progress, int $total): void
     {
         if ($io->isDecorated()) {

--- a/src/PhpSpec/Formatter/TapFormatter.php
+++ b/src/PhpSpec/Formatter/TapFormatter.php
@@ -51,25 +51,19 @@ final class TapFormatter extends ConsoleFormatter
      */
     private $currentSpecificationTitle;
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function beforeSuite(SuiteEvent $event)
     {
         $this->getIO()->writeln(self::VERSION);
     }
 
-    /**
-     * @param SpecificationEvent $event
-     */
+    
     public function beforeSpecification(SpecificationEvent $event)
     {
         $this->currentSpecificationTitle = $event->getSpecification()->getTitle();
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     public function afterExample(ExampleEvent $event)
     {
         $this->examplesCount++;
@@ -104,9 +98,7 @@ final class TapFormatter extends ConsoleFormatter
         $this->getIO()->writeln($result);
     }
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function afterSuite(SuiteEvent $event)
     {
         $this->getIO()->writeln(sprintf(
@@ -119,9 +111,7 @@ final class TapFormatter extends ConsoleFormatter
      * Format message as two-space indented YAML when needed outside of a
      * SKIP or TODO directive.
      *
-     * @param ExampleEvent $event
      * @param int $result
-     * @return string
      */
     private function getResultData(ExampleEvent $event, int $result = null): string
     {
@@ -155,19 +145,13 @@ final class TapFormatter extends ConsoleFormatter
         return $message;
     }
 
-    /**
-     * @param string $string
-     * @return string
-     */
+    
     private function stripNewlines(string $string): string
     {
         return str_replace(array("\r\n", "\n", "\r"), ' / ', $string);
     }
 
-    /**
-     * @param string $string
-     * @return string
-     */
+    
     private function indent(string $string): string
     {
         return preg_replace(

--- a/src/PhpSpec/Formatter/Template.php
+++ b/src/PhpSpec/Formatter/Template.php
@@ -15,9 +15,6 @@ namespace PhpSpec\Formatter;
 
 interface Template
 {
-    /**
-     * @param string $text
-     * @param array  $templateVars
-     */
+    
     public function render(string $text, array $templateVars = array()): void;
 }

--- a/src/PhpSpec/Listener/ClassNotFoundListener.php
+++ b/src/PhpSpec/Listener/ClassNotFoundListener.php
@@ -29,11 +29,7 @@ final class ClassNotFoundListener implements EventSubscriberInterface
     private $generator;
     private $classes = array();
 
-    /**
-     * @param ConsoleIO $io
-     * @param ResourceManager $resources
-     * @param GeneratorManager $generator
-     */
+    
     public function __construct(ConsoleIO $io, ResourceManager $resources, GeneratorManager $generator)
     {
         $this->io        = $io;
@@ -41,9 +37,7 @@ final class ClassNotFoundListener implements EventSubscriberInterface
         $this->generator = $generator;
     }
 
-    /**
-     * @return array
-     */
+    
     public static function getSubscribedEvents(): array
     {
         return array(
@@ -52,9 +46,7 @@ final class ClassNotFoundListener implements EventSubscriberInterface
         );
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     public function afterExample(ExampleEvent $event)
     {
         if (null === $exception = $event->getException()) {
@@ -69,9 +61,7 @@ final class ClassNotFoundListener implements EventSubscriberInterface
         $this->classes[$exception->getClassname()] = true;
     }
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function afterSuite(SuiteEvent $event)
     {
         if (!$this->io->isCodeGenerationEnabled()) {

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -58,12 +58,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
      */
     private $wrongMethodNames = array();
 
-    /**
-     * @param ConsoleIO $io
-     * @param ResourceManager $resources
-     * @param GeneratorManager $generator
-     * @param NameChecker $nameChecker
-     */
+    
     public function __construct(
         ConsoleIO $io,
         ResourceManager $resources,
@@ -76,9 +71,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         $this->nameChecker = $nameChecker;
     }
 
-    /**
-     * @return array
-     */
+    
     public static function getSubscribedEvents(): array
     {
         return array(
@@ -87,9 +80,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         );
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     public function afterExample(ExampleEvent $event): void
     {
         if (!$exception = $this->getMethodNotFoundException($event)) {
@@ -109,10 +100,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         $this->checkIfMethodNameAllowed($methodName);
     }
 
-    /**
-     * @param string|object $classname
-     * @return mixed
-     */
+    
     private function getDoubledInterface($class)
     {
         if (class_parents($class) !== array('stdClass'=>'stdClass')) {
@@ -132,9 +120,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         return current($interfaces);
     }
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function afterSuite(SuiteEvent $event): void
     {
         foreach ($this->interfaces as $interface => $methods) {
@@ -169,10 +155,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         }
     }
 
-    /**
-     * @param mixed $prophecyArguments
-     * @return array
-     */
+    
     private function getRealArguments($prophecyArguments): array
     {
         if ($prophecyArguments instanceof ArgumentsWildcard) {
@@ -183,7 +166,6 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
     }
 
     /**
-     * @param ExampleEvent $event
      * @return void|MethodNotFoundException
      */
     private function getMethodNotFoundException(ExampleEvent $event)

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -44,11 +44,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
      */
     private $generator;
 
-    /**
-     * @param ConsoleIO $io
-     * @param ResourceManager $resources
-     * @param GeneratorManager $generator
-     */
+    
     public function __construct(ConsoleIO $io, ResourceManager $resources, GeneratorManager $generator)
     {
         $this->io = $io;
@@ -56,9 +52,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
         $this->generator = $generator;
     }
 
-    /**
-     * @return array
-     */
+    
     public static function getSubscribedEvents(): array
     {
         return array(
@@ -67,9 +61,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
         );
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
+    
     public function afterExample(ExampleEvent $event): void
     {
         if (($exception = $event->getException()) &&
@@ -78,9 +70,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @param SuiteEvent $event
-     */
+    
     public function afterSuite(SuiteEvent $event): void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
@@ -103,11 +93,7 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @param CollaboratorNotFoundException $exception
-     * @param Resource $resource
-     * @return bool
-     */
+    
     private function resourceIsInSpecNamespace(CollaboratorNotFoundException $exception, Resource $resource): bool
     {
         return strpos($exception->getCollaboratorName(), $resource->getSpecNamespace()) === 0;

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -34,12 +34,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
      */
     private $nameChecker;
 
-    /**
-     * @param ConsoleIO $io
-     * @param ResourceManager $resources
-     * @param GeneratorManager $generator
-     * @param NameChecker $nameChecker
-     */
+    
     public function __construct(
         ConsoleIO $io,
         ResourceManager $resources,

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -52,12 +52,7 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
      */
     private $methodAnalyser;
 
-    /**
-     * @param ConsoleIO $io
-     * @param ResourceManager $resources
-     * @param GeneratorManager $generator
-     * @param MethodAnalyser $methodAnalyser
-     */
+    
     public function __construct(
         ConsoleIO $io,
         ResourceManager $resources,

--- a/src/PhpSpec/Listener/RerunListener.php
+++ b/src/PhpSpec/Listener/RerunListener.php
@@ -30,10 +30,7 @@ final class RerunListener implements EventSubscriberInterface
      */
     private $suitePrerequisites;
 
-    /**
-     * @param ReRunner $reRunner
-     * @param PrerequisiteTester $suitePrerequisites
-     */
+    
     public function __construct(ReRunner $reRunner, PrerequisiteTester $suitePrerequisites)
     {
         $this->reRunner = $reRunner;
@@ -51,17 +48,13 @@ final class RerunListener implements EventSubscriberInterface
         );
     }
 
-    /**
-     * @param SuiteEvent $suiteEvent
-     */
+    
     public function beforeSuite(SuiteEvent $suiteEvent): void
     {
         $this->suitePrerequisites->guardPrerequisites();
     }
 
-    /**
-     * @param SuiteEvent $suiteEvent
-     */
+    
     public function afterSuite(SuiteEvent $suiteEvent): void
     {
         if ($suiteEvent->isWorthRerunning()) {

--- a/src/PhpSpec/Listener/StopOnFailureListener.php
+++ b/src/PhpSpec/Listener/StopOnFailureListener.php
@@ -25,17 +25,13 @@ final class StopOnFailureListener implements EventSubscriberInterface
      */
     private $io;
 
-    /**
-     * @param ConsoleIO $io
-     */
+    
     public function __construct(ConsoleIO $io)
     {
         $this->io = $io;
     }
 
-    /**
-     * @return array
-     */
+    
     public static function getSubscribedEvents(): array
     {
         return array(
@@ -44,7 +40,6 @@ final class StopOnFailureListener implements EventSubscriberInterface
     }
 
     /**
-     * @param ExampleEvent $event
      *
      * @throws \PhpSpec\Exception\Example\StopOnFailureException
      */

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -34,59 +34,44 @@ class ExampleNode
      */
     private $isPending = false;
 
-    /**
-     * @param string                     $title
-     * @param ReflectionFunctionAbstract $function
-     */
+    
     public function __construct(string $title, ReflectionFunctionAbstract $function)
     {
         $this->setTitle($title);
         $this->function = $function;
     }
 
-    /**
-     * @param string $title
-     */
+    
     public function setTitle(string $title)
     {
       $this->title = $title;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getTitle(): string
     {
         return $this->title;
     }
 
-    /**
-     * @param bool $isPending
-     */
+    
     public function markAsPending(bool $isPending = true): void
     {
         $this->isPending = $isPending;
     }
 
-    /**
-     * @return bool
-     */
+    
     public function isPending(): bool
     {
         return $this->isPending;
     }
 
-    /**
-     * @return ReflectionFunctionAbstract
-     */
+    
     public function getFunctionReflection(): ReflectionFunctionAbstract
     {
         return $this->function;
     }
 
-    /**
-     * @param SpecificationNode $specification
-     */
+    
     public function setSpecification(SpecificationNode $specification): void
     {
         $this->specification = $specification;
@@ -100,9 +85,7 @@ class ExampleNode
         return $this->specification;
     }
 
-    /**
-     * @return int
-     */
+    
     public function getLineNumber(): int
     {
         return $this->function->isClosure() ? 0 : $this->function->getStartLine();

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -40,11 +40,7 @@ class SpecificationNode implements \Countable
      */
     private $examples = array();
 
-    /**
-     * @param string            $title
-     * @param ReflectionClass   $class
-     * @param Resource $resource
-     */
+    
     public function __construct(string $title, ReflectionClass $class, Resource $resource)
     {
         $this->title    = $title;
@@ -52,33 +48,25 @@ class SpecificationNode implements \Countable
         $this->resource = $resource;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getTitle(): string
     {
         return $this->title;
     }
 
-    /**
-     * @return ReflectionClass
-     */
+    
     public function getClassReflection(): ReflectionClass
     {
         return $this->class;
     }
 
-    /**
-     * @return Resource
-     */
+    
     public function getResource(): Resource
     {
         return $this->resource;
     }
 
-    /**
-     * @param ExampleNode $example
-     */
+    
     public function addExample(ExampleNode $example): void
     {
         $this->examples[] = $example;
@@ -93,9 +81,7 @@ class SpecificationNode implements \Countable
         return $this->examples;
     }
 
-    /**
-     * @param Suite $suite
-     */
+    
     public function setSuite(Suite $suite)
     {
         $this->suite = $suite;
@@ -109,9 +95,7 @@ class SpecificationNode implements \Countable
         return $this->suite;
     }
 
-    /**
-     * @return int
-     */
+    
     public function count(): int
     {
         return \count($this->examples);

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -31,10 +31,7 @@ class ResourceLoader
      */
     private $methodAnalyser;
 
-    /**
-     * @param ResourceManager $manager
-     * @param MethodAnalyser $methodAnalyser
-     */
+    
     public function __construct(ResourceManager $manager, MethodAnalyser $methodAnalyser)
     {
         $this->manager = $manager;
@@ -42,10 +39,8 @@ class ResourceLoader
     }
 
     /**
-     * @param string       $locator
      * @param integer|null $line
      *
-     * @return Suite
      */
     public function load(string $locator = '', int $line = null): Suite
     {
@@ -97,12 +92,7 @@ class ResourceLoader
         return $suite;
     }
 
-    /**
-     * @param int              $line
-     * @param ReflectionMethod $method
-     *
-     * @return bool
-     */
+    
     private function lineIsInsideMethod(int $line, ReflectionMethod $method): bool
     {
         $line = \intval($line);

--- a/src/PhpSpec/Loader/Suite.php
+++ b/src/PhpSpec/Loader/Suite.php
@@ -20,9 +20,7 @@ class Suite implements \Countable
      */
     private $specs = array();
 
-    /**
-     * @param Node\SpecificationNode $spec
-     */
+    
     public function addSpecification(Node\SpecificationNode $spec): void
     {
         $this->specs[] = $spec;
@@ -37,9 +35,7 @@ class Suite implements \Countable
         return $this->specs;
     }
 
-    /**
-     * @return int
-     */
+    
     public function count(): int
     {
         return array_sum(array_map('count', $this->specs));

--- a/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
@@ -20,34 +20,19 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
      */
     private $typehints = array();
 
-    /**
-     * @param string $class
-     * @param string $method
-     * @param string $argument
-     * @param string $typehint
-     */
+    
     public function add(string $class, string $method, string $argument, string $typehint): void
     {
         $this->store($class, $method, $argument, $typehint);
     }
 
-    /**
-     * @param string $class
-     * @param string $method
-     * @param string $argument
-     * @param \Exception $exception
-     */
+    
     public function addInvalid(string $class, string $method, string $argument, \Exception $exception): void
     {
         $this->store($class, $method, $argument, $exception);
     }
 
-    /**
-     * @param string $class
-     * @param string $method
-     * @param string $argument
-     * @param mixed $typehint
-     */
+    
     private function store(string $class, string $method, string $argument, $typehint): void
     {
         $class = strtolower($class);
@@ -65,9 +50,6 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
     }
 
     /**
-     * @param string $class
-     * @param string $method
-     * @param string $argument
      *
      * @return string|false
      */

--- a/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
@@ -15,26 +15,13 @@ namespace PhpSpec\Loader\Transformer;
 
 interface TypeHintIndex
 {
-    /**
-     * @param string $class
-     * @param string $method
-     * @param string $argument
-     * @param string $typehint
-     */
+    
     public function add(string $class, string $method, string $argument, string $typehint): void;
 
-    /**
-     * @param string $class
-     * @param string $method
-     * @param string $argument
-     * @param \Exception $exception
-     */
+    
     public function addInvalid(string $class, string $method, string $argument, \Exception $exception): void;
 
     /**
-     * @param string $class
-     * @param string $method
-     * @param string $argument
      *
      * @return string|null
      */

--- a/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
@@ -23,19 +23,13 @@ final class TypeHintRewriter implements SpecTransformer
      */
     private $rewriter;
 
-    /**
-     * @param TypeHintRewriterInterface $rewriter
-     */
+    
     public function __construct(TypeHintRewriterInterface $rewriter)
     {
         $this->rewriter = $rewriter;
     }
 
-    /**
-     * @param string $spec
-     *
-     * @return string
-     */
+    
     public function transform(string $spec): string
     {
         return $this->rewriter->rewrite($spec);

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -55,11 +55,6 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     private $psr4Prefix;
 
     /**
-     * @param Filesystem $filesystem
-     * @param string     $srcNamespace
-     * @param string     $specNamespacePrefix
-     * @param string     $srcPath
-     * @param string     $specPath
      * @param string     $psr4Prefix
      */
     public function __construct(
@@ -108,33 +103,25 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         }
     }
 
-    /**
-     * @return string
-     */
+    
     public function getFullSrcPath(): string
     {
         return $this->fullSrcPath;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getFullSpecPath(): string
     {
         return $this->fullSpecPath;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSrcNamespace(): string
     {
         return $this->srcNamespace;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSpecNamespace(): string
     {
         return $this->specNamespace;
@@ -148,11 +135,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return $this->findSpecResources($this->fullSpecPath);
     }
 
-    /**
-     * @param string $query
-     *
-     * @return bool
-     */
+    
     public function supportsQuery(string $query): bool
     {
         $path = $this->getQueryPath($query);
@@ -166,16 +149,12 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         ;
     }
 
-    /**
-     * @return boolean
-     */
     public function isPSR4(): bool
     {
         return $this->psr4Prefix !== null;
     }
 
     /**
-     * @param string $query
      *
      * @return Resource[]
      */
@@ -208,11 +187,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return array();
     }
 
-    /**
-     * @param string $classname
-     *
-     * @return bool
-     */
+    
     public function supportsClass(string $classname): bool
     {
         $classname = str_replace('/', '\\', $classname);
@@ -224,7 +199,6 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     }
 
     /**
-     * @param string $classname
      *
      * @return null|PSR0Resource
      */
@@ -250,16 +224,13 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return null;
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 0;
     }
 
     /**
-     * @param string $path
      *
      * @return PSR0Resource[]
      */
@@ -319,11 +290,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return null;
     }
 
-    /**
-     * @param string $path
-     *
-     * @return PSR0Resource
-     */
+    
     private function createResourceFromSpecFile(string $path): PSR0Resource
     {
         $classname = $this->findSpecClassname($path);
@@ -353,7 +320,6 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     }
 
     /**
-     * @param string $classname
      *
      * @throws InvalidArgumentException
      */
@@ -370,11 +336,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         }
     }
 
-    /**
-     * @param string $query
-     *
-     * @return string
-     */
+    
     private function getQueryPath(string $query): string
     {
         $sepr = DIRECTORY_SEPARATOR;
@@ -395,31 +357,19 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return rtrim(realpath($replacedQuery), $sepr);
     }
 
-    /**
-     * @param string $query
-     *
-     * @return bool
-     */
+    
     private function queryContainsQualifiedClassName(string $query): bool
     {
         return $this->queryContainsBlackslashes($query) && !$this->isWindowsPath($query);
     }
 
-    /**
-     * @param string $query
-     *
-     * @return bool
-     */
+    
     private function queryContainsBlackslashes(string $query): bool
     {
         return false !== strpos($query, '\\');
     }
 
-    /**
-     * @param string $query
-     *
-     * @return bool
-     */
+    
     private function isWindowsPath(string $query): bool
     {
         return preg_match('/^\w:/', $query);

--- a/src/PhpSpec/Locator/PSR0/PSR0Resource.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Resource.php
@@ -26,35 +26,26 @@ final class PSR0Resource implements Resource
      */
     private $locator;
 
-    /**
-     * @param array       $parts
-     * @param PSR0Locator $locator
-     */
+    
     public function __construct(array $parts, PSR0Locator $locator)
     {
         $this->parts   = $parts;
         $this->locator = $locator;
     }
 
-    /**
-     * @return string
-     */
+    
     public function getName(): string
     {
         return end($this->parts);
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSpecName(): string
     {
         return $this->getName().'Spec';
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSrcFilename(): string
     {
         if ($this->locator->isPSR4()) {
@@ -68,9 +59,7 @@ final class PSR0Resource implements Resource
         return $this->locator->getFullSrcPath().implode(DIRECTORY_SEPARATOR, $parts).'.php';
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSrcNamespace(): string
     {
         $nsParts = $this->parts;
@@ -79,17 +68,13 @@ final class PSR0Resource implements Resource
         return rtrim($this->locator->getSrcNamespace().implode('\\', $nsParts), '\\');
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSrcClassname(): string
     {
         return $this->locator->getSrcNamespace().implode('\\', $this->parts);
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSpecFilename(): string
     {
         if ($this->locator->isPSR4()) {
@@ -105,9 +90,7 @@ final class PSR0Resource implements Resource
             implode(DIRECTORY_SEPARATOR, $parts).'Spec.php';
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSpecNamespace(): string
     {
         $nsParts = $this->parts;
@@ -116,9 +99,7 @@ final class PSR0Resource implements Resource
         return rtrim($this->locator->getSpecNamespace().implode('\\', $nsParts), '\\');
     }
 
-    /**
-     * @return string
-     */
+    
     public function getSpecClassname(): string
     {
         return $this->locator->getSpecNamespace().implode('\\', $this->parts).'Spec';

--- a/src/PhpSpec/Locator/PrioritizedResourceManager.php
+++ b/src/PhpSpec/Locator/PrioritizedResourceManager.php
@@ -22,9 +22,7 @@ final class PrioritizedResourceManager implements ResourceManager
      */
     private $locators = array();
 
-    /**
-     * @param ResourceLocator $locator
-     */
+    
     public function registerLocator(ResourceLocator $locator)
     {
         $this->locators[] = $locator;
@@ -35,7 +33,6 @@ final class PrioritizedResourceManager implements ResourceManager
     }
 
     /**
-     * @param string $query
      *
      * @return Resource[]
      */
@@ -59,9 +56,7 @@ final class PrioritizedResourceManager implements ResourceManager
     }
 
     /**
-     * @param string $classname
      *
-     * @return Resource
      *
      * @throws \RuntimeException
      */
@@ -82,7 +77,6 @@ final class PrioritizedResourceManager implements ResourceManager
     }
 
     /**
-     * @param array $resources
      *
      * @return Resource[]
      */

--- a/src/PhpSpec/Locator/Resource.php
+++ b/src/PhpSpec/Locator/Resource.php
@@ -15,43 +15,27 @@ namespace PhpSpec\Locator;
 
 interface Resource
 {
-    /**
-     * @return string
-     */
+    
     public function getName(): string;
 
-    /**
-     * @return string
-     */
+    
     public function getSpecName(): string;
 
-    /**
-     * @return string
-     */
+    
     public function getSrcFilename(): string;
 
-    /**
-     * @return string
-     */
+    
     public function getSrcNamespace(): string;
 
-    /**
-     * @return string
-     */
+    
     public function getSrcClassname(): string;
 
-    /**
-     * @return string
-     */
+    
     public function getSpecFilename(): string;
 
-    /**
-     * @return string
-     */
+    
     public function getSpecNamespace(): string;
 
-    /**
-     * @return string
-     */
+    
     public function getSpecClassname(): string;
 }

--- a/src/PhpSpec/Locator/ResourceLocator.php
+++ b/src/PhpSpec/Locator/ResourceLocator.php
@@ -20,29 +20,19 @@ interface ResourceLocator
      */
     public function getAllResources(): array;
 
-    /**
-     * @param string $query
-     *
-     * @return boolean
-     */
+    
     public function supportsQuery(string $query): bool;
 
     /**
-     * @param string $query
      *
      * @return Resource[]
      */
     public function findResources(string $query);
 
-    /**
-     * @param string $classname
-     *
-     * @return boolean
-     */
+    
     public function supportsClass(string $classname): bool;
 
     /**
-     * @param string $classname
      *
      * @return Resource|null
      */

--- a/src/PhpSpec/Locator/ResourceManager.php
+++ b/src/PhpSpec/Locator/ResourceManager.php
@@ -16,16 +16,11 @@ namespace PhpSpec\Locator;
 interface ResourceManager
 {
     /**
-     * @param string $query
      *
      * @return \PhpSpec\Locator\Resource[]
      */
     public function locateResources(string $query): array;
 
-    /**
-     * @param string $classname
-     *
-     * @return \PhpSpec\Locator\Resource
-     */
+    
     public function createResource(string $classname): \PhpSpec\Locator\Resource;
 }

--- a/src/PhpSpec/Locator/SrcPathLocator.php
+++ b/src/PhpSpec/Locator/SrcPathLocator.php
@@ -3,8 +3,6 @@ namespace PhpSpec\Locator;
 
 interface SrcPathLocator
 {
-    /**
-     * @return string
-     */
+    
     public function getFullSrcPath(): string;
 }

--- a/src/PhpSpec/Matcher/ApproximatelyMatcher.php
+++ b/src/PhpSpec/Matcher/ApproximatelyMatcher.php
@@ -35,32 +35,19 @@ final class ApproximatelyMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return \in_array($name, self::$keywords) && 2 == \count($arguments);
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         $value = (float)$arguments[0];

--- a/src/PhpSpec/Matcher/ArrayContainMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayContainMatcher.php
@@ -23,21 +23,13 @@ final class ArrayContainMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'contain' === $name
@@ -46,24 +38,13 @@ final class ArrayContainMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         return \in_array($arguments[0], $subject, true);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
@@ -73,13 +54,7 @@ final class ArrayContainMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/ArrayCountMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayCountMatcher.php
@@ -23,21 +23,13 @@ final class ArrayCountMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveCount' === $name
@@ -46,24 +38,13 @@ final class ArrayCountMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         return $arguments[0] === \count($subject);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
@@ -74,13 +55,7 @@ final class ArrayCountMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/ArrayKeyMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyMatcher.php
@@ -24,21 +24,13 @@ final class ArrayKeyMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveKey' === $name
@@ -47,12 +39,7 @@ final class ArrayKeyMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         $key = $arguments[0];
@@ -64,13 +51,7 @@ final class ArrayKeyMatcher extends BasicMatcher
         return isset($subject[$key]) || array_key_exists($arguments[0], $subject);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
@@ -80,13 +61,7 @@ final class ArrayKeyMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -24,21 +24,13 @@ final class ArrayKeyValueMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return
@@ -50,9 +42,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
 
     /**
      * @param ArrayAccess|array $subject
-     * @param array $arguments
      *
-     * @return bool
      */
     protected function matches($subject, array $arguments): bool
     {
@@ -66,13 +56,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
         return (isset($subject[$key]) || array_key_exists($arguments[0], $subject)) && $subject[$key] === $value;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         $key = $arguments[0];
@@ -93,13 +77,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/BasicMatcher.php
+++ b/src/PhpSpec/Matcher/BasicMatcher.php
@@ -19,9 +19,6 @@ use PhpSpec\Wrapper\DelayedCall;
 abstract class BasicMatcher implements Matcher
 {
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      *
      * @return void
      *
@@ -37,9 +34,6 @@ abstract class BasicMatcher implements Matcher
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      *
      * @return void
      *
@@ -54,37 +48,18 @@ abstract class BasicMatcher implements Matcher
         return null;
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 100;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return boolean
-     */
+    
     abstract protected function matches($subject, array $arguments): bool;
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     abstract protected function getFailureException(string $name, $subject, array $arguments): FailureException;
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     abstract protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException;
 }

--- a/src/PhpSpec/Matcher/CallbackMatcher.php
+++ b/src/PhpSpec/Matcher/CallbackMatcher.php
@@ -31,11 +31,7 @@ final class CallbackMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param string             $name
-     * @param callable           $callback
-     * @param Presenter $presenter
-     */
+    
     public function __construct(string $name, callable $callback, Presenter $presenter)
     {
         $this->name      = $name;
@@ -43,24 +39,13 @@ final class CallbackMatcher extends BasicMatcher
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return $name === $this->name;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         array_unshift($arguments, $subject);
@@ -68,13 +53,7 @@ final class CallbackMatcher extends BasicMatcher
         return (Boolean) \call_user_func_array($this->callback, $arguments);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
@@ -85,13 +64,7 @@ final class CallbackMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/ComparisonMatcher.php
+++ b/src/PhpSpec/Matcher/ComparisonMatcher.php
@@ -24,21 +24,13 @@ final class ComparisonMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'beLike' === $name
@@ -46,21 +38,13 @@ final class ComparisonMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         return $subject == $arguments[0];
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      *
      * @return NotEqualException
      */
@@ -73,13 +57,7 @@ final class ComparisonMatcher extends BasicMatcher
         ), $arguments[0], $subject);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/IdentityMatcher.php
+++ b/src/PhpSpec/Matcher/IdentityMatcher.php
@@ -33,21 +33,13 @@ final class IdentityMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return \in_array($name, self::$keywords)
@@ -55,24 +47,13 @@ final class IdentityMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         return $subject === $arguments[0];
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new NotEqualException(sprintf(
@@ -82,13 +63,7 @@ final class IdentityMatcher extends BasicMatcher
         ), $arguments[0], $subject);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -11,9 +11,7 @@ final class IterablesMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
@@ -22,7 +20,6 @@ final class IterablesMatcher
     /**
      * @param array|\Traversable $subject
      * @param array|\Traversable $expected
-     * @param bool               $strict
      *
      * @throws \InvalidArgumentException
      * @throws SubjectElementDoesNotMatchException
@@ -66,11 +63,7 @@ final class IterablesMatcher
         }
     }
 
-    /**
-     * @param mixed $variable
-     *
-     * @return bool
-     */
+    
     private function isIterable($variable): bool
     {
         return \is_array($variable) || $variable instanceof \Traversable;
@@ -79,7 +72,6 @@ final class IterablesMatcher
     /**
      * @param array|\Traversable $iterable
      *
-     * @return \Iterator
      */
     private function createIteratorFromIterable($iterable): \Iterator
     {

--- a/src/PhpSpec/Matcher/Iterate/SubjectElementDoesNotMatchException.php
+++ b/src/PhpSpec/Matcher/Iterate/SubjectElementDoesNotMatchException.php
@@ -17,13 +17,7 @@ use PhpSpec\Exception\Example\FailureException;
 
 class SubjectElementDoesNotMatchException extends FailureException
 {
-    /**
-     * @param int $elementNumber
-     * @param string $subjectKey
-     * @param string $subjectValue
-     * @param string $expectedKey
-     * @param string $expectedValue
-     */
+    
     public function __construct(int $elementNumber, string $subjectKey, string $subjectValue, string $expectedKey, string $expectedValue)
     {
         parent::__construct(sprintf(

--- a/src/PhpSpec/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Matcher/IterateAsMatcher.php
@@ -25,9 +25,7 @@ final class IterateAsMatcher implements Matcher
      */
     private $iterablesMatcher;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->iterablesMatcher = new IterablesMatcher($presenter);

--- a/src/PhpSpec/Matcher/IterateLikeMatcher.php
+++ b/src/PhpSpec/Matcher/IterateLikeMatcher.php
@@ -25,9 +25,7 @@ final class IterateLikeMatcher implements Matcher
      */
     private $iterablesMatcher;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->iterablesMatcher = new IterablesMatcher($presenter);

--- a/src/PhpSpec/Matcher/Matcher.php
+++ b/src/PhpSpec/Matcher/Matcher.php
@@ -20,29 +20,18 @@ interface Matcher
     /**
      * Checks if matcher supports provided subject and matcher name.
      *
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return Boolean
      */
     public function supports(string $name, $subject, array $arguments): bool;
 
     /**
      * Evaluates positive match.
      *
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      */
     public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall;
 
     /**
      * Evaluates negative match.
      *
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      */
     public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall;
 

--- a/src/PhpSpec/Matcher/MatchersProvider.php
+++ b/src/PhpSpec/Matcher/MatchersProvider.php
@@ -15,8 +15,6 @@ namespace PhpSpec\Matcher;
 
 interface MatchersProvider
 {
-    /**
-     * @return array
-     */
+    
     public function getMatchers(): array;
 }

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -29,21 +29,13 @@ final class ObjectStateMatcher implements Matcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return \is_object($subject) && !is_callable($subject)
@@ -52,9 +44,6 @@ final class ObjectStateMatcher implements Matcher
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
@@ -80,9 +69,6 @@ final class ObjectStateMatcher implements Matcher
     }
 
     /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
@@ -107,20 +93,15 @@ final class ObjectStateMatcher implements Matcher
         return null;
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 50;
     }
 
     /**
-     * @param callable $callable
      * @param boolean  $expectedBool
-     * @param mixed    $result
      *
-     * @return FailureException
      */
     private function getFailureExceptionFor(callable $callable, bool $expectedBool, $result): FailureException
     {

--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -24,9 +24,7 @@ final class ScalarMatcher implements Matcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
@@ -35,11 +33,6 @@ final class ScalarMatcher implements Matcher
     /**
      * Checks if matcher supports provided subject and matcher name.
      *
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return Boolean
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
@@ -51,12 +44,8 @@ final class ScalarMatcher implements Matcher
     /**
      * Evaluates positive match.
      *
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      *
      * @throws \PhpSpec\Exception\Example\FailureException
-     * @return boolean
      */
     public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
@@ -80,12 +69,8 @@ final class ScalarMatcher implements Matcher
     /**
      * Evaluates negative match.
      *
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
      *
      * @throws \PhpSpec\Exception\Example\FailureException
-     * @return boolean
      */
     public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
     {
@@ -102,7 +87,7 @@ final class ScalarMatcher implements Matcher
                 $this->presenter->presentValue(true)
             ));
         }
-        
+
         return null;
     }
 
@@ -117,7 +102,6 @@ final class ScalarMatcher implements Matcher
     }
 
     /**
-     * @param string $name
      *
      * @return string|boolean
      */

--- a/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
@@ -25,9 +25,7 @@ final class StartIteratingAsMatcher implements Matcher
      */
     private $iterablesMatcher;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->iterablesMatcher = new IterablesMatcher($presenter);

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -23,9 +23,7 @@ final class StringContainMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;

--- a/src/PhpSpec/Matcher/StringEndMatcher.php
+++ b/src/PhpSpec/Matcher/StringEndMatcher.php
@@ -23,21 +23,13 @@ final class StringEndMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'endWith' === $name
@@ -46,24 +38,13 @@ final class StringEndMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         return $arguments[0] === substr($subject, 0 - \strlen($arguments[0]));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
@@ -73,13 +54,7 @@ final class StringEndMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/StringRegexMatcher.php
+++ b/src/PhpSpec/Matcher/StringRegexMatcher.php
@@ -23,21 +23,13 @@ final class StringRegexMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'match' === $name
@@ -46,24 +38,13 @@ final class StringRegexMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         return (Boolean) preg_match($arguments[0], $subject);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
@@ -73,13 +54,7 @@ final class StringRegexMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/StringStartMatcher.php
+++ b/src/PhpSpec/Matcher/StringStartMatcher.php
@@ -23,21 +23,13 @@ final class StringStartMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'startWith' === $name
@@ -46,24 +38,13 @@ final class StringStartMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         return 0 === strpos($subject, $arguments[0]);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
@@ -73,13 +54,7 @@ final class StringStartMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -45,8 +45,6 @@ final class ThrowMatcher implements Matcher
     private $factory;
 
     /**
-     * @param Unwrapper              $unwrapper
-     * @param Presenter              $presenter
      * @param ReflectionFactory|null $factory
      */
     public function __construct(Unwrapper $unwrapper, Presenter $presenter, ReflectionFactory $factory)
@@ -56,45 +54,25 @@ final class ThrowMatcher implements Matcher
         $this->factory   = $factory;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'throw' === $name;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return DelayedCall
-     */
+    
     public function positiveMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyPositive'), $subject, $arguments);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return DelayedCall
-     */
+    
     public function negativeMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyNegative'), $subject, $arguments);
     }
 
     /**
-     * @param callable           $callable
-     * @param array              $arguments
      * @param null|object|string $exception
      *
      * @throws \PhpSpec\Exception\Example\FailureException
@@ -163,8 +141,6 @@ final class ThrowMatcher implements Matcher
     }
 
     /**
-     * @param callable           $callable
-     * @param array              $arguments
      * @param string|null|object $exception
      *
      * @throws \PhpSpec\Exception\Example\FailureException
@@ -231,21 +207,13 @@ final class ThrowMatcher implements Matcher
         }
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 1;
     }
 
-    /**
-     * @param callable $check
-     * @param mixed    $subject
-     * @param array    $arguments
-     *
-     * @return DelayedCall
-     */
+    
     private function getDelayedCall(callable $check, $subject, array $arguments): DelayedCall
     {
         $exception = $this->getException($arguments);
@@ -275,7 +243,6 @@ final class ThrowMatcher implements Matcher
     }
 
     /**
-     * @param array $arguments
      *
      * @return null|string|\Throwable
      * @throws \PhpSpec\Exception\Example\MatcherException

--- a/src/PhpSpec/Matcher/TraversableContainMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableContainMatcher.php
@@ -23,9 +23,7 @@ final class TraversableContainMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -28,9 +28,7 @@ final class TraversableCountMatcher implements Matcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
@@ -93,8 +91,6 @@ final class TraversableCountMatcher implements Matcher
     }
 
     /**
-     * @param \Traversable $subject
-     * @param int $expected
      *
      * @return int self::*
      */

--- a/src/PhpSpec/Matcher/TraversableKeyMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyMatcher.php
@@ -24,9 +24,7 @@ final class TraversableKeyMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;

--- a/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
@@ -24,9 +24,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -26,55 +26,31 @@ final class TriggerMatcher implements Matcher
      */
     private $unwrapper;
 
-    /**
-     * @param Unwrapper $unwrapper
-     */
+    
     public function __construct(Unwrapper $unwrapper)
     {
         $this->unwrapper = $unwrapper;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'trigger' === $name;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return DelayedCall
-     */
+    
     public function positiveMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyPositive'), $subject, $arguments);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return DelayedCall
-     */
+    
     public function negativeMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyNegative'), $subject, $arguments);
     }
 
     /**
-     * @param callable    $callable
-     * @param array       $arguments
-     * @param int|null    $level
-     * @param string|null $message
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
@@ -104,10 +80,6 @@ final class TriggerMatcher implements Matcher
     }
 
     /**
-     * @param callable    $callable
-     * @param array       $arguments
-     * @param int|null    $level
-     * @param string|null $message
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
@@ -141,21 +113,13 @@ final class TriggerMatcher implements Matcher
         }
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 1;
     }
 
-    /**
-     * @param callable $check
-     * @param mixed    $subject
-     * @param array    $arguments
-     *
-     * @return DelayedCall
-     */
+    
     private function getDelayedCall(callable $check, $subject, array $arguments): DelayedCall
     {
         $unwrapper = $this->unwrapper;
@@ -184,9 +148,7 @@ final class TriggerMatcher implements Matcher
         );
     }
 
-    /**
-     * @return array
-     */
+    
     private function unpackArguments(array $arguments): array
     {
         $count = \count($arguments);

--- a/src/PhpSpec/Matcher/TypeMatcher.php
+++ b/src/PhpSpec/Matcher/TypeMatcher.php
@@ -32,21 +32,13 @@ final class TypeMatcher extends BasicMatcher
      */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return bool
-     */
+    
     public function supports(string $name, $subject, array $arguments): bool
     {
         return \in_array($name, self::$keywords)
@@ -54,24 +46,13 @@ final class TypeMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param mixed $subject
-     * @param array $arguments
-     *
-     * @return bool
-     */
+    
     protected function matches($subject, array $arguments): bool
     {
         return (null !== $subject) && ($subject instanceof $arguments[0]);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
@@ -81,13 +62,7 @@ final class TypeMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return FailureException
-     */
+    
     protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -95,7 +95,6 @@ abstract class ObjectBehavior implements
      * to prepare the subject with all the needed collaborators for proxying
      * object behaviour
      *
-     * @param Subject $subject
      */
     public function setSpecificationSubject(Subject $subject): void
     {
@@ -117,7 +116,6 @@ abstract class ObjectBehavior implements
      *
      * @param string|integer $key
      *
-     * @return Subject
      */
     public function offsetExists($key): Subject
     {
@@ -129,7 +127,6 @@ abstract class ObjectBehavior implements
      *
      * @param string|integer $key
      *
-     * @return Subject
      */
     public function offsetGet($key): Subject
     {
@@ -140,7 +137,6 @@ abstract class ObjectBehavior implements
      * Sets the value in a particular position in the ArrayAccess object
      *
      * @param string|integer $key
-     * @param mixed          $value
      */
     public function offsetSet($key, $value)
     {
@@ -160,10 +156,7 @@ abstract class ObjectBehavior implements
     /**
      * Proxies all calls to the PhpSpec subject
      *
-     * @param string $method
-     * @param array  $arguments
      *
-     * @return mixed
      */
     public function __call(string $method, array $arguments = array())
     {
@@ -173,8 +166,6 @@ abstract class ObjectBehavior implements
     /**
      * Proxies setting to the PhpSpec subject
      *
-     * @param string $property
-     * @param mixed  $value
      */
     public function __set(string $property, $value)
     {
@@ -184,9 +175,7 @@ abstract class ObjectBehavior implements
     /**
      * Proxies getting to the PhpSpec subject
      *
-     * @param string $property
      *
-     * @return mixed
      */
     public function __get(string $property)
     {
@@ -196,7 +185,6 @@ abstract class ObjectBehavior implements
     /**
      * Proxies functor calls to PhpSpec subject
      *
-     * @return mixed
      */
     public function __invoke()
     {

--- a/src/PhpSpec/Process/Context/ExecutionContext.php
+++ b/src/PhpSpec/Process/Context/ExecutionContext.php
@@ -15,18 +15,12 @@ namespace PhpSpec\Process\Context;
 
 interface ExecutionContext
 {
-    /**
-     * @param string $type
-     */
+    
     public function addGeneratedType(string $type);
 
-    /**
-     * @return array
-     */
+    
     public function getGeneratedTypes(): array;
 
-    /**
-     * @return array
-     */
+    
     public function asEnv(): array;
 }

--- a/src/PhpSpec/Process/Context/JsonExecutionContext.php
+++ b/src/PhpSpec/Process/Context/JsonExecutionContext.php
@@ -21,11 +21,7 @@ final class JsonExecutionContext implements ExecutionContext
      */
     private $generatedTypes;
 
-    /**
-     * @param array $env
-     *
-     * @return JsonExecutionContext
-     */
+    
     public static function fromEnv(array $env): JsonExecutionContext
     {
         $executionContext = new JsonExecutionContext();
@@ -41,25 +37,19 @@ final class JsonExecutionContext implements ExecutionContext
         return $executionContext;
     }
 
-    /**
-     * @param string $generatedType
-     */
+    
     public function addGeneratedType(string $generatedType)
     {
         $this->generatedTypes[] = $generatedType;
     }
 
-    /**
-     * @return array
-     */
+    
     public function getGeneratedTypes(): array
     {
         return $this->generatedTypes;
     }
 
-    /**
-     * @return array
-     */
+    
     public function asEnv(): array
     {
         return array(

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
@@ -22,9 +22,7 @@ final class SuitePrerequisites implements PrerequisiteTester
      */
     private $executionContext;
 
-    /**
-     * @param ExecutionContext $executionContext
-     */
+    
     public function __construct(ExecutionContext $executionContext)
     {
         $this->executionContext = $executionContext;

--- a/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
@@ -27,9 +27,7 @@ final class OptionalReRunner implements ReRunner
      */
     private $decoratedRerunner;
 
-    /**
-     * @param ConsoleIO $io
-     */
+    
     public function __construct(ReRunner $decoratedRerunner, ConsoleIO $io)
     {
         $this->io = $io;

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -24,8 +24,6 @@ final class PcntlReRunner extends PhpExecutableReRunner
     private $executionContext;
 
     /**
-     * @param PhpExecutableFinder $phpExecutableFinder
-     * @param ExecutionContext $executionContext
      * @return static
      */
     public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext)
@@ -36,9 +34,7 @@ final class PcntlReRunner extends PhpExecutableReRunner
         return $reRunner;
     }
 
-    /**
-     * @return bool
-     */
+    
     public function isSupported(): bool
     {
         return (php_sapi_name() == 'cli')

--- a/src/PhpSpec/Process/ReRunner/PhpExecutableReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PhpExecutableReRunner.php
@@ -27,9 +27,7 @@ abstract class PhpExecutableReRunner implements PlatformSpecificReRunner
      */
     private $executablePath;
 
-    /**
-     * @param PhpExecutableFinder $executableFinder
-     */
+    
     public function __construct(PhpExecutableFinder $executableFinder)
     {
         $this->executableFinder = $executableFinder;

--- a/src/PhpSpec/Process/ReRunner/PlatformSpecificReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PlatformSpecificReRunner.php
@@ -20,7 +20,6 @@ interface PlatformSpecificReRunner extends ReRunner
     /**
      * Does the current platform support this rerunner
      *
-     * @return bool
      */
     public function isSupported(): bool;
 }

--- a/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
@@ -24,8 +24,6 @@ final class ProcOpenReRunner extends PhpExecutableReRunner
     private $executionContext;
 
     /**
-     * @param PhpExecutableFinder $phpExecutableFinder
-     * @param ExecutionContext $executionContext
      * @return static
      */
     public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext)
@@ -36,9 +34,6 @@ final class ProcOpenReRunner extends PhpExecutableReRunner
         return $reRunner;
     }
 
-    /**
-     * @return boolean
-     */
     public function isSupported(): bool
     {
         return (php_sapi_name() == 'cli')

--- a/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
@@ -24,8 +24,6 @@ final class WindowsPassthruReRunner extends PhpExecutableReRunner
     private $executionContext;
 
     /**
-     * @param PhpExecutableFinder $phpExecutableFinder
-     * @param ExecutionContext $executionContext
      * @return static
      */
     public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext)
@@ -36,9 +34,6 @@ final class WindowsPassthruReRunner extends PhpExecutableReRunner
         return $reRunner;
     }
 
-    /**
-     * @return boolean
-     */
     public function isSupported(): bool
     {
         return (php_sapi_name() == 'cli')

--- a/src/PhpSpec/Runner/CollaboratorManager.php
+++ b/src/PhpSpec/Runner/CollaboratorManager.php
@@ -29,16 +29,13 @@ class CollaboratorManager
      */
     private $collaborators = array();
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
     /**
-     * @param string       $name
      * @param object $collaborator
      */
     public function set(string $name, $collaborator): void
@@ -46,18 +43,13 @@ class CollaboratorManager
         $this->collaborators[$name] = $collaborator;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return bool
-     */
+    
     public function has(string $name): bool
     {
         return isset($this->collaborators[$name]);
     }
 
     /**
-     * @param string $name
      *
      * @return object
      *
@@ -74,11 +66,7 @@ class CollaboratorManager
         return $this->collaborators[$name];
     }
 
-    /**
-     * @param ReflectionFunctionAbstract $function
-     *
-     * @return array
-     */
+    
     public function getArgumentsFor(ReflectionFunctionAbstract $function): array
     {
         $parameters = array();

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -45,19 +45,14 @@ class ExampleRunner
      */
     private $maintainers = array();
 
-    /**
-     * @param EventDispatcherInterface $dispatcher
-     * @param Presenter       $presenter
-     */
+    
     public function __construct(EventDispatcherInterface $dispatcher, Presenter $presenter)
     {
         $this->dispatcher = $dispatcher;
         $this->presenter  = $presenter;
     }
 
-    /**
-     * @param Maintainer $maintainer
-     */
+    
     public function registerMaintainer(Maintainer $maintainer): void
     {
         $this->maintainers[] = $maintainer;
@@ -67,11 +62,7 @@ class ExampleRunner
         });
     }
 
-    /**
-     * @param ExampleNode $example
-     *
-     * @return int
-     */
+    
     public function run(ExampleNode $example): int
     {
         $startTime = microtime(true);
@@ -124,8 +115,6 @@ class ExampleRunner
     }
 
     /**
-     * @param Specification $context
-     * @param ExampleNode            $example
      *
      * @throws \PhpSpec\Exception\Example\PendingException
      * @throws \Exception
@@ -173,10 +162,6 @@ class ExampleRunner
 
     /**
      * @param Maintainer[] $maintainers
-     * @param ExampleNode                      $example
-     * @param Specification           $context
-     * @param MatcherManager                   $matchers
-     * @param CollaboratorManager              $collaborators
      */
     private function runMaintainersTeardown(
         array $maintainers,

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -48,32 +48,20 @@ final class CollaboratorsMaintainer implements Maintainer
      */
     private $typeHintIndex;
 
-    /**
-     * @param Unwrapper $unwrapper
-     * @param TypeHintIndex $typeHintIndex
-     */
+    
     public function __construct(Unwrapper $unwrapper, TypeHintIndex $typeHintIndex)
     {
         $this->unwrapper = $unwrapper;
         $this->typeHintIndex = $typeHintIndex;
     }
 
-    /**
-     * @param ExampleNode $example
-     *
-     * @return bool
-     */
+    
     public function supports(ExampleNode $example): bool
     {
         return true;
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -91,12 +79,7 @@ final class CollaboratorsMaintainer implements Maintainer
         $this->generateCollaborators($collaborators, $example->getFunctionReflection(), $classRefl);
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -106,19 +89,13 @@ final class CollaboratorsMaintainer implements Maintainer
         $this->prophet->checkPredictions();
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 50;
     }
 
-    /**
-     * @param CollaboratorManager         $collaborators
-     * @param \ReflectionFunctionAbstract $function
-     * @param \ReflectionClass            $classRefl
-     */
+    
     private function generateCollaborators(CollaboratorManager $collaborators, \ReflectionFunctionAbstract $function, \ReflectionClass $classRefl): void
     {
         foreach ($function->getParameters() as $parameter) {
@@ -156,12 +133,7 @@ final class CollaboratorsMaintainer implements Maintainer
         return !$type instanceof ReflectionNamedType || in_array($type->getName(), ['array', 'callable'], true);
     }
 
-    /**
-     * @param CollaboratorManager $collaborators
-     * @param string              $name
-     *
-     * @return Collaborator
-     */
+    
     private function getOrCreateCollaborator(CollaboratorManager $collaborators, string $name): Collaborator
     {
         if (!$collaborators->has($name)) {
@@ -173,8 +145,6 @@ final class CollaboratorsMaintainer implements Maintainer
     }
 
     /**
-     * @param \Exception $e
-     * @param \ReflectionParameter|null $parameter
      * @param string $className
      * @throws CollaboratorNotFoundException
      */
@@ -188,12 +158,7 @@ final class CollaboratorsMaintainer implements Maintainer
         );
     }
 
-    /**
-     * @param \ReflectionClass $classRefl
-     * @param \ReflectionParameter $parameter
-     *
-     * @return string
-     */
+    
     private function getParameterTypeFromIndex(\ReflectionClass $classRefl, \ReflectionParameter $parameter): string
     {
         return $this->typeHintIndex->lookup(
@@ -204,7 +169,6 @@ final class CollaboratorsMaintainer implements Maintainer
     }
 
     /**
-     * @param \ReflectionParameter $parameter
      *
      * @return string|null
      */

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -38,22 +38,13 @@ final class ErrorMaintainer implements Maintainer
         $this->errorLevel = $errorLevel;
     }
 
-    /**
-     * @param ExampleNode $example
-     *
-     * @return bool
-     */
+    
     public function supports(ExampleNode $example): bool
     {
         return true;
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -63,12 +54,7 @@ final class ErrorMaintainer implements Maintainer
         $this->errorHandler = set_error_handler(array($this, 'errorHandler'), $this->errorLevel);
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -80,9 +66,7 @@ final class ErrorMaintainer implements Maintainer
         }
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 999;
@@ -96,11 +80,8 @@ final class ErrorMaintainer implements Maintainer
      * @see set_error_handler()
      *
      * @param integer $level
-     * @param string  $message
-     * @param string  $file
      * @param integer $line
      *
-     * @return bool
      *
      * @throws ExampleException\ErrorException
      */

--- a/src/PhpSpec/Runner/Maintainer/LetAndLetgoMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/LetAndLetgoMaintainer.php
@@ -20,11 +20,7 @@ use PhpSpec\Runner\CollaboratorManager;
 
 class LetAndLetgoMaintainer implements Maintainer
 {
-    /**
-     * @param ExampleNode $example
-     *
-     * @return bool
-     */
+    
     public function supports(ExampleNode $example): bool
     {
         return $example->getSpecification()->getClassReflection()->hasMethod('let')
@@ -32,12 +28,7 @@ class LetAndLetgoMaintainer implements Maintainer
         ;
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -52,12 +43,7 @@ class LetAndLetgoMaintainer implements Maintainer
         $reflection->invokeArgs($context, $collaborators->getArgumentsFor($reflection));
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -72,9 +58,7 @@ class LetAndLetgoMaintainer implements Maintainer
         $reflection->invokeArgs($context, $collaborators->getArgumentsFor($reflection));
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 10;

--- a/src/PhpSpec/Runner/Maintainer/Maintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/Maintainer.php
@@ -20,19 +20,10 @@ use PhpSpec\Runner\CollaboratorManager;
 
 interface Maintainer
 {
-    /**
-     * @param ExampleNode $example
-     *
-     * @return boolean
-     */
+    
     public function supports(ExampleNode $example): bool;
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -40,12 +31,7 @@ interface Maintainer
         CollaboratorManager $collaborators
     ): void;
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function teardown(
         ExampleNode $example,
         Specification $context,

--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -35,7 +35,6 @@ final class MatchersMaintainer implements Maintainer
     private $defaultMatchers = array();
 
     /**
-     * @param Presenter $presenter
      * @param Matcher[] $matchers
      */
     public function __construct(Presenter $presenter, array $matchers)
@@ -47,22 +46,13 @@ final class MatchersMaintainer implements Maintainer
         });
     }
 
-    /**
-     * @param ExampleNode $example
-     *
-     * @return bool
-     */
+    
     public function supports(ExampleNode $example): bool
     {
         return true;
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -89,12 +79,7 @@ final class MatchersMaintainer implements Maintainer
         }
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -103,9 +88,7 @@ final class MatchersMaintainer implements Maintainer
     ): void {
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 50;

--- a/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
@@ -42,11 +42,7 @@ final class SubjectMaintainer implements Maintainer
      */
     private $accessInspector;
 
-    /**
-     * @param Presenter       $presenter
-     * @param Unwrapper                $unwrapper
-     * @param EventDispatcherInterface $dispatcher
-     */
+    
     public function __construct(
         Presenter $presenter,
         Unwrapper $unwrapper,
@@ -59,11 +55,7 @@ final class SubjectMaintainer implements Maintainer
         $this->accessInspector = $accessInspector;
     }
 
-    /**
-     * @param ExampleNode $example
-     *
-     * @return boolean
-     */
+    
     public function supports(ExampleNode $example): bool
     {
         return $example->getSpecification()->getClassReflection()->implementsInterface(
@@ -71,12 +63,7 @@ final class SubjectMaintainer implements Maintainer
         );
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -92,12 +79,7 @@ final class SubjectMaintainer implements Maintainer
         $context->setSpecificationSubject($subject);
     }
 
-    /**
-     * @param ExampleNode            $example
-     * @param Specification $context
-     * @param MatcherManager         $matchers
-     * @param CollaboratorManager    $collaborators
-     */
+    
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -106,9 +88,7 @@ final class SubjectMaintainer implements Maintainer
     ): void {
     }
 
-    /**
-     * @return int
-     */
+    
     public function getPriority(): int
     {
         return 100;

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -28,17 +28,13 @@ class MatcherManager
      */
     private $matchers = array();
 
-    /**
-     * @param Presenter $presenter
-     */
+    
     public function __construct(Presenter $presenter)
     {
         $this->presenter = $presenter;
     }
 
-    /**
-     * @param Matcher $matcher
-     */
+    
     public function add(Matcher $matcher): void
     {
         $this->matchers[] = $matcher;
@@ -58,11 +54,7 @@ class MatcherManager
     }
 
     /**
-     * @param string $keyword
-     * @param mixed  $subject
-     * @param array  $arguments
      *
-     * @return Matcher
      *
      * @throws \PhpSpec\Exception\Wrapper\MatcherNotFoundException
      */

--- a/src/PhpSpec/Runner/SpecificationRunner.php
+++ b/src/PhpSpec/Runner/SpecificationRunner.php
@@ -31,10 +31,7 @@ class SpecificationRunner
      */
     private $exampleRunner;
 
-    /**
-     * @param EventDispatcherInterface $dispatcher
-     * @param ExampleRunner            $exampleRunner
-     */
+    
     public function __construct(EventDispatcherInterface $dispatcher, ExampleRunner $exampleRunner)
     {
         $this->dispatcher    = $dispatcher;
@@ -42,7 +39,6 @@ class SpecificationRunner
     }
 
     /**
-     * @param  SpecificationNode $specification
      * @return int|mixed
      */
     public function run(SpecificationNode $specification): int

--- a/src/PhpSpec/Runner/SuiteRunner.php
+++ b/src/PhpSpec/Runner/SuiteRunner.php
@@ -32,10 +32,7 @@ class SuiteRunner
      */
     private $specRunner;
 
-    /**
-     * @param EventDispatcher     $dispatcher
-     * @param SpecificationRunner $specRunner
-     */
+    
     public function __construct(EventDispatcher $dispatcher, SpecificationRunner $specRunner)
     {
         $this->dispatcher = $dispatcher;
@@ -43,7 +40,6 @@ class SuiteRunner
     }
 
     /**
-     * @param Suite $suite
      *
      * @return integer
      */

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -11,27 +11,20 @@ interface ServiceContainer
     /**
      * Sets a param in the container
      *
-     * @param string $id
-     * @param mixed $value
      */
     public function setParam(string $id, $value): void;
 
     /**
      * Gets a param from the container or a default value.
      *
-     * @param string $id
-     * @param mixed $default
      *
-     * @return mixed
      */
     public function getParam(string $id, $default = null);
 
     /**
      * Sets a object to be used as a service
      *
-     * @param string $id
      * @param object $service
-     * @param array  $tags
      *
      * @throws \InvalidArgumentException if service is not an object
      */
@@ -41,9 +34,6 @@ interface ServiceContainer
      * Sets a factory for the service creation. The same service will
      * be returned every time
      *
-     * @param string   $id
-     * @param callable $definition
-     * @param array    $tags
      *
      * @throws \InvalidArgumentException if service is not a callable
      */
@@ -52,7 +42,6 @@ interface ServiceContainer
     /**
      * Retrieves a service from the container
      *
-     * @param string $id
      *
      * @return object
      *
@@ -63,15 +52,12 @@ interface ServiceContainer
     /**
      * Determines whether a service is defined
      *
-     * @param string $id
-     * @return bool
      */
     public function has(string $id): bool;
 
     /**
      * Removes a service from the container
      *
-     * @param string $id
      *
      * @throws \InvalidArgumentException if service is not defined
      */
@@ -80,9 +66,7 @@ interface ServiceContainer
     /**
      * Finds all services tagged with a particular string
      *
-     * @param string $tag
      *
-     * @return array
      */
     public function getByTag(string $tag): array;
 }

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -50,8 +50,6 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Sets a param in the container
      *
-     * @param string $id
-     * @param mixed  $value
      */
     public function setParam(string $id, $value): void
     {
@@ -61,10 +59,7 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Gets a param from the container or a default value.
      *
-     * @param string $id
-     * @param mixed  $default
      *
-     * @return mixed
      */
     public function getParam(string $id, $default = null)
     {
@@ -74,9 +69,7 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Sets a object to be used as a service
      *
-     * @param string $id
      * @param object $service
-     * @param array  $tags
      *
      * @throws \InvalidArgumentException if service is not an object
      */
@@ -99,9 +92,6 @@ final class IndexedServiceContainer implements ServiceContainer
      * Sets a factory for the service creation. The same service will
      * be returned every time
      *
-     * @param string   $id
-     * @param callable $definition
-     * @param array    $tags
      */
     public function define(string $id, callable $definition, array $tags = []): void
     {
@@ -114,7 +104,6 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Retrieves a service from the container
      *
-     * @param string $id
      *
      * @return object
      *
@@ -136,8 +125,6 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Determines whether a service is defined
      *
-     * @param string $id
-     * @return bool
      */
     public function has(string $id): bool
     {
@@ -147,7 +134,6 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Removes a service from the container
      *
-     * @param string $id
      *
      * @throws \InvalidArgumentException if service is not defined
      */
@@ -163,8 +149,6 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Adds a service or service definition to the index
      *
-     * @param string $id
-     * @param array  $tags
      */
     private function indexTags(string $id, array $tags): void
     {
@@ -176,9 +160,7 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Finds all services tagged with a particular string
      *
-     * @param string $tag
      *
-     * @return array
      */
     public function getByTag(string $tag): array
     {
@@ -190,7 +172,6 @@ final class IndexedServiceContainer implements ServiceContainer
      *
      * @internal
      *
-     * @param callable $configurator
      *
      * @throws \InvalidArgumentException if configurator is not a value
      */

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -20,10 +20,7 @@ final class ClassFileAnalyser
 {
     private $tokenLists = array();
 
-    /**
-     * @param string $class
-     * @return int
-     */
+    
     public function getStartLineOfFirstMethod(string $class): int
     {
         $tokens = $this->getTokensForClass($class);
@@ -31,10 +28,7 @@ final class ClassFileAnalyser
         return $tokens[$index][2];
     }
 
-    /**
-     * @param string $class
-     * @return int
-     */
+    
     public function getEndLineOfLastMethod(string $class): int
     {
         $tokens = $this->getTokensForClass($class);
@@ -42,10 +36,7 @@ final class ClassFileAnalyser
         return $tokens[$index][2];
     }
 
-    /**
-     * @param string $class
-     * @return bool
-     */
+    
     public function classHasMethods(string $class): bool
     {
         foreach ($this->getTokensForClass($class) as $token) {
@@ -61,11 +52,7 @@ final class ClassFileAnalyser
         return false;
     }
 
-    /**
-     * @param string $class
-     * @param string $methodName
-     * @return int
-     */
+    
     public function getEndLineOfNamedMethod(string $class, string $methodName): int
     {
         $tokens = $this->getTokensForClass($class);
@@ -74,10 +61,7 @@ final class ClassFileAnalyser
         return $tokens[$index][2];
     }
 
-    /**
-     * @param array $tokens
-     * @return int
-     */
+    
     private function findIndexOfFirstMethod(array $tokens): int
     {
         for ($i = 0, $max = \count($tokens); $i < $max; $i++) {
@@ -87,11 +71,7 @@ final class ClassFileAnalyser
         }
     }
 
-    /**
-     * @param array $tokens
-     * @param int $index
-     * @return int
-     */
+    
     private function offsetForDocblock(array $tokens, int $index): int
     {
         $allowedTokens = array(
@@ -125,7 +105,6 @@ final class ClassFileAnalyser
 
     /**
      * @param $class
-     * @return array
      */
     private function getTokensForClass($class): array
     {
@@ -138,11 +117,7 @@ final class ClassFileAnalyser
         return $this->tokenLists[$hash];
     }
 
-    /**
-     * @param array $tokens
-     * @param string $methodName
-     * @return int
-     */
+    
     private function findIndexOfNamedMethodEnd(array $tokens, string $methodName): int
     {
         $index = $this->findIndexOfNamedMethod($tokens, $methodName);
@@ -150,9 +125,6 @@ final class ClassFileAnalyser
     }
 
     /**
-     * @param array $tokens
-     * @param string $methodName
-     * @return int
      * @throws NamedMethodNotFoundException
      */
     private function findIndexOfNamedMethod(array $tokens, string $methodName): int
@@ -186,11 +158,7 @@ final class ClassFileAnalyser
         throw new NamedMethodNotFoundException('Target method not found');
     }
 
-    /**
-     * @param array $tokens
-     * @param int $index
-     * @return int
-     */
+    
     private function findIndexOfMethodOrClassEnd(array $tokens, int $index): int
     {
         $braceCount = 0;
@@ -221,19 +189,13 @@ final class ClassFileAnalyser
         return $token[1] === "{";
     }
 
-    /**
-     * @param mixed $token
-     * @return bool
-     */
+    
     private function tokenIsFunction($token): bool
     {
         return \is_array($token) && $token[0] === T_FUNCTION;
     }
 
-    /**
-     * @param array $tokens
-     * @return int
-     */
+    
     private function findIndexOfClassEnd(array $tokens): int
     {
         $classTokens = array_filter($tokens, function ($token) {
@@ -243,11 +205,7 @@ final class ClassFileAnalyser
         return $this->findIndexOfMethodOrClassEnd($tokens, $classTokenIndex) - 1;
     }
 
-    /**
-     * @param array $tokens
-     * @param int $index
-     * @return int
-     */
+    
     public function findEndOfLastMethod(array $tokens, int $index): int
     {
         for ($i = $index - 1; $i > 0; $i--) {

--- a/src/PhpSpec/Util/Filesystem.php
+++ b/src/PhpSpec/Util/Filesystem.php
@@ -17,55 +17,37 @@ use Symfony\Component\Finder\Finder;
 
 class Filesystem
 {
-    /**
-     * @param string $path
-     *
-     * @return bool
-     */
+    
     public function pathExists(string $path): bool
     {
         return file_exists($path);
     }
 
-    /**
-     * @param string $path
-     *
-     * @return string
-     */
+    
     public function getFileContents(string $path): string
     {
         return file_get_contents($path);
     }
 
-    /**
-     * @param string $path
-     * @param string $content
-     */
+    
     public function putFileContents(string $path, string $content)
     {
         file_put_contents($path, $content);
     }
 
-    /**
-     * @param string $path
-     *
-     * @return bool
-     */
+    
     public function isDirectory(string $path): bool
     {
         return is_dir($path);
     }
 
-    /**
-     * @param string $path
-     */
+    
     public function makeDirectory(string $path): void
     {
         mkdir($path, 0777, true);
     }
 
     /**
-     * @param string $path
      *
      * @return \SplFileInfo[]
      */

--- a/src/PhpSpec/Util/Instantiator.php
+++ b/src/PhpSpec/Util/Instantiator.php
@@ -18,7 +18,6 @@ use PhpSpec\Exception\Fracture\ClassNotFoundException;
 class Instantiator
 {
     /**
-     * @param string $className
      *
      * @return object
      */

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -17,22 +17,13 @@ use PhpSpec\Loader\StreamWrapper;
 
 class MethodAnalyser
 {
-    /**
-     * @param string $class
-     * @param string $method
-     *
-     * @return boolean
-     */
+    
     public function methodIsEmpty(string $class, string $method): bool
     {
         return $this->reflectionMethodIsEmpty(new \ReflectionMethod($class, $method));
     }
 
-    /**
-     * @param \ReflectionMethod $method
-     *
-     * @return bool
-     */
+    
     public function reflectionMethodIsEmpty(\ReflectionMethod $method): bool
     {
         if ($this->isNotImplementedInPhp($method)) {
@@ -45,12 +36,7 @@ class MethodAnalyser
         return $this->codeIsOnlyBlocksAndWhitespace($codeWithoutComments);
     }
 
-    /**
-     * @param string $class
-     * @param string $method
-     *
-     * @return string
-     */
+    
     public function getMethodOwnerName(string $class, string $method): string
     {
         $reflectionMethod = new \ReflectionMethod($class, $method);
@@ -61,11 +47,7 @@ class MethodAnalyser
         return $reflectionClass->getName();
     }
 
-    /**
-     * @param \ReflectionMethod $reflectionMethod
-     *
-     * @return string
-     */
+    
     private function getCodeBody(\ReflectionMethod $reflectionMethod): string
     {
         $endLine = $reflectionMethod->getEndLine();
@@ -79,13 +61,7 @@ class MethodAnalyser
         return preg_replace('/.*function[^{]+{/s', '', $code);
     }
 
-    /**
-     * @param  \ReflectionMethod $reflectionMethod
-     * @param  int $methodStartLine
-     * @param  int $methodEndLine
-     *
-     * @return \ReflectionClass
-     */
+    
     private function getMethodOwner(\ReflectionMethod $reflectionMethod, int $methodStartLine, int $methodEndLine): \ReflectionClass
     {
         $reflectionClass = $reflectionMethod->getDeclaringClass();
@@ -98,11 +74,7 @@ class MethodAnalyser
 
     /**
      * @param  \ReflectionClass[] $traits
-     * @param  string  $file
-     * @param  int $start
-     * @param  int $end
      *
-     * @return null|\ReflectionClass
      */
     private function getDeclaringTrait(array $traits, string $file, int $start, int $end): ?\ReflectionClass
     {
@@ -118,10 +90,7 @@ class MethodAnalyser
         return null;
     }
 
-    /**
-     * @param  string $code
-     * @return string
-     */
+    
     private function stripComments(string $code): string
     {
         $tokens = token_get_all('<?php ' . $code);
@@ -142,19 +111,13 @@ class MethodAnalyser
         return $commentless;
     }
 
-    /**
-     * @param  string $codeWithoutComments
-     * @return bool
-     */
+    
     private function codeIsOnlyBlocksAndWhitespace(string $codeWithoutComments): bool
     {
         return (bool) preg_match('/^[\s{}]*$/s', $codeWithoutComments);
     }
 
-    /**
-     * @param  \ReflectionMethod $method
-     * @return bool
-     */
+    
     private function isNotImplementedInPhp(\ReflectionMethod $method): bool
     {
         $filename = $method->getDeclaringClass()->getFileName();

--- a/src/PhpSpec/Util/NameChecker.php
+++ b/src/PhpSpec/Util/NameChecker.php
@@ -15,10 +15,6 @@ namespace PhpSpec\Util;
 
 interface NameChecker
 {
-    /**
-     * @param string $name
-     *
-     * @return bool
-     */
+    
     public function isNameValid(string $name): bool;
 }

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -22,17 +22,13 @@ final class Collaborator implements ObjectWrapper
      */
     private $prophecy;
 
-    /**
-     * @param ObjectProphecy $prophecy
-     */
+    
     public function __construct(ObjectProphecy $prophecy)
     {
         $this->prophecy  = $prophecy;
     }
 
-    /**
-     * @param string $classOrInterface
-     */
+    
     public function beADoubleOf(string $classOrInterface): void
     {
         if (interface_exists($classOrInterface)) {
@@ -50,39 +46,25 @@ final class Collaborator implements ObjectWrapper
         $this->prophecy->willBeConstructedWith($arguments);
     }
 
-    /**
-     * @param string $interface
-     */
+    
     public function implement(string $interface): void
     {
         $this->prophecy->willImplement($interface);
     }
 
-    /**
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     public function __call(string $method, array $arguments)
     {
         return \call_user_func_array(array($this->prophecy, '__call'), array($method, $arguments));
     }
 
-    /**
-     * @param string $parameter
-     * @param mixed  $value
-     */
+    
     public function __set(string $parameter, $value)
     {
         $this->prophecy->$parameter = $value;
     }
 
-    /**
-     * @param string $parameter
-     *
-     * @return mixed
-     */
+    
     public function __get(string $parameter)
     {
         return $this->prophecy->$parameter;

--- a/src/PhpSpec/Wrapper/DelayedCall.php
+++ b/src/PhpSpec/Wrapper/DelayedCall.php
@@ -20,20 +20,13 @@ class DelayedCall
      */
     private $callable;
 
-    /**
-     * @param callable $callable
-     */
+    
     public function __construct(callable $callable)
     {
         $this->callable = $callable;
     }
 
-    /**
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     public function __call(string $method, array $arguments)
     {
         return \call_user_func($this->callable, $method, $arguments);

--- a/src/PhpSpec/Wrapper/ObjectWrapper.php
+++ b/src/PhpSpec/Wrapper/ObjectWrapper.php
@@ -15,8 +15,6 @@ namespace PhpSpec\Wrapper;
 
 interface ObjectWrapper
 {
-    /**
-     * @return mixed
-     */
+    
     public function getWrappedObject();
 }

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -121,9 +121,7 @@ use ArrayAccess;
  */
 class Subject implements ArrayAccess, ObjectWrapper
 {
-    /**
-     * @var mixed
-     */
+    
     private $subject;
     /**
      * @var Subject\WrappedObject
@@ -146,14 +144,7 @@ class Subject implements ArrayAccess, ObjectWrapper
      */
     private $expectationFactory;
 
-    /**
-     * @param mixed                  $subject
-     * @param Wrapper                $wrapper
-     * @param WrappedObject          $wrappedObject
-     * @param Caller                 $caller
-     * @param SubjectWithArrayAccess $arrayAccess
-     * @param ExpectationFactory     $expectationFactory
-     */
+    
     public function __construct(
         $subject,
         Wrapper $wrapper,
@@ -170,10 +161,7 @@ class Subject implements ArrayAccess, ObjectWrapper
         $this->expectationFactory = $expectationFactory;
     }
 
-    /**
-     * @param string $className
-     * @param array  $arguments
-     */
+    
     public function beAnInstanceOf(string $className, array $arguments = array()): void
     {
         $this->wrappedObject->beAnInstanceOf($className, $arguments);
@@ -189,16 +177,13 @@ class Subject implements ArrayAccess, ObjectWrapper
 
     /**
      * @param array|string $factoryMethod
-     * @param array        $arguments
      */
     public function beConstructedThrough($factoryMethod, array $arguments = array()): void
     {
         $this->wrappedObject->beConstructedThrough($factoryMethod, $arguments);
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getWrappedObject()
     {
         if ($this->subject) {
@@ -208,30 +193,19 @@ class Subject implements ArrayAccess, ObjectWrapper
         return $this->subject = $this->caller->getWrappedObject();
     }
 
-    /**
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return Subject
-     */
+    
     public function callOnWrappedObject(string $method, array $arguments = array()): Subject
     {
         return $this->caller->call($method, $arguments);
     }
 
-    /**
-     * @param string $property
-     * @param mixed  $value
-     *
-     * @return mixed
-     */
+    
     public function setToWrappedObject(string $property, $value = null)
     {
         return $this->caller->set($property, $value);
     }
 
     /**
-     * @param string $property
      *
      * @return string|Subject
      */
@@ -243,7 +217,6 @@ class Subject implements ArrayAccess, ObjectWrapper
     /**
      * @param string|integer $key
      *
-     * @return Subject
      */
     public function offsetExists($key): Subject
     {
@@ -253,7 +226,6 @@ class Subject implements ArrayAccess, ObjectWrapper
     /**
      * @param string|integer $key
      *
-     * @return Subject
      */
     public function offsetGet($key): Subject
     {
@@ -262,7 +234,6 @@ class Subject implements ArrayAccess, ObjectWrapper
 
     /**
      * @param string|integer $key
-     * @param mixed          $value
      */
     public function offsetSet($key, $value): void
     {
@@ -278,8 +249,6 @@ class Subject implements ArrayAccess, ObjectWrapper
     }
 
     /**
-     * @param string $method
-     * @param array  $arguments
      *
      * @return mixed|Subject
      */
@@ -300,27 +269,19 @@ class Subject implements ArrayAccess, ObjectWrapper
         return $this->caller->call($method, $arguments);
     }
 
-    /**
-     * @return Subject
-     */
+    
     public function __invoke(): Subject
     {
         return $this->caller->call('__invoke', \func_get_args());
     }
 
-    /**
-     * @param string $property
-     * @param mixed  $value
-     *
-     * @return mixed
-     */
+    
     public function __set(string $property, $value = null)
     {
         return $this->caller->set($property, $value);
     }
 
     /**
-     * @param string $property
      *
      * @return string|Subject
      */
@@ -329,22 +290,13 @@ class Subject implements ArrayAccess, ObjectWrapper
         return $this->caller->get($property);
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @return Subject
-     */
+    
     private function wrap($value): Subject
     {
         return $this->wrapper->wrap($value);
     }
 
-    /**
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     private function callExpectation(string $method, array $arguments)
     {
         $subject = $this->makeSureWeHaveASubject();

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -56,14 +56,7 @@ class Caller
      */
     private $accessInspector;
 
-    /**
-     * @param WrappedObject $wrappedObject
-     * @param ExampleNode $example
-     * @param Dispatcher $dispatcher
-     * @param ExceptionFactory $exceptions
-     * @param Wrapper $wrapper
-     * @param AccessInspector $accessInspector
-     */
+    
     public function __construct(
         WrappedObject $wrappedObject,
         ExampleNode $example,
@@ -81,10 +74,7 @@ class Caller
     }
 
     /**
-     * @param string $method
-     * @param array  $arguments
      *
-     * @return Subject
      *
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      * @throws \PhpSpec\Exception\Fracture\MethodNotVisibleException
@@ -108,8 +98,6 @@ class Caller
     }
 
     /**
-     * @param string $property
-     * @param mixed  $value
      *
      * @return mixed
      *
@@ -135,7 +123,6 @@ class Caller
     }
 
     /**
-     * @param string $property
      *
      * @return Subject|string
      *
@@ -190,11 +177,7 @@ class Caller
         return $instance;
     }
 
-    /**
-     * @param string $property
-     *
-     * @return bool
-     */
+    
     private function isObjectPropertyReadable(string $property): bool
     {
         $subject = $this->getWrappedObject();
@@ -202,11 +185,7 @@ class Caller
         return \is_object($subject) && $this->accessInspector->isPropertyReadable($subject, $property);
     }
 
-    /**
-     * @param string $property
-     *
-     * @return bool
-     */
+    
     private function isObjectPropertyWritable(string $property): bool
     {
         $subject = $this->getWrappedObject();
@@ -214,11 +193,7 @@ class Caller
         return \is_object($subject) && $this->accessInspector->isPropertyWritable($subject, $property);
     }
 
-    /**
-     * @param string $method
-     *
-     * @return bool
-     */
+    
     private function isObjectMethodCallable(string $method): bool
     {
         return $this->accessInspector->isMethodCallable($this->getWrappedObject(), $method);
@@ -245,9 +220,7 @@ class Caller
     /**
      * @param object $subject
      * @param string $method
-     * @param array  $arguments
      *
-     * @return Subject
      */
     private function invokeAndWrapMethodResult($subject, $method, array $arguments = array()): Subject
     {
@@ -268,18 +241,13 @@ class Caller
         return $this->wrap($returnValue);
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @return Subject
-     */
+    
     private function wrap($value): Subject
     {
         return $this->wrapper->wrap($value);
     }
 
     /**
-     * @param ReflectionClass $reflection
      *
      * @return object
      *
@@ -304,7 +272,6 @@ class Caller
     }
 
     /**
-     * @return mixed
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
      */
@@ -329,11 +296,7 @@ class Caller
         );
     }
 
-    /**
-     * @param ReflectionException $exception
-     *
-     * @return bool
-     */
+    
     private function detectMissingConstructorMessage(ReflectionException $exception): bool
     {
         return strpos(
@@ -342,9 +305,7 @@ class Caller
         ) !== 0;
     }
 
-    /**
-     * @return \PhpSpec\Exception\Fracture\ClassNotFoundException
-     */
+    
     private function classNotFound(): \PhpSpec\Exception\Fracture\ClassNotFoundException
     {
         return $this->exceptionFactory->classNotFound($this->wrappedObject->getClassName());
@@ -359,7 +320,6 @@ class Caller
 
     /**
      * @param $method
-     * @param array $arguments
      * @return \PhpSpec\Exception\Fracture\MethodNotFoundException|\PhpSpec\Exception\Fracture\MethodNotVisibleException
      */
     private function methodNotFound($method, array $arguments = array())
@@ -373,62 +333,38 @@ class Caller
         return $this->exceptionFactory->methodNotVisible($className, $method, $arguments);
     }
 
-    /**
-     * @param string $property
-     *
-     * @return \PhpSpec\Exception\Fracture\PropertyNotFoundException
-     */
+    
     private function propertyNotFound(string $property): \PhpSpec\Exception\Fracture\PropertyNotFoundException
     {
         return $this->exceptionFactory->propertyNotFound($this->getWrappedObject(), $property);
     }
 
-    /**
-     * @param string $method
-     *
-     * @return \PhpSpec\Exception\Wrapper\SubjectException
-     */
+    
     private function callingMethodOnNonObject(string $method): \PhpSpec\Exception\Wrapper\SubjectException
     {
         return $this->exceptionFactory->callingMethodOnNonObject($method);
     }
 
-    /**
-     * @param string $property
-     *
-     * @return \PhpSpec\Exception\Wrapper\SubjectException
-     */
+    
     private function settingPropertyOnNonObject(string $property): \PhpSpec\Exception\Wrapper\SubjectException
     {
         return $this->exceptionFactory->settingPropertyOnNonObject($property);
     }
 
-    /**
-     * @param string $property
-     *
-     * @return \PhpSpec\Exception\Wrapper\SubjectException
-     */
+    
     private function accessingPropertyOnNonObject(string $property): \PhpSpec\Exception\Wrapper\SubjectException
     {
         return $this->exceptionFactory->gettingPropertyOnNonObject($property);
     }
 
-    /**
-     * @param string $property
-     *
-     * @return bool
-     */
+    
     private function lookingForConstants(string $property): bool
     {
         return null !== $this->wrappedObject->getClassName() &&
             $property === strtoupper($property);
     }
 
-    /**
-     * @param string $property
-     *
-     * @return bool
-     */
+    
     public function constantDefined(string $property): bool
     {
         return \defined($this->wrappedObject->getClassName().'::'.$property);

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -18,21 +18,14 @@ use PhpSpec\Wrapper\Subject\WrappedObject;
 
 final class ConstructorDecorator extends Decorator implements Expectation
 {
-    /**
-     * @param Expectation $expectation
-     */
+    
     public function __construct(Expectation $expectation)
     {
         $this->setExpectation($expectation);
     }
 
     /**
-     * @param string             $alias
-     * @param mixed              $subject
-     * @param array              $arguments
-     * @param WrappedObject|null $wrappedObject
      *
-     * @return mixed
      *
      * @throws \PhpSpec\Exception\ErrorException
      * @throws \PhpSpec\Exception\Example\ErrorException

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
@@ -20,33 +20,25 @@ abstract class Decorator implements Expectation
      */
     private $expectation;
 
-    /**
-     * @param Expectation $expectation
-     */
+    
     public function __construct(Expectation $expectation)
     {
         $this->expectation = $expectation;
     }
 
-    /**
-     * @return Expectation
-     */
+    
     public function getExpectation(): Expectation
     {
         return $this->expectation;
     }
 
-    /**
-     * @param Expectation $expectation
-     */
+    
     protected function setExpectation(Expectation $expectation): void
     {
         $this->expectation = $expectation;
     }
 
-    /**
-     * @return Expectation
-     */
+    
     public function getNestedExpectation(): Expectation
     {
         $expectation = $this->getExpectation();

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
@@ -38,12 +38,7 @@ final class DispatcherDecorator extends Decorator implements Expectation
      */
     private $example;
 
-    /**
-     * @param Expectation     $expectation
-     * @param EventDispatcherInterface $dispatcher
-     * @param Matcher         $matcher
-     * @param ExampleNode              $example
-     */
+    
     public function __construct(
         Expectation $expectation,
         EventDispatcherInterface $dispatcher,
@@ -57,10 +52,6 @@ final class DispatcherDecorator extends Decorator implements Expectation
     }
 
     /**
-     * @param  string  $alias
-     * @param  mixed   $subject
-     * @param  array   $arguments
-     * @return mixed
      *
      * @throws \Exception
      * @throws \PhpSpec\Exception\Example\FailureException

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -24,9 +24,7 @@ abstract class DuringCall
      * @var Matcher
      */
     private $matcher;
-    /**
-     * @var mixed
-     */
+    
     private $subject;
     /**
      * @var array
@@ -37,18 +35,13 @@ abstract class DuringCall
      */
     private $wrappedObject;
 
-    /**
-     * @param Matcher $matcher
-     */
+    
     public function __construct(Matcher $matcher)
     {
         $this->matcher = $matcher;
     }
 
     /**
-     * @param string $alias
-     * @param mixed  $subject
-     * @param array  $arguments
      *
      * @param WrappedObject|null $wrappedObject
      *
@@ -63,12 +56,7 @@ abstract class DuringCall
         return $this;
     }
 
-    /**
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     public function during(string $method, array $arguments = array())
     {
         if ($method === '__construct') {
@@ -82,9 +70,7 @@ abstract class DuringCall
         return $this->runDuring($object, $method, $arguments);
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function duringInstantiation()
     {
         if ($factoryMethod = $this->wrappedObject->getFactoryMethod()) {
@@ -99,10 +85,7 @@ abstract class DuringCall
     }
 
     /**
-     * @param string $method
-     * @param array  $arguments
      *
-     * @return mixed
      *
      * @throws MatcherException
      */
@@ -120,17 +103,13 @@ abstract class DuringCall
             '->during(\''.$method.'\', array(arguments))');
     }
 
-    /**
-     * @return array
-     */
+    
     protected function getArguments(): array
     {
         return $this->arguments;
     }
 
-    /**
-     * @return Matcher
-     */
+    
     protected function getMatcher(): Matcher
     {
         return $this->matcher;
@@ -139,9 +118,7 @@ abstract class DuringCall
     /**
      * @param object $object
      * @param string $method
-     * @param array  $arguments
      *
-     * @return mixed
      */
     abstract protected function runDuring($object, $method, array $arguments = array());
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Expectation.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Expectation.php
@@ -15,12 +15,6 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 interface Expectation
 {
-    /**
-     * @param string $alias
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     public function match(string $alias, $subject, array $arguments = array());
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Negative.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Negative.php
@@ -22,21 +22,13 @@ final class Negative implements Expectation
      */
     private $matcher;
 
-    /**
-     * @param Matcher $matcher
-     */
+    
     public function __construct(Matcher $matcher)
     {
         $this->matcher = $matcher;
     }
 
-    /**
-     * @param string $alias
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     public function match(string $alias, $subject, array $arguments = array())
     {
         return $this->matcher->negativeMatch($alias, $subject, $arguments);

--- a/src/PhpSpec/Wrapper/Subject/Expectation/NegativeThrow.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/NegativeThrow.php
@@ -18,9 +18,7 @@ final class NegativeThrow extends DuringCall implements ThrowExpectation
     /**
      * @param object $object
      * @param string $method
-     * @param array  $arguments
      *
-     * @return mixed
      */
     protected function runDuring($object, $method, array $arguments = array())
     {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php
@@ -18,9 +18,7 @@ final class NegativeTrigger extends DuringCall implements ThrowExpectation
     /**
      * @param object $object
      * @param string $method
-     * @param array  $arguments
      *
-     * @return mixed
      */
     protected function runDuring($object, $method, array $arguments = array())
     {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Positive.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Positive.php
@@ -22,21 +22,13 @@ final class Positive implements Expectation
      */
     private $matcher;
 
-    /**
-     * @param Matcher $matcher
-     */
+    
     public function __construct(Matcher $matcher)
     {
         $this->matcher = $matcher;
     }
 
-    /**
-     * @param string $alias
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     public function match(string $alias, $subject, array $arguments = array())
     {
         return $this->matcher->positiveMatch($alias, $subject, $arguments);

--- a/src/PhpSpec/Wrapper/Subject/Expectation/PositiveThrow.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/PositiveThrow.php
@@ -18,9 +18,7 @@ final class PositiveThrow extends DuringCall implements ThrowExpectation
     /**
      * @param object $object
      * @param string $method
-     * @param array  $arguments
      *
-     * @return mixed
      */
     protected function runDuring($object, $method, array $arguments = array())
     {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php
@@ -18,9 +18,7 @@ final class PositiveTrigger extends DuringCall implements ThrowExpectation
     /**
      * @param object $object
      * @param string $method
-     * @param array  $arguments
      *
-     * @return mixed
      */
     protected function runDuring($object, $method, array $arguments = array())
     {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ThrowExpectation.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ThrowExpectation.php
@@ -15,11 +15,6 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 interface ThrowExpectation extends Expectation
 {
-    /**
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     public function during(string $method, array $arguments = array());
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
@@ -22,23 +22,14 @@ final class UnwrapDecorator extends Decorator implements Expectation
      */
     private $unwrapper;
 
-    /**
-     * @param Expectation $expectation
-     * @param Unwrapper            $unwrapper
-     */
+    
     public function __construct(Expectation $expectation, Unwrapper $unwrapper)
     {
         parent::__construct($expectation);
         $this->unwrapper = $unwrapper;
     }
 
-    /**
-     * @param string $alias
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
+    
     public function match(string $alias, $subject, array $arguments = array())
     {
         $arguments = $this->unwrapper->unwrapAll($arguments);

--- a/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
+++ b/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
@@ -39,11 +39,7 @@ class ExpectationFactory
      */
     private $matchers;
 
-    /**
-     * @param ExampleNode              $example
-     * @param EventDispatcherInterface $dispatcher
-     * @param MatcherManager           $matchers
-     */
+    
     public function __construct(ExampleNode $example, EventDispatcherInterface $dispatcher, MatcherManager $matchers)
     {
         $this->example = $example;
@@ -51,13 +47,7 @@ class ExpectationFactory
         $this->matchers = $matchers;
     }
 
-    /**
-     * @param string $expectation
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return Expectation
-     */
+    
     public function create(string $expectation, $subject, array $arguments = array()): Expectation
     {
         if (0 === strpos($expectation, 'shouldNot')) {
@@ -69,13 +59,7 @@ class ExpectationFactory
         }
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return Expectation
-     */
+    
     private function createPositive(string $name, $subject, array $arguments = array()): Expectation
     {
         if (strtolower($name) === 'throw') {
@@ -89,13 +73,7 @@ class ExpectationFactory
         return $this->createDecoratedExpectation("Positive", $name, $subject, $arguments);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return Expectation
-     */
+    
     private function createNegative(string $name, $subject, array $arguments = array()): Expectation
     {
         if (strtolower($name) === 'throw') {
@@ -109,14 +87,7 @@ class ExpectationFactory
         return $this->createDecoratedExpectation("Negative", $name, $subject, $arguments);
     }
 
-    /**
-     * @param string $expectation
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return Expectation
-     */
+    
     private function createDecoratedExpectation(string $expectation, string $name, $subject, array $arguments): Expectation
     {
         $matcher = $this->findMatcher($name, $subject, $arguments);
@@ -131,13 +102,7 @@ class ExpectationFactory
         return $this->decoratedExpectation($expectation, $matcher);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $subject
-     * @param array  $arguments
-     *
-     * @return Matcher
-     */
+    
     private function findMatcher(string $name, $subject, array $arguments = array()): Matcher
     {
         $unwrapper = new Unwrapper();
@@ -146,12 +111,7 @@ class ExpectationFactory
         return $this->matchers->find($name, $subject, $arguments);
     }
 
-    /**
-     * @param Expectation $expectation
-     * @param Matcher     $matcher
-     *
-     * @return ConstructorDecorator
-     */
+    
     private function decoratedExpectation(Expectation $expectation, Matcher $matcher): ConstructorDecorator
     {
         $dispatcherDecorator = new DispatcherDecorator($expectation, $this->dispatcher, $matcher, $this->example);

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -34,11 +34,7 @@ class SubjectWithArrayAccess
      */
     private $dispatcher;
 
-    /**
-     * @param Caller                   $caller
-     * @param Presenter       $presenter
-     * @param EventDispatcherInterface $dispatcher
-     */
+    
     public function __construct(
         Caller $caller,
         Presenter $presenter,
@@ -52,7 +48,6 @@ class SubjectWithArrayAccess
     /**
      * @param string|integer $key
      *
-     * @return bool
      */
     public function offsetExists($key): bool
     {
@@ -68,7 +63,6 @@ class SubjectWithArrayAccess
     /**
      * @param string|integer $key
      *
-     * @return mixed
      */
     public function offsetGet($key)
     {
@@ -83,7 +77,6 @@ class SubjectWithArrayAccess
 
     /**
      * @param string|integer $key
-     * @param mixed          $value
      */
     public function offsetSet($key, $value): void
     {
@@ -112,7 +105,6 @@ class SubjectWithArrayAccess
     }
 
     /**
-     * @param mixed $subject
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      * @throws \PhpSpec\Exception\Fracture\InterfaceNotImplementedException
@@ -126,9 +118,7 @@ class SubjectWithArrayAccess
         }
     }
 
-    /**
-     * @return InterfaceNotImplementedException
-     */
+    
     private function interfaceNotImplemented(): InterfaceNotImplementedException
     {
         return new InterfaceNotImplementedException(
@@ -142,11 +132,7 @@ class SubjectWithArrayAccess
         );
     }
 
-    /**
-     * @param mixed $subject
-     *
-     * @return SubjectException
-     */
+    
     private function cantUseAsArray($subject): SubjectException
     {
         return new SubjectException(sprintf(

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -47,7 +47,6 @@ class WrappedObject
 
     /**
      * @param object|null        $instance
-     * @param Presenter $presenter
      */
     public function __construct($instance, Presenter $presenter)
     {
@@ -60,8 +59,6 @@ class WrappedObject
     }
 
     /**
-     * @param string $classname
-     * @param array  $arguments
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
@@ -82,7 +79,6 @@ class WrappedObject
     }
 
     /**
-     * @param array $args
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
@@ -104,7 +100,6 @@ class WrappedObject
 
     /**
      * @param callable|string|null $factoryMethod
-     * @param array                $arguments
      */
     public function beConstructedThrough($factoryMethod, array $arguments = array()): void
     {
@@ -132,9 +127,7 @@ class WrappedObject
         return $this->factoryMethod;
     }
 
-    /**
-     * @return bool
-     */
+    
     public function isInstantiated(): bool
     {
         return $this->isInstantiated;
@@ -156,17 +149,13 @@ class WrappedObject
         return $this->classname;
     }
 
-    /**
-     * @param string $classname
-     */
+    
     public function setClassName(string $classname): void
     {
         $this->classname = $classname;
     }
 
-    /**
-     * @return array
-     */
+    
     public function getArguments(): array
     {
         return $this->arguments;

--- a/src/PhpSpec/Wrapper/SubjectContainer.php
+++ b/src/PhpSpec/Wrapper/SubjectContainer.php
@@ -15,8 +15,6 @@ namespace PhpSpec\Wrapper;
 
 interface SubjectContainer
 {
-    /**
-     * @param Subject $subject
-     */
+    
     public function setSpecificationSubject(Subject $subject): void;
 }

--- a/src/PhpSpec/Wrapper/Unwrapper.php
+++ b/src/PhpSpec/Wrapper/Unwrapper.php
@@ -18,11 +18,7 @@ use Prophecy\Prophecy\ProphecyInterface;
 
 class Unwrapper implements RevealerInterface
 {
-    /**
-     * @param array $arguments
-     *
-     * @return array
-     */
+    
     public function unwrapAll(array $arguments): array
     {
         if (null === $arguments) {
@@ -32,11 +28,7 @@ class Unwrapper implements RevealerInterface
         return array_map(array($this, 'unwrapOne'), $arguments);
     }
 
-    /**
-     * @param mixed $argument
-     *
-     * @return mixed
-     */
+    
     public function unwrapOne($argument)
     {
         if (\is_array($argument)) {
@@ -58,11 +50,7 @@ class Unwrapper implements RevealerInterface
         return $argument;
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @return mixed
-     */
+    
     public function reveal($value)
     {
         return $this->unwrapOne($value);

--- a/src/PhpSpec/Wrapper/Wrapper.php
+++ b/src/PhpSpec/Wrapper/Wrapper.php
@@ -48,10 +48,6 @@ class Wrapper
     private $accessInspector;
 
     /**
-     * @param MatcherManager $matchers
-     * @param Presenter $presenter
-     * @param EventDispatcherInterface $dispatcher
-     * @param ExampleNode $example
      * @param AccessInspector $accessInspector
      */
     public function __construct(
@@ -71,7 +67,6 @@ class Wrapper
     /**
      * @param object $value
      *
-     * @return Subject
      */
     public function wrap($value = null): Subject
     {
@@ -90,11 +85,7 @@ class Wrapper
         );
     }
 
-    /**
-     * @param WrappedObject $wrappedObject
-     *
-     * @return Caller
-     */
+    
     private function createCaller(WrappedObject $wrappedObject): Caller
     {
         $exceptionFactory = new ExceptionFactory($this->presenter);


### PR DESCRIPTION
Hello,

While doing a new extension ([loophp/phpspec-time](https://github.com/loophp/phpspec-time)) and fixing Psalm issues, I noticed this issue:

```
ERROR: UndefinedDocblockClass - src/Matcher/TakeInBetweenMatcher.php:23:73 - Docblock-defined class or interface PhpSpec\Matcher\Boolean does not exist (see https://psalm.dev/200)
    public function supports(string $name, $subject, array $arguments): bool
```

The supports method is defined in [Matcher.php](https://github.com/phpspec/phpspec/blob/main/src/PhpSpec/Matcher/Matcher.php#L29).

As we can see, Psalm is (often) right and `Boolean` is not a PHP type nor a Class.

We should either replace it with `bool` or remove it because it's superfluous and already announced in the signature of the method.

This PR:

* [x] Remove all the superluous tags from the source code with PHPCSFixer
* [x] Add the `bool` return type to `features/bootstrap/Fake/ReRunner.php` (_that's the only manual edit in the PR_)

To remove those superfluous tags, I used PHP CS Fixer:  

`php-cs-fixer fix --rules=no_superfluous_phpdoc_tags,no_empty_phpdoc src/`