### PR TITLE
PHPDoc cleanup and improvements.

### DIFF
--- a/src/PhpSpec/CodeGenerator/GeneratorManager.php
+++ b/src/PhpSpec/CodeGenerator/GeneratorManager.php
@@ -38,6 +38,7 @@ class GeneratorManager
 
     /**
      * @return mixed
+     *
      * @throws \InvalidArgumentException
      */
     public function generate(Resource $resource, string $name, array $data = array()): void

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -38,7 +38,7 @@ class OptionsConfig
     private $fakingEnabled;
 
     /**
-     * @var string|bool
+     * @var bool|string
      */
     private $bootstrapPath;
 
@@ -48,7 +48,7 @@ class OptionsConfig
     private $isVerbose;
 
     /**
-     * @param string|bool $bootstrapPath
+     * @param bool|string $bootstrapPath
      * @param bool $isVerbose
      */
     public function __construct(

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -194,8 +194,6 @@ final class Application extends BaseApplication
     }
 
     /**
-     *
-     *
      * @throws \RuntimeException
      */
     protected function parseConfigurationFile(InputInterface $input): array

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -55,7 +55,6 @@ EOF
     }
 
     /**
-     *
      * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -53,7 +53,7 @@ class ConsoleIO implements IO
     private $config;
 
     /**
-     * @var integer
+     * @var int
      */
     private $consoleWidth;
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -507,7 +507,6 @@ final class ContainerAssembler
     }
 
     /**
-     *
      * @throws \RuntimeException
      */
     protected function setupFormatter(IndexedServiceContainer $container): void

