### PR TITLE
Update .gitattributes to save space and trees.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,12 +10,8 @@
 /.gitignore        export-ignore
 /behat.yml.dist    export-ignore
 /box.json          export-ignore
-/CHANGES-v2.md     export-ignore
-/CHANGES-v3.md     export-ignore
-/CHANGES-v4.md     export-ignore
-/CHANGES-v5.md     export-ignore
-/CHANGES-v6.md     export-ignore
-/CHANGES-v7.md     export-ignore
+/CHANGES*.md       export-ignore
+/CHANGES.md        export-ignore
 /CONTRIBUTING.md   export-ignore
 /check-release.php export-ignore
 /Makefile          export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,6 @@
 /behat.yml.dist    export-ignore
 /box.json          export-ignore
 /CHANGES*.md       export-ignore
-/CHANGES.md        export-ignore
 /CONTRIBUTING.md   export-ignore
 /check-release.php export-ignore
 /Makefile          export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,23 @@
 *      text=auto
 *.bat  eol=crlf
 
-docs     export-ignore
+/.github           export-ignore
+/docs              export-ignore
+/features          export-ignore
+/integration       export-ignore
+/spec              export-ignore
+/.gitattributes    export-ignore
+/.gitignore        export-ignore
+/behat.yml.dist    export-ignore
+/box.json          export-ignore
+/CHANGES-v2.md     export-ignore
+/CHANGES-v3.md     export-ignore
+/CHANGES-v4.md     export-ignore
+/CHANGES-v5.md     export-ignore
+/CHANGES-v6.md     export-ignore
+/CHANGES-v7.md     export-ignore
+/CONTRIBUTING.md   export-ignore
+/check-release.php export-ignore
+/Makefile          export-ignore
+/phpunit.xml       export-ignore
+/psalm.xml         export-ignore


### PR DESCRIPTION
This PR:

- [x] Update the `.gitattributes` file

Test this locally:

1. `git checkout main`
2. `git archive --format zip HEAD > archive-main.zip`
3. `ls -la archive-main.zip` # 452k
4. `git checkout update-gitattributes`
5. `git archive --format zip HEAD > archive-update-gitattributes.zip`
6. `ls -la archive-update-gitattributes.zip` # 248k

The package downloaded by Composer every time we require PHPSpec is 452k. After applying this PR, the size drop by 46% to 248k.

Using a `.gitattributes` file function called `export-ignore`, it is possible to dramatically reduce the file size of a Composer package download.

When Composer downloads a package, a zip/tar file is created using `git archive` command. This behavior can be changed, but by default, Composer downloads an archive of the specified package. When using GitHub, GitLab, or BitBucket, Composer can directly download the zip file, and all those services will imitate a git archive command output to generate the downloadable archive.

`git archive` command looks up for files matching an `export-ignore` rule, and if matched, it will exclude those files from the archive.

With `export-ignore` rules in `.gitattributes` file, Composer packages can opt to exclude build files and test files (_such as Github CI configuration file, tests and configuration files, documentation, etc._) when the package is downloaded by Composer.

All these excluded files will remain in the repository when it is cloned/forked, and are otherwise available to those who download the package source files; The `export-ignore` rule will exclude them in the zip file downloads, thus reducing the download size and time when the packages are consumed.

PHPUnit package, for examples, has a `.gitattributes` file with several export-ignore rules to fine to the downloadable package, and it reduces the package size from ~2,000 KB (without bundled binaries) or ~8,000 KB to ~394 KB. This is a cherry-picking example of course, but a simple `.gitattributes` file can make a difference in the overall package download size specially on packages that are downloaded several thousands of times a day.

Note: I also checked `phpspec/prophecy` but the .gitattributes there is correct and there is no need to update it.

Link: https://php.watch/articles/composer-gitattributes