### PR TITLE
Run psalm against PHP version that is being used by workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
             -   name: Run static analysis (psalm)
                 if: matrix.composer-flags != '--prefer-lowest'
-                run: ./vendor/bin/psalm
+                run: ./vendor/bin/psalm --php-version=${{ matrix.php }}
 
             -   name: Run tests (phpspec)
                 run: bin/phpspec run --format=dot


### PR DESCRIPTION
**Changes**
This change runs psalm against the same version of PHP used by the workflow. Psalm will otherwise infer the target PHP version from composer.json (which currently comes out as 7.3).

This does not fix or address any existing issues but is required for Symony 6.0 support PRs to have a chance at passing the build. This change to the workflow needs to be in the main branch for any SF 6.0-related PR to ever pass checks.

**Example failure related to mixed return type**
SF 6.0 adds method return types where previously not present.

`Symfony\Component\Yaml\Yaml::parse()` (called by `PhpSpec\Console\Application` hence analysed by psalm) is type-hinted in SF 6.0 as returning `mixed`.

The return type `mixed` was introduced in PHP 8.0.

If psalm targets PHP 7.3 when SF 6.0 is being used, psalm will (correctly) state:
```
ERROR: ReservedWord - src/PhpSpec/Console/Application.php:242:16 - mixed is a reserved word (see https://psalm.dev/095)
        return Yaml::parse(file_get_contents($path)) ?: [];
```

It seems to make sense to have psalm target the same PHP version as used by a workflow run.





