### PR TITLE
Disallow intersection type hints in specs

### DIFF
--- a/features/doubles/intersection_doubles.feature
+++ b/features/doubles/intersection_doubles.feature
@@ -1,0 +1,23 @@
+Feature: Intersection Doubles
+
+  Currently these are not supported so we show an appropriate message
+
+  Scenario: Error when using a intersection double
+    Given the spec file "spec/Doubles/IntersectionDoublesSpec.php" contains:
+       """
+       <?php
+
+       namespace spec\Doubles;
+
+       use PhpSpec\ObjectBehavior;
+
+       class IntersectionDoublesSpec extends ObjectBehavior
+       {
+            function it_does_something_with_a_double(\stdClass&\ArrayObject $double)
+            {
+                return;
+            }
+       }
+       """
+    When I run phpspec
+    Then I should see "intersection type \stdClass&\ArrayObject cannot be used to create a double"

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -166,6 +166,17 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                 return;
             }
 
+            if (\strpos($typehint, '&') !== false) {
+                $this->typeHintIndex->addInvalid(
+                    $class,
+                    trim($this->currentFunction),
+                    $token[1],
+                    new DisallowedUnionTypehintException("Intersection type $typehint cannot be used to create a double")
+                );
+
+                return;
+            }
+
             try {
                 $typehintFcqn = $this->namespaceResolver->resolve($typehint);
                 $this->typeHintIndex->add(
@@ -187,7 +198,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
 
     private function haveNotReachedEndOfTypeHint($token) : bool
     {
-        if ($token == '|') {
+        if ($token == '|' || $token == '&') {
             return false;
         }
 


### PR DESCRIPTION
A temporary fix until we can implement #1394 