### PR TITLE
Remove backward compat layer for older symfony event dispatcher

### DIFF
--- a/src/PhpSpec/Event/BaseEvent.php
+++ b/src/PhpSpec/Event/BaseEvent.php
@@ -2,17 +2,8 @@
 
 namespace PhpSpec\Event;
 
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\Event as OldEvent;
 use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 
-if (\is_subclass_of(EventDispatcher::class, EventDispatcherInterface::class)) {
-    class BaseEvent extends ContractEvent
-    {
-    }
-} else {
-    class BaseEvent extends OldEvent
-    {
-    }
+class BaseEvent extends ContractEvent
+{
 }


### PR DESCRIPTION
The next major removes older event dispatcher support so this is no longer needed