### PR TITLE
Eases autoloading issue debugging

### DIFF
--- a/features/bootstrap/ApplicationContext.php
+++ b/features/bootstrap/ApplicationContext.php
@@ -411,6 +411,7 @@ class ApplicationContext implements Context
         $string = str_replace("\r", '', $string);
         $string = preg_replace('#(Double\\\\.+?\\\\P)\d+#u', '$1', $string);
         $string = preg_replace('/\(\s+("[^"]*")\s+\)/', '($1)', $string);
+        $string = preg_replace('/at path(.*)/', 'at path', $string);
 
         return $string;
     }

--- a/features/formatter/display_ignored_resources.feature
+++ b/features/formatter/display_ignored_resources.feature
@@ -48,3 +48,16 @@ Feature: Display ignored resources using the progress formatter
     """
      # IGNORE spec\MilkyWay\OrionCygnusArm\MyClassSpec could not be loaded at path
     """
+
+   Scenario: Dot output
+    When I run phpspec using the "dot" format
+    Then I should see:
+    """
+
+
+    spec\MilkyWay\OrionCygnusArm\MyClassSpec                                        
+          - cannot be autoloaded
+          expected to find spec at path
+
+    0 spec (1 ignored)
+    """

--- a/features/formatter/display_ignored_resources.feature
+++ b/features/formatter/display_ignored_resources.feature
@@ -27,17 +27,24 @@ Feature: Display ignored resources using the progress formatter
     }
     """
 
-  Scenario: Non verbose output
+  Scenario: Non verbose progress output
     When I run phpspec
     Then I should see:
       """
       1 ignored
       """
 
-  Scenario: Verbose output
+  Scenario: Verbose progress output
     When I run phpspec with the "verbose" option
     Then I should see:
       """
       1 ignored
         ! spec\MilkyWay\OrionCygnusArm\MyClassSpec could not be loaded at path
       """
+
+  Scenario: TAP output
+    When I run phpspec using the "tap" format
+    Then I should see:
+    """
+     # IGNORE spec\MilkyWay\OrionCygnusArm\MyClassSpec could not be loaded at path
+    """

--- a/features/ignored_resources/display_ignored_resources.feature
+++ b/features/ignored_resources/display_ignored_resources.feature
@@ -1,0 +1,43 @@
+Feature: Display ignored resources using the progress formatter
+  In order to know and understand why some specs are not executed
+  As a developer
+  I should be shown a counter and a list of ignored specs while using the progress formatter
+
+  Background:
+    Given the config file located in "." contains:
+    """
+    composer_suite_detection: true
+    """
+    And there is a PSR-4 namespace "MilkyWay\OrionCygnusArm\" configured for the "src" folder
+    And the spec file "spec/MilkyWay/OrionCygnusArm/MyClassSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\MilkyWay\OrionCygnusArm;
+
+    use MilkyWay\OrionCygnusArm\MyClass;
+    use PhpSpec\ObjectBehavior;
+
+    class MyClassSpec extends ObjectBehavior
+    {
+      function it_is_initializable()
+      {
+        $this->shouldHaveType(MyClass::class);
+      }
+    }
+    """
+
+  Scenario: Non verbose output
+    When I run phpspec
+    Then I should see:
+      """
+      1 ignored
+      """
+
+  Scenario: Verbose output
+    When I run phpspec with the "verbose" option
+    Then I should see:
+      """
+      1 ignored
+        ! spec\MilkyWay\OrionCygnusArm\MyClassSpec could not be loaded at path
+      """

--- a/spec/PhpSpec/Formatter/ProgressFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/ProgressFormatterSpec.php
@@ -4,8 +4,11 @@ namespace spec\PhpSpec\Formatter;
 
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\ResourceEvent;
+use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Listener\StatisticsCollector;
+use PhpSpec\Locator\Resource;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 

--- a/spec/PhpSpec/Listener/StatisticsCollectorSpec.php
+++ b/spec/PhpSpec/Listener/StatisticsCollectorSpec.php
@@ -3,6 +3,7 @@
 namespace spec\PhpSpec\Listener;
 
 use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\ResourceEvent;
 use PhpSpec\Event\SpecificationEvent;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Loader\Node\SpecificationNode;
