### PR TITLE
Fixed support for PHP 8.1

### DIFF
--- a/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
+++ b/spec/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeExceptionSpec.php
@@ -8,6 +8,7 @@ class InvalidCollaboratorTypeExceptionSpec extends ObjectBehavior
 {
     function let(\ReflectionParameter $parameter, \ReflectionFunctionAbstract $function)
     {
+        $parameter->getPosition()->willReturn(0);
         $function->getName()->willReturn('bar');
         $this->beConstructedWith($parameter, $function);
     }

--- a/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
+++ b/spec/PhpSpec/Locator/PSR0/PSR0LocatorSpec.php
@@ -5,7 +5,7 @@ namespace spec\PhpSpec\Locator\PSR0;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\Filesystem;
 
-use SplFileInfo;
+use Symfony\Component\Finder\SplFileInfo;
 
 class PSR0LocatorSpec extends ObjectBehavior
 {

--- a/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ArrayKeyValueMatcherSpec.php
@@ -74,6 +74,7 @@ class ArrayKeyValueMatcherSpec extends ObjectBehavior
 
     function it_does_not_match_ArrayObject_with_missing_key(ArrayObject $array)
     {
+        $array->offsetExists('abc')->willReturn(false);
         $this->shouldThrow(new FailureException('Expected object to have key abc, but it didn\'t.'))->duringPositiveMatch('haveKeyWithValue', $array, array('abc', 123));
     }
 

--- a/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/ThrowMatcherSpec.php
@@ -49,12 +49,14 @@ class ThrowMatcherSpec extends ObjectBehavior
 
     function it_accepts_a_method_during_which_an_exception_should_not_be_thrown(ArrayObject $arr)
     {
+        $arr->ksort()->willReturn(true);
         $this->negativeMatch('throw', $arr, array('\Exception'))->during('ksort', array());
     }
 
     function it_accepts_a_method_during_which_an_error_should_not_be_thrown(ArrayObject $arr)
     {
-       $this->negativeMatch('throw', $arr, array('\Error'))->during('ksort', array());
+        $arr->ksort()->willReturn(true);
+        $this->negativeMatch('throw', $arr, array('\Error'))->during('ksort', array());
     }
 
     function it_throws_a_failure_exception_with_the_thrown_exceptions_message_if_a_positive_match_failed(Presenter $presenter)

--- a/spec/PhpSpec/Matcher/TriggerMatcherSpec.php
+++ b/spec/PhpSpec/Matcher/TriggerMatcherSpec.php
@@ -23,25 +23,33 @@ class TriggerMatcherSpec extends ObjectBehavior
 
     function it_accepts_a_method_during_which_an_error_should_be_triggered(ArrayObject $arr)
     {
-        $arr->ksort()->will(function () { trigger_error('An error', E_USER_NOTICE); });
+        $arr->ksort()->will(function () {
+            trigger_error('An error', E_USER_NOTICE);
+            return true;
+        });
 
         $this->positiveMatch('trigger', $arr, array(E_USER_NOTICE, 'An error'))->during('ksort', array());
     }
 
     function it_accepts_a_method_during_which_any_error_should_be_triggered(ArrayObject $arr)
     {
-        $arr->ksort()->will(function () { trigger_error('An error', E_USER_NOTICE); });
+        $arr->ksort()->will(function () {
+            trigger_error('An error', E_USER_NOTICE);
+            return true;
+        });
 
         $this->positiveMatch('trigger', $arr, array(null, null))->during('ksort', array());
     }
 
     function it_accepts_a_method_during_which_an_error_should_not_be_triggered(ArrayObject $arr)
     {
+        $arr->ksort()->willReturn(true);
         $this->negativeMatch('trigger', $arr, array(E_USER_NOTICE, 'An error'))->during('ksort', array());
     }
 
     function it_accepts_a_method_during_which_any_error_should_not_be_triggered(ArrayObject $arr)
     {
+        $arr->ksort()->willReturn(true);
         $this->negativeMatch('trigger', $arr, array(null, null))->during('ksort', array());
     }
 }

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -52,6 +52,10 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
             $this->typehintTokens[] = T_NAME_FULLY_QUALIFIED;
             $this->typehintTokens[] = T_NAME_QUALIFIED;
         }
+
+        if (\PHP_VERSION_ID >= 80100) {
+            $this->typehintTokens[] = T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG;
+        }
     }
 
     public function rewrite(string $classDefinition): string

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -172,7 +172,7 @@ EOF
 
         $container->configure();
 
-        $locator = $input->getArgument('spec');
+        $locator = $input->getArgument('spec') ?? '';
         $linenum = null;
         if (preg_match('/^(.*)\:(\d+)$/', $locator, $matches)) {
             list($_, $locator, $linenum) = $matches;

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -86,7 +86,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
         ));
     }
 
-    private function offsetExists($key, $subject)
+    private function offsetExists($key, $subject): bool
     {
         if ($subject instanceof ArrayAccess && $subject->offsetExists($key)) {
             return true;

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -130,7 +130,7 @@ abstract class ObjectBehavior implements
      *
      * @param int|string $key
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->object->offsetSet($key, $value);
     }
@@ -140,7 +140,7 @@ abstract class ObjectBehavior implements
      *
      * @param int|string $key
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         $this->object->offsetUnset($key);
     }


### PR DESCRIPTION
What's included:

* Added missing typehints to classes that implement `ArrayAccess`
* Ensure `preg_match` never receives a `null` subject
* Take into account ampersands used for intersection types when rewriting tokens (PHP 8.1 only)
* Added missing returns to collaborators in specs