### PR TITLE
Improve RunCommand help

### DIFF
--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -97,6 +97,10 @@ The <info>%command.name%</info> command runs specifications:
 
 Will run all the specifications in the spec directory.
 
+  <info>php %command.full_name% src/ClassName.php</info>
+
+Will run only the specifications in the ClassName.php file. The argument must be a file path from the root of project directory.
+
   <info>php %command.full_name% spec/ClassNameSpec.php</info>
 
 Will run only the ClassNameSpec.

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -99,7 +99,7 @@ Will run all the specifications in the spec directory.
 
   <info>php %command.full_name% src/ClassName.php</info>
 
-Will run only the specifications in the ClassName.php file. The argument must be a file path from the root of project directory.
+Will run only the specifications related to the ClassName.php file. The argument must be a file path from the root of the project directory.
 
   <info>php %command.full_name% spec/ClassNameSpec.php</info>
 


### PR DESCRIPTION
I found the use case that I can run specifications by the class related to the Spec definition. Thought it may be worth mentioning in the command's help.