### PR TITLE
Allow ApproximatelyMatcher to compare arrays

### DIFF
--- a/features/matchers/developer_uses_approximately_matcher.feature
+++ b/features/matchers/developer_uses_approximately_matcher.feature
@@ -6,36 +6,68 @@ Feature: Developer uses approximately matcher
   @issue581
   Scenario: "Approximately" alias matches using the approximately matcher
     Given the spec file "spec/Matchers/FloatApproximatelyExample1/GeoCoordSpec.php" contains:
-    """
-    <?php
+      """
+      <?php
 
-    namespace spec\Matchers\FloatApproximatelyExample1;
+      namespace spec\Matchers\FloatApproximatelyExample1;
 
-    use PhpSpec\ObjectBehavior;
+      use PhpSpec\ObjectBehavior;
 
-    class GeoCoordSpec extends ObjectBehavior
-    {
-        function it_should_have_lat_approximate()
-        {
-            $this->getLat()->shouldBeApproximately(1.4477, 1.0e-2);
-        }
-    }
-    """
-
+      class GeoCoordSpec extends ObjectBehavior
+      {
+          function it_should_have_lat_approximate()
+          {
+              $this->getLat()->shouldBeApproximately(1.4477, 1.0e-2);
+          }
+      }
+      """
     And the class file "src/Matchers/FloatApproximatelyExample1/GeoCoord.php" contains:
-    """
-    <?php
+      """
+      <?php
 
-    namespace Matchers\FloatApproximatelyExample1;
+      namespace Matchers\FloatApproximatelyExample1;
 
-    class GeoCoord
-    {
-        public function getLat()
-        {
+      class GeoCoord
+      {
+          public function getLat()
+          {
             return 1.444444;
-        }
-    }
-    """
-
+          }
+      }
+      """
     When I run phpspec
+    Then the suite should pass
+
+  Scenario: Approximately matching an array
+    Given the spec file "spec/Matchers/FloatApproximatelyExample2/GeoCoordSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Matchers\FloatApproximatelyExample2;
+
+      use PhpSpec\ObjectBehavior;
+
+      class GeoCoordSpec extends ObjectBehavior
+      {
+          function it_should_have_lat_long_approximate()
+          {
+              $this->getLatLong()->shouldBeApproximately([1.4477, 2.3422], 1.0e-1);
+          }
+      }
+      """
+    And the class file "src/Matchers/FloatApproximatelyExample1/GeoCoord.php" contains:
+      """
+      <?php
+
+      namespace Matchers\FloatApproximatelyExample2;
+
+      class GeoCoord
+      {
+          public function getLatLong()
+          {
+            return [1.444444, 2.3321];
+          }
+      }
+      """
+    When I run phpspec with the verbose option
     Then the suite should pass

--- a/spec/PhpSpec/Matcher/ApproximatelyMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ApproximatelyMatcherSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Matcher;
 
+use PhpSpec\Exception\Example\NotEqualException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use PhpSpec\Formatter\Presenter\Presenter;
@@ -27,6 +28,28 @@ class ApproximatelyMatcherSpec extends ObjectBehavior
         $this->supports('returnApproximately', 1.0, [1.0, 5])->shouldReturn(true);
     }
 
+    function it_supports_valid_pairings()
+    {
+        $this->supports('beApproximately', 1.0, [1.0, 5])->shouldReturn(true);
+        $this->supports('beApproximately', 1, [1.0, 5])->shouldReturn(true);
+        $this->supports('beApproximately', '1', [1.0, 5])->shouldReturn(true);
+        $this->supports('beApproximately', 1.0, [1, 5])->shouldReturn(true);
+        $this->supports('beApproximately', 1.0, ['1', 5])->shouldReturn(true);
+    }
+
+    function it_does_not_support_comparing_objects()
+    {
+        $this->supports('beApproximately', 1.0, [new \stdClass, 5])->shouldReturn(false);
+        $this->supports('beApproximately', new \stdClass, [1.0, 5])->shouldReturn(false);
+        $this->supports('beApproximately', new \stdClass, [new \stdClass, 5])->shouldReturn(false);
+    }
+
+    function it_does_not_support_comparing_arrays_to_scalar()
+    {
+        $this->supports('beApproximately', 1.0, [[], 5])->shouldReturn(false);
+        $this->supports('beApproximately', [], [1.0, 5])->shouldReturn(false);
+    }
+
     function it_matches_same_float()
     {
         $this->shouldNotThrow()->duringPositiveMatch('shouldBeApproximately', 1.4444444444, array(1.4444444445,  1.0e-9));
@@ -40,5 +63,30 @@ class ApproximatelyMatcherSpec extends ObjectBehavior
     function it_match_floats_with_near_float()
     {
         $this->shouldNotThrow()->duringPositiveMatch('shouldBeApproximately', 1.4455, array(1.4466,  1.0e-2));
+    }
+
+    function it_matches_int_with_same_ints()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('shouldBeApproximately', 2, [2, 1.0e-1]);
+    }
+
+    function it_matches_string_with_same_string()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('shouldBeApproximately', '2.0', ['2.0', 1.0e-1]);
+    }
+
+    function it_matches_arrays_with_same_values()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('shouldBeApproximately', ['3.142', '2.0'], [['3.1','2.0'], 1.0e-1]);
+    }
+
+    function it_does_not_match_arrays_with_wrong_values()
+    {
+        $this->shouldThrow(NotEqualException::class)->duringPositiveMatch('shouldBeApproximately', ['3.142', '2.0'], [['3.3','2.0'], 1.0e-1]);
+    }
+
+    function it_does_not_match_arrays_with_different_lengths()
+    {
+        $this->shouldThrow(NotEqualException::class)->duringPositiveMatch('shouldBeApproximately', ['3.142', '2.0', '5.0'], [['3.3','2.0'], 1.0e-1]);
     }
 }


### PR DESCRIPTION
As suggested in #1367 

My only concern is that the Differ doesn't know the precision the Matcher used, so in some case the verbose diff could be misleading