### PR TITLE
Make sure we are calling export with a strict integer

### DIFF
--- a/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
@@ -65,7 +65,7 @@ final class ArrayEngine extends StringEngine
                     $line = sprintf(
                         '%s => %s,',
                         $key,
-                        $this->exporter->export($val, ($pad + 1) * $padCorrection)
+                        $this->exporter->export($val, (int)(($pad + 1) * $padCorrection))
                     );
                     break;
                 case 'string':


### PR DESCRIPTION
The underlying Sebastian/exporter doesn't type hint the parameter but naively passes it to str_repeat, which is stricter in newer PHP