### PR TITLE
Handle cases where prophecy reports wrong classname

### DIFF
--- a/features/bootstrap/FilesystemContext.php
+++ b/features/bootstrap/FilesystemContext.php
@@ -82,6 +82,7 @@ class FilesystemContext implements Context
 
     /**
      * @Given the class file :file contains:
+     * @Given the interface file :file contains:
      * @Given the trait file :file contains:
      */
     public function theClassOrTraitFileContains($file, PyStringNode $contents)
@@ -120,7 +121,7 @@ class FilesystemContext implements Context
     }
 
     /**
-     * @Then the class in :file should contain:
+     * @Then the class/interface in :file should contain:
      * @Then a new class/spec should be generated in the :file:
      */
     public function theFileShouldContain($file, PyStringNode $contents)

--- a/features/code_generation/developer_generates_collaborator_method.feature
+++ b/features/code_generation/developer_generates_collaborator_method.feature
@@ -207,3 +207,63 @@ Feature: Developer generates a collaborator's method
       """
     When I run phpspec and answer "n" when asked if I want to generate the code
     Then I should not be prompted for code generation
+
+  Scenario: Collaborator method is generated when it's called by the class under test
+    Given the spec file "spec/CodeGeneration/CollaboratorMethodExample6/MarkdownSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\CodeGeneration\CollaboratorMethodExample6;
+
+      use PhpSpec\ObjectBehavior;
+      use CodeGeneration\CollaboratorMethodExample6\Parser;
+
+      class MarkdownSpec extends ObjectBehavior
+      {
+          function it_interacts_with_a_collaborator(Parser $parser)
+          {
+              $this->foo($parser);
+          }
+      }
+
+      """
+    And the class file "src/CodeGeneration/CollaboratorMethodExample6/Markdown.php" contains:
+      """
+      <?php
+
+      namespace CodeGeneration\CollaboratorMethodExample6;
+
+      class Markdown
+      {
+          public function foo(Parser $parser)
+          {
+              $parser->parse();
+          }
+      }
+
+      """
+    And the class file "src/CodeGeneration/CollaboratorMethodExample6/Parser.php" contains:
+      """
+      <?php
+
+      namespace CodeGeneration\CollaboratorMethodExample6;
+
+      interface Parser
+      {
+      }
+
+      """
+    When I run phpspec and answer "y" when asked if I want to generate the code
+    Then the interface in "src/CodeGeneration/CollaboratorMethodExample6/Parser.php" should contain:
+      """
+      <?php
+
+      namespace CodeGeneration\CollaboratorMethodExample6;
+
+      interface Parser
+      {
+
+          public function parse();
+      }
+
+      """

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -92,8 +92,11 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
 
         // Prophecy sometimes throws the exception with the Prophecy rather than the FCQN - in these cases we need to parse the error
         if ($className instanceof ObjectProphecy) {
+
+            $classPattern = '[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*'; //from https://www.php.net/manual/en/language.oop5.basic.php
+            $fcqnPattern = "(?:$classPattern)(?:\\\\$classPattern)*)";
             $method = preg_quote($exception->getMethodName());
-            $fcqnPattern = '(?:[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)(?:\\\\[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*)';
+
             if(preg_match("/(?<fcqn>$fcqnPattern::$method\(/", $exception->getMessage(), $matches)) {
                 $className = $matches['fcqn'];
             }


### PR DESCRIPTION
Fixes #1350  on the phpspec side

I have PRed a fix on https://github.com/phpspec/prophecy/pull/514 but this will fix it for older versions