### PR TITLE
GitHub-formatted actions

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -48,6 +48,8 @@ class ApplicationContext implements Context
     {
         StreamWrapper::register();
 
+        putenv('GITHUB_ACTIONS=0');
+
         $this->application = new Application('2.1-dev');
         $this->application->setAutoExit(false);
         $this->setFixedTerminalDimensions();

--- a/features/bootstrap/IsolatedProcessContext.php
+++ b/features/bootstrap/IsolatedProcessContext.php
@@ -18,6 +18,16 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
 
     protected $executablePath = __DIR__ . '/../../bin/phpspec';
 
+    private $env = [];
+
+    /**
+     * @Given the :var environment variable is set to :value
+     */
+    public function theEnvironmentVariableIsSetTo($var, $value)
+    {
+        $this->env[$var] = $value;
+    }
+
     /**
      * @Given I have started describing the :class class
      */
@@ -118,9 +128,12 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
 
     /**
      * @Then I should see :message
+     * @Then I should see:
      */
     public function iShouldSee($message)
     {
+        $message = (string)$message;
+
         if (strpos($this->lastOutput, $message) === false) {
             throw new \Exception("Missing message: $message\nActual: {$this->lastOutput}");
         }
@@ -139,12 +152,14 @@ class IsolatedProcessContext implements Context, SnippetAcceptingContext
 
     private function createPhpSpecProcess(array $arguments)
     {
+
+
         $command = $this->buildPhpSpecCmd() . ' ' . implode(' ', $arguments);
 
         if (method_exists(Process::class, 'fromShellCommandline')) {
-            return Process::fromShellCommandline($command);
+            return Process::fromShellCommandline($command, null, $this->env);
         }
 
-        return new Process($command);
+        return new Process($command, null, $this->env);
     }
 }

--- a/features/formatter/github_ci_shows_annotations.feature
+++ b/features/formatter/github_ci_shows_annotations.feature
@@ -1,0 +1,41 @@
+Feature: Github CI annotations
+
+  If we are running in a Github Action we can emit extra strings to enhance the way results are displayed
+
+  @isolated
+  Scenario: Error messages shown inline
+    Given the GITHUB_ACTIONS environment variable is set to true
+    And the spec file "spec/Github/FailingSpec.php" contains:
+       """
+       <?php
+
+       namespace spec\Github;
+
+       use PhpSpec\ObjectBehavior;
+
+       class FailingSpec extends ObjectBehavior
+       {
+           function it_is_equal()
+           {
+               $this->foo()->shouldReturn(true);
+           }
+       }
+       """
+    And the class file "src/Github/Failing.php" contains:
+       """
+       <?php
+
+       namespace Github;
+
+       class Failing
+       {
+           function foo() { return false; }
+       }
+       """
+    When I run phpspec
+    Then I should see:
+       """
+       ::error file=spec/Github/FailingSpec.php,line=9,col=1::Failed: Expected true, but got false
+       """
+
+

--- a/spec/PhpSpec/Formatter/GithubFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/GithubFormatterSpec.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace spec\PhpSpec\Formatter;
+
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\SuiteEvent;
+use PhpSpec\IO\IO;
+use PhpSpec\Loader\Node\ExampleNode;
+use PhpSpec\Loader\Node\SpecificationNode;
+use PhpSpec\Locator\Resource;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class GithubFormatterSpec extends ObjectBehavior
+{
+    function let(
+        ExampleEvent $event,
+        IO $io,
+        ExampleNode $example,
+        SpecificationNode $specification,
+        Resource $resource
+    )
+    {
+        $this->beConstructedWith($io, '/home/someuser/phpspec');
+
+        $event->getExample()->willReturn($example);
+        $example->getLineNumber()->willReturn(100);
+
+        $event->getSpecification()->willReturn($specification);
+        $specification->getResource()->willReturn($resource);
+        $resource->getSpecFilename()->willReturn('/home/someuser/phpspec/MySpec.php');
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            'afterExample' => 'logError',
+            'afterSuite' => 'printErrors'
+        ]);
+    }
+
+    function it_outputs_failures_after_suite(
+        ExampleEvent $event,
+        IO $io,
+        SuiteEvent $suiteEvent
+    )
+    {
+        $event->getResult()->willReturn(ExampleEvent::FAILED);
+        $event->getMessage()->willReturn("Oops it failed");
+
+        $this->logError($event);
+        $this->printErrors($suiteEvent);
+
+        $io->write("\n")->shouldHaveBeenCalled();
+        $io->write("::error file=MySpec.php,line=100,col=1::Failed: Oops it failed\n")->shouldHaveBeenCalled();
+    }
+
+    function it_outputs_broken_examples_after_suite(
+        ExampleEvent $event,
+        IO $io,
+        SuiteEvent $suiteEvent
+    )
+    {
+        $event->getResult()->willReturn(ExampleEvent::BROKEN);
+        $event->getMessage()->willReturn("Oops it broke");
+
+        $this->logError($event);
+        $this->printErrors($suiteEvent);
+
+        $io->write("\n")->shouldHaveBeenCalled();
+        $io->write("::error file=MySpec.php,line=100,col=1::Broken: Oops it broke\n")->shouldHaveBeenCalled();
+    }
+}
+

