### PR TITLE
Fix error with unset properties on ThrowMatcher

### DIFF
--- a/features/exception_handling/developer_specifies_exceptions.feature
+++ b/features/exception_handling/developer_specifies_exceptions.feature
@@ -45,3 +45,99 @@ Feature: Developer specifies exception behaviour
       """
     When I run phpspec
     Then the suite should pass
+
+  Scenario: Throwing an exception with unset properties
+    Given the spec file "spec/Runner/ExceptionExample/UnsetPropertyClassSpec.php" contains:
+      """
+      <?php
+
+      namespace spec\Runner\ExceptionExample;
+
+      use PhpSpec\ObjectBehavior;
+
+      class UnsetPropertyClassSpec extends ObjectBehavior
+      {
+          function it_throws_an_exception_with_unset_property()
+          {
+              $this->shouldThrow(new \Runner\ExceptionExample\ChildException('exception message'))
+                  ->duringDoSomething();
+          }
+      }
+
+      """
+    And the class file "src/Runner/ExceptionExample/UnsetPropertyClass.php" contains:
+      """
+      <?php
+
+      namespace Runner\ExceptionExample;
+
+      class UnsetPropertyClass
+      {
+          public function doSomething()
+          {
+              $e = new \Runner\ExceptionExample\ChildException('exception message');
+              throw $e;
+          }
+      }
+
+      """
+    And the class file "src/Runner/ExceptionExample/UnsetPropertyException.php" contains:
+      """
+      <?php
+
+      namespace Runner\ExceptionExample;
+
+      class UnsetPropertyException extends \RuntimeException
+      {
+          protected $serialized;
+
+          private $token;
+
+          public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+          {
+              unset($this->serialized);
+              parent::__construct($message, $code, $previous);
+          }
+
+          public function __serialize(): array
+          {
+              return [$this->token, $this->code, $this->message, $this->file, $this->line];
+          }
+
+          public function __unserialize(array $data): void
+          {
+              [$this->token, $this->code, $this->message, $this->file, $this->line] = $data;
+          }
+
+          public function __sleep(): array
+          {
+              $this->serialized = $this->__serialize();
+
+              return ['serialized'];
+          }
+
+          public function __wakeup(): void
+          {
+              $this->__unserialize($this->serialized);
+              unset($this->serialized);
+          }
+      }
+
+      """
+    And the class file "src/Runner/ExceptionExample/ChildException.php" contains:
+      """
+      <?php
+
+      namespace Runner\ExceptionExample;
+
+      class ChildException extends UnsetPropertyException
+      {
+          public function childMethod()
+          {
+              return 'this is child method';
+          }
+      }
+
+      """
+    When I run phpspec
+    Then the suite should pass

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -51,19 +51,19 @@ final class ThrowMatcher implements Matcher
         $this->factory   = $factory;
     }
 
-    
+
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'throw' === $name;
     }
 
-    
+
     public function positiveMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyPositive'), $subject, $arguments);
     }
 
-    
+
     public function negativeMatch(string $name, $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyNegative'), $subject, $arguments);
@@ -120,8 +120,14 @@ final class ThrowMatcher implements Matcher
                 }
 
                 $property->setAccessible(true);
-                $expected = $property->getValue($exception);
-                $actual = $property->getValue($exceptionThrown);
+
+                if (method_exists($property, 'isInitialized')) {
+                    $expected = $property->isInitialized($exception) ? $property->getValue($exception) : null;
+                    $actual = $property->isInitialized($exceptionThrown) ? $property->getValue($exceptionThrown) : null;
+                } else {
+                    $expected = $property->getValue($exception);
+                    $actual = $property->getValue($exceptionThrown);
+                }
 
                 if (null !== $expected && $actual !== $expected) {
                     throw new NotEqualException(
@@ -173,8 +179,16 @@ final class ThrowMatcher implements Matcher
                     }
 
                     $property->setAccessible(true);
-                    $expected = $property->getValue($exception);
-                    $actual = $property->getValue($exceptionThrown);
+
+                    if (method_exists($property, 'isInitialized')) {
+                        $expected = $property->isInitialized($exception) ?
+                            $property->getValue($exception) : null;
+                        $actual = $property->isInitialized($exceptionThrown) ?
+                            $property->getValue($exceptionThrown) : null;
+                    } else {
+                        $expected = $property->getValue($exception);
+                        $actual = $property->getValue($exceptionThrown);
+                    }
 
                     if (null !== $expected && $actual === $expected) {
                         $invalidProperties[] = sprintf(
@@ -204,13 +218,13 @@ final class ThrowMatcher implements Matcher
         }
     }
 
-    
+
     public function getPriority(): int
     {
         return 1;
     }
 
-    
+
     private function getDelayedCall(callable $check, $subject, array $arguments): DelayedCall
     {
         $exception = $this->getException($arguments);

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -121,6 +121,7 @@ final class ThrowMatcher implements Matcher
 
                 $property->setAccessible(true);
 
+                /** @psalm-suppress RedundantCondition */
                 if (method_exists($property, 'isInitialized')) {
                     $expected = $property->isInitialized($exception) ? $property->getValue($exception) : null;
                     $actual = $property->isInitialized($exceptionThrown) ? $property->getValue($exceptionThrown) : null;
@@ -180,6 +181,7 @@ final class ThrowMatcher implements Matcher
 
                     $property->setAccessible(true);
 
+                    /** @psalm-suppress RedundantCondition */
                     if (method_exists($property, 'isInitialized')) {
                         $expected = $property->isInitialized($exception) ?
                             $property->getValue($exception) : null;


### PR DESCRIPTION
The ThrowMatcher could crash when class properties are unset. Alas, the `isInitialized` method only exists since PHP 7.4 and the fix will not work in PHP 7.3.

This behavior was detected after this Symfony PR: https://github.com/symfony/symfony/pull/44037 related to the use of dynamic properties.