@@ -29,6 +30,7 @@ class StatisticsCollectorSpec extends ObjectBehavior
         $subscribedEvents->shouldHaveKey('afterExample');
         $subscribedEvents->shouldHaveKey('afterSpecification');
         $subscribedEvents->shouldHaveKey('beforeSuite');
+        $subscribedEvents->shouldHaveKey('resourceIgnored');
     }
 
     function it_knows_no_specs_have_run_initially()
@@ -108,5 +110,12 @@ class StatisticsCollectorSpec extends ObjectBehavior
         $this->beforeSuite($suiteEvent);
 
         $this->getTotalSpecsCount()->shouldReturn(1);
+    }
+
+    function it_records_ignored_resources(ResourceEvent $resourceEvent)
+    {
+        $this->onResourceIgnored($resourceEvent);
+
+        $this->getIgnoredResourceEvents()->shouldReturn([$resourceEvent]);
     }
 }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -481,7 +481,8 @@ final class ContainerAssembler
         $container->define('loader.resource_loader', function (IndexedServiceContainer $c) {
             return new Loader\ResourceLoader(
                 $c->get('locator.resource_manager'),
-                $c->get('util.method_analyser')
+                $c->get('util.method_analyser'),
+                $c->get('event_dispatcher')
             );
         });
 

--- a/src/PhpSpec/Console/Formatter.php
+++ b/src/PhpSpec/Console/Formatter.php
@@ -42,6 +42,7 @@ class Formatter extends OutputFormatter
         $this->setStyle('passed-bg', new OutputFormatterStyle('black', 'green', array('bold')));
 
         $this->setStyle('ignored', new OutputFormatterStyle('yellow'));
+        $this->setStyle('ignored-bg', new OutputFormatterStyle('black', 'yellow', array('bold')));
 
         $this->setStyle('value', new OutputFormatterStyle('yellow'));
         $this->setStyle('lineno', new OutputFormatterStyle(null));

