### PR TITLE
docs: Rephrase DuringCall matcher exception message

### DIFF
--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -24,7 +24,7 @@ abstract class DuringCall
      * @var Matcher
      */
     private $matcher;
-    
+
     private $subject;
     /**
      * @var array
@@ -35,7 +35,7 @@ abstract class DuringCall
      */
     private $wrappedObject;
 
-    
+
     public function __construct(Matcher $matcher)
     {
         $this->matcher = $matcher;
@@ -56,7 +56,7 @@ abstract class DuringCall
         return $this;
     }
 
-    
+
     public function during(string $method, array $arguments = array())
     {
         if ($method === '__construct') {
@@ -70,7 +70,7 @@ abstract class DuringCall
         return $this->runDuring($object, $method, $arguments);
     }
 
-    
+
     public function duringInstantiation()
     {
         if ($factoryMethod = $this->wrappedObject->getFactoryMethod()) {
@@ -95,21 +95,30 @@ abstract class DuringCall
             return $this->during(lcfirst($matches[1]), $arguments);
         }
 
-        throw new MatcherException('Incorrect usage of matcher Throw, '.
-            'either prefix the method with "during" and capitalize the '.
-            'first character of the method or use ->during(\'callable\', '.
-            'array(arguments)).'.PHP_EOL.'E.g.'.PHP_EOL.'->during'.
-            ucfirst($method).'(arguments)'.PHP_EOL.'or'.PHP_EOL.
-            '->during(\''.$method.'\', array(arguments))');
+        throw new MatcherException(
+            sprintf(
+                'Incorrect usage of matcher, '.
+                'either prefix the method with "during" and capitalize the '.
+                "first character of the method or use ->during('callable', ".
+                'array(arguments)).%sE.g.%s->during%s(arguments)%s'.
+                "or%s->during('%s', array(arguments))",
+                PHP_EOL,
+                PHP_EOL,
+                ucfirst($method),
+                PHP_EOL,
+                PHP_EOL,
+                $method
+            )
+        );
     }
 
-    
+
     protected function getArguments(): array
     {
         return $this->arguments;
     }
 
-    
+
     protected function getMatcher(): Matcher
     {
         return $this->matcher;

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -95,21 +95,12 @@ abstract class DuringCall
             return $this->during(lcfirst($matches[1]), $arguments);
         }
 
-        throw new MatcherException(
-            sprintf(
-                'Incorrect usage of matcher, '.
-                'either prefix the method with "during" and capitalize the '.
-                "first character of the method or use ->during('callable', ".
-                'array(arguments)).%sE.g.%s->during%s(arguments)%s'.
-                "or%s->during('%s', array(arguments))",
-                PHP_EOL,
-                PHP_EOL,
-                ucfirst($method),
-                PHP_EOL,
-                PHP_EOL,
-                $method
-            )
-        );
+        throw new MatcherException('Incorrect usage of matcher, '.
+            'either prefix the method with "during" and capitalize the '.
+            'first character of the method or use ->during(\'callable\', '.
+            'array(arguments)).'.PHP_EOL.'E.g.'.PHP_EOL.'->during'.
+            ucfirst($method).'(arguments)'.PHP_EOL.'or'.PHP_EOL.
+            '->during(\''.$method.'\', array(arguments))');
     }
 
 


### PR DESCRIPTION
Hello,

Context: https://github.com/phpspec/phpspec/blob/ab63d218fd2124e7455c3ef39407af2ec3733f7a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php#L98

It means that the DuringCall is only for the Throw matcher? Which is wrong.

This is a bit misleading, when I read that error, I have the impression that I'm doing something wrong with the Throw matcher, but I don't use it in my tests.

This PR:

* [x] Update the message
* [x] Use sprintf instead of string concat