### PR TITLE
Fix `error_reporting()` with PHP >= 8

### DIFF
--- a/features/exception_handling/developer_can_suppress_errors.feature
+++ b/features/exception_handling/developer_can_suppress_errors.feature
@@ -1,0 +1,80 @@
+Feature: Developer uses error control operator "@"
+  As a Developer
+  I want to be able to use the error control operator "@"
+  In order to suppress certain errors and still have my specs passing
+
+  Scenario: An unsuppressed error will cause a valid spec failure
+    Given the spec file "spec/Runner/ErrorSuppression1/ErrorControlSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\ErrorSuppression1;
+
+      use PhpSpec\ObjectBehavior;
+
+      class ErrorControlSpec extends ObjectBehavior
+      {
+          function it_returns_string()
+          {
+              $this->notSuppressing()->shouldBe('it works!');
+          }
+      }
+
+      """
+    And the class file "src/Runner/ErrorSuppression1/ErrorControl.php" contains:
+      """
+      <?php
+
+      namespace Runner\ErrorSuppression1;
+
+      class ErrorControl
+      {
+          public function notSuppressing(): string
+          {
+              trigger_error('Nope!', E_USER_WARNING);
+
+              return 'it works!';
+          }
+      }
+
+      """
+    When I run phpspec
+    Then I should see "1 broken"
+
+  Scenario: A suppressed error will not cause a spec failure
+    Given the spec file "spec/Runner/ErrorSuppression2/ErrorControlSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\ErrorSuppression2;
+
+      use PhpSpec\ObjectBehavior;
+
+      class ErrorControlSpec extends ObjectBehavior
+      {
+          function it_returns_string()
+          {
+              $this->suppressing()->shouldBe('it works!');
+          }
+      }
+
+      """
+    And the class file "src/Runner/ErrorSuppression2/ErrorControl.php" contains:
+      """
+      <?php
+
+      namespace Runner\ErrorSuppression2;
+
+      class ErrorControl
+      {
+          public function suppressing(): string
+          {
+              @trigger_error('Nope!', E_USER_WARNING);
+
+              return 'it works!';
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass

--- a/spec/PhpSpec/Runner/Maintainer/ErrorMaintainerSpec.php
+++ b/spec/PhpSpec/Runner/Maintainer/ErrorMaintainerSpec.php
@@ -18,22 +18,51 @@ class ErrorMaintainerSpec extends ObjectBehavior
         $this->shouldHaveType(ErrorMaintainer::class);
     }
 
-    function it_return_false_when_error_suppresed_or_no_error_reporting()
+    function it_returns_false_when_error_suppresed_or_no_error_reporting()
     {
         $oldLevel = error_reporting(0);
+
         $this->errorHandler(0, 'error message', 'file', 1)->shouldBe(false);
+
+        error_reporting($oldLevel);
+    }
+
+    /**
+     * In PHP 8 error_reporting() will not return 0 anymore when
+     * and error is suppressed with the error control operator "@":
+     *
+     * @link https://www.php.net/manual/en/language.operators.errorcontrol.php
+     */
+    function it_returns_false_when_error_suppressed_in_php_8()
+    {
+        /**
+         * Based on manual testing and:
+         * @link https://www.php.net/manual/en/language.operators.errorcontrol.php#125938
+         */
+        $oldLevel = error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
+
+        $this->errorHandler(E_WARNING, 'error message', 'file', 1)->shouldBe(false);
+
         error_reporting($oldLevel);
     }
 
     function it_return_true_when_recoverable_level_and_message_match()
     {
+        $oldLevel = error_reporting(E_ALL);
+
         $msg = 'Argument 1 passed to ' . self::class . '::test() must be an instance of string, string given';
         $this->errorHandler(E_RECOVERABLE_ERROR, $msg, 'file', 1)->shouldBe(true);
+
+        error_reporting($oldLevel);
     }
 
     function it_throws_error_exception_when_message_not_match()
     {
+        $oldLevel = error_reporting(E_ALL);
+
         $this->shouldThrow(ExampleException\ErrorException::class)
-             ->during('errorHandler', [0, 'error message', 'file', 1]);
+            ->during('errorHandler', [E_ERROR, 'error message', 'file', 1]);
+
+        error_reporting($oldLevel);
     }
 }

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -30,19 +30,19 @@ final class ErrorMaintainer implements Maintainer
      */
     private $errorHandler;
 
-    
+
     public function __construct(int $errorLevel)
     {
         $this->errorLevel = $errorLevel;
     }
 
-    
+
     public function supports(ExampleNode $example): bool
     {
         return true;
     }
 
-    
+
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -52,7 +52,7 @@ final class ErrorMaintainer implements Maintainer
         $this->errorHandler = set_error_handler(array($this, 'errorHandler'), $this->errorLevel);
     }
 
-    
+
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -64,7 +64,7 @@ final class ErrorMaintainer implements Maintainer
         }
     }
 
-    
+
     public function getPriority(): int
     {
         return 999;
@@ -82,7 +82,7 @@ final class ErrorMaintainer implements Maintainer
     final public function errorHandler(int $level, string $message, string $file, int $line): bool
     {
         $regex = '/^Argument (\d)+ passed to (?:(?P<class>[\w\\\]+)::)?(\w+)\(\)' .
-                 ' must (?:be an instance of|implement interface) ([\w\\\]+),(?: instance of)? ([\w\\\]+) given/';
+            ' must (?:be an instance of|implement interface) ([\w\\\]+),(?: instance of)? ([\w\\\]+) given/';
 
         if (E_RECOVERABLE_ERROR === $level && preg_match($regex, $message, $matches)) {
             $class = $matches['class'];
@@ -92,11 +92,11 @@ final class ErrorMaintainer implements Maintainer
             }
         }
 
-        if (0 !== error_reporting()) {
-            throw new ExampleException\ErrorException($level, $message, $file, $line);
+        // error reporting turned off or more likely suppressed with error control operator "@"
+        if (0 === (error_reporting() & $level)) {
+            return false;
         }
 
-        // error reporting turned off or more likely suppressed with @
-        return false;
+        throw new ExampleException\ErrorException($level, $message, $file, $line);
     }
 }


### PR DESCRIPTION
This PR improves on #1376 with a Behat feature and clearer specs.

Solves #1375.

The code change is based on:
- https://www.php.net/manual/en/function.set-error-handler (see Example 1)
- https://github.com/phpspec/phpspec/issues/1375#issuecomment-852935131
- https://www.php.net/manual/en/language.operators.errorcontrol.php

In a nutshell this is the main issue:
`Warning
Prior to PHP 8.0.0, the value of the severity passed to the custom error handler was always 0 if the diagnostic was suppressed. This is no longer the case as of PHP 8.0.0.`

The code change allows use of the error control operator `@` in PHP 8 without causing PHPSpec to fail.