--- a/spec/PhpSpec/Formatter/GithubFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/GithubFormatterSpec.php
@@ -75,5 +75,22 @@ class GithubFormatterSpec extends ObjectBehavior
         $io->write("\n")->shouldHaveBeenCalled();
         $io->write("::error file=MySpec.php,line=100,col=1::Broken: Oops it broke\n")->shouldHaveBeenCalled();
     }
+
+    function it_outputs_error_with_escaping(
+        ExampleEvent $event,
+        IO $io,
+        SuiteEvent $suiteEvent
+    )
+    {
+        $event->getResult()->willReturn(ExampleEvent::FAILED);
+        $event->getMessage()->willReturn("Oops:\r\nIt 100% broke");
+
+        $this->logError($event);
+        $this->printErrors($suiteEvent);
+
+        $io->write("\n")->shouldHaveBeenCalled();
+        $io->write("::error file=MySpec.php,line=100,col=1::Failed: Oops:%0D%0AIt 100%25 broke\n")->shouldHaveBeenCalled();
+
+    }
 }
 

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -606,8 +606,18 @@ final class ContainerAssembler
             } catch (\InvalidArgumentException $e) {
                 throw new \RuntimeException(sprintf('Formatter not recognised: "%s"', $formatterName));
             }
+
             $c->set('event_dispatcher.listeners.formatter', $formatter, ['event_dispatcher.listeners']);
         });
+
+        if (getenv('GITHUB_ACTIONS')) {
+            $container->define('event_dispatcher.listeners.github', function(IndexedServiceContainer $c) {
+                return new SpecFormatter\GithubFormatter(
+                    $c->get('console.io'),
+                    getcwd()
+                );
+            }, ['event_dispatcher.listeners']);
+        }
     }
 
     

--- a/src/PhpSpec/Formatter/GithubFormatter.php
+++ b/src/PhpSpec/Formatter/GithubFormatter.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Formatter;
+
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\SuiteEvent;
+use PhpSpec\IO\IO;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class GithubFormatter implements EventSubscriberInterface
+{
+    /**
+     * @var IO
+     */
+    private $io;
+
+    /**
+     * @var string
+     */
+    private $basePath;
+    /**
+     * @var array
+     */
+    private $errorEvents = [];
+
+    public function __construct(IO $io, string $basePath)
+    {
+        $this->io = $io;
+        $this->basePath = $basePath;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'afterExample' => 'logError',
+            'afterSuite' => 'printErrors'
+        ];
+    }
+
+    public function logError(ExampleEvent $event)
+    {
+        if ($event->getResult() !== ExampleEvent::FAILED
+         && $event->getResult() !== ExampleEvent::BROKEN) {
+            return;
+        }
+
+        $this->errorEvents[] = $event;
+    }
+
+    public function printErrors(SuiteEvent $suiteEvent)
+    {
+        if ($this->errorEvents) {
+            $this->io->write("\n");
+        }
+
+        foreach ($this->errorEvents as $event) {
+            $this->io->write(
+                sprintf(
+                    "::error file=%s,line=%d,col=1::%s: %s\n",
+                    $this->getSpecFilename($event),
+                    $event->getExample()->getLineNumber(),
+                    $event->getResult() === ExampleEvent::FAILED ? 'Failed' : 'Broken',
+                    $event->getMessage()
+                )
+            );
+        }
+    }
+
+    private function getSpecFilename(ExampleEvent $event)
+    {
+        $specFilename = $event->getSpecification()->getResource()->getSpecFilename();
+
+        if (strpos($specFilename, $this->basePath) === 0) {
+            $specFilename = ltrim(substr($specFilename, strlen($this->basePath)), '/');
+        }
+
+        return $specFilename;
+    }
+}

--- a/src/PhpSpec/Formatter/GithubFormatter.php
+++ b/src/PhpSpec/Formatter/GithubFormatter.php
@@ -71,7 +71,7 @@ final class GithubFormatter implements EventSubscriberInterface
                     $this->getSpecFilename($event),
                     $event->getExample()->getLineNumber(),
                     $event->getResult() === ExampleEvent::FAILED ? 'Failed' : 'Broken',
-                    $event->getMessage()
+                    $this->escapeMessage($event->getMessage())
                 )
             );
         }
@@ -86,5 +86,10 @@ final class GithubFormatter implements EventSubscriberInterface
         }
 
         return $specFilename;
+    }
+
+    private function escapeMessage(string $message) : string
+    {
+        return strtr($message, ["%" => "%25", "\r" => '%0D', "\n" => '%0A']);
     }
 }


### PR DESCRIPTION
When running in a Github Action, we can output errors in a specific format so that they show inline in the code

This implements it in a fairly trivial way, I'd like feedback on:

* Should this be automatic based on environment, or opt-in/opt-out via config?
* Should it be in PhpSpec, or an extension?
* Is it something people want?

To-do
- [ ] Escape the messages properly (needs testing/research)
- [ ] Find a way to use the line number of the failing matcher (not present in stack trace currently)

![Screenshot 2020-11-05 at 14 36 16](https://user-images.githubusercontent.com/237866/98255084-ec88fc80-1f74-11eb-86aa-40c838fa3b09.png)
