### PR TITLE
Don't use experimental builds to test PHP8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
                     -   php: 7.3
                         composer-extras: "symfony/event-dispatcher ^3.4 symfony/contracts ^2.0"
                     -   php: 8.0
-                        stability: "dev"
 
         env:
             COMPOSER_ROOT_VERSION: dev-master


### PR DESCRIPTION
We weren't actually testing with stable dependencies on PHP 8 so this fixes that.

However, it's unclear to me how we can test against dev dependencies but allow it to fail?