### PR TITLE
Add basic TeamCity formatter

### DIFF
--- a/CHANGES-v7.md
+++ b/CHANGES-v7.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.2.0]
+### Added
+- TeamCityFormatter added 
+
 ## [7.1.0]
 ### Fixed
 - Suppressed errors on PHP 8 no longer cause failing tests [@AlexandruGG](https://github.com/AlexandruGG)

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -1,7 +1,0 @@
-# be aware TeamCity configuration stays in 'phpspec.tc.yaml'
-suites:
-    main:
-        namespace: \
-        psr4_prefix: \
-        spec_path: .
-        src_path: src

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -1,0 +1,7 @@
+# be aware TeamCity configuration stays in 'phpspec.tc.yaml'
+suites:
+    main:
+        namespace: \
+        psr4_prefix: \
+        spec_path: .
+        src_path: src

--- a/spec/PhpSpec/Formatter/TeamCityFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/TeamCityFormatterSpec.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace spec\PhpSpec\Formatter;
+
+use PhpSpec\Console\ConsoleIO;
+use PhpSpec\Event\SpecificationEvent;
+use PhpSpec\Event\SuiteEvent;
+use PhpSpec\Loader\Node\SpecificationNode;
+use PhpSpec\Loader\Suite;
+use PhpSpec\Locator\Resource;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Listener\StatisticsCollector;
+use ReflectionClass;
+
+class TeamCityFormatterSpec extends ObjectBehavior
+{
+    function let(Presenter $presenter, ConsoleIO $io, StatisticsCollector $stats)
+    {
+        $this->beConstructedWith($presenter, $io, $stats);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldHaveType('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+    }
+
+    function it_outputs_test_suite_started_and_count_for_before_suite(
+        SuiteEvent $event,
+        ConsoleIO $io,
+        ExampleEvent $exampleMock,
+        Suite $suiteMock,
+        SpecificationNode $specNode
+    ) {
+        $event->getTime()->willReturn(0.1);
+        $specNode->getExamples()->willReturn([$exampleMock]);
+        $suiteMock->getSpecifications()->willReturn([$specNode]);
+        $event->getSuite()->willReturn($suiteMock);
+
+        $this->beforeSuite($event);
+
+        $io->write("\n##teamcity[testCount")->shouldHaveBeenCalled();
+        $io->write(" count='1'")->shouldHaveBeenCalled();
+
+        $io->write("\n##teamcity[testSuiteStarted")->shouldHaveBeenCalled();
+        $io->write(" name='PHPSpecTestSuite'")->shouldHaveBeenCalled();
+    }
+
+    function it_outputs_test_suite_finished_for_after_suite(
+        Presenter $presenter,
+        SuiteEvent $event,
+        ConsoleIO $io,
+        StatisticsCollector $stats
+    ) {
+        $stats->getTotalSpecs()->willReturn(1);
+        $stats->getEventsCount()->willReturn(1);
+        $stats->getCountsHash()->willReturn(
+            [
+                'passed' => 1,
+                'pending' => 0,
+                'skipped' => 0,
+                'failed' => 0,
+                'broken' => 0,
+            ]
+        );
+        $event->getTime()->willReturn(0.1);
+
+        $this->beConstructedWith($presenter, $io, $stats);
+
+        $this->afterSuite($event);
+
+        $io->write("\n##teamcity[testSuiteFinished")->shouldHaveBeenCalled();
+        $io->write(" name='PHPSpecTestSuite'")->shouldHaveBeenCalled();
+        $io->write(" duration='100'")->shouldHaveBeenCalled();
+
+        $io->write("\n\n")->shouldHaveBeenCalled();
+        $io->write("1 spec\n")->shouldHaveBeenCalled();
+        $io->write("1 example ")->shouldHaveBeenCalled();
+        $io->write('(<passed>1 passed</passed>)')->shouldHaveBeenCalled();
+        $io->write("\n100ms\n")->shouldHaveBeenCalled();
+    }
+
+    function it_outputs_test_suite_started_for_before_specification(
+        SpecificationEvent $event,
+        ConsoleIO $io,
+        SpecificationNode $specNode,
+        Resource $resource
+    ) {
+        $resource->getSpecFilename()->willReturn('spec/PhpSpec/Formatter/TeamCityFormatterSpec.php');
+        $resource->getSpecClassname()->willReturn('spec\PhpSpec\Formatter\TeamCityFormatterSpec');
+        $specNode->getResource()->willReturn($resource);
+        $event->getSpecification()->willReturn($specNode);
+
+        $this->beforeSpecification($event);
+
+        $io->write("\n##teamcity[testSuiteStarted")->shouldHaveBeenCalled();
+        $io->write(" name='spec\PhpSpec\Formatter\TeamCityFormatterSpec'")->shouldHaveBeenCalled();
+        $io->write(
+            " locationHint='php_qn://spec/PhpSpec/Formatter/TeamCityFormatterSpec.php::\\spec\PhpSpec\Formatter\TeamCityFormatterSpec'"
+        )->shouldHaveBeenCalled();
+    }
+
+    function it_outputs_test_suite_started_for_after_specification(
+        SpecificationEvent $event,
+        ConsoleIO $io,
+        SpecificationNode $specNode,
+        Resource $resource
+    ) {
+        $resource->getSpecClassname()->willReturn('spec\PhpSpec\Formatter\TeamCityFormatterSpec');
+        $specNode->getResource()->willReturn($resource);
+        $event->getSpecification()->willReturn($specNode);
+
+        $this->afterSpecification($event);
+
+        $io->write("\n##teamcity[testSuiteFinished")->shouldHaveBeenCalled();
+        $io->write(" name='spec\PhpSpec\Formatter\TeamCityFormatterSpec'")->shouldHaveBeenCalled();
+    }
+
+    function it_outputs_test_started_for_before_example(
+        ExampleEvent $event,
+        ConsoleIO $io,
+        StatisticsCollector $stats,
+        SpecificationNode $specNode,
+        ReflectionClass $reflectionClass
+    ) {
+        $event->getTitle()->willReturn('it works nice before example');
+        $event->getTime()->willReturn(0.1);
+        $reflectionClass->getName()->willReturn('spec\PhpSpec\Formatter\TeamCityFormatterSpec');
+        $reflectionClass->getFileName()->willReturn('spec/PhpSpec/Formatter/TeamCityFormatterSpec.php');
+        $specNode->getClassReflection()->willReturn($reflectionClass);
+        $event->getSpecification()->willReturn($specNode);
+        $event->getResult()->willReturn(ExampleEvent::PASSED);
+        $stats->getEventsCount()->willReturn(1);
+
+        $this->beforeExample($event);
+
+        $io->write("\n##teamcity[testStarted")->shouldHaveBeenCalled();
+        $io->write(" name='it works nice before example'")->shouldHaveBeenCalled();
+        $io->write(
+            " locationHint='php_qn://spec/PhpSpec/Formatter/TeamCityFormatterSpec.php::\\spec\PhpSpec\Formatter\TeamCityFormatterSpec::it_works_nice_before_example'"
+        )->shouldHaveBeenCalled();
+    }
+
+    function it_outputs_test_finished_for_a_passed_example(
+        ExampleEvent $event,
+        ConsoleIO $io,
+        StatisticsCollector $stats
+    ) {
+        $event->getTitle()->willReturn('it works nice');
+        $event->getTime()->willReturn(0.1);
+        $event->getResult()->willReturn(ExampleEvent::PASSED);
+        $stats->getEventsCount()->willReturn(1);
+
+        $this->afterExample($event);
+
+        $io->write("\n##teamcity[testFinished")->shouldHaveBeenCalled();
+        $io->write(" name='it works nice'")->shouldHaveBeenCalled();
+        $io->write(" duration='100'")->shouldHaveBeenCalled();
+    }
+}

--- a/src/PhpSpec/Formatter/TeamCityFormatter.php
+++ b/src/PhpSpec/Formatter/TeamCityFormatter.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSpec\Formatter;
+
+use Exception;
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\SpecificationEvent;
+use PhpSpec\Event\SuiteEvent;
+
+class TeamCityFormatter extends BasicFormatter
+{
+    /** @var string|null */
+    private $startedTestName = null;
+    /** @var bool */
+    private $isSummaryTestCountPrinted = false;
+    /** @var false|int */
+    private $flowId;
+
+    private function startTest(ExampleEvent $event): void
+    {
+        $testName = $event->getTitle();
+        $this->startedTestName = $testName;
+        $params = ['name' => $testName];
+
+        $className = $event->getSpecification()->getClassReflection()->getName();
+        $fileName = (string)$event->getSpecification()->getClassReflection()->getFileName();
+        $referenceName = str_replace(' ', '_', $testName);
+        $params['locationHint'] = "php_qn://{$fileName}::\\{$className}::{$referenceName}";
+
+        $this->printEvent('testStarted', $params);
+    }
+
+    private function printIgnoredTest(string $testName, Exception $t, float $time): void
+    {
+        $this->printEvent(
+            'testIgnored',
+            [
+                'name' => $testName,
+                'message' => $this->getMessage($t),
+                'details' => $this->getDetails($t),
+                'duration' => $this->toMilliseconds($time),
+            ]
+        );
+    }
+
+    /**
+     * A test ended.
+     */
+    private function endTest(ExampleEvent $event): void
+    {
+        $this->printEvent(
+            'testFinished',
+            [
+                'name' => $event->getTitle(),
+                'duration' => $this->toMilliseconds($event->getTime()),
+            ]
+        );
+    }
+
+    private function printEvent(string $eventName, array $params = []): void
+    {
+        $this->write("\n##teamcity[{$eventName}");
+
+        if ($this->flowId) {
+            $params['flowId'] = $this->flowId;
+        }
+
+        foreach ($params as $key => $value) {
+            $escapedValue = self::escapeValue((string)$value);
+            $this->write(" {$key}='{$escapedValue}'");
+        }
+
+        $this->write("]\n");
+    }
+
+    private function getMessage(Exception $t): string
+    {
+        return $this->getPresenter()->presentException($t, $this->getIO()->isVerbose());
+    }
+
+    private function getDetails(Exception $t): string
+    {
+        return ' '.str_replace("\n", "\n ", $t->getTraceAsString());
+    }
+
+    private static function escapeValue(string $text): string
+    {
+        return str_replace(
+            ['|', "'", "\n", "\r", ']', '['],
+            ['||', "|'", '|n', '|r', '|]', '|['],
+            $text
+        );
+    }
+
+    /**
+     * @param float $time microseconds
+     */
+    private function toMilliseconds(float $time): int
+    {
+        return (int)round($time * 1000);
+    }
+
+    public function write(string $buffer): void
+    {
+        $this->getIO()->write($buffer);
+    }
+
+    private function plural(int $count): string
+    {
+        return $count !== 1 ? 's' : '';
+    }
+
+    private function outputSuiteSummary(SuiteEvent $event): void
+    {
+        $this->getIO()->write("\n\n");
+
+        $count = $this->getStatisticsCollector()->getTotalSpecs();
+        $this->getIO()->write(sprintf("%d spec%s\n", $count, $this->plural($count)));
+        $count = $this->getStatisticsCollector()->getEventsCount();
+        $this->getIO()->write(sprintf("%d example%s ", $count, $this->plural($count)));
+
+        $typesWithEvents = array_filter($this->getStatisticsCollector()->getCountsHash());
+
+        $counts = array();
+        foreach ($typesWithEvents as $type => $count) {
+            $counts[] = sprintf('<%s>%d %s</%s>', $type, $count, $type, $type);
+        }
+
+        if (\count($counts)) {
+            $this->getIO()->write(sprintf("(%s)", implode(', ', $counts)));
+        }
+
+        $this->getIO()->write(sprintf("\n%sms\n", $this->toMilliseconds($event->getTime())));
+    }
+
+    /**
+     * A test started.
+     */
+    public function beforeSuite(SuiteEvent $event): void
+    {
+        $this->flowId = stripos((string)ini_get('disable_functions'), 'getmypid') === false
+            ? getmypid()
+            : false;
+
+        if (!$this->isSummaryTestCountPrinted) {
+            $this->isSummaryTestCountPrinted = true;
+
+            $this->printEvent(
+                'testCount',
+                [
+                    'count' => array_sum(
+                        array_map(
+                            static function ($spec) {
+                                return count($spec->getExamples());
+                            },
+                            $event->getSuite()->getSpecifications()
+                        )
+                    )
+                ]
+            );
+        }
+
+        $this->printEvent(
+            'testSuiteStarted',
+            ['name' => 'PHPSpecTestSuite']
+        );
+    }
+
+    /**
+     * @param SuiteEvent $event
+     */
+    public function afterSuite(SuiteEvent $event): void
+    {
+        $this->printEvent(
+            'testSuiteFinished',
+            [
+                'name' => 'PHPSpecTestSuite',
+                'duration' => $this->toMilliseconds($event->getTime()),
+            ]
+        );
+
+        $this->outputSuiteSummary($event);
+    }
+
+    public function beforeExample(ExampleEvent $event): void
+    {
+        $this->startTest($event);
+    }
+
+    /**
+     * @param ExampleEvent $event
+     */
+    public function afterExample(ExampleEvent $event): void
+    {
+        switch ($event->getResult()) {
+            case ExampleEvent::BROKEN:
+            case ExampleEvent::FAILED:
+                if ($exception = $event->getException()) {
+                    $this->printEvent(
+                        'testFailed',
+                        [
+                            'name' => $event->getTitle(),
+                            'message' => $this->getMessage($exception),
+                            'details' => $this->getDetails($exception),
+                            'duration' => $this->toMilliseconds($event->getTime()),
+                        ]
+                    );
+                }
+                break;
+            case ExampleEvent::SKIPPED:
+                if ($exception = $event->getException()) {
+                    if ($this->startedTestName !== $event->getTitle()) {
+                        $this->startTest($event);
+                        $this->printIgnoredTest($event->getTitle(), $exception, $event->getTime());
+                        $this->endTest($event);
+                        break;
+                    }
+
+                    $this->printIgnoredTest($event->getTitle(), $exception, $event->getTime());
+                }
+                break;
+            case ExampleEvent::PENDING:
+                if ($exception = $event->getException()) {
+                    $this->printIgnoredTest($event->getTitle(), $exception, $event->getTime());
+                }
+                break;
+        }
+
+        $this->endTest($event);
+    }
+
+    /**
+     * @param SpecificationEvent $event
+     */
+    public function beforeSpecification(SpecificationEvent $event): void
+    {
+        $suiteName = $event->getSpecification()->getResource()->getSpecClassname();
+
+        if (empty($suiteName)) {
+            return;
+        }
+
+        $parameters = ['name' => $suiteName];
+        $fileName = $event->getSpecification()->getResource()->getSpecFilename();
+        $parameters['locationHint'] = "php_qn://{$fileName}::\\{$suiteName}";
+
+        $this->printEvent('testSuiteStarted', $parameters);
+    }
+
+    /**
+     * @param SpecificationEvent $event
+     */
+    public function afterSpecification(SpecificationEvent $event): void
+    {
+        $suiteName = $event->getSpecification()->getResource()->getSpecClassname();
+
+        if (empty($suiteName)) {
+            return;
+        }
+
+        $this->printEvent('testSuiteFinished', ['name' => $suiteName]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'beforeSuite' => ['beforeSuite', -10],
+            'afterSuite' => ['afterSuite', -10],
+            'beforeSpecification' => ['beforeSpecification', -10],
+            'afterSpecification' => ['afterSpecification', -10],
+            'beforeExample' => ['beforeExample', -10],
+            'afterExample' => ['afterExample', -10],
+        ];
+    }
+}

--- a/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
@@ -59,7 +59,7 @@ final class ProcOpenReRunner extends PhpExecutableReRunner
             $status = proc_get_status($proc);
         } while ($status['running']);
 
-        exit((int)$status['exitcode']);
+        exit($status['exitcode']);
     }
 
     private function buildArgString() : string


### PR DESCRIPTION
To have a better overview about the tests during TeamCity builds.

Extracted from: https://github.com/sebastianbergmann/phpunit/blob/master/src/Logging/TeamCityLogger.php
TeamCity docs: https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Messages+for+Build+Log

This also helps to easily identify failed tests and its reasons:
![image](https://user-images.githubusercontent.com/3937889/133266249-7cbae132-0ff5-4b24-bb37-04f2b5681feb.png)



**Question**
Are you willing to accept a PR where I add a multi-formatter to phpspec core?
_I would like to be able to output to TeamCity and at the same time output to a JUnit file._


