### PR TITLE
Increase Psalm checking to level 6, and associated fixes

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="7"
+    errorLevel="6"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,5 +32,11 @@
                 <referencedClass name="Prophecy\Exception\Prediction\PredictionException"/>
             </errorLevel>
         </InvalidCatch>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <!-- Error from symfony BC code -->
+                <referencedFunction name="Symfony\Contracts\EventDispatcher\EventDispatcherInterface::dispatch"></referencedFunction>
+            </errorLevel>
+        </InvalidArgument>
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,5 +26,11 @@
                 <file name="src/PhpSpec/Locator/PSR0/PSR0Locator.php" />
             </errorLevel>
         </UndefinedConstant>
+        <InvalidCatch>
+            <errorLevel type="suppress">
+                <!-- Prophecy's exception interface does not extend throwable -->
+                <referencedClass name="Prophecy\Exception\Prediction\PredictionException"/>
+            </errorLevel>
+        </InvalidCatch>
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -36,6 +36,7 @@
             <errorLevel type="suppress">
                 <!-- Error from symfony BC code -->
                 <referencedFunction name="Symfony\Contracts\EventDispatcher\EventDispatcherInterface::dispatch"></referencedFunction>
+                <referencedFunction name="Symfony\Component\EventDispatcher\EventDispatcher::dispatch"></referencedFunction>
             </errorLevel>
         </InvalidArgument>
     </issueHandlers>

--- a/spec/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriterSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\CodeGenerator\Writer;
 
+use PhpSpec\Exception\Generator\GenerationFailed;
 use PhpSpec\Exception\Generator\NamedMethodNotFoundException;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\ClassFileAnalyser;
@@ -74,6 +75,17 @@ class TokenizedCodeWriterSpec extends ObjectBehavior
         $result = $this->getClassWithBraceTextAndNewMethod();
 
         $this->insertMethodLastInClass($class, $method)->shouldReturn($result);
+    }
+
+    function it_should_error_if_method_could_not_be_inserted()
+    {
+        $class = <<<CLASS
+<?php
+
+CLASS;
+        $method = $this->getMethod();
+
+        $this->shouldThrow(GenerationFailed::class)->duringInsertMethodFirstInClass($class, $method);
     }
 
     private function getSingleMethodClass()

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\CodeGenerator\Writer;
 
+use PhpSpec\Exception\Generator\GenerationFailed;
 use PhpSpec\Util\ClassFileAnalyser;
 
 final class TokenizedCodeWriter implements CodeWriter
@@ -120,6 +121,8 @@ final class TokenizedCodeWriter implements CodeWriter
                 return substr_replace($class, "\n" . $method . "\n", $position, 0);
             }
         }
+
+        throw new GenerationFailed('Could not locate end of class');
     }
 
     /**

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -43,7 +43,7 @@ class OptionsConfig
     private $bootstrapPath;
 
     /**
-     * @var string
+     * @var bool
      */
     private $isVerbose;
 

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Console\Command;
 
