### PR TITLE
Relax `require` and `require-dev` dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,23 +22,23 @@
     ],
 
     "require": {
-        "php":                      "^7.3 || 8.0.*",
+        "php":                      ">= 7.3",
         "phpspec/prophecy":         "^1.9",
         "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "^3.0 || ^4.0",
-        "symfony/console":          "^3.4 || ^4.4 || ^5.0",
-        "symfony/event-dispatcher": "^3.4 || ^4.4 || ^5.0",
-        "symfony/process":          "^3.4 || ^4.4 || ^5.0",
-        "symfony/finder":           "^3.4 || ^4.4 || ^5.0",
-        "symfony/yaml":             "^3.4 || ^4.4 || ^5.0",
+        "sebastian/exporter":       ">= 3.0",
+        "symfony/console":          ">= 3.4",
+        "symfony/event-dispatcher": ">= 3.4",
+        "symfony/process":          ">= 3.4",
+        "symfony/finder":           ">= 3.4",
+        "symfony/yaml":             ">= 3.4",
         "doctrine/instantiator":    "^1.0.5",
         "ext-tokenizer":            "*"
     },
 
     "require-dev": {
-        "behat/behat":           "^3.3",
-        "symfony/filesystem":    "^3.4 || ^4.0 || ^5.0",
-        "phpunit/phpunit":       "^8.0 || ^9.0",
+        "behat/behat":           ">= 3.3",
+        "symfony/filesystem":    ">= 3.4",
+        "phpunit/phpunit":       ">= 8.0",
         "vimeo/psalm": "^4.3"
     },
 


### PR DESCRIPTION
Hi there,

I tried this morning to test a package of mine against PHP 8.1 and it was not working.

We are currently unable to get PHPSpec working on PHP 8.1 because of constraint in the `composer.json` file.

This PR propose to adopt the Symfony and PHPunit way to constraint PHP in the `composer.json` file.

See for Symfony here: https://github.com/symfony/symfony/pull/36876
See for PHPUnit here: https://packagist.org/packages/phpunit/phpunit#9.5.8

Let me know what you think.