--- a/src/PhpSpec/Console/Formatter.php
+++ b/src/PhpSpec/Console/Formatter.php
@@ -22,7 +22,6 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
  */
 class Formatter extends OutputFormatter
 {
-    
     public function __construct(bool $decorated = false, array $styles = array())
     {
         parent::__construct($decorated, $styles);
@@ -41,6 +40,8 @@ class Formatter extends OutputFormatter
 
         $this->setStyle('passed', new OutputFormatterStyle('green'));
         $this->setStyle('passed-bg', new OutputFormatterStyle('black', 'green', array('bold')));
+
+        $this->setStyle('ignored', new OutputFormatterStyle('yellow'));
 
         $this->setStyle('value', new OutputFormatterStyle('yellow'));
         $this->setStyle('lineno', new OutputFormatterStyle(null));

--- a/src/PhpSpec/Event/ResourceEvent.php
+++ b/src/PhpSpec/Event/ResourceEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Event;
+
+use PhpSpec\Locator\Resource;
+
+class ResourceEvent extends BaseEvent implements PhpSpecEvent
+{
+    /**
+     * @var Resource
+     */
+    private $resource;
+
+    private function __construct(Resource $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    public static function ignored(Resource $resource): self
+    {
+        return new self($resource);
+    }
+
+    public function getResource(): Resource
+    {
+        return $this->resource;
+    }
+}

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -15,6 +15,8 @@ namespace PhpSpec\Formatter;
 
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\PhpSpecEvent;
+use PhpSpec\Event\ResourceEvent;
 use PhpSpec\Exception\Example\PendingException;
 use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\Formatter\Presenter\Presenter;
@@ -44,7 +46,6 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
         return $this->io;
     }
 
-    
     protected function printException(ExampleEvent $event): void
     {
         if (null === $exception = $event->getException()) {
@@ -64,7 +65,19 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
         }
     }
 
-    
+    protected function printIgnoredResource(ResourceEvent $event): void
+    {
+        $resource = $event->getResource();
+
+        $this->io->writeln(sprintf(
+            '<ignored-bg>%s</ignored-bg>',
+            str_pad($resource->getSpecClassname(), $this->io->getBlockWidth()),
+        ));
+        $this->io->writeln('      <ignored>- cannot be autoloaded</ignored>');
+        $this->io->writeln(sprintf('      <ignored>expected to find spec at path %s</ignored>.', $resource->getSpecFilename()));
+        $this->io->writeln();
+    }
+
     protected function printSpecificException(ExampleEvent $event, string $type): void
     {
         $title = str_replace('\\', DIRECTORY_SEPARATOR, $event->getSpecification()->getTitle());

--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -99,6 +99,10 @@ final class DotFormatter extends ConsoleFormatter
         foreach ($notPassed as $events) {
             array_map(array($this, 'printException'), $events);
         }
+
+        foreach ($stats->getIgnoredResourceEvents() as $event) {
+            $this->printIgnoredResource($event);
+        }
     }
 
     private function outputSuiteSummary(SuiteEvent $event): void
@@ -112,13 +116,19 @@ final class DotFormatter extends ConsoleFormatter
 
     private function plural($count)
     {
-        return $count !== 1 ? 's' : '';
+        return $count > 1 ? 's' : '';
     }
 
     private function outputTotalSpecCount(): void
     {
-        $count = $this->getStatisticsCollector()->getTotalSpecs();
-        $this->getIO()->writeln(sprintf("%d spec%s", $count, $this->plural($count)));
+        $stats = $this->getStatisticsCollector();
+        $count = $stats->getTotalSpecs();
+        $line = sprintf("%d spec%s", $count, $this->plural($count));
+
+        if (($ignoredCount = count($stats->getIgnoredResourceEvents())) > 0) {
+            $line .= sprintf(' (%d ignored)', $ignoredCount);
+        }
+        $this->getIO()->writeln($line);
     }
 
     private function outputTotalExamplesCount(): void

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -34,6 +34,24 @@ final class ProgressFormatter extends ConsoleFormatter
         }
     }
 
