### PR TITLE
Normalize composer.json with ergebnis/composer-normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,73 +1,74 @@
 {
-    "name":         "phpspec/phpspec",
-    "description":  "Specification-oriented BDD framework for PHP 7.1+",
-    "keywords":     ["BDD", "SpecBDD", "TDD", "spec", "specification", "tests", "testing"],
-    "homepage":     "http://phpspec.net/",
-    "type":         "library",
-    "license":      "MIT",
-    "authors":      [
+    "name": "phpspec/phpspec",
+    "type": "library",
+    "description": "Specification-oriented BDD framework for PHP 7.1+",
+    "keywords": [
+        "BDD",
+        "SpecBDD",
+        "TDD",
+        "spec",
+        "specification",
+        "tests",
+        "testing"
+    ],
+    "homepage": "http://phpspec.net/",
+    "license": "MIT",
+    "authors": [
         {
-            "name":      "Konstantin Kudryashov",
-            "email":     "ever.zet@gmail.com",
-            "homepage":  "http://everzet.com"
+            "name": "Konstantin Kudryashov",
+            "email": "ever.zet@gmail.com",
+            "homepage": "http://everzet.com"
         },
         {
-            "name":      "Marcello Duarte",
-            "homepage":  "http://marcelloduarte.net/"
+            "name": "Marcello Duarte",
+            "homepage": "http://marcelloduarte.net/"
         },
         {
-            "name":      "Ciaran McNulty",
-            "homepage":  "https://ciaranmcnulty.com/"
+            "name": "Ciaran McNulty",
+            "homepage": "https://ciaranmcnulty.com/"
         }
     ],
-
     "require": {
-        "php":                      "^7.3 || 8.0.*",
-        "phpspec/prophecy":         "^1.9",
-        "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "^3.0 || ^4.0",
-        "symfony/console":          "^3.4 || ^4.4 || ^5.0",
+        "php": "^7.3 || 8.0.*",
+        "ext-tokenizer": "*",
+        "doctrine/instantiator": "^1.0.5",
+        "phpspec/php-diff": "^1.0.0",
+        "phpspec/prophecy": "^1.9",
+        "sebastian/exporter": "^3.0 || ^4.0",
+        "symfony/console": "^3.4 || ^4.4 || ^5.0",
         "symfony/event-dispatcher": "^3.4 || ^4.4 || ^5.0",
-        "symfony/process":          "^3.4 || ^4.4 || ^5.0",
-        "symfony/finder":           "^3.4 || ^4.4 || ^5.0",
-        "symfony/yaml":             "^3.4 || ^4.4 || ^5.0",
-        "doctrine/instantiator":    "^1.0.5",
-        "ext-tokenizer":            "*"
+        "symfony/finder": "^3.4 || ^4.4 || ^5.0",
+        "symfony/process": "^3.4 || ^4.4 || ^5.0",
+        "symfony/yaml": "^3.4 || ^4.4 || ^5.0"
     },
-
+    "conflict": {
+        "sebastian/comparator": "<1.2.4"
+    },
     "require-dev": {
-        "behat/behat":           "^3.3",
-        "symfony/filesystem":    "^3.4 || ^4.0 || ^5.0",
-        "phpunit/phpunit":       "^8.0 || ^9.0",
+        "behat/behat": "^3.3",
+        "phpunit/phpunit": "^8.0 || ^9.0",
+        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
         "vimeo/psalm": "^4.3"
     },
-
     "suggest": {
         "phpspec/nyan-formatters": "Adds Nyan formatters"
     },
-
-    "conflict": {
-        "sebastian/comparator" : "<1.2.4"
+    "extra": {
+        "branch-alias": {
+            "dev-main": "7.0.x-dev"
+        }
     },
-
     "autoload": {
         "psr-0": {
             "PhpSpec": "src/"
         }
     },
-
     "autoload-dev": {
         "psr-0": {
             "spec\\PhpSpec": "."
         }
     },
-
-    "bin": ["bin/phpspec"],
-
-    "extra": {
-        "branch-alias": {
-            "dev-main": "7.0.x-dev"
-        }
-    }
-
+    "bin": [
+        "bin/phpspec"
+    ]
 }


### PR DESCRIPTION
Hello,

Recently I saw that the README file of [ergebnis/composer-normalize](https://github.com/ergebnis/composer-normalize) has been updated and it takes the composer.json file of phpspec as example.

This gave me the idea to submit a PR to fix and normalize the composer.json using that tool.

Here it is.

To reproduce:

1. `composer require --dev ergebnis/composer-normalize`
2. `composer normalize`