--- a/src/PhpSpec/Console/Formatter.php
+++ b/src/PhpSpec/Console/Formatter.php
@@ -22,10 +22,7 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
  */
 class Formatter extends OutputFormatter
 {
-    /**
-     * @param boolean $decorated
-     *
-     */
+    
     public function __construct(bool $decorated = false, array $styles = array())
     {
         parent::__construct($decorated, $styles);

--- a/src/PhpSpec/Console/Prompter/Question.php
+++ b/src/PhpSpec/Console/Prompter/Question.php
@@ -43,9 +43,7 @@ final class Question implements Prompter
         $this->helper = $helper;
     }
 
-    /**
-     * @param boolean $default
-     */
+    
     public function askConfirmation(string $question, bool $default = true): bool
     {
         return (bool)$this->helper->ask($this->input, $this->output, new ConfirmationQuestion($question, $default));

--- a/src/PhpSpec/Console/ResultConverter.php
+++ b/src/PhpSpec/Console/ResultConverter.php
@@ -22,8 +22,6 @@ class ResultConverter
 {
     /**
      * Convert Example result into exit code
-     *
-     *
      */
     public function convert($result): int
     {

--- a/src/PhpSpec/Event/ExampleEvent.php
+++ b/src/PhpSpec/Event/ExampleEvent.php
@@ -58,7 +58,7 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
     private $time;
 
     /**
-     * @var integer
+     * @var int
      */
     private $result;
 
@@ -68,8 +68,8 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
     private $exception;
 
     /**
-     * @param float|null   $time
-     * @param integer|null $result
+     * @param null|float   $time
+     * @param null|int $result
      * @param \Exception   $exception
      */
     public function __construct(
@@ -126,16 +126,14 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
         return $this->time;
     }
 
-    /**
-     * @return integer
-     */
+    
     public function getResult(): int
     {
         return $this->result;
     }
 
     /**
-     * @return \Exception|null
+     * @return null|\Exception
      */
     public function getException()
     {

--- a/src/PhpSpec/Event/ExpectationEvent.php
+++ b/src/PhpSpec/Event/ExpectationEvent.php
@@ -62,7 +62,7 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
     private $arguments;
 
     /**
-     * @var integer
+     * @var int
      */
     private $result;
 
@@ -74,7 +74,7 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
     /**
      * @param string           $method
      * @param array            $arguments
-     * @param integer          $result
+     * @param int          $result
      * @param \Exception       $exception
      */
     public function __construct(
@@ -138,16 +138,14 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
     }
 
     /**
-     * @return \Exception|null
+     * @return null|\Exception
      */
     public function getException()
     {
         return $this->exception;
     }
 
-    /**
-     * @return integer
-     */
+    
     public function getResult(): int
     {
         return $this->result;

--- a/src/PhpSpec/Event/SpecificationEvent.php
+++ b/src/PhpSpec/Event/SpecificationEvent.php
@@ -32,13 +32,11 @@ class SpecificationEvent extends BaseEvent implements PhpSpecEvent
     private $time;
 
     /**
-     * @var integer
+     * @var int
      */
     private $result;
 
-    /**
-     * @param integer           $result
-     */
+    
     public function __construct(SpecificationNode $specification, float $time = 0.0, int $result = 0)
     {
         $this->specification = $specification;
@@ -70,9 +68,7 @@ class SpecificationEvent extends BaseEvent implements PhpSpecEvent
         return $this->time;
     }
 
-    /**
-     * @return integer
-     */
+    
     public function getResult(): int
     {
         return $this->result;

--- a/src/PhpSpec/Event/SuiteEvent.php
+++ b/src/PhpSpec/Event/SuiteEvent.php
@@ -31,18 +31,16 @@ class SuiteEvent extends BaseEvent implements PhpSpecEvent
     private $time;
 
     /**
-     * @var integer
+     * @var int
      */
     private $result;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $worthRerunning = false;
 
-    /**
-     * @param integer $result
-     */
+    
     public function __construct(Suite $suite, float $time = 0.0, int $result = 0)
     {
         $this->suite  = $suite;
@@ -62,9 +60,7 @@ class SuiteEvent extends BaseEvent implements PhpSpecEvent
         return $this->time;
     }
 
-    /**
-     * @return integer
-     */
+    
     public function getResult(): int
     {
         return $this->result;

--- a/src/PhpSpec/Exception/Example/MethodFailureException.php
+++ b/src/PhpSpec/Exception/Example/MethodFailureException.php
@@ -15,9 +15,7 @@ namespace PhpSpec\Exception\Example;
 
 class MethodFailureException extends NotEqualException
 {
-    /**
-     * @var mixed
-     */
+    
     private $subject;
 
     /**
@@ -26,10 +24,6 @@ class MethodFailureException extends NotEqualException
     private $method;
 
     /**
-     * @param string $message
-     * @param mixed  $expected
-     * @param mixed  $actual
-     * @param mixed  $subject
      * @param string $method
      */
     public function __construct(string $message, $expected, $actual, $subject, $method)
@@ -40,9 +34,7 @@ class MethodFailureException extends NotEqualException
         $this->method = $method;
     }
 
-    /**
-     * @return mixed
-     */
+    
     public function getSubject()
     {
         return $this->subject;

--- a/src/PhpSpec/Exception/Example/StopOnFailureException.php
+++ b/src/PhpSpec/Exception/Example/StopOnFailureException.php
@@ -21,7 +21,7 @@ use Exception;
 class StopOnFailureException extends ExampleException
 {
     /**
-     * @var integer
+     * @var int
      */
     private $result;
 

--- a/src/PhpSpec/Exception/ExceptionFactory.php
+++ b/src/PhpSpec/Exception/ExceptionFactory.php
@@ -89,7 +89,6 @@ class ExceptionFactory
 
     /**
      * @param string $property
-     *
      */
     public function propertyNotFound($subject, $property): Fracture\PropertyNotFoundException
     {

--- a/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
@@ -26,7 +26,6 @@ class CollaboratorNotFoundException extends FractureException
     private $collaboratorName;
 
     /**
-     * @param integer $code
      * @param Exception $previous
      */
     public function __construct(

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -31,7 +31,6 @@ class ReportItemFactory
     }
 
     /**
-     *
      * @return ReportFailedItem|ReportPassedItem|ReportPendingItem|ReportSkippedItem
      */
     public function create(ExampleEvent $event, Presenter $presenter)
@@ -52,8 +51,6 @@ class ReportItemFactory
     }
 
     /**
-     * @param integer $result
-     *
      * @throws InvalidExampleResultException
      */
     private function invalidResultException(int $result): void

--- a/src/PhpSpec/Formatter/JUnitFormatter.php
+++ b/src/PhpSpec/Formatter/JUnitFormatter.php
@@ -61,7 +61,6 @@ final class JUnitFormatter extends BasicFormatter
 
     /**
      * Set testcase nodes
-     *
      */
     public function setTestCaseNodes(array $testCaseNodes): void
     {
@@ -70,7 +69,6 @@ final class JUnitFormatter extends BasicFormatter
 
     /**
      * Get testcase nodes
-     *
      */
     public function getTestCaseNodes(): array
     {
@@ -79,7 +77,6 @@ final class JUnitFormatter extends BasicFormatter
 
     /**
      * Set testsuite nodes
-     *
      */
     public function setTestSuiteNodes(array $testSuiteNodes)
     {
@@ -88,7 +85,6 @@ final class JUnitFormatter extends BasicFormatter
 
     /**
      * Get testsuite nodes
-     *
      */
     public function getTestSuiteNodes(): array
     {
@@ -97,7 +93,6 @@ final class JUnitFormatter extends BasicFormatter
 
     /**
      * Set example status counts
-     *
      */
     public function setExampleStatusCounts(array $exampleStatusCounts)
     {
@@ -106,7 +101,6 @@ final class JUnitFormatter extends BasicFormatter
 
     /**
      * Get example status counts
-     *
      */
     public function getExampleStatusCounts(): array
     {

--- a/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
@@ -42,7 +42,6 @@ final class ObjectEngine implements DifferEngine
     /**
      * @param object $expected
      * @param object $actual
-     *
      */
     public function compare($expected, $actual): string
     {

--- a/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
@@ -43,10 +43,6 @@ abstract class AbstractPhpSpecExceptionPresenter
         return array($exception->getFile(), $exception->getLine());
     }
 
-    /**
-     * @param integer $lineno
-     * @param integer $context
-     *
-     */
+    
     abstract protected function presentFileCode(string $file, int $lineno, int $context = 6): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
@@ -68,7 +68,7 @@ class CallArgumentsPresenter
     /**
      * @param MethodProphecy[] $methodProphecies
      *
-     * @return MethodProphecy|null
+     * @return null|MethodProphecy
      */
     private function findFirstUnexpectedArgumentsCallProphecy(
         array $methodProphecies,

--- a/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
@@ -26,11 +26,7 @@ final class GenericPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPre
         $this->exceptionElementPresenter = $exceptionElementPresenter;
     }
 
-    /**
-     * @param integer $lineno
-     * @param integer $context
-     *
-     */
+    
     protected function presentFileCode(string $file, int $lineno, int $context = 6): string
     {
         $lines  = explode(PHP_EOL, file_get_contents($file));

--- a/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
@@ -15,11 +15,7 @@ namespace PhpSpec\Formatter\Presenter\Exception;
 
 final class HtmlPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresenter implements PhpSpecExceptionPresenter
 {
-    /**
-     * @param integer $lineno
-     * @param integer $context
-     *
-     */
+    
     protected function presentFileCode(string $file, int $lineno, int $context = 6): string
     {
         $lines  = explode(PHP_EOL, file_get_contents($file));

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -99,9 +99,7 @@ final class ProgressFormatter extends ConsoleFormatter
         return $barLengths;
     }
 
-    /**
-     * @param  boolean $isDecorated
-     */
+    
     private function formatProgressOutput(array $barLengths, array $percents, bool $isDecorated): array
     {
         $size = $this->getIO()->getBlockWidth();

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -166,7 +166,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
     }
 
     /**
-     * @return void|MethodNotFoundException
+     * @return MethodNotFoundException|void
      */
     private function getMethodNotFoundException(ExampleEvent $event)
     {

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -36,7 +36,7 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
     private $nullMethods = array();
 
     /**
-     * @var MethodCallEvent|null
+     * @var null|MethodCallEvent
      */
     private $lastMethodCallEvent = null;
     /**

--- a/src/PhpSpec/Listener/StopOnFailureListener.php
+++ b/src/PhpSpec/Listener/StopOnFailureListener.php
@@ -40,7 +40,6 @@ final class StopOnFailureListener implements EventSubscriberInterface
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Example\StopOnFailureException
      */
     public function afterExample(ExampleEvent $event): void

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -26,7 +26,7 @@ class ExampleNode
      */
     private $function;
     /**
-     * @var SpecificationNode|null
+     * @var null|SpecificationNode
      */
     private $specification;
     /**
@@ -78,7 +78,7 @@ class ExampleNode
     }
 
     /**
-     * @return SpecificationNode|null
+     * @return null|SpecificationNode
      */
     public function getSpecification()
     {

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -88,7 +88,7 @@ class SpecificationNode implements \Countable
     }
 
     /**
-     * @return Suite|null
+     * @return null|Suite
      */
     public function getSuite()
     {

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -38,10 +38,7 @@ class ResourceLoader
         $this->methodAnalyser = $methodAnalyser;
     }
 
-    /**
-     * @param integer|null $line
-     *
-     */
+    
     public function load(string $locator = '', int $line = null): Suite
     {
         $suite = new Suite();

--- a/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
@@ -50,8 +50,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
     }
 
     /**
-     *
-     * @return string|false
+     * @return false|string
      */
     public function lookup(string $class, string $method, string $argument)
     {

--- a/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
@@ -22,8 +22,7 @@ interface TypeHintIndex
     public function addInvalid(string $class, string $method, string $argument, \Exception $exception): void;
 
     /**
-     *
-     * @return string|null
+     * @return null|string
      */
     public function lookup(string $class, string $method, string $argument);
 }

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -155,7 +155,6 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     }
 
     /**
-     *
      * @return Resource[]
      */
     public function findResources(string $query)
@@ -199,7 +198,6 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     }
 
     /**
-     *
      * @return null|PSR0Resource
      */
     public function createResource(string $classname)
@@ -231,7 +229,6 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     }
 
     /**
-     *
      * @return PSR0Resource[]
      */
     protected function findSpecResources(string $path)
@@ -320,7 +317,6 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     }
 
     /**
-     *
      * @throws InvalidArgumentException
      */
     private function validatePsr0Classname(string $classname)

--- a/src/PhpSpec/Locator/PrioritizedResourceManager.php
+++ b/src/PhpSpec/Locator/PrioritizedResourceManager.php
@@ -33,7 +33,6 @@ final class PrioritizedResourceManager implements ResourceManager
     }
 
     /**
-     *
      * @return Resource[]
      */
     public function locateResources(string $query): array
@@ -56,8 +55,6 @@ final class PrioritizedResourceManager implements ResourceManager
     }
 
     /**
-     *
-     *
      * @throws \RuntimeException
      */
     public function createResource(string $classname): Resource
@@ -77,7 +74,6 @@ final class PrioritizedResourceManager implements ResourceManager
     }
 
     /**
-     *
      * @return Resource[]
      */
     private function removeDuplicateResources(array $resources): array

--- a/src/PhpSpec/Locator/ResourceLocator.php
+++ b/src/PhpSpec/Locator/ResourceLocator.php
@@ -24,7 +24,6 @@ interface ResourceLocator
     public function supportsQuery(string $query): bool;
 
     /**
-     *
      * @return Resource[]
      */
     public function findResources(string $query);
@@ -33,13 +32,10 @@ interface ResourceLocator
     public function supportsClass(string $classname): bool;
 
     /**
-     *
-     * @return Resource|null
+     * @return null|Resource
      */
     public function createResource(string $classname);
 
-    /**
-     * @return integer
-     */
+    
     public function getPriority(): int;
 }

--- a/src/PhpSpec/Locator/ResourceManager.php
+++ b/src/PhpSpec/Locator/ResourceManager.php
@@ -16,7 +16,6 @@ namespace PhpSpec\Locator;
 interface ResourceManager
 {
     /**
-     *
      * @return \PhpSpec\Locator\Resource[]
      */
     public function locateResources(string $query): array;

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -41,8 +41,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
     }
 
     /**
-     * @param ArrayAccess|array $subject
-     *
+     * @param array|ArrayAccess $subject
      */
     protected function matches($subject, array $arguments): bool
     {

--- a/src/PhpSpec/Matcher/BasicMatcher.php
+++ b/src/PhpSpec/Matcher/BasicMatcher.php
@@ -19,7 +19,6 @@ use PhpSpec\Wrapper\DelayedCall;
 abstract class BasicMatcher implements Matcher
 {
     /**
-     *
      * @return void
      *
      * @throws FailureException
@@ -34,7 +33,6 @@ abstract class BasicMatcher implements Matcher
     }
 
     /**
-     *
      * @return void
      *
      * @throws FailureException

--- a/src/PhpSpec/Matcher/ComparisonMatcher.php
+++ b/src/PhpSpec/Matcher/ComparisonMatcher.php
@@ -45,7 +45,6 @@ final class ComparisonMatcher extends BasicMatcher
     }
 
     /**
-     *
      * @return NotEqualException
      */
     protected function getFailureException(string $name, $subject, array $arguments): FailureException

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -71,7 +71,6 @@ final class IterablesMatcher
 
     /**
      * @param array|\Traversable $iterable
-     *
      */
     private function createIteratorFromIterable($iterable): \Iterator
     {

--- a/src/PhpSpec/Matcher/Matcher.php
+++ b/src/PhpSpec/Matcher/Matcher.php
@@ -19,26 +19,21 @@ interface Matcher
 {
     /**
      * Checks if matcher supports provided subject and matcher name.
-     *
      */
     public function supports(string $name, $subject, array $arguments): bool;
 
     /**
      * Evaluates positive match.
-     *
      */
     public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall;
 
     /**
      * Evaluates negative match.
-     *
      */
     public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall;
 
     /**
      * Returns matcher priority.
-     *
-     * @return integer
      */
     public function getPriority(): int;
 }

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -44,7 +44,6 @@ final class ObjectStateMatcher implements Matcher
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Example\MethodFailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      */
@@ -69,7 +68,6 @@ final class ObjectStateMatcher implements Matcher
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Example\MethodFailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      */

--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -32,7 +32,6 @@ final class ScalarMatcher implements Matcher
 
     /**
      * Checks if matcher supports provided subject and matcher name.
-     *
      */
     public function supports(string $name, $subject, array $arguments): bool
     {
@@ -93,8 +92,6 @@ final class ScalarMatcher implements Matcher
 
     /**
      * Returns matcher priority.
-     *
-     * @return integer
      */
     public function getPriority(): int
     {
@@ -102,8 +99,7 @@ final class ScalarMatcher implements Matcher
     }
 
     /**
-     *
-     * @return string|boolean
+     * @return bool|string
      */
     private function getCheckerName(string $name)
     {

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -45,7 +45,7 @@ final class ThrowMatcher implements Matcher
     private $factory;
 
     /**
-     * @param ReflectionFactory|null $factory
+     * @param null|ReflectionFactory $factory
      */
     public function __construct(Unwrapper $unwrapper, Presenter $presenter, ReflectionFactory $factory)
     {
@@ -141,7 +141,7 @@ final class ThrowMatcher implements Matcher
     }
 
     /**
-     * @param string|null|object $exception
+     * @param null|object|string $exception
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
@@ -243,8 +243,8 @@ final class ThrowMatcher implements Matcher
     }
 
     /**
-     *
      * @return null|string|\Throwable
+     *
      * @throws \PhpSpec\Exception\Example\MatcherException
      */
     private function getException(array $arguments)

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -91,7 +91,6 @@ final class TraversableCountMatcher implements Matcher
     }
 
     /**
-     *
      * @return int self::*
      */
     private function countDifference(\Traversable $subject, int $expected): int

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -51,7 +51,6 @@ final class TriggerMatcher implements Matcher
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
     public function verifyPositive(callable $callable, array $arguments, int $level = null, string $message = null)
@@ -80,7 +79,6 @@ final class TriggerMatcher implements Matcher
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
     public function verifyNegative(callable $callable, array $arguments, int $level = null, string $message = null)

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -31,33 +31,27 @@ use ArrayAccess;
  * @method void beConstructedWith(...$arguments)
  * @method void beConstructedThrough($factoryMethod, array $constructorArguments = array())
  * @method void beAnInstanceOf($class)
- *
  * @method void shouldHaveType($type)
  * @method void shouldNotHaveType($type)
  * @method void shouldBeAnInstanceOf($type)
  * @method void shouldNotBeAnInstanceOf($type)
  * @method void shouldImplement($interface)
  * @method void shouldNotImplement($interface)
- *
  * @method void shouldIterateAs($iterable)
  * @method void shouldYield($iterable)
  * @method void shouldNotIterateAs($iterable)
  * @method void shouldNotYield($iterable)
- *
  * @method void shouldIterateLike($iterable)
  * @method void shouldYieldLike($iterable)
  * @method void shouldNotIterateLike($iterable)
  * @method void shouldNotYieldLike($iterable)
- *
  * @method void shouldStartIteratingAs($iterable)
  * @method void shouldStartYielding($iterable)
  * @method void shouldNotStartIteratingAs($iterable)
  * @method void shouldNotStartYielding($iterable)
- *
  * @method Subject\Expectation\DuringCall shouldThrow($exception = null)
  * @method Subject\Expectation\DuringCall shouldNotThrow($exception = null)
  * @method Subject\Expectation\DuringCall shouldTrigger($level = null, $message = null)
- *
  * @method void shouldHaveCount($count)
  * @method void shouldNotHaveCount($count)
  * @method void shouldContain($element)
@@ -83,6 +77,7 @@ abstract class ObjectBehavior implements
      * Override this method to provide your own inline matchers
      *
      * @link http://phpspec.net/cookbook/matchers.html Matchers cookbook
+     *
      * @return array a list of inline matchers
      */
     public function getMatchers(): array
@@ -94,7 +89,6 @@ abstract class ObjectBehavior implements
      * Used by { @link PhpSpec\Runner\Maintainer\SubjectMaintainer::prepare() }
      * to prepare the subject with all the needed collaborators for proxying
      * object behaviour
-     *
      */
     public function setSpecificationSubject(Subject $subject): void
     {
@@ -114,8 +108,7 @@ abstract class ObjectBehavior implements
     /**
      * Checks if a key exists in case object implements ArrayAccess
      *
-     * @param string|integer $key
-     *
+     * @param int|string $key
      */
     public function offsetExists($key): Subject
     {
@@ -125,8 +118,7 @@ abstract class ObjectBehavior implements
     /**
      * Gets the value in a particular position in the ArrayAccess object
      *
-     * @param string|integer $key
-     *
+     * @param int|string $key
      */
     public function offsetGet($key): Subject
     {
@@ -136,7 +128,7 @@ abstract class ObjectBehavior implements
     /**
      * Sets the value in a particular position in the ArrayAccess object
      *
-     * @param string|integer $key
+     * @param int|string $key
      */
     public function offsetSet($key, $value)
     {
@@ -146,7 +138,7 @@ abstract class ObjectBehavior implements
     /**
      * Unsets a position in the ArrayAccess object
      *
-     * @param string|integer $key
+     * @param int|string $key
      */
     public function offsetUnset($key)
     {
@@ -155,8 +147,6 @@ abstract class ObjectBehavior implements
 
     /**
      * Proxies all calls to the PhpSpec subject
-     *
-     *
      */
     public function __call(string $method, array $arguments = array())
     {
@@ -165,7 +155,6 @@ abstract class ObjectBehavior implements
 
     /**
      * Proxies setting to the PhpSpec subject
-     *
      */
     public function __set(string $property, $value)
     {
@@ -174,8 +163,6 @@ abstract class ObjectBehavior implements
 
     /**
      * Proxies getting to the PhpSpec subject
-     *
-     *
      */
     public function __get(string $property)
     {
@@ -184,7 +171,6 @@ abstract class ObjectBehavior implements
 
     /**
      * Proxies functor calls to PhpSpec subject
-     *
      */
     public function __invoke()
     {

--- a/src/PhpSpec/Process/ReRunner/PlatformSpecificReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PlatformSpecificReRunner.php
@@ -19,7 +19,6 @@ interface PlatformSpecificReRunner extends ReRunner
 {
     /**
      * Does the current platform support this rerunner
-     *
      */
     public function isSupported(): bool;
 }

--- a/src/PhpSpec/Runner/CollaboratorManager.php
+++ b/src/PhpSpec/Runner/CollaboratorManager.php
@@ -50,7 +50,6 @@ class CollaboratorManager
     }
 
     /**
-     *
      * @return object
      *
      * @throws \PhpSpec\Exception\Wrapper\CollaboratorException

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -115,7 +115,6 @@ class ExampleRunner
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Example\PendingException
      * @throws \Exception
      */

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -146,6 +146,7 @@ final class CollaboratorsMaintainer implements Maintainer
 
     /**
      * @param string $className
+     *
      * @throws CollaboratorNotFoundException
      */
     private function throwCollaboratorNotFound(\Exception $e, \ReflectionParameter $parameter = null, string $className = null): void
@@ -169,8 +170,7 @@ final class CollaboratorsMaintainer implements Maintainer
     }
 
     /**
-     *
-     * @return string|null
+     * @return null|string
      */
     private function getParameterTypeFromReflection(\ReflectionParameter $parameter): string
     {

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -22,17 +22,15 @@ use PhpSpec\Exception\Example as ExampleException;
 final class ErrorMaintainer implements Maintainer
 {
     /**
-     * @var integer
+     * @var int
      */
     private $errorLevel;
     /**
-     * @var callable|null
+     * @var null|callable
      */
     private $errorHandler;
 
-    /**
-     * @param integer $errorLevel
-     */
+    
     public function __construct(int $errorLevel)
     {
         $this->errorLevel = $errorLevel;
@@ -78,10 +76,6 @@ final class ErrorMaintainer implements Maintainer
      * This method used as custom error handler when step is running.
      *
      * @see set_error_handler()
-     *
-     * @param integer $level
-     * @param integer $line
-     *
      *
      * @throws ExampleException\ErrorException
      */

--- a/src/PhpSpec/Runner/Maintainer/Maintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/Maintainer.php
@@ -39,8 +39,6 @@ interface Maintainer
         CollaboratorManager $collaborators
     ): void;
 
-    /**
-     * @return integer
-     */
+    
     public function getPriority(): int;
 }

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -54,8 +54,6 @@ class MatcherManager
     }
 
     /**
-     *
-     *
      * @throws \PhpSpec\Exception\Wrapper\MatcherNotFoundException
      */
     public function find(string $keyword, $subject, array $arguments): Matcher

--- a/src/PhpSpec/Runner/SuiteRunner.php
+++ b/src/PhpSpec/Runner/SuiteRunner.php
@@ -39,10 +39,7 @@ class SuiteRunner
         $this->specRunner = $specRunner;
     }
 
-    /**
-     *
-     * @return integer
-     */
+    
     public function run(Suite $suite): int
     {
         $this->dispatch($this->dispatcher, new SuiteEvent($suite), 'beforeSuite');

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -10,14 +10,11 @@ interface ServiceContainer
 {
     /**
      * Sets a param in the container
-     *
      */
     public function setParam(string $id, $value): void;
 
     /**
      * Gets a param from the container or a default value.
-     *
-     *
      */
     public function getParam(string $id, $default = null);
 
@@ -51,7 +48,6 @@ interface ServiceContainer
 
     /**
      * Determines whether a service is defined
-     *
      */
     public function has(string $id): bool;
 
@@ -65,8 +61,6 @@ interface ServiceContainer
 
     /**
      * Finds all services tagged with a particular string
-     *
-     *
      */
     public function getByTag(string $tag): array;
 }

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -49,7 +49,6 @@ final class IndexedServiceContainer implements ServiceContainer
 
     /**
      * Sets a param in the container
-     *
      */
     public function setParam(string $id, $value): void
     {
@@ -58,8 +57,6 @@ final class IndexedServiceContainer implements ServiceContainer
 
     /**
      * Gets a param from the container or a default value.
-     *
-     *
      */
     public function getParam(string $id, $default = null)
     {
@@ -91,7 +88,6 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Sets a factory for the service creation. The same service will
      * be returned every time
-     *
      */
     public function define(string $id, callable $definition, array $tags = []): void
     {
@@ -124,7 +120,6 @@ final class IndexedServiceContainer implements ServiceContainer
 
     /**
      * Determines whether a service is defined
-     *
      */
     public function has(string $id): bool
     {
@@ -148,7 +143,6 @@ final class IndexedServiceContainer implements ServiceContainer
 
     /**
      * Adds a service or service definition to the index
-     *
      */
     private function indexTags(string $id, array $tags): void
     {
@@ -159,8 +153,6 @@ final class IndexedServiceContainer implements ServiceContainer
 
     /**
      * Finds all services tagged with a particular string
-     *
-     *
      */
     public function getByTag(string $tag): array
     {
@@ -171,7 +163,6 @@ final class IndexedServiceContainer implements ServiceContainer
      * Adds a configurator, that can configure many services in one value
      *
      * @internal
-     *
      *
      * @throws \InvalidArgumentException if configurator is not a value
      */

--- a/src/PhpSpec/Util/Filesystem.php
+++ b/src/PhpSpec/Util/Filesystem.php
@@ -48,7 +48,6 @@ class Filesystem
     }
 
     /**
-     *
      * @return \SplFileInfo[]
      */
     public function findSpecFilesIn(string $path): array

--- a/src/PhpSpec/Util/Instantiator.php
+++ b/src/PhpSpec/Util/Instantiator.php
@@ -18,7 +18,6 @@ use PhpSpec\Exception\Fracture\ClassNotFoundException;
 class Instantiator
 {
     /**
-     *
      * @return object
      */
     public function instantiate(string $className)

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -74,7 +74,6 @@ class MethodAnalyser
 
     /**
      * @param  \ReflectionClass[] $traits
-     *
      */
     private function getDeclaringTrait(array $traits, string $file, int $start, int $end): ?\ReflectionClass
     {

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -29,7 +29,6 @@ use ArrayAccess;
  * @method void shouldNotBeAnInstanceOf($type)
  * @method void shouldImplement($interface)
  * @method void shouldNotImplement($interface)
- *
  * @method void shouldBe($value)
  * @method void shouldNotBe($value)
  * @method void shouldBeEqualTo($value)
@@ -38,13 +37,10 @@ use ArrayAccess;
  * @method void shouldNotReturn($value)
  * @method void shouldEqual($value)
  * @method void shouldNotEqual($value)
- *
  * @method void shouldBeLike($value)
  * @method void shouldNotBeLike($value)
- *
  * @method void shouldHaveCount($count)
  * @method void shouldNotHaveCount($count)
- *
  * @method void shouldBeArray()
  * @method void shouldNotBeArray()
  * @method void shouldBeBool()
@@ -83,37 +79,27 @@ use ArrayAccess;
  * @method void shouldNotBeFinite()
  * @method void shouldBeInfinite()
  * @method void shouldNotBeInfinite()
- *
  * @method void shouldBeApproximately($value, $precision)
- *
  * @method void shouldContain($value)
  * @method void shouldNotContain($value)
- *
  * @method void shouldHaveKeyWithValue($key, $value)
  * @method void shouldNotHaveKeyWithValue($key, $value)
- *
  * @method void shouldHaveKey($key)
  * @method void shouldNotHaveKey($key)
- *
  * @method void shouldStartWith($string)
  * @method void shouldNotStartWith($string)
- *
  * @method void shouldEndWith($string)
  * @method void shouldNotEndWith($string)
- *
  * @method void shouldMatch($regex)
  * @method void shouldNotMatch($regex)
- *
  * @method void shouldIterateAs($iterable)
  * @method void shouldYield($iterable)
  * @method void shouldNotIterateAs($iterable)
  * @method void shouldNotYield($iterable)
- *
  * @method void shouldIterateLike($iterable)
  * @method void shouldYieldLike($iterable)
  * @method void shouldNotIterateLike($iterable)
  * @method void shouldNotYieldLike($iterable)
- *
  * @method void shouldStartIteratingAs($iterable)
  * @method void shouldStartYielding($iterable)
  * @method void shouldNotStartIteratingAs($iterable)
@@ -206,7 +192,6 @@ class Subject implements ArrayAccess, ObjectWrapper
     }
 
     /**
-     *
      * @return string|Subject
      */
     public function getFromWrappedObject(string $property)
@@ -215,8 +200,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     }
 
     /**
-     * @param string|integer $key
-     *
+     * @param int|string $key
      */
     public function offsetExists($key): Subject
     {
@@ -224,8 +208,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     }
 
     /**
-     * @param string|integer $key
-     *
+     * @param int|string $key
      */
     public function offsetGet($key): Subject
     {
@@ -233,7 +216,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     }
 
     /**
-     * @param string|integer $key
+     * @param int|string $key
      */
     public function offsetSet($key, $value): void
     {
@@ -241,7 +224,7 @@ class Subject implements ArrayAccess, ObjectWrapper
     }
 
     /**
-     * @param string|integer $key
+     * @param int|string $key
      */
     public function offsetUnset($key): void
     {
@@ -249,7 +232,6 @@ class Subject implements ArrayAccess, ObjectWrapper
     }
 
     /**
-     *
      * @return mixed|Subject
      */
     public function __call(string $method, array $arguments = array())
@@ -282,7 +264,6 @@ class Subject implements ArrayAccess, ObjectWrapper
     }
 
     /**
-     *
      * @return string|Subject
      */
     public function __get(string $property)

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -74,8 +74,6 @@ class Caller
     }
 
     /**
-     *
-     *
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      * @throws \PhpSpec\Exception\Fracture\MethodNotVisibleException
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
@@ -98,7 +96,6 @@ class Caller
     }
 
     /**
-     *
      * @return mixed
      *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
@@ -123,8 +120,7 @@ class Caller
     }
 
     /**
-     *
-     * @return Subject|string
+     * @return string|Subject
      *
      * @throws \PhpSpec\Exception\Fracture\PropertyNotFoundException
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
@@ -220,7 +216,6 @@ class Caller
     /**
      * @param object $subject
      * @param string $method
-     *
      */
     private function invokeAndWrapMethodResult($subject, $method, array $arguments = array()): Subject
     {
@@ -248,7 +243,6 @@ class Caller
     }
 
     /**
-     *
      * @return object
      *
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
@@ -320,6 +314,7 @@ class Caller
 
     /**
      * @param $method
+     *
      * @return \PhpSpec\Exception\Fracture\MethodNotFoundException|\PhpSpec\Exception\Fracture\MethodNotVisibleException
      */
     private function methodNotFound($method, array $arguments = array())

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -25,8 +25,6 @@ final class ConstructorDecorator extends Decorator implements Expectation
     }
 
     /**
-     *
-     *
      * @throws \PhpSpec\Exception\ErrorException
      * @throws \PhpSpec\Exception\Example\ErrorException
      * @throws \PhpSpec\Exception\Fracture\FractureException

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
@@ -52,7 +52,6 @@ final class DispatcherDecorator extends Decorator implements Expectation
     }
 
     /**
-     *
      * @throws \Exception
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \Exception

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -42,8 +42,7 @@ abstract class DuringCall
     }
 
     /**
-     *
-     * @param WrappedObject|null $wrappedObject
+     * @param null|WrappedObject $wrappedObject
      *
      * @return $this
      */
@@ -85,8 +84,6 @@ abstract class DuringCall
     }
 
     /**
-     *
-     *
      * @throws MatcherException
      */
     public function __call(string $method, array $arguments = array())
@@ -118,7 +115,6 @@ abstract class DuringCall
     /**
      * @param object $object
      * @param string $method
-     *
      */
     abstract protected function runDuring($object, $method, array $arguments = array());
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/NegativeThrow.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/NegativeThrow.php
@@ -18,7 +18,6 @@ final class NegativeThrow extends DuringCall implements ThrowExpectation
     /**
      * @param object $object
      * @param string $method
-     *
      */
     protected function runDuring($object, $method, array $arguments = array())
     {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php
@@ -18,7 +18,6 @@ final class NegativeTrigger extends DuringCall implements ThrowExpectation
     /**
      * @param object $object
      * @param string $method
-     *
      */
     protected function runDuring($object, $method, array $arguments = array())
     {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/PositiveThrow.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/PositiveThrow.php
@@ -18,7 +18,6 @@ final class PositiveThrow extends DuringCall implements ThrowExpectation
     /**
      * @param object $object
      * @param string $method
-     *
      */
     protected function runDuring($object, $method, array $arguments = array())
     {

--- a/src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php
@@ -18,7 +18,6 @@ final class PositiveTrigger extends DuringCall implements ThrowExpectation
     /**
      * @param object $object
      * @param string $method
-     *
      */
     protected function runDuring($object, $method, array $arguments = array())
     {

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -46,8 +46,7 @@ class SubjectWithArrayAccess
     }
 
     /**
-     * @param string|integer $key
-     *
+     * @param int|string $key
      */
     public function offsetExists($key): bool
     {
@@ -61,8 +60,7 @@ class SubjectWithArrayAccess
     }
 
     /**
-     * @param string|integer $key
-     *
+     * @param int|string $key
      */
     public function offsetGet($key)
     {
@@ -76,7 +74,7 @@ class SubjectWithArrayAccess
     }
 
     /**
-     * @param string|integer $key
+     * @param int|string $key
      */
     public function offsetSet($key, $value): void
     {
@@ -91,7 +89,7 @@ class SubjectWithArrayAccess
     }
 
     /**
-     * @param string|integer $key
+     * @param int|string $key
      */
     public function offsetUnset($key): void
     {
@@ -105,7 +103,6 @@ class SubjectWithArrayAccess
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      * @throws \PhpSpec\Exception\Fracture\InterfaceNotImplementedException
      */

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -33,7 +33,7 @@ class WrappedObject
      */
     private $classname;
     /**
-     * @var callable|null
+     * @var null|callable
      */
     private $factoryMethod;
     /**
@@ -46,7 +46,7 @@ class WrappedObject
     private $isInstantiated = false;
 
     /**
-     * @param object|null        $instance
+     * @param null|object        $instance
      */
     public function __construct($instance, Presenter $presenter)
     {
@@ -59,7 +59,6 @@ class WrappedObject
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
     public function beAnInstanceOf(string $classname, array $arguments = array()): void
@@ -79,7 +78,6 @@ class WrappedObject
     }
 
     /**
-     *
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      */
     public function beConstructedWith(array $args): void
@@ -99,7 +97,7 @@ class WrappedObject
     }
 
     /**
-     * @param callable|string|null $factoryMethod
+     * @param null|callable|string $factoryMethod
      */
     public function beConstructedThrough($factoryMethod, array $arguments = array()): void
     {
@@ -120,7 +118,7 @@ class WrappedObject
     }
 
     /**
-     * @return callable|null
+     * @return null|callable
      */
     public function getFactoryMethod()
     {
@@ -133,16 +131,14 @@ class WrappedObject
         return $this->isInstantiated;
     }
 
-    /**
-     * @param boolean $instantiated
-     */
+    
     public function setInstantiated(bool $instantiated): void
     {
         $this->isInstantiated = $instantiated;
     }
 
     /**
-     * @return string|null
+     * @return null|string
      */
     public function getClassName()
     {
@@ -162,7 +158,7 @@ class WrappedObject
     }
 
     /**
-     * @return object|null
+     * @return null|object
      */
     public function getInstance()
     {

--- a/src/PhpSpec/Wrapper/Wrapper.php
+++ b/src/PhpSpec/Wrapper/Wrapper.php
@@ -66,7 +66,6 @@ class Wrapper
 
     /**
      * @param object $value
-     *
      */
     public function wrap($value = null): Subject
     {


### PR DESCRIPTION
Hello,

This PR:

* [x] Apply the following PHP CS Fixer rules: phpdoc_trim,no_blank_lines_after_phpdoc,phpdoc_scalar,phpdoc_separation,phpdoc_types_order,no_superfluous_phpdoc_tags,no_empty_phpdoc
* [x] Does not edit anything manually, only PHP CS Fixer was used.

To redo this locally, I used PHP CS Fixer:  

`./vendor/bin/php-cs-fixer fix --rules=phpdoc_trim,no_blank_lines_after_phpdoc,phpdoc_scalar,phpdoc_separation,phpdoc_types_order,no_superfluous_phpdoc_tags,no_empty_phpdoc src/`