+    private function displayIgnoredResources(): void
+    {
+        $io = $this->getIO();
+        $stats = $this->getStatisticsCollector();
+        $ignoredResourceEvents = $stats->getIgnoredResourceEvents();
+        if (0 !== $ignoredResourcesCount = count($ignoredResourceEvents)) {
+            $io->writeln(sprintf('<ignored>%d ignored</ignored>', $ignoredResourcesCount));
+            foreach ($ignoredResourceEvents as $event) {
+                $resource = $event->getResource();
+                $io->writeln(sprintf(
+                    '  <ignored>! <label>%s</label> could not be loaded at path <label>%s</label>.</ignored>',
+                    $resource->getSpecClassname(),
+                    $resource->getSpecFilename()
+                ));
+            }
+        }
+    }
+
     public function afterSuite(SuiteEvent $event)
     {
         $this->drawStats();
@@ -43,6 +61,8 @@ final class ProgressFormatter extends ConsoleFormatter
 
         $io->freezeTemp();
         $io->writeln();
+
+        $this->displayIgnoredResources();
 
         $io->writeln(sprintf("%d specs", $stats->getTotalSpecs()));
 

--- a/src/PhpSpec/Formatter/TapFormatter.php
+++ b/src/PhpSpec/Formatter/TapFormatter.php
@@ -20,7 +20,6 @@ use Symfony\Component\Yaml\Yaml;
 
 final class TapFormatter extends ConsoleFormatter
 {
-
     const VERSION = 'TAP version 13';
 
     const OK = 'ok %d';
@@ -32,6 +31,8 @@ final class TapFormatter extends ConsoleFormatter
     const SKIP = ' # SKIP %s';
 
     const TODO = ' # TODO %s';
+
+    const IGNORE = ' # IGNORE %s could not be loaded at path %s';
 
     const PLAN = '1..%d';
 
@@ -51,19 +52,24 @@ final class TapFormatter extends ConsoleFormatter
      */
     private $currentSpecificationTitle;
 
-    
     public function beforeSuite(SuiteEvent $event)
     {
         $this->getIO()->writeln(self::VERSION);
+        foreach ($this->getStatisticsCollector()->getIgnoredResourceEvents() as $event) {
+            $resource = $event->getResource();
+            $this->getIO()->writeln(sprintf(
+                self::IGNORE,
+                $resource->getSpecClassname(),
+                $resource->getSpecFilename()
+            ));
+        }
     }
 
-    
     public function beforeSpecification(SpecificationEvent $event)
     {
         $this->currentSpecificationTitle = $event->getSpecification()->getTitle();
     }
 
-    
     public function afterExample(ExampleEvent $event)
     {
         $this->examplesCount++;
@@ -98,7 +104,6 @@ final class TapFormatter extends ConsoleFormatter
         $this->getIO()->writeln($result);
     }
 
-    
     public function afterSuite(SuiteEvent $event)
     {
         $this->getIO()->writeln(sprintf(
@@ -145,13 +150,11 @@ final class TapFormatter extends ConsoleFormatter
         return $message;
     }
 
-    
     private function stripNewlines(string $string): string
     {
         return str_replace(array("\r\n", "\n", "\r"), ' / ', $string);
     }
 
-    
     private function indent(string $string): string
     {
         return preg_replace(

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Listener;
 
+use PhpSpec\Event\ResourceEvent;
 use PhpSpec\Event\SuiteEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use PhpSpec\Event\ExampleEvent;
@@ -20,23 +21,24 @@ use PhpSpec\Event\SpecificationEvent;
 
 class StatisticsCollector implements EventSubscriberInterface
 {
-    private $globalResult    = 0;
-    private $totalSpecs      = 0;
+    private $globalResult = 0;
+    private $totalSpecs = 0;
     private $totalSpecsCount = 0;
 
-    private $passedEvents  = array();
+    private $passedEvents = array();
     private $pendingEvents = array();
     private $skippedEvents = array();
-    private $failedEvents  = array();
-    private $brokenEvents  = array();
+    private $failedEvents = array();
+    private $brokenEvents = array();
+    private $resourceIgnoredEvents = array();
 
     public static function getSubscribedEvents()
     {
         return array(
             'afterSpecification' => array('afterSpecification', 10),
-            'afterExample'       => array('afterExample', 10),
-            'beforeSuite'       => array('beforeSuite', 10),
-
+            'afterExample' => array('afterExample', 10),
+            'beforeSuite' => array('beforeSuite', 10),
+            'resourceIgnored' => array('onResourceIgnored', 1),
         );
     }
 
@@ -71,6 +73,11 @@ class StatisticsCollector implements EventSubscriberInterface
     public function beforeSuite(SuiteEvent $suiteEvent): void
     {
         $this->totalSpecsCount = \count($suiteEvent->getSuite()->getSpecifications());
+    }
+
+    public function onResourceIgnored(ResourceEvent $resourceEvent)
+    {
+        $this->resourceIgnoredEvents[] = $resourceEvent;
     }
 
     public function getGlobalResult() : int
@@ -112,6 +119,11 @@ class StatisticsCollector implements EventSubscriberInterface
     public function getBrokenEvents() : array
     {
         return $this->brokenEvents;
+    }
+
+    public function getIgnoredResourceEvents()
+    {
+        return $this->resourceIgnoredEvents;
     }
 
     /**

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -121,7 +121,7 @@ class StatisticsCollector implements EventSubscriberInterface
         return $this->brokenEvents;
     }
 
-    public function getIgnoredResourceEvents()
+    public function getIgnoredResourceEvents() : array
     {
         return $this->resourceIgnoredEvents;
     }


### PR DESCRIPTION
By being explicit about files that are ignored while running the specs
suite, we help developers resolve autoloading issue.

This PR superseds #1272 


Let's agree on the scope of this feature:
- Should it be ported on all formatters ?
- Should it impact the exit code ?
- Any other concerns ?