### PR TITLE
[Fix] Do not break on deprecations

### DIFF
--- a/spec/PhpSpec/Runner/Maintainer/ErrorMaintainerSpec.php
+++ b/spec/PhpSpec/Runner/Maintainer/ErrorMaintainerSpec.php
@@ -18,7 +18,7 @@ class ErrorMaintainerSpec extends ObjectBehavior
         $this->shouldHaveType(ErrorMaintainer::class);
     }
 
-    function it_returns_false_when_error_suppresed_or_no_error_reporting()
+    function it_returns_false_when_error_suppressed_or_no_error_reporting()
     {
         $oldLevel = error_reporting(0);
 
@@ -42,6 +42,19 @@ class ErrorMaintainerSpec extends ObjectBehavior
         $oldLevel = error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
 
         $this->errorHandler(E_WARNING, 'error message', 'file', 1)->shouldBe(false);
+
+        error_reporting($oldLevel);
+    }
+
+    function it_returns_false_when_error_is_a_deprecation()
+    {
+        /**
+         * Based on manual testing and:
+         * @link https://www.php.net/manual/en/language.operators.errorcontrol.php#125938
+         */
+        $oldLevel = error_reporting(E_DEPRECATED);
+
+        $this->errorHandler(E_DEPRECATED, 'error message', 'file', 1)->shouldBe(false);
 
         error_reporting($oldLevel);
     }

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -92,6 +92,10 @@ final class ErrorMaintainer implements Maintainer
             }
         }
 
+        if (E_DEPRECATED === $level) {
+            return false;
+        }
+
         // error reporting turned off or more likely suppressed with error control operator "@"
         if (0 === (error_reporting() & $level)) {
             return false;


### PR DESCRIPTION
```php
<?php

declare(strict_types=1);

namespace App;

final class User implements \Serializable
{
    public function serialize(): string
    {
        return '';
    }

    public function unserialize($data): void
    {
    }
}

```

```php
<?php

namespace spec\App;

use App\User;
use PhpSpec\ObjectBehavior;

class UserSpec extends ObjectBehavior
{
    function it_is_initializable()
    {
        $this->shouldHaveType(User::class);
    }
}

```

<img width="1042" alt="Capture d’écran 2022-03-09 à 10 18 56" src="https://user-images.githubusercontent.com/8329789/157411142-0ec26058-5ab4-47f3-ab54-14f4cbbe0eaa.png">