### PR TITLE
Fix Psalm issues

### DIFF
--- a/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
@@ -59,7 +59,7 @@ final class ProcOpenReRunner extends PhpExecutableReRunner
             $status = proc_get_status($proc);
         } while ($status['running']);
 
-        exit((int)$status['exitcode']);
+        exit($status['exitcode']);
     }
 
     private function buildArgString() : string


### PR DESCRIPTION
The int type cast seems redundant here: https://psalm.dev/docs/running_psalm/issues/RedundantCast. This should make most of the build pass (except the PHP 8.1 failures).