+use PhpSpec\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -27,6 +28,17 @@ use Symfony\Component\Console\Question\Question;
  */
 final class DescribeCommand extends Command
 {
+    public function getApplication() : Application
+    {
+        $application = parent::getApplication();
+
+        if (!$application instanceof Application) {
+            throw new \RuntimeException('PhpSpec commands require PhpSpec application');
+        }
+
+        return $application;
+    }
+
     protected function configure(): void
     {
         $this

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Console\Command;
 
+use PhpSpec\Console\Application;
 use PhpSpec\Formatter\FatalPresenter;
 use PhpSpec\Process\Shutdown\UpdateConsoleAction;
 use PhpSpec\ServiceContainer\IndexedServiceContainer;
@@ -30,6 +31,17 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class RunCommand extends Command
 {
+    public function getApplication() : Application
+    {
+        $application = parent::getApplication();
+
+        if (!$application instanceof Application) {
+            throw new \RuntimeException('PhpSpec commands require PhpSpec application');
+        }
+
+        return $application;
+    }
+
     protected function configure()
     {
         $this

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -254,7 +254,7 @@ class ConsoleIO implements IO
     public function getBootstrapPath(): ?string
     {
         if ($path = $this->input->getOption('bootstrap')) {
-            return $path;
+            return (string) $path;
         }
 
         if ($path = $this->config->getBootstrapPath()) {

--- a/src/PhpSpec/Exception/Generator/GenerationFailed.php
+++ b/src/PhpSpec/Exception/Generator/GenerationFailed.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpSpec\Exception\Generator;
+
+class GenerationFailed extends \RuntimeException
+{
+}

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -30,9 +30,6 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
      */
     private $io;
 
-    /**
-     * @var MethodCallEvent[]
-     */
     private $nullMethods = array();
 
     /**

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -18,6 +18,7 @@ use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\MethodCallEvent;
 use PhpSpec\Event\SuiteEvent;
+use PhpSpec\Exception\Example\MethodFailureException;
 use PhpSpec\Exception\Example\NotEqualException;
 use PhpSpec\Locator\ResourceManager;
 use PhpSpec\Util\MethodAnalyser;
@@ -99,6 +100,11 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
         }
 
         if (!$this->lastMethodCallEvent) {
+
+            if (!$exception instanceof MethodFailureException) {
+                return;
+            }
+
             $subject = $exception->getSubject();
             $method = $exception->getMethod();
             if (is_null($subject) || is_null($method)) {

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -114,6 +114,9 @@ class StatisticsCollector implements EventSubscriberInterface
         return $this->brokenEvents;
     }
 
+    /**
+     * @return int[]
+     */
     public function getCountsHash() : array
     {
         return array(

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -369,6 +369,6 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     
     private function isWindowsPath(string $query): bool
     {
-        return preg_match('/^\w:/', $query);
+        return (bool) preg_match('/^\w:/', $query);
     }
 }

--- a/src/PhpSpec/Matcher/BasicMatcher.php
+++ b/src/PhpSpec/Matcher/BasicMatcher.php
@@ -19,8 +19,6 @@ use PhpSpec\Wrapper\DelayedCall;
 abstract class BasicMatcher implements Matcher
 {
     /**
-     * @return void
-     *
      * @throws FailureException
      */
     final public function positiveMatch(string $name, $subject, array $arguments): ?DelayedCall
@@ -33,8 +31,6 @@ abstract class BasicMatcher implements Matcher
     }
 
     /**
-     * @return void
-     *
      * @throws FailureException
      */
     final public function negativeMatch(string $name, $subject, array $arguments): ?DelayedCall

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -97,7 +97,7 @@ final class ObjectStateMatcher implements Matcher
         return 50;
     }
 
-    private function getMethodFailureExceptionFor(callable $callable, bool $expectedBool, $result): MethodFailureException
+    private function getMethodFailureExceptionFor(array $callable, bool $expectedBool, $result): MethodFailureException
     {
         return new MethodFailureException(sprintf(
             "Expected %s to return %s, but got %s.",

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -26,7 +26,7 @@ class ComposerPsrNamespaceProvider
     }
 
     /**
-     * @return string[] a map associating a namespace to a location, e.g
+     * @return NamespaceLocation[] a map associating a namespace to a location, e.g
      *                  [
      *                      'My\PSR4Namespace' => 'my/PSR4Namespace',
      *                      'My\PSR0Namespace' => '',

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -142,8 +142,11 @@ class ExampleRunner
             if ($reflection instanceof \ReflectionMethod) {
                 $reflection->invokeArgs($context, $collaborators->getArgumentsFor($reflection));
             }
-            else {
+            elseif ($reflection instanceof \ReflectionFunction)  {
                 $reflection->invokeArgs($collaborators->getArgumentsFor($reflection));
+            }
+            else {
+                throw new \RuntimeException('Not able to invoke example');
             }
         } catch (\Exception $e) {
             $this->runMaintainersTeardown(

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -69,6 +69,8 @@ final class ClassFileAnalyser
                 return $i;
             }
         }
+
+        throw new \RuntimeException('Could not find index of first method');
     }
 
     
@@ -101,6 +103,8 @@ final class ClassFileAnalyser
 
             return $index;
         }
+
+        throw new \RuntimeException('Could not find index of for docblock');
     }
 
     /**
@@ -178,6 +182,8 @@ final class ClassFileAnalyser
                 }
             }
         }
+
+        throw new \RuntimeException('Could not find last method or class end');
     }
 
     private function isSpecialBraceToken($token): bool

--- a/src/PhpSpec/Util/DispatchTrait.php
+++ b/src/PhpSpec/Util/DispatchTrait.php
@@ -3,6 +3,7 @@
 namespace PhpSpec\Util;
 
 use PhpSpec\Wrapper\Collaborator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -11,7 +12,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 trait DispatchTrait
 {
     /**
-     * @param EventDispatcherInterface $eventDispatcher
+     * @param EventDispatcher $eventDispatcher
      * @param object $event
      * @param string $eventName
      */

--- a/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
+++ b/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
@@ -57,6 +57,8 @@ class ExpectationFactory
         if (0 === strpos($expectation, 'should')) {
             return $this->createPositive(lcfirst(substr($expectation, 6)), $subject, $arguments);
         }
+
+        throw new \RuntimeException('Could not create match');
     }
 
     

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -56,6 +56,7 @@ class SubjectWithArrayAccess
 
         $this->checkIfSubjectImplementsArrayAccess($subject);
 
+        /** @var \ArrayAccess|array $subject */
         return isset($subject[$key]);
     }
 
@@ -70,6 +71,7 @@ class SubjectWithArrayAccess
 
         $this->checkIfSubjectImplementsArrayAccess($subject);
 
+        /** @var \ArrayAccess|array $subject */
         return $subject[$key];
     }
 
@@ -85,6 +87,7 @@ class SubjectWithArrayAccess
 
         $this->checkIfSubjectImplementsArrayAccess($subject);
 
+        /** @var \ArrayAccess|array $subject */
         $subject[$key] = $value;
     }
 
@@ -99,6 +102,7 @@ class SubjectWithArrayAccess
 
         $this->checkIfSubjectImplementsArrayAccess($subject);
 
+        /** @var \ArrayAccess|array $subject */
         unset($subject[$key]);
     }
 


### PR DESCRIPTION
This is a mixture of type annotation corrections, and extra code to handle error states explicitly (mostly by throwing instead of returning an invalid type)