### PR TITLE
Refactoring for PHP 8.0

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,24 +2,19 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Php74\Rector\Property\TypedPropertyRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector;
-use Rector\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector;
-use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
+use Rector\Php71\Rector\FuncCall\CountOnNullRector;
+use Rector\Php80\Rector\FuncCall\TokenGetAllToObjectRector;
+use Rector\Set\ValueObject\LevelSetList;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([LevelSetList::UP_TO_PHP_80]);
+    $rectorConfig->skip([
+        TokenGetAllToObjectRector::class, # causing rector to crash
+        CountOnNullRector::class, #needs manual review
+    ]);
 
-    $services = $containerConfigurator->services();
-//    $services->set(TypedPropertyRector::class);
-//    $services->set(ParamTypeDeclarationRector::class);
-//    $services->set(ReturnTypeDeclarationRector::class);
-//    $services->set(AddVoidReturnTypeWhereNoReturnRector::class);
+    $rectorConfig->rule();
 
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
-    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+    $rectorConfig->paths([__DIR__ . '/src']);
 };

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -15,11 +15,8 @@ namespace PhpSpec\CodeAnalysis;
 
 final class MagicAwareAccessInspector implements AccessInspector
 {
-    private AccessInspector $accessInspector;
-
-    public function __construct(AccessInspector $accessInspector)
+    public function __construct(private AccessInspector $accessInspector)
     {
-        $this->accessInspector = $accessInspector;
     }
 
     public function isPropertyReadable(object $object, string $property): bool

--- a/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
@@ -15,11 +15,8 @@ namespace PhpSpec\CodeAnalysis;
 
 final class StaticRejectingNamespaceResolver implements NamespaceResolver
 {
-    private NamespaceResolver $namespaceResolver;
-
-    public function __construct(NamespaceResolver $namespaceResolver)
+    public function __construct(private NamespaceResolver $namespaceResolver)
     {
-        $this->namespaceResolver = $namespaceResolver;
     }
 
     public function analyse(string $code): void

--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -94,7 +94,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
 
     public function resolve(string $typeAlias): string
     {
-        if (strpos($typeAlias, '\\') === 0) {
+        if (str_starts_with($typeAlias, '\\')) {
             return substr($typeAlias, 1);
         }
         if (($divider = strpos($typeAlias, '\\')) && array_key_exists(strtolower(substr($typeAlias, 0, $divider)), $this->uses)) {

--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -15,10 +15,10 @@ namespace PhpSpec\CodeAnalysis;
 
 final class TokenizedNamespaceResolver implements NamespaceResolver
 {
-    const STATE_DEFAULT = 0;
-    const STATE_READING_NAMESPACE = 1;
-    const STATE_READING_USE = 2;
-    const STATE_READING_USE_GROUP = 3;
+    private const STATE_DEFAULT = 0;
+    private const STATE_READING_NAMESPACE = 1;
+    private const STATE_READING_USE = 2;
+    private const STATE_READING_USE_GROUP = 3;
 
     private int $state = self::STATE_DEFAULT;
 

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -121,9 +121,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     
     private function tokensToString(array $tokens): string
     {
-        return join('', array_map(function ($token) : string {
-            return \is_array($token) ? $token[1] : $token;
-        }, $tokens));
+        return join('', array_map(fn($token): string => \is_array($token) ? $token[1] : $token, $tokens));
     }
 
     private function extractTypehints(array &$tokens, int $index, array $token): void

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -151,7 +151,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
 
             $class = $this->namespaceResolver->resolve($this->currentClass);
 
-            if (\strpos($typehint, '|') !== false) {
+            if (str_contains($typehint, '|')) {
                 $this->typeHintIndex->addInvalid(
                     $class,
                     trim($this->currentFunction),
@@ -162,7 +162,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                 return;
             }
 
-            if (\strpos($typehint, '&') !== false) {
+            if (str_contains($typehint, '&')) {
                 $this->typeHintIndex->addInvalid(
                     $class,
                     trim($this->currentFunction),

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -17,11 +17,11 @@ use PhpSpec\Loader\Transformer\TypeHintIndex;
 
 final class TokenizedTypeHintRewriter implements TypeHintRewriter
 {
-    const STATE_DEFAULT = 0;
-    const STATE_READING_CLASS = 1;
-    const STATE_READING_FUNCTION = 2;
-    const STATE_READING_ARGUMENTS = 3;
-    const STATE_READING_FUNCTION_BODY = 4;
+    private const STATE_DEFAULT = 0;
+    private const STATE_READING_CLASS = 1;
+    private const STATE_READING_FUNCTION = 2;
+    private const STATE_READING_ARGUMENTS = 3;
+    private const STATE_READING_FUNCTION_BODY = 4;
 
     private int $state = self::STATE_DEFAULT;
 

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -33,14 +33,8 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         T_WHITESPACE, T_STRING, T_NS_SEPARATOR, T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED
     );
 
-    private TypeHintIndex $typeHintIndex;
-    private NamespaceResolver $namespaceResolver;
-
-    public function __construct(TypeHintIndex $typeHintIndex, NamespaceResolver $namespaceResolver)
+    public function __construct(private TypeHintIndex $typeHintIndex, private NamespaceResolver $namespaceResolver)
     {
-        $this->typeHintIndex = $typeHintIndex;
-        $this->namespaceResolver = $namespaceResolver;
-
         if (\PHP_VERSION_ID >= 80100) {
             $this->typehintTokens[] = T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG;
         }

--- a/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
@@ -18,17 +18,8 @@ use PhpSpec\Locator\Resource;
 
 final class ConfirmingGenerator implements Generator
 {
-    private ConsoleIO $io;
-
-    private string $message;
-
-    private Generator $generator;
-
-    public function __construct(ConsoleIO $io, string $message, Generator $generator)
+    public function __construct(private ConsoleIO $io, private string $message, private Generator $generator)
     {
-        $this->io = $io;
-        $this->message = $message;
-        $this->generator = $generator;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
@@ -17,17 +17,8 @@ use PhpSpec\CodeGenerator\TemplateRenderer;
 
 class CreateObjectTemplate
 {
-    private TemplateRenderer $templates;
-    private string $methodName;
-    private array $arguments;
-    private string $className;
-
-    public function __construct(TemplateRenderer $templates, string $methodName, array $arguments, string $className)
+    public function __construct(private TemplateRenderer $templates, private string $methodName, private array $arguments, private string $className)
     {
-        $this->templates  = $templates;
-        $this->methodName = $methodName;
-        $this->arguments  = $arguments;
-        $this->className  = $className;
     }
 
     public function getContent(): string

--- a/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
@@ -18,23 +18,11 @@ use ReflectionMethod;
 
 class ExistingConstructorTemplate
 {
-    private TemplateRenderer $templates;
-    /** @var class-string */
-    private string $class;
-    private string $className;
-    private array $arguments;
-    private string $methodName;
-
     /**
      * @param class-string $class
      */
-    public function __construct(TemplateRenderer $templates, string $methodName, array $arguments, string $className, string $class)
+    public function __construct(private TemplateRenderer $templates, private string $methodName, private array $arguments, private string $className, private string $class)
     {
-        $this->templates  = $templates;
-        $this->class      = $class;
-        $this->className  = $className;
-        $this->arguments  = $arguments;
-        $this->methodName = $methodName;
     }
 
     public function getContent(): string

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -24,21 +24,8 @@ use PhpSpec\Locator\Resource;
  */
 final class MethodGenerator implements Generator
 {
-    private ConsoleIO $io;
-
-    private TemplateRenderer $templates;
-
-    private Filesystem $filesystem;
-
-    private CodeWriter $codeWriter;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(private ConsoleIO $io, private TemplateRenderer $templates, private Filesystem $filesystem, private CodeWriter $codeWriter)
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
-        $this->codeWriter = $codeWriter;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
@@ -23,18 +23,8 @@ use PhpSpec\Locator\Resource;
  */
 final class MethodSignatureGenerator implements Generator
 {
-    private ConsoleIO $io;
-
-    private TemplateRenderer $templates;
-
-    private Filesystem $filesystem;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
+    public function __construct(private ConsoleIO $io, private TemplateRenderer $templates, private Filesystem $filesystem)
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
@@ -22,20 +22,8 @@ use PhpSpec\Util\Filesystem;
 
 final class NamedConstructorGenerator implements Generator
 {
-    private ConsoleIO $io;
-
-    private TemplateRenderer $templates;
-
-    private Filesystem $filesystem;
-    private CodeWriter $codeWriter;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(private ConsoleIO $io, private TemplateRenderer $templates, private Filesystem $filesystem, private CodeWriter $codeWriter)
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
-        $this->codeWriter = $codeWriter;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
@@ -83,7 +83,7 @@ final class NamedConstructorGenerator implements Generator
     {
         try {
             return $this->codeWriter->insertAfterMethod($code, '__construct', $method);
-        } catch (NamedMethodNotFoundException $e) {
+        } catch (NamedMethodNotFoundException) {
             return $this->codeWriter->insertMethodFirstInClass($code, $method);
         }
     }

--- a/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
@@ -9,18 +9,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class NewFileNotifyingGenerator implements Generator
 {
-    private Generator $generator;
-
-    private EventDispatcherInterface $dispatcher;
-
-    private Filesystem $filesystem;
-
-    
-    public function __construct(Generator $generator, EventDispatcherInterface $dispatcher, Filesystem $filesystem)
+    public function __construct(private Generator $generator, private EventDispatcherInterface $dispatcher, private Filesystem $filesystem)
     {
-        $this->generator = $generator;
-        $this->dispatcher = $dispatcher;
-        $this->filesystem = $filesystem;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
@@ -17,14 +17,11 @@ use PhpSpec\Locator\Resource;
 
 final class OneTimeGenerator implements Generator
 {
-    private Generator $generator;
-
     private array $alreadyGenerated = array();
 
     
-    public function __construct(Generator $generator)
+    public function __construct(private Generator $generator)
     {
-        $this->generator = $generator;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
@@ -22,21 +22,8 @@ use PhpSpec\Util\Filesystem;
 
 final class PrivateConstructorGenerator implements Generator
 {
-    private ConsoleIO $io;
-
-    private TemplateRenderer $templates;
-
-    private Filesystem $filesystem;
-
-    private CodeWriter $codeWriter;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(private ConsoleIO $io, private TemplateRenderer $templates, private Filesystem $filesystem, private CodeWriter $codeWriter)
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
-        $this->codeWriter = $codeWriter;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -24,20 +24,8 @@ use PhpSpec\Locator\Resource;
  */
 abstract class PromptingGenerator implements Generator
 {
-    private ConsoleIO $io;
-
-    private TemplateRenderer $templates;
-
-    private Filesystem $filesystem;
-
-    private ExecutionContext $executionContext;
-
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, ExecutionContext $executionContext)
+    public function __construct(private ConsoleIO $io, private TemplateRenderer $templates, private Filesystem $filesystem, private ExecutionContext $executionContext)
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
-        $this->executionContext = $executionContext;
     }
 
     public function generate(Resource $resource, array $data = array()): void

--- a/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
@@ -20,16 +20,8 @@ use PhpSpec\Util\Filesystem;
 
 final class ReturnConstantGenerator implements Generator
 {
-    private ConsoleIO $io;
-    private TemplateRenderer $templates;
-    private Filesystem $filesystem;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
+    public function __construct(private ConsoleIO $io, private TemplateRenderer $templates, private Filesystem $filesystem)
     {
-        $this->io = $io;
-        $this->templates = $templates;
-        $this->filesystem = $filesystem;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGenerator.php
@@ -21,15 +21,8 @@ use PhpSpec\Locator\Resource;
 final class ValidateClassNameSpecificationGenerator implements Generator
 {
 
-    private NameChecker $classNameChecker;
-    private ConsoleIO $io;
-    private Generator $originalGenerator;
-
-    public function __construct(NameChecker $classNameChecker, ConsoleIO $io, Generator $originalGenerator)
+    public function __construct(private NameChecker $classNameChecker, private ConsoleIO $io, private Generator $originalGenerator)
     {
-        $this->classNameChecker = $classNameChecker;
-        $this->io = $io;
-        $this->originalGenerator = $originalGenerator;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/GeneratorManager.php
+++ b/src/PhpSpec/CodeGenerator/GeneratorManager.php
@@ -31,9 +31,7 @@ class GeneratorManager
     public function registerGenerator(Generator $generator): void
     {
         $this->generators[] = $generator;
-        @usort($this->generators, function (Generator $generator1, Generator $generator2) {
-            return $generator2->getPriority() - $generator1->getPriority();
-        });
+        @usort($this->generators, fn(Generator $generator1, Generator $generator2) => $generator2->getPriority() - $generator1->getPriority());
     }
 
     /**

--- a/src/PhpSpec/CodeGenerator/TemplateRenderer.php
+++ b/src/PhpSpec/CodeGenerator/TemplateRenderer.php
@@ -23,12 +23,9 @@ class TemplateRenderer
 {
     private array $locations = array();
 
-    private Filesystem $filesystem;
-
     
-    public function __construct(Filesystem $filesystem)
+    public function __construct(private Filesystem $filesystem)
     {
-        $this->filesystem = $filesystem;
     }
 
     

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -18,12 +18,8 @@ use PhpSpec\Util\ClassFileAnalyser;
 
 final class TokenizedCodeWriter implements CodeWriter
 {
-    private ClassFileAnalyser $analyser;
-
-    
-    public function __construct(ClassFileAnalyser $analyser)
+    public function __construct(private ClassFileAnalyser $analyser)
     {
-        $this->analyser = $analyser;
     }
 
     public function insertMethodFirstInClass(string $class, string $method): string

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -17,32 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class OptionsConfig
 {
-    private bool $stopOnFailureEnabled;
-
-    private bool $codeGenerationEnabled;
-
-    private bool $reRunEnabled;
-
-    private bool $fakingEnabled;
-
-    private string|false $bootstrapPath;
-
-    private bool $isVerbose;
-
-    public function __construct(
-        bool $stopOnFailureEnabled,
-        bool $codeGenerationEnabled,
-        bool $reRunEnabled,
-        bool $fakingEnabled,
-        false|string $bootstrapPath,
-        bool $isVerbose
-    ) {
-        $this->stopOnFailureEnabled  = $stopOnFailureEnabled;
-        $this->codeGenerationEnabled = $codeGenerationEnabled;
-        $this->reRunEnabled = $reRunEnabled;
-        $this->fakingEnabled = $fakingEnabled;
-        $this->bootstrapPath = $bootstrapPath;
-        $this->isVerbose = $isVerbose;
+    public function __construct(private bool $stopOnFailureEnabled, private bool $codeGenerationEnabled, private bool $reRunEnabled, private bool $fakingEnabled, private false|string $bootstrapPath, private bool $isVerbose)
+    {
     }
 
     

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -121,7 +121,6 @@ final class Application extends BaseApplication
 
     /**
      * @throws \RuntimeException
-     * @return void
      */
     protected function loadConfigurationFile(InputInterface $input, IndexedServiceContainer $container): void
     {

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -57,9 +57,7 @@ final class Application extends BaseApplication
         $this->container->set('console.output', $output);
         $this->container->set('console.helper_set', $helperSet);
 
-        $this->container->define('process.executioncontext', function () {
-            return JsonExecutionContext::fromEnv($_SERVER);
-        });
+        $this->container->define('process.executioncontext', fn() => JsonExecutionContext::fromEnv($_SERVER));
 
         $assembler = new ContainerAssembler();
         $assembler->build($this->container);
@@ -158,10 +156,7 @@ final class Application extends BaseApplication
         foreach ($matchersClassnames as $class) {
             $this->ensureIsValidMatcherClass($class);
 
-            $container->define(sprintf('matchers.%s', $class), function () use ($class) {
-                /** @psalm-suppress InvalidStringClass */
-                return new $class();
-            }, ['matchers']);
+            $container->define(sprintf('matchers.%s', $class), fn() => new $class(), ['matchers']);
         }
     }
 

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -67,51 +67,31 @@ final class PresenterAssembler
 
     private function assembleDifferEngines(IndexedServiceContainer $container): void
     {
-        $container->define('formatter.presenter.differ.engines.string', function () {
-            return new StringEngine();
-        }, ['formatter.presenter.differ.engines']);
+        $container->define('formatter.presenter.differ.engines.string', fn() => new StringEngine(), ['formatter.presenter.differ.engines']);
 
-        $container->define('formatter.presenter.differ.engines.array', function () {
-            return new ArrayEngine(new Exporter());
-        }, ['formatter.presenter.differ.engines']);
+        $container->define('formatter.presenter.differ.engines.array', fn() => new ArrayEngine(new Exporter()), ['formatter.presenter.differ.engines']);
 
-        $container->define('formatter.presenter.differ.engines.object', function (IndexedServiceContainer $c) {
-            return new ObjectEngine(
-                new Exporter(),
-                $c->get('formatter.presenter.differ.engines.string')
-            );
-        }, ['formatter.presenter.differ.engines']);
+        $container->define('formatter.presenter.differ.engines.object', fn(IndexedServiceContainer $c) => new ObjectEngine(
+            new Exporter(),
+            $c->get('formatter.presenter.differ.engines.string')
+        ), ['formatter.presenter.differ.engines']);
     }
 
     private function assembleTypePresenters(IndexedServiceContainer $container): void
     {
-        $container->define('formatter.presenter.value.array_type_presenter', function () {
-            return new ArrayTypePresenter();
-        }, ['formatter.presenter.value']);
+        $container->define('formatter.presenter.value.array_type_presenter', fn() => new ArrayTypePresenter(), ['formatter.presenter.value']);
 
-        $container->define('formatter.presenter.value.boolean_type_presenter', function () {
-            return new BooleanTypePresenter();
-        }, ['formatter.presenter.value']);
+        $container->define('formatter.presenter.value.boolean_type_presenter', fn() => new BooleanTypePresenter(), ['formatter.presenter.value']);
 
-        $container->define('formatter.presenter.value.callable_type_presenter', function (IndexedServiceContainer $c) {
-            return new CallableTypePresenter($c->get('formatter.presenter'));
-        }, ['formatter.presenter.value']);
+        $container->define('formatter.presenter.value.callable_type_presenter', fn(IndexedServiceContainer $c) => new CallableTypePresenter($c->get('formatter.presenter')), ['formatter.presenter.value']);
 
-        $container->define('formatter.presenter.value.exception_type_presenter', function () {
-            return new BaseExceptionTypePresenter();
-        }, ['formatter.presenter.value']);
+        $container->define('formatter.presenter.value.exception_type_presenter', fn() => new BaseExceptionTypePresenter(), ['formatter.presenter.value']);
 
-        $container->define('formatter.presenter.value.null_type_presenter', function () {
-            return new NullTypePresenter();
-        }, ['formatter.presenter.value']);
+        $container->define('formatter.presenter.value.null_type_presenter', fn() => new NullTypePresenter(), ['formatter.presenter.value']);
 
-        $container->define('formatter.presenter.value.object_type_presenter', function () {
-            return new ObjectTypePresenter();
-        }, ['formatter.presenter.value']);
+        $container->define('formatter.presenter.value.object_type_presenter', fn() => new ObjectTypePresenter(), ['formatter.presenter.value']);
 
-        $container->define('formatter.presenter.value.string_type_presenter', function () {
-            return new TruncatingStringTypePresenter(new QuotingStringTypePresenter());
-        }, ['formatter.presenter.value']);
+        $container->define('formatter.presenter.value.string_type_presenter', fn() => new TruncatingStringTypePresenter(new QuotingStringTypePresenter()), ['formatter.presenter.value']);
 
         $container->addConfigurator(function (IndexedServiceContainer $c): void {
             array_map(
@@ -123,61 +103,47 @@ final class PresenterAssembler
 
     private function assemblePresenter(IndexedServiceContainer $container): void
     {
-        $container->define('formatter.presenter', function (IndexedServiceContainer $c) {
-            return new TaggingPresenter(
-                new SimplePresenter(
-                    $c->get('formatter.presenter.value_presenter'),
-                    new SimpleExceptionPresenter(
-                        $c->get('formatter.presenter.differ'),
-                        $c->get('formatter.presenter.exception_element_presenter'),
-                        new CallArgumentsPresenter($c->get('formatter.presenter.differ')),
-                        $c->get('formatter.presenter.exception.phpspec')
-                    )
+        $container->define('formatter.presenter', fn(IndexedServiceContainer $c) => new TaggingPresenter(
+            new SimplePresenter(
+                $c->get('formatter.presenter.value_presenter'),
+                new SimpleExceptionPresenter(
+                    $c->get('formatter.presenter.differ'),
+                    $c->get('formatter.presenter.exception_element_presenter'),
+                    new CallArgumentsPresenter($c->get('formatter.presenter.differ')),
+                    $c->get('formatter.presenter.exception.phpspec')
                 )
-            );
-        });
+            )
+        ));
 
-        $container->define('formatter.presenter.value_presenter', function () {
-            return new ComposedValuePresenter();
-        });
+        $container->define('formatter.presenter.value_presenter', fn() => new ComposedValuePresenter());
 
-        $container->define('formatter.presenter.exception_element_presenter', function (IndexedServiceContainer $c) {
-            return new TaggingExceptionElementPresenter(
-                $c->get('formatter.presenter.value.exception_type_presenter'),
-                $c->get('formatter.presenter.value_presenter')
-            );
-        });
+        $container->define('formatter.presenter.exception_element_presenter', fn(IndexedServiceContainer $c) => new TaggingExceptionElementPresenter(
+            $c->get('formatter.presenter.value.exception_type_presenter'),
+            $c->get('formatter.presenter.value_presenter')
+        ));
 
-        $container->define('formatter.presenter.exception.phpspec', function (IndexedServiceContainer $c) {
-            return new GenericPhpSpecExceptionPresenter(
-                $c->get('formatter.presenter.exception_element_presenter')
-            );
-        });
+        $container->define('formatter.presenter.exception.phpspec', fn(IndexedServiceContainer $c) => new GenericPhpSpecExceptionPresenter(
+            $c->get('formatter.presenter.exception_element_presenter')
+        ));
     }
 
     private function assembleHtmlPresenter(IndexedServiceContainer $container): void
     {
-        $container->define('formatter.presenter.html', function (IndexedServiceContainer $c) {
-            return new SimplePresenter(
-                $c->get('formatter.presenter.value_presenter'),
-                new SimpleExceptionPresenter(
-                    $c->get('formatter.presenter.differ'),
-                    $c->get('formatter.presenter.html.exception_element_presenter'),
-                    new CallArgumentsPresenter($c->get('formatter.presenter.differ')),
-                    $c->get('formatter.presenter.html.exception.phpspec')
-                )
-            );
-        });
+        $container->define('formatter.presenter.html', fn(IndexedServiceContainer $c) => new SimplePresenter(
+            $c->get('formatter.presenter.value_presenter'),
+            new SimpleExceptionPresenter(
+                $c->get('formatter.presenter.differ'),
+                $c->get('formatter.presenter.html.exception_element_presenter'),
+                new CallArgumentsPresenter($c->get('formatter.presenter.differ')),
+                $c->get('formatter.presenter.html.exception.phpspec')
+            )
+        ));
 
-        $container->define('formatter.presenter.html.exception_element_presenter', function (IndexedServiceContainer $c) {
-            return new SimpleExceptionElementPresenter(
-                $c->get('formatter.presenter.value.exception_type_presenter'),
-                $c->get('formatter.presenter.value_presenter')
-            );
-        });
+        $container->define('formatter.presenter.html.exception_element_presenter', fn(IndexedServiceContainer $c) => new SimpleExceptionElementPresenter(
+            $c->get('formatter.presenter.value.exception_type_presenter'),
+            $c->get('formatter.presenter.value_presenter')
+        ));
 
-        $container->define('formatter.presenter.html.exception.phpspec', function () {
-            return new HtmlPhpSpecExceptionPresenter();
-        });
+        $container->define('formatter.presenter.html.exception.phpspec', fn() => new HtmlPhpSpecExceptionPresenter());
     }
 }

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -179,7 +179,7 @@ EOF
         $locator = $input->getArgument('spec') ?? '';
         $linenum = null;
         if (preg_match('/^(.*)\:(\d+)$/', $locator, $matches)) {
-            list($_, $locator, $linenum) = $matches;
+            [$_, $locator, $linenum] = $matches;
         }
 
         $suite       = $container->get('loader.resource_loader')->load((string)$locator, $linenum);

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -27,30 +27,14 @@ class ConsoleIO implements IO
     private const COL_DEFAULT_WIDTH = 60;
     private const COL_MAX_WIDTH = 80;
 
-    private InputInterface $input;
-
-    private OutputInterface $output;
-
     private ?string $lastMessage = null;
 
     private bool $hasTempString = false;
 
-    private OptionsConfig $config;
-
     private ?int $consoleWidth = null;
 
-    private Prompter $prompter;
-
-    public function __construct(
-        InputInterface $input,
-        OutputInterface $output,
-        OptionsConfig $config,
-        Prompter $prompter
-    ) {
-        $this->input   = $input;
-        $this->output  = $output;
-        $this->config  = $config;
-        $this->prompter = $prompter;
+    public function __construct(private InputInterface $input, private OutputInterface $output, private OptionsConfig $config, private Prompter $prompter)
+    {
     }
 
     public function isInteractive(): bool

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -23,9 +23,9 @@ use PhpSpec\Config\OptionsConfig;
  */
 class ConsoleIO implements IO
 {
-    const COL_MIN_WIDTH = 40;
-    const COL_DEFAULT_WIDTH = 60;
-    const COL_MAX_WIDTH = 80;
+    private const COL_MIN_WIDTH = 40;
+    private const COL_DEFAULT_WIDTH = 60;
+    private const COL_MAX_WIDTH = 80;
 
     private InputInterface $input;
 

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -191,9 +191,7 @@ class ConsoleIO implements IO
     private function indentText(string $text, int $indent): string
     {
         return implode("\n", array_map(
-            function ($line) use ($indent) {
-                return str_repeat(' ', $indent).$line;
-            },
+            fn($line) => str_repeat(' ', $indent).$line,
             explode("\n", $text)
         ));
     }

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -677,7 +677,7 @@ final class ContainerAssembler
 
             try {
                 $formatter = $c->get('formatter.formatters.'.$formatterName);
-            } catch (\InvalidArgumentException $e) {
+            } catch (\InvalidArgumentException) {
                 throw new \RuntimeException(sprintf('Formatter not recognised: "%s"', $formatterName));
             }
             $c->set('event_dispatcher.listeners.formatter', $formatter, ['event_dispatcher.listeners']);

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -155,56 +155,42 @@ final class ContainerAssembler
     private function setupIO(IndexedServiceContainer $container): void
     {
         if (!$container->has('console.prompter')) {
-            $container->define('console.prompter', function ($c) {
-                return new Question(
-                    $c->get('console.input'),
-                    $c->get('console.output'),
-                    $c->get('console.helper_set')->get('question')
-                );
-            });
-        }
-        $container->define('console.io', function (IndexedServiceContainer $c) {
-            return new ConsoleIO(
+            $container->define('console.prompter', fn($c) => new Question(
                 $c->get('console.input'),
                 $c->get('console.output'),
-                new OptionsConfig(
-                    $c->getParam('stop_on_failure', false),
-                    $c->getParam('code_generation', true),
-                    $c->getParam('rerun', true),
-                    $c->getParam('fake', false),
-                    $c->getParam('bootstrap', false),
-                    $c->getParam('verbose', false)
-                ),
-                $c->get('console.prompter')
-            );
-        });
-        $container->define('util.filesystem', function () {
-            return new Filesystem();
-        });
-        $container->define('console.autocomplete_provider', function (IndexedServiceContainer $container) {
-            return new NamespacesAutocompleteProvider(
-                new Finder(),
-                $container->getByTag('locator.locators')
-            );
-        });
+                $c->get('console.helper_set')->get('question')
+            ));
+        }
+        $container->define('console.io', fn(IndexedServiceContainer $c) => new ConsoleIO(
+            $c->get('console.input'),
+            $c->get('console.output'),
+            new OptionsConfig(
+                $c->getParam('stop_on_failure', false),
+                $c->getParam('code_generation', true),
+                $c->getParam('rerun', true),
+                $c->getParam('fake', false),
+                $c->getParam('bootstrap', false),
+                $c->getParam('verbose', false)
+            ),
+            $c->get('console.prompter')
+        ));
+        $container->define('util.filesystem', fn() => new Filesystem());
+        $container->define('console.autocomplete_provider', fn(IndexedServiceContainer $container) => new NamespacesAutocompleteProvider(
+            new Finder(),
+            $container->getByTag('locator.locators')
+        ));
     }
 
     private function setupResultConverter(IndexedServiceContainer $container): void
     {
-        $container->define('console.result_converter', function () {
-            return new ResultConverter();
-        });
+        $container->define('console.result_converter', fn() => new ResultConverter());
     }
 
     private function setupCommands(IndexedServiceContainer $container): void
     {
-        $container->define('console.commands.run', function () {
-            return new RunCommand();
-        }, ['console.commands']);
+        $container->define('console.commands.run', fn() => new RunCommand(), ['console.commands']);
 
-        $container->define('console.commands.describe', function () {
-            return new DescribeCommand();
-        }, ['console.commands']);
+        $container->define('console.commands.describe', fn() => new DescribeCommand(), ['console.commands']);
     }
 
     
@@ -225,93 +211,61 @@ final class ContainerAssembler
     
     private function setupEventDispatcher(IndexedServiceContainer $container): void
     {
-        $container->define('event_dispatcher', function () {
-            return new EventDispatcher();
-        });
+        $container->define('event_dispatcher', fn() => new EventDispatcher());
 
-        $container->define('event_dispatcher.listeners.stats', function () {
-            return new StatisticsCollector();
-        }, ['event_dispatcher.listeners']);
-        $container->define('event_dispatcher.listeners.class_not_found', function (IndexedServiceContainer $c) {
-            return new ClassNotFoundListener(
-                $c->get('console.io'),
-                $c->get('locator.resource_manager'),
-                $c->get('code_generator')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('event_dispatcher.listeners.collaborator_not_found', function (IndexedServiceContainer $c) {
-            return new CollaboratorNotFoundListener(
-                $c->get('console.io'),
-                $c->get('locator.resource_manager'),
-                $c->get('code_generator')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('event_dispatcher.listeners.collaborator_method_not_found', function (IndexedServiceContainer $c) {
-            return new CollaboratorMethodNotFoundListener(
-                $c->get('console.io'),
-                $c->get('locator.resource_manager'),
-                $c->get('code_generator'),
-                $c->get('util.reserved_words_checker')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('event_dispatcher.listeners.named_constructor_not_found', function (IndexedServiceContainer $c) {
-            return new NamedConstructorNotFoundListener(
-                $c->get('console.io'),
-                $c->get('locator.resource_manager'),
-                $c->get('code_generator')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('event_dispatcher.listeners.method_not_found', function (IndexedServiceContainer $c) {
-            return new MethodNotFoundListener(
-                $c->get('console.io'),
-                $c->get('locator.resource_manager'),
-                $c->get('code_generator'),
-                $c->get('util.reserved_words_checker')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('event_dispatcher.listeners.stop_on_failure', function (IndexedServiceContainer $c) {
-            return new StopOnFailureListener(
-                $c->get('console.io')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('event_dispatcher.listeners.rerun', function (IndexedServiceContainer $c) {
-            return new RerunListener(
-                $c->get('process.rerunner'),
-                $c->get('process.prerequisites')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('process.prerequisites', function (IndexedServiceContainer $c) {
-            return new SuitePrerequisites(
-                $c->get('process.executioncontext')
-            );
-        });
-        $container->define('event_dispatcher.listeners.method_returned_null', function (IndexedServiceContainer $c) {
-            return new MethodReturnedNullListener(
-                $c->get('console.io'),
-                $c->get('locator.resource_manager'),
-                $c->get('code_generator'),
-                $c->get('util.method_analyser')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('util.method_analyser', function () {
-            return new MethodAnalyser();
-        });
-        $container->define('util.reserved_words_checker', function () {
-            return new ReservedWordsMethodNameChecker();
-        });
-        $container->define('util.class_name_checker', function () {
-            return new ClassNameChecker();
-        });
-        $container->define('event_dispatcher.listeners.bootstrap', function (IndexedServiceContainer $c) {
-            return new BootstrapListener(
-                $c->get('console.io')
-            );
-        }, ['event_dispatcher.listeners']);
-        $container->define('event_dispatcher.listeners.current_example_listener', function (IndexedServiceContainer $c) {
-            return new CurrentExampleListener(
-                $c->get('current_example')
-            );
-        }, ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.stats', fn() => new StatisticsCollector(), ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.class_not_found', fn(IndexedServiceContainer $c) => new ClassNotFoundListener(
+            $c->get('console.io'),
+            $c->get('locator.resource_manager'),
+            $c->get('code_generator')
+        ), ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.collaborator_not_found', fn(IndexedServiceContainer $c) => new CollaboratorNotFoundListener(
+            $c->get('console.io'),
+            $c->get('locator.resource_manager'),
+            $c->get('code_generator')
+        ), ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.collaborator_method_not_found', fn(IndexedServiceContainer $c) => new CollaboratorMethodNotFoundListener(
+            $c->get('console.io'),
+            $c->get('locator.resource_manager'),
+            $c->get('code_generator'),
+            $c->get('util.reserved_words_checker')
+        ), ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.named_constructor_not_found', fn(IndexedServiceContainer $c) => new NamedConstructorNotFoundListener(
+            $c->get('console.io'),
+            $c->get('locator.resource_manager'),
+            $c->get('code_generator')
+        ), ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.method_not_found', fn(IndexedServiceContainer $c) => new MethodNotFoundListener(
+            $c->get('console.io'),
+            $c->get('locator.resource_manager'),
+            $c->get('code_generator'),
+            $c->get('util.reserved_words_checker')
+        ), ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.stop_on_failure', fn(IndexedServiceContainer $c) => new StopOnFailureListener(
+            $c->get('console.io')
+        ), ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.rerun', fn(IndexedServiceContainer $c) => new RerunListener(
+            $c->get('process.rerunner'),
+            $c->get('process.prerequisites')
+        ), ['event_dispatcher.listeners']);
+        $container->define('process.prerequisites', fn(IndexedServiceContainer $c) => new SuitePrerequisites(
+            $c->get('process.executioncontext')
+        ));
+        $container->define('event_dispatcher.listeners.method_returned_null', fn(IndexedServiceContainer $c) => new MethodReturnedNullListener(
+            $c->get('console.io'),
+            $c->get('locator.resource_manager'),
+            $c->get('code_generator'),
+            $c->get('util.method_analyser')
+        ), ['event_dispatcher.listeners']);
+        $container->define('util.method_analyser', fn() => new MethodAnalyser());
+        $container->define('util.reserved_words_checker', fn() => new ReservedWordsMethodNameChecker());
+        $container->define('util.class_name_checker', fn() => new ClassNameChecker());
+        $container->define('event_dispatcher.listeners.bootstrap', fn(IndexedServiceContainer $c) => new BootstrapListener(
+            $c->get('console.io')
+        ), ['event_dispatcher.listeners']);
+        $container->define('event_dispatcher.listeners.current_example_listener', fn(IndexedServiceContainer $c) => new CurrentExampleListener(
+            $c->get('current_example')
+        ), ['event_dispatcher.listeners']);
     }
 
     
@@ -377,55 +331,43 @@ final class ContainerAssembler
                 $c->get('util.filesystem')
             );
         }, ['code_generator.generators']);
-        $container->define('code_generator.writers.tokenized', function () {
-            return new TokenizedCodeWriter(new ClassFileAnalyser());
-        });
-        $container->define('code_generator.generators.method', function (IndexedServiceContainer $c) {
-            return new MethodGenerator(
-                $c->get('console.io'),
-                $c->get('code_generator.templates'),
-                $c->get('util.filesystem'),
-                $c->get('code_generator.writers.tokenized')
-            );
-        }, ['code_generator.generators']);
-        $container->define('code_generator.generators.methodSignature', function (IndexedServiceContainer $c) {
-            return new MethodSignatureGenerator(
-                $c->get('console.io'),
-                $c->get('code_generator.templates'),
-                $c->get('util.filesystem')
-            );
-        }, ['code_generator.generators']);
-        $container->define('code_generator.generators.returnConstant', function (IndexedServiceContainer $c) {
-            return new ReturnConstantGenerator(
-                $c->get('console.io'),
-                $c->get('code_generator.templates'),
-                $c->get('util.filesystem')
-            );
-        }, ['code_generator.generators']);
+        $container->define('code_generator.writers.tokenized', fn() => new TokenizedCodeWriter(new ClassFileAnalyser()));
+        $container->define('code_generator.generators.method', fn(IndexedServiceContainer $c) => new MethodGenerator(
+            $c->get('console.io'),
+            $c->get('code_generator.templates'),
+            $c->get('util.filesystem'),
+            $c->get('code_generator.writers.tokenized')
+        ), ['code_generator.generators']);
+        $container->define('code_generator.generators.methodSignature', fn(IndexedServiceContainer $c) => new MethodSignatureGenerator(
+            $c->get('console.io'),
+            $c->get('code_generator.templates'),
+            $c->get('util.filesystem')
+        ), ['code_generator.generators']);
+        $container->define('code_generator.generators.returnConstant', fn(IndexedServiceContainer $c) => new ReturnConstantGenerator(
+            $c->get('console.io'),
+            $c->get('code_generator.templates'),
+            $c->get('util.filesystem')
+        ), ['code_generator.generators']);
 
-        $container->define('code_generator.generators.named_constructor', function (IndexedServiceContainer $c) {
-            return new NamedConstructorGenerator(
-                $c->get('console.io'),
-                $c->get('code_generator.templates'),
-                $c->get('util.filesystem'),
-                $c->get('code_generator.writers.tokenized')
-            );
-        }, ['code_generator.generators']);
+        $container->define('code_generator.generators.named_constructor', fn(IndexedServiceContainer $c) => new NamedConstructorGenerator(
+            $c->get('console.io'),
+            $c->get('code_generator.templates'),
+            $c->get('util.filesystem'),
+            $c->get('code_generator.writers.tokenized')
+        ), ['code_generator.generators']);
 
-        $container->define('code_generator.generators.private_constructor', function (IndexedServiceContainer $c) {
-            return new OneTimeGenerator(
-                new ConfirmingGenerator(
+        $container->define('code_generator.generators.private_constructor', fn(IndexedServiceContainer $c) => new OneTimeGenerator(
+            new ConfirmingGenerator(
+                $c->get('console.io'),
+                $c->getParam('generator.private-constructor.message'),
+                new PrivateConstructorGenerator(
                     $c->get('console.io'),
-                    $c->getParam('generator.private-constructor.message'),
-                    new PrivateConstructorGenerator(
-                        $c->get('console.io'),
-                        $c->get('code_generator.templates'),
-                        $c->get('util.filesystem'),
-                        $c->get('code_generator.writers.tokenized')
-                    )
+                    $c->get('code_generator.templates'),
+                    $c->get('util.filesystem'),
+                    $c->get('code_generator.writers.tokenized')
                 )
-            );
-        }, ['code_generator.generators']);
+            )
+        ), ['code_generator.generators']);
 
         $container->define('code_generator.templates', function (IndexedServiceContainer $c) {
             $renderer = new TemplateRenderer(
@@ -532,16 +474,14 @@ final class ContainerAssembler
 
                 $c->define(
                     sprintf('locator.locators.%s_suite', $name),
-                    function (IndexedServiceContainer $c) use ($config) {
-                        return new PSR0Locator(
-                            $c->get('util.filesystem'),
-                            $config['namespace'],
-                            $config['spec_prefix'],
-                            $config['src_path'],
-                            $config['spec_path'],
-                            $config['psr4_prefix']
-                        );
-                    },
+                    fn(IndexedServiceContainer $c) => new PSR0Locator(
+                        $c->get('util.filesystem'),
+                        $config['namespace'],
+                        $config['spec_prefix'],
+                        $config['src_path'],
+                        $config['spec_path'],
+                        $config['psr4_prefix']
+                    ),
                     ['locator.locators']
                 );
             }
@@ -551,33 +491,21 @@ final class ContainerAssembler
     
     private function setupLoader(IndexedServiceContainer $container): void
     {
-        $container->define('loader.resource_loader', function (IndexedServiceContainer $c) {
-            return new ResourceLoader(
-                $c->get('locator.resource_manager'),
-                $c->get('util.method_analyser'),
-                $c->get('event_dispatcher')
-            );
-        });
+        $container->define('loader.resource_loader', fn(IndexedServiceContainer $c) => new ResourceLoader(
+            $c->get('locator.resource_manager'),
+            $c->get('util.method_analyser'),
+            $c->get('event_dispatcher')
+        ));
 
-        $container->define('loader.resource_loader.spec_transformer.typehint_rewriter', function (IndexedServiceContainer $c) {
-            return new TypeHintRewriter($c->get('analysis.typehintrewriter'));
-        }, ['loader.resource_loader.spec_transformer']);
+        $container->define('loader.resource_loader.spec_transformer.typehint_rewriter', fn(IndexedServiceContainer $c) => new TypeHintRewriter($c->get('analysis.typehintrewriter')), ['loader.resource_loader.spec_transformer']);
 
-        $container->define('analysis.typehintrewriter', function ($c) {
-            return new TokenizedTypeHintRewriter(
-                $c->get('loader.transformer.typehintindex'),
-                $c->get('analysis.namespaceresolver')
-            );
-        });
-        $container->define('loader.transformer.typehintindex', function () {
-            return new InMemoryTypeHintIndex();
-        });
-        $container->define('analysis.namespaceresolver.tokenized', function () {
-            return new TokenizedNamespaceResolver();
-        });
-        $container->define('analysis.namespaceresolver', function ($c) {
-            return new StaticRejectingNamespaceResolver($c->get('analysis.namespaceresolver.tokenized'));
-        });
+        $container->define('analysis.typehintrewriter', fn($c) => new TokenizedTypeHintRewriter(
+            $c->get('loader.transformer.typehintindex'),
+            $c->get('analysis.namespaceresolver')
+        ));
+        $container->define('loader.transformer.typehintindex', fn() => new InMemoryTypeHintIndex());
+        $container->define('analysis.namespaceresolver.tokenized', fn() => new TokenizedNamespaceResolver());
+        $container->define('analysis.namespaceresolver', fn($c) => new StaticRejectingNamespaceResolver($c->get('analysis.namespaceresolver.tokenized')));
     }
 
     /**
@@ -587,63 +515,51 @@ final class ContainerAssembler
     {
         $container->define(
             'formatter.formatters.progress',
-            function (IndexedServiceContainer $c) {
-                return new SpecFormatter\ProgressFormatter(
-                    $c->get('formatter.presenter'),
-                    $c->get('console.io'),
-                    $c->get('event_dispatcher.listeners.stats')
-                );
-            }
+            fn(IndexedServiceContainer $c) => new SpecFormatter\ProgressFormatter(
+                $c->get('formatter.presenter'),
+                $c->get('console.io'),
+                $c->get('event_dispatcher.listeners.stats')
+            )
         );
         $container->define(
             'formatter.formatters.pretty',
-            function (IndexedServiceContainer $c) {
-                return new SpecFormatter\PrettyFormatter(
-                    $c->get('formatter.presenter'),
-                    $c->get('console.io'),
-                    $c->get('event_dispatcher.listeners.stats')
-                );
-            }
+            fn(IndexedServiceContainer $c) => new SpecFormatter\PrettyFormatter(
+                $c->get('formatter.presenter'),
+                $c->get('console.io'),
+                $c->get('event_dispatcher.listeners.stats')
+            )
         );
         $container->define(
             'formatter.formatters.junit',
-            function (IndexedServiceContainer $c) {
-                return new SpecFormatter\JUnitFormatter(
-                    $c->get('formatter.presenter'),
-                    $c->get('console.io'),
-                    $c->get('event_dispatcher.listeners.stats')
-                );
-            }
+            fn(IndexedServiceContainer $c) => new SpecFormatter\JUnitFormatter(
+                $c->get('formatter.presenter'),
+                $c->get('console.io'),
+                $c->get('event_dispatcher.listeners.stats')
+            )
         );
         $container->define(
             'formatter.formatters.json',
-            function (IndexedServiceContainer $c) {
-                return new SpecFormatter\JsonFormatter(
-                    $c->get('formatter.presenter'),
-                    $c->get('console.io'),
-                    $c->get('event_dispatcher.listeners.stats')
-                );
-            }
+            fn(IndexedServiceContainer $c) => new SpecFormatter\JsonFormatter(
+                $c->get('formatter.presenter'),
+                $c->get('console.io'),
+                $c->get('event_dispatcher.listeners.stats')
+            )
         );
         $container->define(
             'formatter.formatters.dot',
-            function (IndexedServiceContainer $c) {
-                return new SpecFormatter\DotFormatter(
-                    $c->get('formatter.presenter'),
-                    $c->get('console.io'),
-                    $c->get('event_dispatcher.listeners.stats')
-                );
-            }
+            fn(IndexedServiceContainer $c) => new SpecFormatter\DotFormatter(
+                $c->get('formatter.presenter'),
+                $c->get('console.io'),
+                $c->get('event_dispatcher.listeners.stats')
+            )
         );
         $container->define(
             'formatter.formatters.tap',
-            function (IndexedServiceContainer $c) {
-                return new SpecFormatter\TapFormatter(
-                    $c->get('formatter.presenter'),
-                    $c->get('console.io'),
-                    $c->get('event_dispatcher.listeners.stats')
-                );
-            }
+            fn(IndexedServiceContainer $c) => new SpecFormatter\TapFormatter(
+                $c->get('formatter.presenter'),
+                $c->get('console.io'),
+                $c->get('event_dispatcher.listeners.stats')
+            )
         );
         $container->define(
             'formatter.formatters.html',
@@ -663,9 +579,7 @@ final class ContainerAssembler
         );
         $container->define(
             'formatter.formatters.h',
-            function (IndexedServiceContainer $c) {
-                return $c->get('formatter.formatters.html');
-            }
+            fn(IndexedServiceContainer $c) => $c->get('formatter.formatters.html')
         );
 
         $container->addConfigurator(function (IndexedServiceContainer $c) {
@@ -687,19 +601,15 @@ final class ContainerAssembler
     
     private function setupRunner(IndexedServiceContainer $container): void
     {
-        $container->define('runner.suite', function (IndexedServiceContainer $c) {
-            return new SuiteRunner(
-                $c->get('event_dispatcher'),
-                $c->get('runner.specification')
-            );
-        });
+        $container->define('runner.suite', fn(IndexedServiceContainer $c) => new SuiteRunner(
+            $c->get('event_dispatcher'),
+            $c->get('runner.specification')
+        ));
 
-        $container->define('runner.specification', function (IndexedServiceContainer $c) {
-            return new SpecificationRunner(
-                $c->get('event_dispatcher'),
-                $c->get('runner.example')
-            );
-        });
+        $container->define('runner.specification', fn(IndexedServiceContainer $c) => new SpecificationRunner(
+            $c->get('event_dispatcher'),
+            $c->get('runner.example')
+        ));
 
         $container->define('runner.example', function (IndexedServiceContainer $c) {
             $runner = new ExampleRunner(
@@ -715,20 +625,14 @@ final class ContainerAssembler
             return $runner;
         });
 
-        $container->define('runner.maintainers.errors', function (IndexedServiceContainer $c) {
-            return new ErrorMaintainer(
-                $c->getParam('runner.maintainers.errors.level', E_ALL ^ E_STRICT)
-            );
-        }, ['runner.maintainers']);
-        $container->define('runner.maintainers.collaborators', function (IndexedServiceContainer $c) {
-            return new CollaboratorsMaintainer(
-                $c->get('unwrapper'),
-                $c->get('loader.transformer.typehintindex')
-            );
-        }, ['runner.maintainers']);
-        $container->define('runner.maintainers.let_letgo', function () {
-            return new LetAndLetgoMaintainer();
-        }, ['runner.maintainers']);
+        $container->define('runner.maintainers.errors', fn(IndexedServiceContainer $c) => new ErrorMaintainer(
+            $c->getParam('runner.maintainers.errors.level', E_ALL ^ E_STRICT)
+        ), ['runner.maintainers']);
+        $container->define('runner.maintainers.collaborators', fn(IndexedServiceContainer $c) => new CollaboratorsMaintainer(
+            $c->get('unwrapper'),
+            $c->get('loader.transformer.typehintindex')
+        ), ['runner.maintainers']);
+        $container->define('runner.maintainers.let_letgo', fn() => new LetAndLetgoMaintainer(), ['runner.maintainers']);
 
         $container->define('runner.maintainers.matchers', function (IndexedServiceContainer $c) {
             $matchers = $c->getByTag('matchers');
@@ -738,146 +642,78 @@ final class ContainerAssembler
             );
         }, ['runner.maintainers']);
 
-        $container->define('runner.maintainers.subject', function (IndexedServiceContainer $c) {
-            return new SubjectMaintainer(
-                $c->get('formatter.presenter'),
-                $c->get('unwrapper'),
-                $c->get('event_dispatcher'),
-                $c->get('access_inspector')
-            );
-        }, ['runner.maintainers']);
+        $container->define('runner.maintainers.subject', fn(IndexedServiceContainer $c) => new SubjectMaintainer(
+            $c->get('formatter.presenter'),
+            $c->get('unwrapper'),
+            $c->get('event_dispatcher'),
+            $c->get('access_inspector')
+        ), ['runner.maintainers']);
 
-        $container->define('unwrapper', function () {
-            return new Unwrapper();
-        });
+        $container->define('unwrapper', fn() => new Unwrapper());
 
-        $container->define('access_inspector', function ($c) {
-            return $c->get('access_inspector.magic');
-        });
+        $container->define('access_inspector', fn($c) => $c->get('access_inspector.magic'));
 
-        $container->define('access_inspector.magic', function ($c) {
-            return new MagicAwareAccessInspector($c->get('access_inspector.visibility'));
-        });
+        $container->define('access_inspector.magic', fn($c) => new MagicAwareAccessInspector($c->get('access_inspector.visibility')));
 
-        $container->define('access_inspector.visibility', function () {
-            return new VisibilityAccessInspector();
-        });
+        $container->define('access_inspector.visibility', fn() => new VisibilityAccessInspector());
     }
 
     
     private function setupMatchers(IndexedServiceContainer $container): void
     {
-        $container->define('matchers.identity', function (IndexedServiceContainer $c) {
-            return new IdentityMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.comparison', function (IndexedServiceContainer $c) {
-            return new ComparisonMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.throwm', function (IndexedServiceContainer $c) {
-            return new ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory());
-        }, ['matchers']);
-        $container->define('matchers.trigger', function (IndexedServiceContainer $c) {
-            return new TriggerMatcher($c->get('unwrapper'));
-        }, ['matchers']);
-        $container->define('matchers.type', function (IndexedServiceContainer $c) {
-            return new TypeMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.object_state', function (IndexedServiceContainer $c) {
-            return new ObjectStateMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.scalar', function (IndexedServiceContainer $c) {
-            return new ScalarMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.array_count', function (IndexedServiceContainer $c) {
-            return new ArrayCountMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.array_key', function (IndexedServiceContainer $c) {
-            return new ArrayKeyMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.array_key_with_value', function (IndexedServiceContainer $c) {
-            return new ArrayKeyValueMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.array_contain', function (IndexedServiceContainer $c) {
-            return new ArrayContainMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.string_start', function (IndexedServiceContainer $c) {
-            return new StringStartMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.string_end', function (IndexedServiceContainer $c) {
-            return new StringEndMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.string_regex', function (IndexedServiceContainer $c) {
-            return new StringRegexMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.string_contain', function (IndexedServiceContainer $c) {
-            return new StringContainMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.traversable_count', function (IndexedServiceContainer $c) {
-            return new TraversableCountMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.traversable_key', function (IndexedServiceContainer $c) {
-            return new TraversableKeyMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.traversable_key_with_value', function (IndexedServiceContainer $c) {
-            return new TraversableKeyValueMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.traversable_contain', function (IndexedServiceContainer $c) {
-            return new TraversableContainMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.iterate', function (IndexedServiceContainer $c) {
-            return new IterateAsMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.iterate_like', function (IndexedServiceContainer $c) {
-            return new IterateLikeMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.start_iterating', function (IndexedServiceContainer $c) {
-            return new StartIteratingAsMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
-        $container->define('matchers.approximately', function (IndexedServiceContainer $c) {
-            return new ApproximatelyMatcher($c->get('formatter.presenter'));
-        }, ['matchers']);
+        $container->define('matchers.identity', fn(IndexedServiceContainer $c) => new IdentityMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.comparison', fn(IndexedServiceContainer $c) => new ComparisonMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.throwm', fn(IndexedServiceContainer $c) => new ThrowMatcher($c->get('unwrapper'), $c->get('formatter.presenter'), new ReflectionFactory()), ['matchers']);
+        $container->define('matchers.trigger', fn(IndexedServiceContainer $c) => new TriggerMatcher($c->get('unwrapper')), ['matchers']);
+        $container->define('matchers.type', fn(IndexedServiceContainer $c) => new TypeMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.object_state', fn(IndexedServiceContainer $c) => new ObjectStateMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.scalar', fn(IndexedServiceContainer $c) => new ScalarMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.array_count', fn(IndexedServiceContainer $c) => new ArrayCountMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.array_key', fn(IndexedServiceContainer $c) => new ArrayKeyMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.array_key_with_value', fn(IndexedServiceContainer $c) => new ArrayKeyValueMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.array_contain', fn(IndexedServiceContainer $c) => new ArrayContainMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.string_start', fn(IndexedServiceContainer $c) => new StringStartMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.string_end', fn(IndexedServiceContainer $c) => new StringEndMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.string_regex', fn(IndexedServiceContainer $c) => new StringRegexMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.string_contain', fn(IndexedServiceContainer $c) => new StringContainMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.traversable_count', fn(IndexedServiceContainer $c) => new TraversableCountMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.traversable_key', fn(IndexedServiceContainer $c) => new TraversableKeyMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.traversable_key_with_value', fn(IndexedServiceContainer $c) => new TraversableKeyValueMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.traversable_contain', fn(IndexedServiceContainer $c) => new TraversableContainMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.iterate', fn(IndexedServiceContainer $c) => new IterateAsMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.iterate_like', fn(IndexedServiceContainer $c) => new IterateLikeMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.start_iterating', fn(IndexedServiceContainer $c) => new StartIteratingAsMatcher($c->get('formatter.presenter')), ['matchers']);
+        $container->define('matchers.approximately', fn(IndexedServiceContainer $c) => new ApproximatelyMatcher($c->get('formatter.presenter')), ['matchers']);
     }
 
     
     private function setupRerunner(IndexedServiceContainer $container): void
     {
-        $container->define('process.rerunner', function (IndexedServiceContainer $c) {
-            return new OptionalReRunner(
-                $c->get('process.rerunner.platformspecific'),
-                $c->get('console.io')
-            );
-        });
+        $container->define('process.rerunner', fn(IndexedServiceContainer $c) => new OptionalReRunner(
+            $c->get('process.rerunner.platformspecific'),
+            $c->get('console.io')
+        ));
 
         if ($container->has('process.rerunner.platformspecific')) {
             return;
         }
 
-        $container->define('process.rerunner.platformspecific', function (IndexedServiceContainer $c) {
-            return new CompositeReRunner(
-                $c->getByTag('process.rerunner.platformspecific')
-            );
-        });
-        $container->define('process.rerunner.platformspecific.pcntl', function (IndexedServiceContainer $c) {
-            return PcntlReRunner::withExecutionContext(
-                $c->get('process.phpexecutablefinder'),
-                $c->get('process.executioncontext')
-            );
-        }, ['process.rerunner.platformspecific']);
-        $container->define('process.rerunner.platformspecific.passthru', function (IndexedServiceContainer $c) {
-            return ProcOpenReRunner::withExecutionContext(
-                $c->get('process.phpexecutablefinder'),
-                $c->get('process.executioncontext')
-            );
-        }, ['process.rerunner.platformspecific']);
-        $container->define('process.rerunner.platformspecific.windowspassthru', function (IndexedServiceContainer $c) {
-            return WindowsPassthruReRunner::withExecutionContext(
-                $c->get('process.phpexecutablefinder'),
-                $c->get('process.executioncontext')
-            );
-        }, ['process.rerunner.platformspecific']);
-        $container->define('process.phpexecutablefinder', function () {
-            return new PhpExecutableFinder();
-        });
+        $container->define('process.rerunner.platformspecific', fn(IndexedServiceContainer $c) => new CompositeReRunner(
+            $c->getByTag('process.rerunner.platformspecific')
+        ));
+        $container->define('process.rerunner.platformspecific.pcntl', fn(IndexedServiceContainer $c) => PcntlReRunner::withExecutionContext(
+            $c->get('process.phpexecutablefinder'),
+            $c->get('process.executioncontext')
+        ), ['process.rerunner.platformspecific']);
+        $container->define('process.rerunner.platformspecific.passthru', fn(IndexedServiceContainer $c) => ProcOpenReRunner::withExecutionContext(
+            $c->get('process.phpexecutablefinder'),
+            $c->get('process.executioncontext')
+        ), ['process.rerunner.platformspecific']);
+        $container->define('process.rerunner.platformspecific.windowspassthru', fn(IndexedServiceContainer $c) => WindowsPassthruReRunner::withExecutionContext(
+            $c->get('process.phpexecutablefinder'),
+            $c->get('process.executioncontext')
+        ), ['process.rerunner.platformspecific']);
+        $container->define('process.phpexecutablefinder', fn() => new PhpExecutableFinder());
     }
 
     
@@ -894,16 +730,12 @@ final class ContainerAssembler
     
     private function setupCurrentExample(IndexedServiceContainer $container): void
     {
-        $container->define('current_example', function () {
-            return new CurrentExampleTracker();
-        });
+        $container->define('current_example', fn() => new CurrentExampleTracker());
     }
 
   
     private function setupShutdown(IndexedServiceContainer $container): void
     {
-        $container->define('process.shutdown', function () {
-            return new Shutdown();
-        });
+        $container->define('process.shutdown', fn() => new Shutdown());
     }
 }

--- a/src/PhpSpec/Console/Prompter/Question.php
+++ b/src/PhpSpec/Console/Prompter/Question.php
@@ -21,17 +21,8 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 final class Question implements Prompter
 {
-    private InputInterface $input;
-
-    private OutputInterface $output;
-
-    private QuestionHelper $helper;
-
-    public function __construct(InputInterface $input, OutputInterface $output, QuestionHelper $helper)
+    public function __construct(private InputInterface $input, private OutputInterface $output, private QuestionHelper $helper)
     {
-        $this->input = $input;
-        $this->output = $output;
-        $this->helper = $helper;
     }
 
     

--- a/src/PhpSpec/Console/Provider/NamespacesAutocompleteProvider.php
+++ b/src/PhpSpec/Console/Provider/NamespacesAutocompleteProvider.php
@@ -19,19 +19,15 @@ use Symfony\Component\Finder\Finder;
 
 final class NamespacesAutocompleteProvider
 {
-    private Finder $finder;
-
     private array $paths = [];
 
-    public function __construct(Finder $finder, array $locators)
+    public function __construct(private Finder $finder, array $locators)
     {
         foreach ($locators as $locator) {
             if ($locator instanceof SrcPathLocator) {
                 $this->paths[] = $locator->getFullSrcPath();
             }
         }
-
-        $this->finder = $finder;
     }
 
     /**

--- a/src/PhpSpec/Console/ResultConverter.php
+++ b/src/PhpSpec/Console/ResultConverter.php
@@ -25,12 +25,9 @@ class ResultConverter
      */
     public function convert(int $result): int
     {
-        switch ($result) {
-            case ExampleEvent::PASSED:
-            case ExampleEvent::SKIPPED:
-                return 0;
-        }
-
-        return 1;
+        return match ($result) {
+            ExampleEvent::PASSED, ExampleEvent::SKIPPED => 0,
+            default => 1,
+        };
     }
 }

--- a/src/PhpSpec/Event/ExampleEvent.php
+++ b/src/PhpSpec/Event/ExampleEvent.php
@@ -25,27 +25,27 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
     /**
      * Spec passed
      */
-    const PASSED  = 0;
+    public const PASSED  = 0;
 
     /**
      * Spec is pending
      */
-    const PENDING = 1;
+    public const PENDING = 1;
 
     /**
      * Spec is skipped
      */
-    const SKIPPED = 2;
+    public const SKIPPED = 2;
 
     /**
      * Spec failed
      */
-    const FAILED  = 3;
+    public const FAILED  = 3;
 
     /**
      * Spec is broken
      */
-    const BROKEN  = 4;
+    public const BROKEN  = 4;
 
     private ExampleNode $example;
 

--- a/src/PhpSpec/Event/ExampleEvent.php
+++ b/src/PhpSpec/Event/ExampleEvent.php
@@ -47,25 +47,14 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
      */
     public const BROKEN  = 4;
 
-    private ExampleNode $example;
-
-    private float $time;
-
-    private int $result;
-
-    private ?\Exception $exception;
-
     public function __construct(
-        ExampleNode $example,
+        private ExampleNode $example,
         // options below are not provided beforeExample
-        float $time = 0.0,
-        int $result = self::PASSED,
-        \Exception $exception = null
-    ) {
-        $this->example   = $example;
-        $this->time      = $time;
-        $this->result    = $result;
-        $this->exception = $exception;
+        private float $time = 0.0,
+        private int $result = self::PASSED,
+        private ?\Exception $exception = null
+    )
+    {
     }
 
     

--- a/src/PhpSpec/Event/ExpectationEvent.php
+++ b/src/PhpSpec/Event/ExpectationEvent.php
@@ -26,17 +26,17 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
     /**
      * Expectation passed
      */
-    const PASSED  = 0;
+    public const PASSED  = 0;
 
     /**
      * Expectation failed
      */
-    const FAILED  = 1;
+    public const FAILED  = 1;
 
     /**
      * Expectation broken
      */
-    const BROKEN  = 2;
+    public const BROKEN  = 2;
 
     private ExampleNode $example;
 

--- a/src/PhpSpec/Event/ExpectationEvent.php
+++ b/src/PhpSpec/Event/ExpectationEvent.php
@@ -38,36 +38,8 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
      */
     public const BROKEN  = 2;
 
-    private ExampleNode $example;
-
-    private Matcher $matcher;
-
-    private mixed $subject;
-
-    private string $method;
-
-    private array $arguments;
-
-    private int $result;
-
-    private ?\Exception $exception;
-
-    public function __construct(
-        ExampleNode $example,
-        Matcher $matcher,
-        mixed $subject,
-        string $method,
-        array $arguments,
-        int $result = self::PASSED,
-        ?\Exception $exception = null
-    ) {
-        $this->example = $example;
-        $this->matcher = $matcher;
-        $this->subject = $subject;
-        $this->method = $method;
-        $this->arguments = $arguments;
-        $this->result = $result;
-        $this->exception = $exception;
+    public function __construct(private ExampleNode $example, private Matcher $matcher, private mixed $subject, private string $method, private array $arguments, private int $result = self::PASSED, private ?\Exception $exception = null)
+    {
     }
 
     

--- a/src/PhpSpec/Event/FileCreationEvent.php
+++ b/src/PhpSpec/Event/FileCreationEvent.php
@@ -15,12 +15,8 @@ namespace PhpSpec\Event;
 
 final class FileCreationEvent extends BaseEvent implements PhpSpecEvent
 {
-    private string $filepath;
-
-    public function __construct(string $filepath)
+    public function __construct(private string $filepath)
     {
-
-        $this->filepath = $filepath;
     }
 
     

--- a/src/PhpSpec/Event/MethodCallEvent.php
+++ b/src/PhpSpec/Event/MethodCallEvent.php
@@ -22,23 +22,8 @@ use PhpSpec\Loader\Suite;
  */
 class MethodCallEvent extends BaseEvent implements PhpSpecEvent
 {
-    private ExampleNode $example;
-
-    private mixed $subject;
-
-    private string $method;
-
-    private array $arguments;
-
-    private mixed $returnValue;
-
-    public function __construct(ExampleNode $example, mixed $subject, string $method, array $arguments, mixed $returnValue = null)
+    public function __construct(private ExampleNode $example, private mixed $subject, private string $method, private array $arguments, private mixed $returnValue = null)
     {
-        $this->example = $example;
-        $this->subject = $subject;
-        $this->method = $method;
-        $this->arguments = $arguments;
-        $this->returnValue = $returnValue;
     }
 
     public function getExample(): ExampleNode

--- a/src/PhpSpec/Event/ResourceEvent.php
+++ b/src/PhpSpec/Event/ResourceEvent.php
@@ -17,11 +17,8 @@ use PhpSpec\Locator\Resource;
 
 class ResourceEvent extends BaseEvent implements PhpSpecEvent
 {
-    private Resource $resource;
-
-    private function __construct(Resource $resource)
+    private function __construct(private Resource $resource)
     {
-        $this->resource = $resource;
     }
 
     public static function ignored(Resource $resource): self

--- a/src/PhpSpec/Event/SpecificationEvent.php
+++ b/src/PhpSpec/Event/SpecificationEvent.php
@@ -21,18 +21,8 @@ use PhpSpec\Loader\Node\SpecificationNode;
  */
 class SpecificationEvent extends BaseEvent implements PhpSpecEvent
 {
-    private SpecificationNode $specification;
-
-    private float $time;
-
-    private int $result;
-
-    
-    public function __construct(SpecificationNode $specification, float $time = 0.0, int $result = 0)
+    public function __construct(private SpecificationNode $specification, private float $time = 0.0, private int $result = 0)
     {
-        $this->specification = $specification;
-        $this->time          = $time;
-        $this->result        = $result;
     }
 
     

--- a/src/PhpSpec/Event/SuiteEvent.php
+++ b/src/PhpSpec/Event/SuiteEvent.php
@@ -20,20 +20,11 @@ use PhpSpec\Loader\Suite;
  */
 class SuiteEvent extends BaseEvent implements PhpSpecEvent
 {
-    private Suite $suite;
-
-    private float $time;
-
-    private int $result;
-
     private bool $worthRerunning = false;
 
     
-    public function __construct(Suite $suite, float $time = 0.0, int $result = 0)
+    public function __construct(private Suite $suite, private float $time = 0.0, private int $result = 0)
     {
-        $this->suite  = $suite;
-        $this->time   = $time;
-        $this->result = $result;
     }
 
     

--- a/src/PhpSpec/Exception/Example/MethodFailureException.php
+++ b/src/PhpSpec/Exception/Example/MethodFailureException.php
@@ -15,16 +15,9 @@ namespace PhpSpec\Exception\Example;
 
 class MethodFailureException extends NotEqualException
 {
-    private mixed $subject;
-
-    private string $method;
-
-    public function __construct(string $message, mixed $expected, mixed $actual, mixed $subject, string $method)
+    public function __construct(string $message, mixed $expected, mixed $actual, private mixed $subject, private string $method)
     {
         parent::__construct($message, $expected, $actual);
-
-        $this->subject = $subject;
-        $this->method = $method;
     }
 
     public function getSubject(): mixed

--- a/src/PhpSpec/Exception/Example/NotEqualException.php
+++ b/src/PhpSpec/Exception/Example/NotEqualException.php
@@ -16,7 +16,7 @@ namespace PhpSpec\Exception\Example;
 /**
  * Class NotEqualException holds information about the non-equal failure exception
  */
-class NotEqualException extends FailureException
+class NotEqualException extends FailureException implements \Stringable
 {
     public function __construct(string $message, private mixed $expected, private mixed $actual)
     {

--- a/src/PhpSpec/Exception/Example/NotEqualException.php
+++ b/src/PhpSpec/Exception/Example/NotEqualException.php
@@ -18,16 +18,9 @@ namespace PhpSpec\Exception\Example;
  */
 class NotEqualException extends FailureException
 {
-    private mixed $expected;
-
-    private mixed $actual;
-
-    public function __construct(string $message, mixed $expected, mixed $actual)
+    public function __construct(string $message, private mixed $expected, private mixed $actual)
     {
         parent::__construct($message);
-
-        $this->expected = $expected;
-        $this->actual   = $actual;
     }
 
     public function getExpected(): mixed

--- a/src/PhpSpec/Exception/Example/StopOnFailureException.php
+++ b/src/PhpSpec/Exception/Example/StopOnFailureException.php
@@ -20,12 +20,9 @@ use Exception;
  */
 class StopOnFailureException extends ExampleException
 {
-    private int $result;
-
-    public function __construct(string $message = "", int $code = 0, Exception $previous = null, int $result = 0)
+    public function __construct(string $message = "", int $code = 0, Exception $previous = null, private int $result = 0)
     {
         parent::__construct($message, $code, $previous);
-        $this->result = $result;
     }
 
     public function getResult(): int

--- a/src/PhpSpec/Exception/ExceptionFactory.php
+++ b/src/PhpSpec/Exception/ExceptionFactory.php
@@ -27,11 +27,8 @@ use PhpSpec\Util\Instantiator;
  */
 class ExceptionFactory
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function namedConstructorNotFound(string $classname, string $method, array $arguments = array()): NamedConstructorNotFoundException

--- a/src/PhpSpec/Exception/Fracture/ClassNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/ClassNotFoundException.php
@@ -18,14 +18,9 @@ namespace PhpSpec\Exception\Fracture;
  */
 class ClassNotFoundException extends FractureException
 {
-    private string $classname;
-
-    
-    public function __construct(string $message, string $classname)
+    public function __construct(string $message, private string $classname)
     {
         parent::__construct($message);
-
-        $this->classname = $classname;
     }
 
     

--- a/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
@@ -20,16 +20,12 @@ class CollaboratorNotFoundException extends FractureException
 {
     private const CLASSNAME_REGEX = '/\\[.* (?P<classname>[_a-z0-9\\\\]+) .*\\]/i';
 
-    private string $collaboratorName;
-
     public function __construct(
         string $message,
-        string $className,
+        private string $collaboratorName,
         int $code = 0,
         Exception $previous = null
     ) {
-        $this->collaboratorName = $className;
-
         parent::__construct($message . ': ' . $this->collaboratorName, $code, $previous);
     }
 

--- a/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
@@ -18,7 +18,7 @@ use ReflectionParameter;
 
 class CollaboratorNotFoundException extends FractureException
 {
-    const CLASSNAME_REGEX = '/\\[.* (?P<classname>[_a-z0-9\\\\]+) .*\\]/i';
+    private const CLASSNAME_REGEX = '/\\[.* (?P<classname>[_a-z0-9\\\\]+) .*\\]/i';
 
     private string $collaboratorName;
 

--- a/src/PhpSpec/Exception/Fracture/InterfaceNotImplementedException.php
+++ b/src/PhpSpec/Exception/Fracture/InterfaceNotImplementedException.php
@@ -20,16 +20,9 @@ namespace PhpSpec\Exception\Fracture;
 class InterfaceNotImplementedException extends FractureException
 {
     
-    private mixed $subject;
-
-    private string $interface;
-
-    public function __construct(string $message, mixed $subject, string $interface)
+    public function __construct(string $message, private mixed $subject, private string $interface)
     {
         parent::__construct($message);
-
-        $this->subject   = $subject;
-        $this->interface = $interface;
     }
 
     public function getSubject(): mixed

--- a/src/PhpSpec/Exception/Fracture/MethodInvocationException.php
+++ b/src/PhpSpec/Exception/Fracture/MethodInvocationException.php
@@ -19,19 +19,9 @@ namespace PhpSpec\Exception\Fracture;
  */
 abstract class MethodInvocationException extends FractureException
 {
-    private mixed $subject;
-
-    private string $method;
-
-    private array $arguments;
-
-    public function __construct(string $message, mixed $subject, string $method, array $arguments = array())
+    public function __construct(string $message, private mixed $subject, private string $method, private array $arguments = array())
     {
         parent::__construct($message);
-
-        $this->subject   = $subject;
-        $this->method    = $method;
-        $this->arguments = $arguments;
     }
 
     public function getSubject(): mixed

--- a/src/PhpSpec/Exception/Fracture/PropertyNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/PropertyNotFoundException.php
@@ -19,16 +19,9 @@ namespace PhpSpec\Exception\Fracture;
  */
 class PropertyNotFoundException extends FractureException
 {
-    private mixed $subject;
-
-    private string $property;
-
-    public function __construct(string $message, mixed $subject, string $property)
+    public function __construct(string $message, private mixed $subject, private string $property)
     {
         parent::__construct($message);
-
-        $this->subject = $subject;
-        $this->property  = $property;
     }
 
     public function getSubject(): mixed

--- a/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
+++ b/src/PhpSpec/Exception/Wrapper/InvalidCollaboratorTypeException.php
@@ -24,8 +24,8 @@ class InvalidCollaboratorTypeException extends CollaboratorException
         ?string $prompt = null
     )
     {
-        $reason = $reason ?? 'Collaborator must be an object';
-        $prompt = $prompt ?? 'You can create non-object values manually.';
+        $reason ??= 'Collaborator must be an object';
+        $prompt ??= 'You can create non-object values manually.';
 
         $message = sprintf(
             $reason . ': argument %s defined in %s. ' .

--- a/src/PhpSpec/Exception/Wrapper/MatcherNotFoundException.php
+++ b/src/PhpSpec/Exception/Wrapper/MatcherNotFoundException.php
@@ -21,19 +21,9 @@ use PhpSpec\Exception\Exception;
  */
 class MatcherNotFoundException extends Exception
 {
-    private string $keyword;
-
-    private mixed $subject;
-
-    private array $arguments;
-
-    public function __construct(string $message, string $keyword, mixed $subject, array $arguments)
+    public function __construct(string $message, private string $keyword, private mixed $subject, private array $arguments)
     {
         parent::__construct($message);
-
-        $this->keyword   = $keyword;
-        $this->subject   = $subject;
-        $this->arguments = $arguments;
     }
 
     public function getKeyword(): string

--- a/src/PhpSpec/Factory/ObjectFactory.php
+++ b/src/PhpSpec/Factory/ObjectFactory.php
@@ -44,7 +44,7 @@ class ObjectFactory
     {
         if (\is_array($callable)) {
             $className = \is_object($callable[0])
-                ? get_class($callable[0])
+                ? $callable[0]::class
                 : $callable[0];
 
             return 'method ' . $className . '::' . $callable[1];

--- a/src/PhpSpec/Formatter/BasicFormatter.php
+++ b/src/PhpSpec/Formatter/BasicFormatter.php
@@ -23,17 +23,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 abstract class BasicFormatter implements EventSubscriberInterface
 {
-    private IO $io;
-
-    private Presenter $presenter;
-
-    private StatisticsCollector $stats;
-
-    public function __construct(Presenter $presenter, IO $io, StatisticsCollector $stats)
+    public function __construct(private Presenter $presenter, private IO $io, private StatisticsCollector $stats)
     {
-        $this->presenter = $presenter;
-        $this->io = $io;
-        $this->stats = $stats;
     }
 
     

--- a/src/PhpSpec/Formatter/Html/ReportFailedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportFailedItem.php
@@ -19,17 +19,11 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportFailedItem
 {
-    private TemplateInterface $template;
-    private ExampleEvent $event;
     private static int $failingExamplesCount = 1;
-    private Presenter $presenter;
 
     
-    public function __construct(TemplateInterface $template, ExampleEvent $event, Presenter $presenter)
+    public function __construct(private TemplateInterface $template, private ExampleEvent $event, private Presenter $presenter)
     {
-        $this->template = $template;
-        $this->event = $event;
-        $this->presenter = $presenter;
     }
 
     public function write(int $index): void

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -25,20 +25,14 @@ class ReportItemFactory
 
     public function create(ExampleEvent $event, Presenter $presenter): ReportFailedItem|ReportPassedItem|ReportPendingItem|ReportSkippedItem
     {
-        switch ($result = $event->getResult()) {
-            case ExampleEvent::PASSED:
-                return new ReportPassedItem($this->template, $event);
-            case ExampleEvent::PENDING:
-                return new ReportPendingItem($this->template, $event);
-            case ExampleEvent::SKIPPED:
-                return new ReportSkippedItem($this->template, $event);
-            case ExampleEvent::FAILED:
-            case ExampleEvent::BROKEN:
-                return new ReportFailedItem($this->template, $event, $presenter);
-            default:
-                throw new InvalidExampleResultException(
-                    "Unrecognised example result $result"
-                );
-        }
+        return match ($result = $event->getResult()) {
+            ExampleEvent::PASSED => new ReportPassedItem($this->template, $event),
+            ExampleEvent::PENDING => new ReportPendingItem($this->template, $event),
+            ExampleEvent::SKIPPED => new ReportSkippedItem($this->template, $event),
+            ExampleEvent::FAILED, ExampleEvent::BROKEN => new ReportFailedItem($this->template, $event, $presenter),
+            default => throw new InvalidExampleResultException(
+                "Unrecognised example result $result"
+            ),
+        };
     }
 }

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -19,12 +19,8 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportItemFactory
 {
-    private TemplateInterface $template;
-
-    
-    public function __construct(TemplateInterface $template)
+    public function __construct(private TemplateInterface $template)
     {
-        $this->template = $template;
     }
 
     public function create(ExampleEvent $event, Presenter $presenter): ReportFailedItem|ReportPassedItem|ReportPendingItem|ReportSkippedItem

--- a/src/PhpSpec/Formatter/Html/ReportPassedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPassedItem.php
@@ -18,14 +18,8 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportPassedItem
 {
-    private TemplateInterface $template;
-    private ExampleEvent $event;
-
-    
-    public function __construct(TemplateInterface $template, ExampleEvent $event)
+    public function __construct(private TemplateInterface $template, private ExampleEvent $event)
     {
-        $this->template = $template;
-        $this->event = $event;
     }
 
     public function write(): void

--- a/src/PhpSpec/Formatter/Html/ReportPendingItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPendingItem.php
@@ -18,15 +18,11 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportPendingItem
 {
-    private TemplateInterface $template;
-    private ExampleEvent $event;
     private static int $pendingExamplesCount = 1;
 
     
-    public function __construct(TemplateInterface $template, ExampleEvent $event)
+    public function __construct(private TemplateInterface $template, private ExampleEvent $event)
     {
-        $this->template = $template;
-        $this->event = $event;
     }
 
     public function write(): void

--- a/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
@@ -18,14 +18,8 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportSkippedItem
 {
-    private TemplateInterface $template;
-    private ExampleEvent $event;
-
-    
-    public function __construct(TemplateInterface $template, ExampleEvent $event)
+    public function __construct(private TemplateInterface $template, private ExampleEvent $event)
     {
-        $this->template = $template;
-        $this->event    = $event;
     }
 
     public function write(): void

--- a/src/PhpSpec/Formatter/Html/Template.php
+++ b/src/PhpSpec/Formatter/Html/Template.php
@@ -18,7 +18,7 @@ use PhpSpec\IO\IO;
 
 final class Template implements TemplateInterface
 {
-    const DIR = __DIR__;
+    public const DIR = __DIR__;
 
     private IO $io;
 

--- a/src/PhpSpec/Formatter/Html/Template.php
+++ b/src/PhpSpec/Formatter/Html/Template.php
@@ -39,8 +39,6 @@ final class Template implements TemplateInterface
     
     private function extractKeys(array $templateVars): array
     {
-        return array_map(function ($e) {
-            return '{'.$e.'}';
-        }, array_keys($templateVars));
+        return array_map(fn($e) => '{'.$e.'}', array_keys($templateVars));
     }
 }

--- a/src/PhpSpec/Formatter/Html/Template.php
+++ b/src/PhpSpec/Formatter/Html/Template.php
@@ -20,12 +20,9 @@ final class Template implements TemplateInterface
 {
     public const DIR = __DIR__;
 
-    private IO $io;
-
     
-    public function __construct(IO $io)
+    public function __construct(private IO $io)
     {
-        $this->io = $io;
     }
 
     

--- a/src/PhpSpec/Formatter/HtmlFormatter.php
+++ b/src/PhpSpec/Formatter/HtmlFormatter.php
@@ -23,18 +23,14 @@ use PhpSpec\Listener\StatisticsCollector;
 
 final class HtmlFormatter extends BasicFormatter
 {
-    private ReportItemFactory $reportItemFactory;
-
     private int $index = 1;
 
     public function __construct(
-        ReportItemFactory $reportItemFactory,
+        private ReportItemFactory $reportItemFactory,
         Presenter $presenter,
         IO $io,
         StatisticsCollector $stats
     ) {
-        $this->reportItemFactory = $reportItemFactory;
-
         parent::__construct($presenter, $io, $stats);
     }
 

--- a/src/PhpSpec/Formatter/JUnitFormatter.php
+++ b/src/PhpSpec/Formatter/JUnitFormatter.php
@@ -130,7 +130,7 @@ final class JUnitFormatter extends BasicFormatter
                 '</system-err>'."\n".
                 '</testcase>',
                 $this->resultTags[$event->getResult()],
-                \get_class($exception),
+                $exception::class,
                 htmlspecialchars($exception->getMessage()),
                 $exception->getTraceAsString()
             );

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -76,6 +76,6 @@ final class JsonFormatter extends BasicFormatter
         $this->data['status'] = self::STATUS_NAME[$event->getResult()];
         $this->data['time'] = $event->getTime();
 
-        $this->getIO()->write(json_encode($this->data));
+        $this->getIO()->write(json_encode($this->data, JSON_THROW_ON_ERROR));
     }
 }

--- a/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
@@ -21,11 +21,8 @@ final class ArrayEngine extends StringEngine
 
     private const PAD_STRING = ' ';
 
-    private Exporter $exporter;
-
-    public function __construct(Exporter $exporter)
+    public function __construct(private Exporter $exporter)
     {
-        $this->exporter = $exporter;
     }
 
     public function supports(mixed $expected, mixed $actual): bool

--- a/src/PhpSpec/Formatter/Presenter/Differ/Differ.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/Differ.php
@@ -15,11 +15,8 @@ namespace PhpSpec\Formatter\Presenter\Differ;
 
 class Differ
 {
-    private array $engines = array();
-
-    public function __construct(array $engines = array())
+    public function __construct(private array $engines = array())
     {
-        $this->engines = $engines;
     }
 
     public function addEngine(DifferEngine $engine): void

--- a/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
@@ -17,14 +17,8 @@ use SebastianBergmann\Exporter\Exporter;
 
 final class ObjectEngine implements DifferEngine
 {
-    private Exporter $exporter;
-    private StringEngine $stringDiffer;
-
-    
-    public function __construct(Exporter $exporter, StringEngine $stringDiffer)
+    public function __construct(private Exporter $exporter, private StringEngine $stringDiffer)
     {
-        $this->exporter = $exporter;
-        $this->stringDiffer = $stringDiffer;
     }
 
     

--- a/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
@@ -32,9 +32,9 @@ class StringEngine implements DifferEngine
 
         $lines = array();
         foreach (explode("\n", $text) as $line) {
-            if (0 === strpos($line, '-')) {
+            if (str_starts_with($line, '-')) {
                 $lines[] = sprintf('<diff-del>%s</diff-del>', $line);
-            } elseif (0 === strpos($line, '+')) {
+            } elseif (str_starts_with($line, '+')) {
                 $lines[] = sprintf('<diff-add>%s</diff-add>', $line);
             } else {
                 $lines[] = $line;

--- a/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/AbstractPhpSpecExceptionPresenter.php
@@ -20,7 +20,7 @@ abstract class AbstractPhpSpecExceptionPresenter
     
     public function presentException(Exception $exception): string
     {
-        list($file, $line) = $this->getExceptionExamplePosition($exception);
+        [$file, $line] = $this->getExceptionExamplePosition($exception);
 
         return $this->presentFileCode($file, $line);
     }

--- a/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
@@ -20,12 +20,8 @@ use Prophecy\Prophecy\MethodProphecy;
 
 class CallArgumentsPresenter
 {
-    private Differ $differ;
-
-    
-    public function __construct(Differ $differ)
+    public function __construct(private Differ $differ)
     {
-        $this->differ = $differ;
     }
 
     

--- a/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
@@ -15,12 +15,8 @@ namespace PhpSpec\Formatter\Presenter\Exception;
 
 final class GenericPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresenter implements PhpSpecExceptionPresenter
 {
-    private ExceptionElementPresenter $exceptionElementPresenter;
-
-    
-    public function __construct(ExceptionElementPresenter $exceptionElementPresenter)
+    public function __construct(private ExceptionElementPresenter $exceptionElementPresenter)
     {
-        $this->exceptionElementPresenter = $exceptionElementPresenter;
     }
 
     

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
@@ -18,15 +18,8 @@ use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
 {
-    private ExceptionTypePresenter $exceptionTypePresenter;
-
-    private ValuePresenter $valuePresenter;
-
-    
-    public function __construct(ExceptionTypePresenter $exceptionTypePresenter, ValuePresenter $valuePresenter)
+    public function __construct(private ExceptionTypePresenter $exceptionTypePresenter, private ValuePresenter $valuePresenter)
     {
-        $this->exceptionTypePresenter = $exceptionTypePresenter;
-        $this->valuePresenter = $valuePresenter;
     }
 
     

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -35,7 +35,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         private CallArgumentsPresenter $callArgumentsPresenter,
         private PhpSpecExceptionPresenter $phpspecExceptionPresenter
     ) {
-        $this->phpspecPath = dirname(dirname(__DIR__));
+        $this->phpspecPath = dirname(__DIR__, 2);
         $this->runnerPath  = $this->phpspecPath.DIRECTORY_SEPARATOR.'Runner';
     }
 

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -160,17 +160,17 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
     
     private function shouldStopTracePresentation(array $call): bool
     {
-        return isset($call['file']) && false !== strpos($call['file'], $this->runnerPath);
+        return isset($call['file']) && str_contains($call['file'], $this->runnerPath);
     }
 
     
     private function shouldSkipTracePresentation(array $call): bool
     {
-        if (isset($call['file']) && 0 === strpos($call['file'], $this->phpspecPath)) {
+        if (isset($call['file']) && str_starts_with($call['file'], $this->phpspecPath)) {
             return true;
         }
 
-        return isset($call['class']) && 0 === strpos($call['class'], "PhpSpec\\");
+        return isset($call['class']) && str_starts_with($call['class'], "PhpSpec\\");
     }
 
     

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -24,30 +24,17 @@ use Prophecy\Exception\Exception as ProphecyException;
 
 final class SimpleExceptionPresenter implements ExceptionPresenter
 {
-    private Differ $differ;
-
     private string $phpspecPath;
 
     private string $runnerPath;
 
-    private ExceptionElementPresenter $exceptionElementPresenter;
-
-    private CallArgumentsPresenter $callArgumentsPresenter;
-
-    private PhpSpecExceptionPresenter $phpspecExceptionPresenter;
-
     
     public function __construct(
-        Differ $differ,
-        ExceptionElementPresenter $exceptionElementPresenter,
-        CallArgumentsPresenter $callArgumentsPresenter,
-        PhpSpecExceptionPresenter $phpspecExceptionPresenter
+        private Differ $differ,
+        private ExceptionElementPresenter $exceptionElementPresenter,
+        private CallArgumentsPresenter $callArgumentsPresenter,
+        private PhpSpecExceptionPresenter $phpspecExceptionPresenter
     ) {
-        $this->differ = $differ;
-        $this->exceptionElementPresenter = $exceptionElementPresenter;
-        $this->callArgumentsPresenter = $callArgumentsPresenter;
-        $this->phpspecExceptionPresenter = $phpspecExceptionPresenter;
-
         $this->phpspecPath = dirname(dirname(__DIR__));
         $this->runnerPath  = $this->phpspecPath.DIRECTORY_SEPARATOR.'Runner';
     }

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -96,7 +96,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
 
         $text .= $this->presentExceptionTraceLocation($offset++, $exception->getFile(), $exception->getLine());
         $text .= $this->presentExceptionTraceFunction(
-            'throw new '.\get_class($exception),
+            'throw new '.$exception::class,
             array($exception->getMessage())
         );
 

--- a/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
@@ -18,15 +18,8 @@ use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 final class TaggingExceptionElementPresenter implements ExceptionElementPresenter
 {
-    private ExceptionTypePresenter $exceptionTypePresenter;
-
-    private ValuePresenter $valuePresenter;
-
-    
-    public function __construct(ExceptionTypePresenter $exceptionTypePresenter, ValuePresenter $valuePresenter)
+    public function __construct(private ExceptionTypePresenter $exceptionTypePresenter, private ValuePresenter $valuePresenter)
     {
-        $this->exceptionTypePresenter = $exceptionTypePresenter;
-        $this->valuePresenter = $valuePresenter;
     }
 
     

--- a/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
@@ -71,9 +71,7 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
     {
         $valuePresenter = $this->valuePresenter;
 
-        $taggedArgs = array_map(function ($arg) use ($valuePresenter) {
-            return sprintf('<value>%s</value>', $valuePresenter->presentValue($arg));
-        }, $args);
+        $taggedArgs = array_map(fn($arg) => sprintf('<value>%s</value>', $valuePresenter->presentValue($arg)), $args);
 
         return implode(', ', $taggedArgs);
     }

--- a/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
@@ -18,14 +18,8 @@ use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 final class SimplePresenter implements Presenter
 {
-    private ValuePresenter $valuePresenter;
-
-    private ExceptionPresenter $exceptionPresenter;
-
-    public function __construct(ValuePresenter $valuePresenter, ExceptionPresenter $exceptionPresenter)
+    public function __construct(private ValuePresenter $valuePresenter, private ExceptionPresenter $exceptionPresenter)
     {
-        $this->valuePresenter = $valuePresenter;
-        $this->exceptionPresenter = $exceptionPresenter;
     }
 
     public function presentValue(mixed $value): string

--- a/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
@@ -15,11 +15,8 @@ namespace PhpSpec\Formatter\Presenter;
 
 final class TaggingPresenter implements Presenter
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function presentException(\Exception $exception, bool $verbose = false): string

--- a/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
@@ -46,7 +46,7 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
         return sprintf(
             '[%s:%s("%s")]',
             $label,
-            \get_class($value),
+            $value::class,
             $message
         );
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
@@ -17,11 +17,8 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class CallableTypePresenter implements TypePresenter
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(mixed $value): bool

--- a/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
@@ -38,7 +38,7 @@ final class CallableTypePresenter implements TypePresenter
         }
 
         if (\is_object($value)) {
-            return sprintf('[obj:%s]', \get_class($value));
+            return sprintf('[obj:%s]', $value::class);
         }
 
         return sprintf('[%s()]', $value);

--- a/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
@@ -24,9 +24,7 @@ final class ComposedValuePresenter implements ValuePresenter
     {
         $this->typePresenters[] = $typePresenter;
 
-        @usort($this->typePresenters, function ($presenter1, $presenter2): int {
-            return $presenter2->getPriority() - $presenter1->getPriority();
-        });
+        @usort($this->typePresenters, fn($presenter1, $presenter2): int => $presenter2->getPriority() - $presenter1->getPriority());
     }
 
     public function presentValue(mixed $value): string

--- a/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
@@ -22,7 +22,7 @@ final class ObjectTypePresenter implements TypePresenter
 
     public function present(mixed $value): string
     {
-        return sprintf('[obj:%s]', \get_class($value));
+        return sprintf('[obj:%s]', $value::class);
     }
 
     public function getPriority(): int

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -15,11 +15,8 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class TruncatingStringTypePresenter implements StringTypePresenter
 {
-    private StringTypePresenter $stringTypePresenter;
-
-    public function __construct(StringTypePresenter $stringTypePresenter)
+    public function __construct(private StringTypePresenter $stringTypePresenter)
     {
-        $this->stringTypePresenter = $stringTypePresenter;
     }
 
     public function supports(mixed $value): bool

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -29,7 +29,7 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
 
     public function present(mixed $value): string
     {
-        if (25 > \strlen($value) && false === strpos($value, "\n")) {
+        if (25 > \strlen($value) && !str_contains($value, "\n")) {
             return $this->stringTypePresenter->present($value);
         }
 

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -19,7 +19,7 @@ use PhpSpec\Event\ExampleEvent;
 
 final class ProgressFormatter extends ConsoleFormatter
 {
-    const FPS = 10;
+    private const FPS = 10;
 
     private ?float $lastDraw = null;
 

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -108,9 +108,7 @@ final class ProgressFormatter extends ConsoleFormatter
         $targetWidth = ceil($this->getIO()->getBlockWidth() * $specProgress);
         asort($counts);
 
-        $barLengths = array_map(function ($count) use ($targetWidth, $counts) {
-            return $count ? max(1, round($targetWidth * $count / array_sum($counts))) : 0;
-        }, $counts);
+        $barLengths = array_map(fn($count) => $count ? max(1, round($targetWidth * $count / array_sum($counts))) : 0, $counts);
 
         return $barLengths;
     }

--- a/src/PhpSpec/Formatter/TapFormatter.php
+++ b/src/PhpSpec/Formatter/TapFormatter.php
@@ -20,27 +20,27 @@ use Symfony\Component\Yaml\Yaml;
 
 final class TapFormatter extends ConsoleFormatter
 {
-    const VERSION = 'TAP version 13';
+    private const VERSION = 'TAP version 13';
 
-    const OK = 'ok %d';
+    private const OK = 'ok %d';
 
-    const NOT_OK = 'not ok %d';
+    private const NOT_OK = 'not ok %d';
 
-    const DESC = ' - %s: %s';
+    private const DESC = ' - %s: %s';
 
-    const SKIP = ' # SKIP %s';
+    private const SKIP = ' # SKIP %s';
 
-    const TODO = ' # TODO %s';
+    private const TODO = ' # TODO %s';
 
-    const IGNORE = ' # IGNORE %s could not be loaded at path %s';
+    private const IGNORE = ' # IGNORE %s could not be loaded at path %s';
 
-    const PLAN = '1..%d';
+    private const PLAN = '1..%d';
 
-    const MESSAGE = "---\nmessage: %s\n...";
+    private const MESSAGE = "---\nmessage: %s\n...";
 
-    const SEVERITY = "\n---\nseverity: %s\n...";
+    private const SEVERITY = "\n---\nseverity: %s\n...";
 
-    const UNDEFINED_RESULT = -1;
+    private const UNDEFINED_RESULT = -1;
 
     private int $examplesCount = 0;
 

--- a/src/PhpSpec/Formatter/TeamCityFormatter.php
+++ b/src/PhpSpec/Formatter/TeamCityFormatter.php
@@ -149,9 +149,7 @@ class TeamCityFormatter extends BasicFormatter
                 [
                     'count' => array_sum(
                         array_map(
-                            static function ($spec) {
-                                return count($spec->getExamples());
-                            },
+                            static fn($spec) => count($spec->getExamples()),
                             $event->getSuite()->getSpecifications()
                         )
                     )

--- a/src/PhpSpec/Listener/BootstrapListener.php
+++ b/src/PhpSpec/Listener/BootstrapListener.php
@@ -7,11 +7,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class BootstrapListener implements EventSubscriberInterface
 {
-    private ConsoleIO $io;
-
-    public function __construct(ConsoleIO $io)
+    public function __construct(private ConsoleIO $io)
     {
-        $this->io = $io;
     }
 
     public static function getSubscribedEvents(): array

--- a/src/PhpSpec/Listener/ClassNotFoundListener.php
+++ b/src/PhpSpec/Listener/ClassNotFoundListener.php
@@ -24,17 +24,11 @@ use Prophecy\Exception\Doubler\ClassNotFoundException as ProphecyClassException;
 
 final class ClassNotFoundListener implements EventSubscriberInterface
 {
-    private ConsoleIO $io;
-    private ResourceManager $resources;
-    private GeneratorManager $generator;
     private array $classes = array();
 
     
-    public function __construct(ConsoleIO $io, ResourceManager $resources, GeneratorManager $generator)
+    public function __construct(private ConsoleIO $io, private ResourceManager $resources, private GeneratorManager $generator)
     {
-        $this->io        = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
     }
 
     

--- a/src/PhpSpec/Listener/ClassNotFoundListener.php
+++ b/src/PhpSpec/Listener/ClassNotFoundListener.php
@@ -67,7 +67,7 @@ final class ClassNotFoundListener implements EventSubscriberInterface
 
             try {
                 $resource = $this->resources->createResource($classname);
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 continue;
             }
 

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -89,9 +89,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         }
 
         $interfaces = array_filter(class_implements($class),
-            function (string $interface): bool {
-                return !preg_match('/^Prophecy/', $interface);
-            }
+            fn(string $interface): bool => !preg_match('/^Prophecy/', $interface)
         );
 
         if (\count($interfaces) !== 1) {

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -29,31 +29,13 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
 {
     private const PROMPT = 'Would you like me to generate a method signature `%s::%s()` for you?';
 
-    private ConsoleIO $io;
-
     private array $interfaces = array();
-
-    private ResourceManager $resources;
-
-    private GeneratorManager $generator;
-
-    private NameChecker $nameChecker;
 
     private array $wrongMethodNames = array();
 
-
-    public function __construct(
-        ConsoleIO $io,
-        ResourceManager $resources,
-        GeneratorManager $generator,
-        NameChecker $nameChecker
-    ) {
-        $this->io = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
-        $this->nameChecker = $nameChecker;
+    public function __construct(private ConsoleIO $io, private ResourceManager $resources, private GeneratorManager $generator, private NameChecker $nameChecker)
+    {
     }
-
 
     public static function getSubscribedEvents(): array
     {

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -27,7 +27,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class CollaboratorMethodNotFoundListener implements EventSubscriberInterface
 {
-    const PROMPT = 'Would you like me to generate a method signature `%s::%s()` for you?';
+    private const PROMPT = 'Would you like me to generate a method signature `%s::%s()` for you?';
 
     private ConsoleIO $io;
 

--- a/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorMethodNotFoundListener.php
@@ -106,7 +106,7 @@ final class CollaboratorMethodNotFoundListener implements EventSubscriberInterfa
         foreach ($this->interfaces as $interface => $methods) {
             try {
                 $resource = $this->resources->createResource($interface);
-            } catch (ResourceCreationException $e) {
+            } catch (ResourceCreationException) {
                 continue;
             }
 

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -24,23 +24,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class CollaboratorNotFoundListener implements EventSubscriberInterface
 {
-    private ConsoleIO $io;
-
     /**
      * @var CollaboratorNotFoundException[]
      */
     private array $exceptions = array();
 
-    private ResourceManager $resources;
-
-    private GeneratorManager $generator;
-
     
-    public function __construct(ConsoleIO $io, ResourceManager $resources, GeneratorManager $generator)
+    public function __construct(private ConsoleIO $io, private ResourceManager $resources, private GeneratorManager $generator)
     {
-        $this->io = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
     }
 
     

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -87,6 +87,6 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
     
     private function resourceIsInSpecNamespace(CollaboratorNotFoundException $exception, Resource $resource): bool
     {
-        return strpos($exception->getCollaboratorName(), $resource->getSpecNamespace()) === 0;
+        return str_starts_with($exception->getCollaboratorName(), $resource->getSpecNamespace());
     }
 }

--- a/src/PhpSpec/Listener/CurrentExampleListener.php
+++ b/src/PhpSpec/Listener/CurrentExampleListener.php
@@ -20,8 +20,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class CurrentExampleListener implements EventSubscriberInterface {
 
-    private CurrentExampleTracker $currentExample;
-
     public static function getSubscribedEvents(): array
     {
         return array(
@@ -31,9 +29,8 @@ final class CurrentExampleListener implements EventSubscriberInterface {
         );
     }
 
-    public function __construct(CurrentExampleTracker $currentExample)
+    public function __construct(private CurrentExampleTracker $currentExample)
     {
-        $this->currentExample = $currentExample;
     }
 
     public function beforeCurrentExample(ExampleEvent $event): void

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -50,7 +50,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
             return;
         }
 
-        $classname = \get_class($exception->getSubject());
+        $classname = $exception->getSubject()::class;
         $methodName = $exception->getMethodName();
         $this->methods[$classname .'::'.$methodName] = $exception->getArguments();
         $this->checkIfMethodNameAllowed($methodName);

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -24,24 +24,12 @@ use PhpSpec\Exception\Fracture\MethodNotFoundException;
 
 final class MethodNotFoundListener implements EventSubscriberInterface
 {
-    private ConsoleIO $io;
-    private ResourceManager $resources;
-    private GeneratorManager $generator;
     private array $methods = array();
     private array $wrongMethodNames = array();
-    private NameChecker $nameChecker;
 
     
-    public function __construct(
-        ConsoleIO $io,
-        ResourceManager $resources,
-        GeneratorManager $generator,
-        NameChecker $nameChecker
-    ) {
-        $this->io        = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
-        $this->nameChecker = $nameChecker;
+    public function __construct(private ConsoleIO $io, private ResourceManager $resources, private GeneratorManager $generator, private NameChecker $nameChecker)
+    {
     }
 
     public static function getSubscribedEvents(): array

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -73,7 +73,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
 
             try {
                 $resource = $this->resources->createResource($classname);
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 continue;
             }
 

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -63,7 +63,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         }
 
         foreach ($this->methods as $call => $arguments) {
-            list($classname, $method) = explode('::', $call);
+            [$classname, $method] = explode('::', $call);
 
             if (\in_array($method, $this->wrongMethodNames)) {
                 continue;

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -133,7 +133,7 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
 
             try {
                 $resource = $this->resources->createResource($class);
-            } catch (\RuntimeException $exception) {
+            } catch (\RuntimeException) {
                 continue;
             }
 

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -26,26 +26,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class MethodReturnedNullListener implements EventSubscriberInterface
 {
-    private ConsoleIO $io;
-
     private array $nullMethods = array();
 
     private ?MethodCallEvent $lastMethodCallEvent = null;
-    private ResourceManager $resources;
-    private GeneratorManager $generator;
-    private MethodAnalyser $methodAnalyser;
 
     
-    public function __construct(
-        ConsoleIO $io,
-        ResourceManager $resources,
-        GeneratorManager $generator,
-        MethodAnalyser $methodAnalyser
-    ) {
-        $this->io = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
-        $this->methodAnalyser = $methodAnalyser;
+    public function __construct(private ConsoleIO $io, private ResourceManager $resources, private GeneratorManager $generator, private MethodAnalyser $methodAnalyser)
+    {
     }
 
     /**

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -82,9 +82,9 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
             if (is_null($subject)) {
                 return;
             }
-            $class = \get_class($subject);
+            $class = $subject::class;
         } else {
-            $class = \get_class($this->lastMethodCallEvent->getSubject());
+            $class = $this->lastMethodCallEvent->getSubject()::class;
             $method = $this->lastMethodCallEvent->getMethod();
         }
 

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -47,7 +47,7 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
             return;
         }
 
-        $className = \get_class($exception->getSubject());
+        $className = $exception->getSubject()::class;
         $this->methods[$className .'::'.$exception->getMethodName()] = $exception->getArguments();
     }
 

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -59,7 +59,7 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
 
         foreach ($this->methods as $call => $arguments) {
             /** @var class-string $classname */
-            list($classname, $method) = explode('::', $call);
+            [$classname, $method] = explode('::', $call);
             $message = sprintf('Do you want me to create `%s()` for you?', $call);
 
             try {

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -23,16 +23,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class NamedConstructorNotFoundListener implements EventSubscriberInterface
 {
-    private ConsoleIO $io;
-    private ResourceManager $resources;
-    private GeneratorManager $generator;
     private array $methods = array();
 
-    public function __construct(ConsoleIO $io, ResourceManager $resources, GeneratorManager $generator)
+    public function __construct(private ConsoleIO $io, private ResourceManager $resources, private GeneratorManager $generator)
     {
-        $this->io        = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
     }
 
     public static function getSubscribedEvents(): array

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -64,7 +64,7 @@ final class NamedConstructorNotFoundListener implements EventSubscriberInterface
 
             try {
                 $resource = $this->resources->createResource($classname);
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 continue;
             }
 

--- a/src/PhpSpec/Listener/RerunListener.php
+++ b/src/PhpSpec/Listener/RerunListener.php
@@ -20,15 +20,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class RerunListener implements EventSubscriberInterface
 {
-    private ReRunner $reRunner;
-
-    private PrerequisiteTester $suitePrerequisites;
-
-    
-    public function __construct(ReRunner $reRunner, PrerequisiteTester $suitePrerequisites)
+    public function __construct(private ReRunner $reRunner, private PrerequisiteTester $suitePrerequisites)
     {
-        $this->reRunner = $reRunner;
-        $this->suitePrerequisites = $suitePrerequisites;
     }
 
     /**

--- a/src/PhpSpec/Listener/StopOnFailureListener.php
+++ b/src/PhpSpec/Listener/StopOnFailureListener.php
@@ -20,12 +20,8 @@ use PhpSpec\Console\ConsoleIO;
 
 final class StopOnFailureListener implements EventSubscriberInterface
 {
-    private ConsoleIO $io;
-
-    
-    public function __construct(ConsoleIO $io)
+    public function __construct(private ConsoleIO $io)
     {
-        $this->io = $io;
     }
 
     

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -17,15 +17,11 @@ use ReflectionFunctionAbstract;
 
 class ExampleNode
 {
-    private string $title;
-    private \ReflectionFunctionAbstract $function;
     private ?SpecificationNode $specification = null;
     private bool $isPending = false;
 
-    public function __construct(string $title, ReflectionFunctionAbstract $function)
+    public function __construct(private string $title, private ReflectionFunctionAbstract $function)
     {
-        $this->title = $title;
-        $this->function = $function;
     }
 
     public function setTitle(string $title): void

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -19,9 +19,6 @@ use ReflectionClass;
 
 class SpecificationNode implements \Countable
 {
-    private string $title;
-    private \ReflectionClass $class;
-    private Resource $resource;
     private ?Suite $suite = null;
     /**
      * @var ExampleNode[]
@@ -29,11 +26,8 @@ class SpecificationNode implements \Countable
     private array $examples = array();
 
     
-    public function __construct(string $title, ReflectionClass $class, Resource $resource)
+    public function __construct(private string $title, private ReflectionClass $class, private Resource $resource)
     {
-        $this->title    = $title;
-        $this->class    = $class;
-        $this->resource = $resource;
     }
 
     

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -27,20 +27,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ResourceLoader
 {
-    private ResourceManager $manager;
-
-    private MethodAnalyser $methodAnalyser;
-
-    private EventDispatcherInterface $eventDispatcher;
-
-    public function __construct(
-        ResourceManager $manager,
-        MethodAnalyser $methodAnalyser,
-        EventDispatcherInterface $eventDispatcher
-    ) {
-        $this->manager = $manager;
-        $this->methodAnalyser = $methodAnalyser;
-        $this->eventDispatcher = $eventDispatcher;
+    public function __construct(private ResourceManager $manager, private MethodAnalyser $methodAnalyser, private EventDispatcherInterface $eventDispatcher)
+    {
     }
 
     public function load(string $locator = '', int $line = null): Suite

--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -29,7 +29,7 @@ class StreamWrapper
         if (\in_array('phpspec', stream_get_wrappers())) {
             stream_wrapper_unregister('phpspec');
         }
-        stream_wrapper_register('phpspec', 'PhpSpec\Loader\StreamWrapper');
+        stream_wrapper_register('phpspec', \PhpSpec\Loader\StreamWrapper::class);
     }
 
     public static function reset(): void

--- a/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
@@ -18,12 +18,8 @@ use PhpSpec\CodeAnalysis\TypeHintRewriter as TypeHintRewriterInterface;
 
 final class TypeHintRewriter implements SpecTransformer
 {
-    private TypeHintRewriterInterface $rewriter;
-
-    
-    public function __construct(TypeHintRewriterInterface $rewriter)
+    public function __construct(private TypeHintRewriterInterface $rewriter)
     {
-        $this->rewriter = $rewriter;
     }
 
     

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -27,19 +27,17 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     private string $specNamespace;
     private string $fullSrcPath;
     private string $fullSpecPath;
-    private Filesystem $filesystem;
 
     private ?string $psr4Prefix;
 
     public function __construct(
-        Filesystem $filesystem,
+        private Filesystem $filesystem,
         string $srcNamespace = '',
         string $specNamespacePrefix = 'spec',
         string $srcPath = 'src',
         string $specPath = '.',
         string $psr4Prefix = null
     ) {
-        $this->filesystem = $filesystem;
         $sepr = DIRECTORY_SEPARATOR;
 
         $this->srcPath       = rtrim(realpath($srcPath), '/\\').$sepr;

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -46,7 +46,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         $this->specPath      = rtrim(realpath($specPath), '/\\').$sepr;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\').'\\', '\\');
         $this->psr4Prefix    = (null === $psr4Prefix) ? null : ltrim(trim($psr4Prefix, ' \\').'\\', '\\');
-        if (null !== $this->psr4Prefix  && substr($this->srcNamespace, 0, \strlen($this->psr4Prefix)) !== $this->psr4Prefix) {
+        if (null !== $this->psr4Prefix  && !str_starts_with($this->srcNamespace, $this->psr4Prefix)) {
             throw new InvalidArgumentException('PSR4 prefix doesn\'t match given class namespace.'.PHP_EOL);
         }
         $srcNamespacePath = null === $this->psr4Prefix ?
@@ -114,8 +114,8 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     {
         $path = $this->getQueryPath($query);
 
-        return 0 === strpos($path, $this->srcPath)
-            || 0 === strpos($path, $this->specPath)
+        return str_starts_with($path, $this->srcPath)
+            || str_starts_with($path, $this->specPath)
         ;
     }
 
@@ -131,22 +131,22 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     {
         $path = $this->getQueryPath($query);
 
-        if ('.php' !== substr($path, -4)) {
+        if (!str_ends_with($path, '.php')) {
             $path .= DIRECTORY_SEPARATOR;
         }
 
-        if ($path && 0 === strpos($path, $this->fullSpecPath)) {
+        if ($path && str_starts_with($path, $this->fullSpecPath)) {
             return $this->findSpecResources($path);
         }
 
-        if ($path && 0 === strpos($path, $this->fullSrcPath)) {
+        if ($path && str_starts_with($path, $this->fullSrcPath)) {
             $path = $this->fullSpecPath.substr($path, \strlen($this->fullSrcPath));
             $path = preg_replace('/\.php/', 'Spec.php', $path);
 
             return $this->findSpecResources($path);
         }
 
-        if ($path && 0 === strpos($path, $this->srcPath)) {
+        if ($path && str_starts_with($path, $this->srcPath)) {
             $path = $this->fullSpecPath.substr($path, \strlen($this->srcPath));
             $path = preg_replace('/\.php/', 'Spec.php', $path);
 
@@ -162,8 +162,8 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         $classname = str_replace('/', '\\', $classname);
 
         return '' === $this->srcNamespace
-            || 0  === strpos($classname, $this->srcNamespace)
-            || 0  === strpos($classname, $this->specNamespace)
+            || str_starts_with($classname, $this->srcNamespace)
+            || str_starts_with($classname, $this->specNamespace)
         ;
     }
 
@@ -174,13 +174,13 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
 
         $classname = str_replace('/', '\\', $classname);
 
-        if (0 === strpos($classname, $this->specNamespace)) {
+        if (str_starts_with($classname, $this->specNamespace)) {
             $relative = substr($classname, \strlen($this->specNamespace));
 
             return new PSR0Resource(explode('\\', $relative), $this);
         }
 
-        if ('' === $this->srcNamespace || 0 === strpos($classname, $this->srcNamespace)) {
+        if ('' === $this->srcNamespace || str_starts_with($classname, $this->srcNamespace)) {
             $relative = substr($classname, \strlen($this->srcNamespace));
 
             return new PSR0Resource(explode('\\', $relative), $this);
@@ -204,7 +204,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
             return array();
         }
 
-        if ('.php' === substr($path, -4)) {
+        if (str_ends_with($path, '.php')) {
             return array($this->createResourceFromSpecFile(realpath($path)));
         }
 
@@ -261,7 +261,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         // Remove spec namespace from the begining of the classname.
         $specNamespace = trim($this->getSpecNamespace(), '\\').'\\';
 
-        if (0 !== strpos($classname, $specNamespace)) {
+        if (!str_starts_with($classname, $specNamespace)) {
             throw new \RuntimeException(sprintf(
                 'Spec class `%s` must be in the base spec namespace `%s`.',
                 $classname,
@@ -324,7 +324,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     
     private function queryContainsBlackslashes(string $query): bool
     {
-        return false !== strpos($query, '\\');
+        return str_contains($query, '\\');
     }
 
     

--- a/src/PhpSpec/Locator/PSR0/PSR0Resource.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Resource.php
@@ -17,14 +17,8 @@ use PhpSpec\Locator\Resource;
 
 final class PSR0Resource implements Resource
 {
-    private array $parts;
-    private PSR0Locator $locator;
-
-    
-    public function __construct(array $parts, PSR0Locator $locator)
+    public function __construct(private array $parts, private PSR0Locator $locator)
     {
-        $this->parts   = $parts;
-        $this->locator = $locator;
     }
 
     

--- a/src/PhpSpec/Locator/PrioritizedResourceManager.php
+++ b/src/PhpSpec/Locator/PrioritizedResourceManager.php
@@ -27,9 +27,7 @@ final class PrioritizedResourceManager implements ResourceManager
     {
         $this->locators[] = $locator;
 
-        @usort($this->locators, function (ResourceLocator $locator1, ResourceLocator $locator2) {
-            return $locator2->getPriority() - $locator1->getPriority();
-        });
+        @usort($this->locators, fn(ResourceLocator $locator1, ResourceLocator $locator2) => $locator2->getPriority() - $locator1->getPriority());
     }
 
     /**

--- a/src/PhpSpec/Matcher/ApproximatelyMatcher.php
+++ b/src/PhpSpec/Matcher/ApproximatelyMatcher.php
@@ -26,11 +26,8 @@ final class ApproximatelyMatcher extends BasicMatcher
         'returnApproximately'
     );
 
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/ArrayContainMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayContainMatcher.php
@@ -18,11 +18,8 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class ArrayContainMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/ArrayCountMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayCountMatcher.php
@@ -18,12 +18,8 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class ArrayCountMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/ArrayCountMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayCountMatcher.php
@@ -30,7 +30,7 @@ final class ArrayCountMatcher extends BasicMatcher
     {
         return 'haveCount' === $name
             && 1 == \count($arguments)
-            && (\is_array($subject) || $subject instanceof \Countable)
+            && (is_countable($subject))
         ;
     }
 

--- a/src/PhpSpec/Matcher/ArrayKeyMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyMatcher.php
@@ -19,12 +19,8 @@ use ArrayAccess;
 
 final class ArrayKeyMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -19,11 +19,8 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class ArrayKeyValueMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/CallbackMatcher.php
+++ b/src/PhpSpec/Matcher/CallbackMatcher.php
@@ -18,18 +18,14 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class CallbackMatcher extends BasicMatcher
 {
-    private string $name;
     /**
      * @var callable
      */
     private $callback;
-    private Presenter $presenter;
 
-    public function __construct(string $name, callable $callback, Presenter $presenter)
+    public function __construct(private string $name, callable $callback, private Presenter $presenter)
     {
-        $this->name      = $name;
         $this->callback  = $callback;
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/ComparisonMatcher.php
+++ b/src/PhpSpec/Matcher/ComparisonMatcher.php
@@ -19,11 +19,8 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class ComparisonMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/IdentityMatcher.php
+++ b/src/PhpSpec/Matcher/IdentityMatcher.php
@@ -25,11 +25,9 @@ final class IdentityMatcher extends BasicMatcher
         'equal',
         'beEqualTo'
     );
-    private Presenter $presenter;
 
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -3,6 +3,7 @@
 namespace PhpSpec\Matcher\Iterate;
 
 use PhpSpec\Formatter\Presenter\Presenter;
+use function is_iterable;
 
 final class IterablesMatcher
 {
@@ -21,11 +22,11 @@ final class IterablesMatcher
      */
     public function match(mixed $subject, mixed $expected, bool $strict = true): void
     {
-        if (!$this->isIterable($subject)) {
+        if (!is_iterable($subject)) {
             throw new \InvalidArgumentException('Subject value should be an array or implement \Traversable.');
         }
 
-        if (!$this->isIterable($expected)) {
+        if (!is_iterable($expected)) {
             throw new \InvalidArgumentException('Expected value should be an array or implement \Traversable.');
         }
 
@@ -54,14 +55,6 @@ final class IterablesMatcher
         if ($expectedIterator->valid()) {
             throw new SubjectHasFewerElementsException();
         }
-    }
-
-    /**
-     * @psalm-assert-if-true array|Traversable $variable
-     */
-    private function isIterable(mixed $variable): bool
-    {
-        return \is_array($variable) || $variable instanceof \Traversable;
     }
 
     private function createIteratorFromIterable(iterable $iterable): \Iterator

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -7,11 +7,8 @@ use function is_iterable;
 
 final class IterablesMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     /**

--- a/src/PhpSpec/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Matcher/IterateAsMatcher.php
@@ -64,7 +64,7 @@ final class IterateAsMatcher implements Matcher
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
-        } catch (FailureException $exception) {
+        } catch (FailureException) {
             return null;
         }
 

--- a/src/PhpSpec/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Matcher/IterateAsMatcher.php
@@ -36,8 +36,8 @@ final class IterateAsMatcher implements Matcher
     {
         return \in_array($name, ['iterateAs', 'yield'])
             && 1 === \count($arguments)
-            && ($subject instanceof \Traversable || \is_array($subject))
-            && ($arguments[0] instanceof \Traversable || \is_array($arguments[0]))
+            && is_iterable($subject)
+            && is_iterable($arguments[0])
         ;
     }
 

--- a/src/PhpSpec/Matcher/IterateLikeMatcher.php
+++ b/src/PhpSpec/Matcher/IterateLikeMatcher.php
@@ -36,8 +36,8 @@ final class IterateLikeMatcher implements Matcher
     {
         return \in_array($name, ['iterateLike', 'yieldLike'])
             && 1 === \count($arguments)
-            && ($subject instanceof \Traversable || \is_array($subject))
-            && ($arguments[0] instanceof \Traversable || \is_array($arguments[0]))
+            && is_iterable($subject)
+            && is_iterable($arguments[0])
         ;
     }
 

--- a/src/PhpSpec/Matcher/IterateLikeMatcher.php
+++ b/src/PhpSpec/Matcher/IterateLikeMatcher.php
@@ -64,7 +64,7 @@ final class IterateLikeMatcher implements Matcher
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
-        } catch (FailureException $exception) {
+        } catch (FailureException) {
             return null;
         }
 

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -32,7 +32,7 @@ final class ObjectStateMatcher implements Matcher
     public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return \is_object($subject) && !is_callable($subject)
-            && (0 === strpos($name, 'be') || 0 === strpos($name, 'have'))
+            && (str_starts_with($name, 'be') || str_starts_with($name, 'have'))
         ;
     }
 

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -21,12 +21,10 @@ use PhpSpec\Wrapper\DelayedCall;
 final class ObjectStateMatcher implements Matcher
 {
     private static string $regex = '/(be|have)(.+)/';
-    private Presenter $presenter;
 
     
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -99,7 +99,7 @@ final class ScalarMatcher implements Matcher
 
     private function getCheckerName(string $name): string|false
     {
-        if (0 !== strpos($name, 'be')) {
+        if (!str_starts_with($name, 'be')) {
             return false;
         }
 

--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -19,12 +19,8 @@ use PhpSpec\Wrapper\DelayedCall;
 
 final class ScalarMatcher implements Matcher
 {
-    private Presenter $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     /**

--- a/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
@@ -65,7 +65,7 @@ final class StartIteratingAsMatcher implements Matcher
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
-        } catch (FailureException $exception) {
+        } catch (FailureException) {
             return null;
         }
 

--- a/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
@@ -37,8 +37,8 @@ final class StartIteratingAsMatcher implements Matcher
     {
         return \in_array($name, ['startIteratingAs', 'startYielding'])
             && 1 === \count($arguments)
-            && ($subject instanceof \Traversable || \is_array($subject))
-            && ($arguments[0] instanceof \Traversable || \is_array($arguments[0]))
+            && is_iterable($subject)
+            && is_iterable($arguments[0])
         ;
     }
 

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -18,12 +18,8 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class StringContainMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     /**

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -42,7 +42,7 @@ final class StringContainMatcher extends BasicMatcher
      */
     protected function matches(mixed $subject, array $arguments): bool
     {
-        return false !== strpos($subject, $arguments[0]);
+        return str_contains($subject, $arguments[0]);
     }
 
     /**

--- a/src/PhpSpec/Matcher/StringEndMatcher.php
+++ b/src/PhpSpec/Matcher/StringEndMatcher.php
@@ -18,11 +18,8 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class StringEndMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/StringRegexMatcher.php
+++ b/src/PhpSpec/Matcher/StringRegexMatcher.php
@@ -18,11 +18,8 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class StringRegexMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/StringStartMatcher.php
+++ b/src/PhpSpec/Matcher/StringStartMatcher.php
@@ -18,11 +18,8 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class StringStartMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/StringStartMatcher.php
+++ b/src/PhpSpec/Matcher/StringStartMatcher.php
@@ -35,7 +35,7 @@ final class StringStartMatcher extends BasicMatcher
 
     protected function matches(mixed $subject, array $arguments): bool
     {
-        return 0 === strpos($subject, $arguments[0]);
+        return str_starts_with($subject, $arguments[0]);
     }
 
     protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -211,7 +211,7 @@ final class ThrowMatcher implements Matcher
                 [$class, $methodName] = array($subject, $methodName);
                 if (!method_exists($class, $methodName) && !method_exists($class, '__call')) {
                     throw new MethodNotFoundException(
-                        sprintf('Method %s::%s not found.', \get_class($class), $methodName),
+                        sprintf('Method %s::%s not found.', $class::class, $methodName),
                         $class,
                         $methodName,
                         $arguments

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -55,8 +55,6 @@ final class ThrowMatcher implements Matcher
 
         try {
             \call_user_func_array($callable, $arguments);
-        } catch (\Exception $e) {
-            $exceptionThrown = $e;
         } catch (\Throwable $e) {
             $exceptionThrown = $e;
         }
@@ -128,8 +126,6 @@ final class ThrowMatcher implements Matcher
 
         try {
             \call_user_func_array($callable, $arguments);
-        } catch (\Exception $e) {
-            $exceptionThrown = $e;
         } catch (\Throwable $e) {
             $exceptionThrown = $e;
         }

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -26,17 +26,8 @@ final class ThrowMatcher implements Matcher
 {
     private static array $ignoredProperties = array('file', 'line', 'string', 'trace', 'previous');
 
-    private Unwrapper $unwrapper;
-
-    private Presenter $presenter;
-
-    private ReflectionFactory $factory;
-
-    public function __construct(Unwrapper $unwrapper, Presenter $presenter, ReflectionFactory $factory)
+    public function __construct(private Unwrapper $unwrapper, private Presenter $presenter, private ReflectionFactory $factory)
     {
-        $this->unwrapper = $unwrapper;
-        $this->presenter = $presenter;
-        $this->factory   = $factory;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -212,7 +212,7 @@ final class ThrowMatcher implements Matcher
                 $arguments = $arguments[1] ?? array();
                 $callable = array($subject, $methodName);
 
-                list($class, $methodName) = array($subject, $methodName);
+                [$class, $methodName] = array($subject, $methodName);
                 if (!method_exists($class, $methodName) && !method_exists($class, '__call')) {
                     throw new MethodNotFoundException(
                         sprintf('Method %s::%s not found.', \get_class($class), $methodName),

--- a/src/PhpSpec/Matcher/TraversableContainMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableContainMatcher.php
@@ -18,12 +18,8 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class TraversableContainMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     /**

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -19,12 +19,11 @@ use PhpSpec\Wrapper\DelayedCall;
 
 final class TraversableCountMatcher implements Matcher
 {
-    const LESS_THAN = 0;
-    const EQUAL = 1;
-    const MORE_THAN = 2;
+    private const LESS_THAN = 0;
+    private const EQUAL = 1;
+    private const MORE_THAN = 2;
 
     private Presenter $presenter;
-
 
     public function __construct(Presenter $presenter)
     {

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -23,11 +23,8 @@ final class TraversableCountMatcher implements Matcher
     private const EQUAL = 1;
     private const MORE_THAN = 2;
 
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     /**

--- a/src/PhpSpec/Matcher/TraversableKeyMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyMatcher.php
@@ -19,11 +19,8 @@ use ArrayAccess;
 
 final class TraversableKeyMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     /**

--- a/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
@@ -19,11 +19,8 @@ use ArrayAccess;
 
 final class TraversableKeyValueMatcher extends BasicMatcher
 {
-    private Presenter $presenter;
-
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     /**

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -21,12 +21,8 @@ use PhpSpec\Exception\Fracture\MethodNotFoundException;
 
 final class TriggerMatcher implements Matcher
 {
-    private Unwrapper $unwrapper;
-
-
-    public function __construct(Unwrapper $unwrapper)
+    public function __construct(private Unwrapper $unwrapper)
     {
-        $this->unwrapper = $unwrapper;
     }
 
     public function supports(string $name, mixed $subject, array $arguments): bool

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -111,7 +111,7 @@ final class TriggerMatcher implements Matcher
     private function getDelayedCall(callable $check, mixed $subject, array $arguments): DelayedCall
     {
         $unwrapper = $this->unwrapper;
-        list($level, $message) = $this->unpackArguments($arguments);
+        [$level, $message] = $this->unpackArguments($arguments);
 
         return new DelayedCall(
             function (string $method, array $arguments) use ($check, $subject, $level, $message, $unwrapper): mixed {
@@ -121,7 +121,7 @@ final class TriggerMatcher implements Matcher
                 $arguments = $arguments[1] ?? array();
                 $callable = array($subject, $methodName);
 
-                list($class, $methodName) = array($subject, $methodName);
+                [$class, $methodName] = array($subject, $methodName);
                 if (!method_exists($class, $methodName) && !method_exists($class, '__call')) {
                     throw new MethodNotFoundException(
                         sprintf('Method %s::%s not found.', \get_class($class), $methodName),

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -124,7 +124,7 @@ final class TriggerMatcher implements Matcher
                 [$class, $methodName] = array($subject, $methodName);
                 if (!method_exists($class, $methodName) && !method_exists($class, '__call')) {
                     throw new MethodNotFoundException(
-                        sprintf('Method %s::%s not found.', \get_class($class), $methodName),
+                        sprintf('Method %s::%s not found.', $class::class, $methodName),
                         $class,
                         $methodName,
                         $arguments

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -56,7 +56,7 @@ final class TriggerMatcher implements Matcher
                 return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }
 
-            if (null !== $message && false === strpos($str, $message)) {
+            if (null !== $message && !str_contains($str, $message)) {
                 return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }
 
@@ -84,7 +84,7 @@ final class TriggerMatcher implements Matcher
                 return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }
 
-            if (null !== $message && false === strpos($str, $message)) {
+            if (null !== $message && !str_contains($str, $message)) {
                 return null !== $prevHandler && \call_user_func($prevHandler, $type, $str, $file, $line, $context);
             }
 

--- a/src/PhpSpec/Matcher/TypeMatcher.php
+++ b/src/PhpSpec/Matcher/TypeMatcher.php
@@ -24,12 +24,10 @@ final class TypeMatcher extends BasicMatcher
         'haveType',
         'implement'
     );
-    private Presenter $presenter;
 
     
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -35,7 +35,7 @@ class ComposerPsrNamespaceProvider
         foreach (get_declared_classes() as $class) {
             if ('C' === $class[0] && str_starts_with($class, 'ComposerAutoloaderInit')) {
                 $r = new \ReflectionClass($class);
-                $v = dirname(dirname($r->getFileName()));
+                $v = dirname($r->getFileName(), 2);
                 if (file_exists($v.'/composer/installed.json')) {
                     $vendors[] = $v;
                 }

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -9,20 +9,17 @@ use Composer\Autoload\ClassLoader;
  */
 class ComposerPsrNamespaceProvider
 {
-    /**
-     *  path to the root directory of the project, without a trailing slash
-     */
-    private string $rootDirectory;
-
-    /**
-     *  prefix of the specifications namespace
-     */
-    private string $specPrefix;
-
-    public function __construct(string $rootDirectory, string $specPrefix)
+    public function __construct(
+        /**
+         *  path to the root directory of the project, without a trailing slash
+         */
+        private string $rootDirectory,
+        /**
+         *  prefix of the specifications namespace
+         */
+        private string $specPrefix
+    )
     {
-        $this->rootDirectory = $rootDirectory;
-        $this->specPrefix = $specPrefix;
     }
 
     /**

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -36,7 +36,7 @@ class ComposerPsrNamespaceProvider
     {
         $vendors = array();
         foreach (get_declared_classes() as $class) {
-            if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
+            if ('C' === $class[0] && str_starts_with($class, 'ComposerAutoloaderInit')) {
                 $r = new \ReflectionClass($class);
                 $v = dirname(dirname($r->getFileName()));
                 if (file_exists($v.'/composer/installed.json')) {
@@ -70,11 +70,11 @@ class ComposerPsrNamespaceProvider
             foreach ($psrPrefix as $location) {
                 foreach ($vendors as $vendor) {
                     $realPath = realpath($location);
-                    if ($realPath === false || strpos($realPath, $vendor) === 0) {
+                    if ($realPath === false || str_starts_with($realPath, $vendor)) {
                         break 2;
                     }
                 }
-                if (strpos($namespace, $this->specPrefix) !== 0) {
+                if (!str_starts_with($namespace, $this->specPrefix)) {
                     $namespaces[$namespace] = new NamespaceLocation(
                         $namespace,
                         $this->normaliseLocation($location),
@@ -89,7 +89,7 @@ class ComposerPsrNamespaceProvider
 
     private function normaliseLocation(string $location): string
     {
-        return strpos(realpath($location), realpath($this->rootDirectory)) === 0 ?
+        return str_starts_with(realpath($location), realpath($this->rootDirectory)) ?
             substr(
                 realpath($location),
                 \strlen(realpath($this->rootDirectory)) + 1 // trailing slash

--- a/src/PhpSpec/NamespaceProvider/NamespaceLocation.php
+++ b/src/PhpSpec/NamespaceProvider/NamespaceLocation.php
@@ -4,15 +4,8 @@ namespace PhpSpec\NamespaceProvider;
 
 final class NamespaceLocation
 {
-    private string $namespace;
-    private string $location;
-    private string $autoloadingStandard;
-
-    public function __construct(string $namespace, string $location, string $autoloadingStandard)
+    public function __construct(private string $namespace, private string $location, private string $autoloadingStandard)
     {
-        $this->namespace = $namespace;
-        $this->location = $location;
-        $this->autoloadingStandard = $autoloadingStandard;
     }
 
     public function getNamespace(): string

--- a/src/PhpSpec/NamespaceProvider/NamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/NamespaceProvider.php
@@ -7,8 +7,8 @@ namespace PhpSpec\NamespaceProvider;
  */
 interface NamespaceProvider
 {
-    const AUTOLOADING_STANDARD_PSR0 = 'PSR0';
-    const AUTOLOADING_STANDARD_PSR4 = 'PSR4';
+    public const AUTOLOADING_STANDARD_PSR0 = 'PSR0';
+    public const AUTOLOADING_STANDARD_PSR4 = 'PSR4';
 
     /**
      * @return string[] a map associating a namespace to a location, e.g

--- a/src/PhpSpec/Process/Context/JsonExecutionContext.php
+++ b/src/PhpSpec/Process/Context/JsonExecutionContext.php
@@ -23,7 +23,7 @@ final class JsonExecutionContext implements ExecutionContext
         $executionContext = new self();
 
         if (array_key_exists(self::ENV_NAME, $env)) {
-            $serialized = json_decode($env[self::ENV_NAME], true);
+            $serialized = json_decode($env[self::ENV_NAME], true, 512, JSON_THROW_ON_ERROR);
             $executionContext->generatedTypes = $serialized['generated-types'];
         }
         else {
@@ -52,7 +52,7 @@ final class JsonExecutionContext implements ExecutionContext
             self::ENV_NAME => json_encode(
                 array(
                     'generated-types' => $this->generatedTypes
-                )
+                ), JSON_THROW_ON_ERROR
             )
         );
     }

--- a/src/PhpSpec/Process/Context/JsonExecutionContext.php
+++ b/src/PhpSpec/Process/Context/JsonExecutionContext.php
@@ -15,7 +15,7 @@ namespace PhpSpec\Process\Context;
 
 final class JsonExecutionContext implements ExecutionContext
 {
-    const ENV_NAME = 'PHPSPEC_EXECUTION_CONTEXT';
+    private const ENV_NAME = 'PHPSPEC_EXECUTION_CONTEXT';
     private array $generatedTypes = [];
 
     public static function fromEnv(array $env): JsonExecutionContext

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
@@ -17,12 +17,8 @@ use PhpSpec\Process\Context\ExecutionContext;
 
 final class SuitePrerequisites implements PrerequisiteTester
 {
-    private ExecutionContext $executionContext;
-
-    
-    public function __construct(ExecutionContext $executionContext)
+    public function __construct(private ExecutionContext $executionContext)
     {
-        $this->executionContext = $executionContext;
     }
 
     /**

--- a/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
@@ -18,14 +18,8 @@ use PhpSpec\Process\ReRunner;
 
 final class OptionalReRunner implements ReRunner
 {
-    private ConsoleIO $io;
-    private ReRunner $decoratedRerunner;
-
-    
-    public function __construct(ReRunner $decoratedRerunner, ConsoleIO $io)
+    public function __construct(private ReRunner $decoratedRerunner, private ConsoleIO $io)
     {
-        $this->io = $io;
-        $this->decoratedRerunner = $decoratedRerunner;
     }
 
     public function reRunSuite(): void

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -49,7 +49,7 @@ final class PcntlReRunner extends PhpExecutableReRunner
 
         $env = array_filter(
             array_merge($env, $_SERVER),
-            function($x): bool { return !is_array($x); }
+            fn($x): bool => !is_array($x)
         );
 
         pcntl_exec($executablePath, $args, $env);

--- a/src/PhpSpec/Process/ReRunner/PhpExecutableReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PhpExecutableReRunner.php
@@ -17,13 +17,10 @@ use Symfony\Component\Process\PhpExecutableFinder;
 
 abstract class PhpExecutableReRunner implements PlatformSpecificReRunner
 {
-    private PhpExecutableFinder $executableFinder;
-
     private string|false|null $executablePath = null;
 
-    public function __construct(PhpExecutableFinder $executableFinder)
+    public function __construct(private PhpExecutableFinder $executableFinder)
     {
-        $this->executableFinder = $executableFinder;
     }
 
     /**

--- a/src/PhpSpec/Process/Shutdown/UpdateConsoleAction.php
+++ b/src/PhpSpec/Process/Shutdown/UpdateConsoleAction.php
@@ -18,14 +18,8 @@ use PhpSpec\Message\CurrentExampleTracker;
 
 final class UpdateConsoleAction implements ShutdownAction
 {
-    private CurrentExampleTracker $currentExample;
-
-    private FatalPresenter $currentExampleWriter;
-
-    public function __construct(CurrentExampleTracker $currentExample, FatalPresenter $currentExampleWriter)
+    public function __construct(private CurrentExampleTracker $currentExample, private FatalPresenter $currentExampleWriter)
     {
-        $this->currentExample = $currentExample;
-        $this->currentExampleWriter = $currentExampleWriter;
     }
 
     public function runAction(?array $error): void

--- a/src/PhpSpec/Runner/CollaboratorManager.php
+++ b/src/PhpSpec/Runner/CollaboratorManager.php
@@ -20,16 +20,14 @@ use ReflectionFunctionAbstract;
 
 class CollaboratorManager
 {
-    private Presenter $presenter;
     /**
      * @var Collaborator[]
      */
     private array $collaborators = array();
 
     
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function set(string $name, Collaborator $collaborator): void

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -31,17 +31,13 @@ use Exception;
 
 class ExampleRunner
 {
-    private EventDispatcherInterface $dispatcher;
-    private Presenter $presenter;
     /**
      * @var Maintainer[]
      */
     private array $maintainers = array();
 
-    public function __construct(EventDispatcherInterface $dispatcher, Presenter $presenter)
+    public function __construct(private EventDispatcherInterface $dispatcher, private Presenter $presenter)
     {
-        $this->dispatcher = $dispatcher;
-        $this->presenter  = $presenter;
     }
 
     public function registerMaintainer(Maintainer $maintainer): void

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -44,9 +44,7 @@ class ExampleRunner
     {
         $this->maintainers[] = $maintainer;
 
-        @usort($this->maintainers, function (Maintainer $maintainer1, Maintainer $maintainer2): int {
-            return $maintainer2->getPriority() - $maintainer1->getPriority();
-        });
+        @usort($this->maintainers, fn(Maintainer $maintainer1, Maintainer $maintainer2): int => $maintainer2->getPriority() - $maintainer1->getPriority());
     }
 
     public function run(ExampleNode $example): int
@@ -115,9 +113,7 @@ class ExampleRunner
 
         $matchers      = new MatcherManager($this->presenter);
         $collaborators = new CollaboratorManager($this->presenter);
-        $maintainers   = array_filter($this->maintainers, function (Maintainer $maintainer) use ($example) {
-            return $maintainer->supports($example);
-        });
+        $maintainers   = array_filter($this->maintainers, fn(Maintainer $maintainer) => $maintainer->supports($example));
 
         // run maintainers prepare
         foreach ($maintainers as $maintainer) {
@@ -175,9 +171,7 @@ class ExampleRunner
     {
         return array_filter(
             $maintainers,
-            function ($maintainer) {
-                return $maintainer instanceof LetAndLetgoMaintainer;
-            }
+            fn($maintainer) => $maintainer instanceof LetAndLetgoMaintainer
         );
     }
 }

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -30,16 +30,11 @@ use ReflectionNamedType;
 
 final class CollaboratorsMaintainer implements Maintainer
 {
-    private Unwrapper $unwrapper;
     private ?Prophet $prophet = null;
 
-    private TypeHintIndex $typeHintIndex;
-
     
-    public function __construct(Unwrapper $unwrapper, TypeHintIndex $typeHintIndex)
+    public function __construct(private Unwrapper $unwrapper, private TypeHintIndex $typeHintIndex)
     {
-        $this->unwrapper = $unwrapper;
-        $this->typeHintIndex = $typeHintIndex;
     }
 
     

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -100,7 +100,7 @@ final class CollaboratorsMaintainer implements Maintainer
             catch (DisallowedUnionTypehintException $e) {
                 throw new InvalidCollaboratorTypeException($parameter, $function, $e->getMessage(), 'Use a specific type');
             }
-            catch (DisallowedNonObjectTypehintException $e) {
+            catch (DisallowedNonObjectTypehintException) {
                 throw new InvalidCollaboratorTypeException($parameter, $function);
             }
         }

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -21,16 +21,14 @@ use PhpSpec\Exception\Example as ExampleException;
 
 final class ErrorMaintainer implements Maintainer
 {
-    private int $errorLevel;
     /**
      * @var null|callable
      */
     private $errorHandler;
 
 
-    public function __construct(int $errorLevel)
+    public function __construct(private int $errorLevel)
     {
-        $this->errorLevel = $errorLevel;
     }
 
 

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -84,7 +84,7 @@ final class ErrorMaintainer implements Maintainer
         if (E_RECOVERABLE_ERROR === $level && preg_match($regex, $message, $matches)) {
             $class = $matches['class'];
 
-            if (\in_array('PhpSpec\Specification', class_implements($class))) {
+            if (\in_array(\PhpSpec\Specification::class, class_implements($class))) {
                 return true;
             }
         }

--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -24,20 +24,11 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class MatchersMaintainer implements Maintainer
 {
-    private Presenter $presenter;
-
     /**
-     * @var Matcher[]
+     * @param Matcher[] $defaultMatchers
      */
-    private array $defaultMatchers = array();
-
-    /**
-     * @param Matcher[] $matchers
-     */
-    public function __construct(Presenter $presenter, array $matchers)
+    public function __construct(private Presenter $presenter, private array $defaultMatchers)
     {
-        $this->presenter = $presenter;
-        $this->defaultMatchers = $matchers;
         @usort($this->defaultMatchers, function (Matcher $matcher1, Matcher $matcher2) {
             return $matcher2->getPriority() - $matcher1->getPriority();
         });

--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -29,9 +29,7 @@ final class MatchersMaintainer implements Maintainer
      */
     public function __construct(private Presenter $presenter, private array $defaultMatchers)
     {
-        @usort($this->defaultMatchers, function (Matcher $matcher1, Matcher $matcher2) {
-            return $matcher2->getPriority() - $matcher1->getPriority();
-        });
+        @usort($this->defaultMatchers, fn(Matcher $matcher1, Matcher $matcher2) => $matcher2->getPriority() - $matcher1->getPriority());
     }
 
     

--- a/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
@@ -27,22 +27,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class SubjectMaintainer implements Maintainer
 {
-    private Presenter $presenter;
-    private Unwrapper $unwrapper;
-    private EventDispatcherInterface $dispatcher;
-    private AccessInspector $accessInspector;
-
-    
-    public function __construct(
-        Presenter $presenter,
-        Unwrapper $unwrapper,
-        EventDispatcherInterface $dispatcher,
-        AccessInspector $accessInspector
-    ) {
-        $this->presenter = $presenter;
-        $this->unwrapper = $unwrapper;
-        $this->dispatcher = $dispatcher;
-        $this->accessInspector = $accessInspector;
+    public function __construct(private Presenter $presenter, private Unwrapper $unwrapper, private EventDispatcherInterface $dispatcher, private AccessInspector $accessInspector)
+    {
     }
 
     

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -31,9 +31,7 @@ class MatcherManager
     public function add(Matcher $matcher): void
     {
         $this->matchers[] = $matcher;
-        @usort($this->matchers, function (Matcher $matcher1, Matcher $matcher2) {
-            return $matcher2->getPriority() - $matcher1->getPriority();
-        });
+        @usort($this->matchers, fn(Matcher $matcher1, Matcher $matcher2) => $matcher2->getPriority() - $matcher1->getPriority());
     }
 
     /**

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -19,15 +19,13 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 class MatcherManager
 {
-    private Presenter $presenter;
     /**
      * @var Matcher[]
      */
     private array $matchers = array();
 
-    public function __construct(Presenter $presenter)
+    public function __construct(private Presenter $presenter)
     {
-        $this->presenter = $presenter;
     }
 
     public function add(Matcher $matcher): void

--- a/src/PhpSpec/Runner/SpecificationRunner.php
+++ b/src/PhpSpec/Runner/SpecificationRunner.php
@@ -21,14 +21,8 @@ use PhpSpec\Loader\Node\SpecificationNode;
 
 class SpecificationRunner
 {
-    private EventDispatcherInterface $dispatcher;
-    private ExampleRunner $exampleRunner;
-
-    
-    public function __construct(EventDispatcherInterface $dispatcher, ExampleRunner $exampleRunner)
+    public function __construct(private EventDispatcherInterface $dispatcher, private ExampleRunner $exampleRunner)
     {
-        $this->dispatcher    = $dispatcher;
-        $this->exampleRunner = $exampleRunner;
     }
 
     public function run(SpecificationNode $specification): int

--- a/src/PhpSpec/Runner/SuiteRunner.php
+++ b/src/PhpSpec/Runner/SuiteRunner.php
@@ -20,14 +20,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class SuiteRunner
 {
-    private EventDispatcher $dispatcher;
-    private SpecificationRunner $specRunner;
-
-    
-    public function __construct(EventDispatcher $dispatcher, SpecificationRunner $specRunner)
+    public function __construct(private EventDispatcher $dispatcher, private SpecificationRunner $specRunner)
     {
-        $this->dispatcher = $dispatcher;
-        $this->specRunner = $specRunner;
     }
 
     

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -191,7 +191,7 @@ final class ClassFileAnalyser
     /**
      * @param string|array{0:int,1:string,2:int} $token
      */
-    private function tokenIsFunction($token): bool
+    private function tokenIsFunction(string|array $token): bool
     {
         return \is_array($token) && $token[0] === T_FUNCTION;
     }

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -198,9 +198,7 @@ final class ClassFileAnalyser
     
     private function findIndexOfClassEnd(array $tokens): int
     {
-        $classTokens = array_filter($tokens, function ($token) {
-            return \is_array($token) && $token[0] === T_CLASS;
-        });
+        $classTokens = array_filter($tokens, fn($token) => \is_array($token) && $token[0] === T_CLASS);
         $classTokenIndex = key($classTokens);
         return $this->findIndexOfMethodOrClassEnd($tokens, $classTokenIndex) - 1;
     }

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -73,7 +73,7 @@ class MethodAnalyser
         $fileName = $reflectionMethod->getFileName();
         $trait = $this->getDeclaringTrait($reflectionClass->getTraits(), $fileName, $methodStartLine, $methodEndLine);
 
-        return $trait === null ? $reflectionClass : $trait;
+        return $trait ?? $reflectionClass;
     }
 
     /**

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -99,14 +99,10 @@ class MethodAnalyser
         $tokens = token_get_all('<?php ' . $code);
 
         $comments = array_map(
-            function ($token) {
-                return $token[1];
-            },
+            fn($token) => $token[1],
             array_filter(
                 $tokens,
-                function ($token) {
-                    return \is_array($token) && \in_array($token[0], array(T_COMMENT, T_DOC_COMMENT));
-                })
+                fn($token) => \is_array($token) && \in_array($token[0], array(T_COMMENT, T_DOC_COMMENT)))
         );
 
         $commentless = str_replace($comments, '', $code);

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -17,11 +17,8 @@ use Prophecy\Prophecy\ObjectProphecy;
 
 class Collaborator implements ObjectWrapper
 {
-    private ObjectProphecy $prophecy;
-
-    public function __construct(ObjectProphecy $prophecy)
+    public function __construct(private ObjectProphecy $prophecy)
     {
-        $this->prophecy  = $prophecy;
     }
 
     public function beADoubleOf(string $classOrInterface): void

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -215,7 +215,7 @@ class Subject implements ArrayAccess, ObjectWrapper
 
     public function __call(string $method, array $arguments = array()): mixed
     {
-        if (0 === strpos($method, 'should')) {
+        if (str_starts_with($method, 'should')) {
             return $this->callExpectation($method, $arguments);
         }
 
@@ -257,7 +257,7 @@ class Subject implements ArrayAccess, ObjectWrapper
 
         $expectation = $this->expectationFactory->create($method, $subject, $arguments);
 
-        if (0 === strpos($method, 'shouldNot')) {
+        if (str_starts_with($method, 'shouldNot')) {
             return $expectation->match(lcfirst(substr($method, 9)), $this, $arguments, $this->wrappedObject);
         }
 

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -111,27 +111,8 @@ use ArrayAccess;
  */
 class Subject implements ArrayAccess, ObjectWrapper
 {
-    private mixed $subject;
-    private WrappedObject $wrappedObject;
-    private Caller $caller;
-    private SubjectWithArrayAccess $arrayAccess;
-    private Wrapper $wrapper;
-    private ExpectationFactory $expectationFactory;
-
-    public function __construct(
-        mixed $subject,
-        Wrapper $wrapper,
-        WrappedObject $wrappedObject,
-        Caller $caller,
-        SubjectWithArrayAccess $arrayAccess,
-        ExpectationFactory $expectationFactory
-    ) {
-        $this->subject            = $subject;
-        $this->wrapper            = $wrapper;
-        $this->wrappedObject      = $wrappedObject;
-        $this->caller             = $caller;
-        $this->arrayAccess        = $arrayAccess;
-        $this->expectationFactory = $expectationFactory;
+    public function __construct(private mixed $subject, private Wrapper $wrapper, private WrappedObject $wrappedObject, private Caller $caller, private SubjectWithArrayAccess $arrayAccess, private ExpectationFactory $expectationFactory)
+    {
     }
 
     /**

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -271,10 +271,7 @@ class Caller
 
     private function detectMissingConstructorMessage(ReflectionException $exception): bool
     {
-        return strpos(
-            $exception->getMessage(),
-            'does not have a constructor'
-        ) !== 0;
+        return !str_starts_with($exception->getMessage(), 'does not have a constructor');
     }
 
     private function classNotFound(): ClassNotFoundException

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -34,27 +34,8 @@ use ReflectionException;
 
 class Caller
 {
-    private WrappedObject $wrappedObject;
-    private ExampleNode $example;
-    private Dispatcher $dispatcher;
-    private Wrapper $wrapper;
-    private ExceptionFactory $exceptionFactory;
-    private AccessInspector $accessInspector;
-
-    public function __construct(
-        WrappedObject $wrappedObject,
-        ExampleNode $example,
-        Dispatcher $dispatcher,
-        ExceptionFactory $exceptions,
-        Wrapper $wrapper,
-        AccessInspector $accessInspector
-    ) {
-        $this->wrappedObject    = $wrappedObject;
-        $this->example          = $example;
-        $this->dispatcher       = $dispatcher;
-        $this->wrapper          = $wrapper;
-        $this->exceptionFactory = $exceptions;
-        $this->accessInspector  = $accessInspector;
+    public function __construct(private WrappedObject $wrappedObject, private ExampleNode $example, private Dispatcher $dispatcher, private ExceptionFactory $exceptionFactory, private Wrapper $wrapper, private AccessInspector $accessInspector)
+    {
     }
 
     /**

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -16,7 +16,6 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 use PhpSpec\Exception\ErrorException;
 use PhpSpec\Exception\Fracture\FractureException;
 use PhpSpec\Util\Instantiator;
-use PhpSpec\Wrapper\DelayedCall;
 use PhpSpec\Wrapper\Subject\WrappedObject;
 
 final class ConstructorDecorator extends Decorator implements Expectation
@@ -28,16 +27,13 @@ final class ConstructorDecorator extends Decorator implements Expectation
 
     /**
      * @throws ErrorException
-     * @throws \PhpSpec\Exception\Example\ErrorException
      * @throws FractureException
      */
     public function match(string $alias, mixed $subject, array $arguments = [], WrappedObject $wrappedObject = null): mixed
     {
         try {
             $wrapped = $subject->getWrappedObject();
-        } catch (\PhpSpec\Exception\Example\ErrorException $e) {
-            throw $e;
-        } catch (FractureException $e) {
+        } catch (ErrorException|FractureException $e) {
             throw $e;
         } catch (\Exception $e) {
             $className = $wrappedObject?->getClassName();

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
@@ -15,11 +15,8 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 abstract class Decorator implements Expectation
 {
-    private Expectation $expectation;
-
-    public function __construct(Expectation $expectation)
+    public function __construct(private Expectation $expectation)
     {
-        $this->expectation = $expectation;
     }
 
     public function getExpectation(): Expectation

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
@@ -23,20 +23,13 @@ use Exception;
 
 final class DispatcherDecorator extends Decorator implements Expectation
 {
-    private EventDispatcherInterface $dispatcher;
-    private Matcher $matcher;
-    private ExampleNode $example;
-
     public function __construct(
         Expectation $expectation,
-        EventDispatcherInterface $dispatcher,
-        Matcher $matcher,
-        ExampleNode $example
+        private EventDispatcherInterface $dispatcher,
+        private Matcher $matcher,
+        private ExampleNode $example
     ) {
         $this->setExpectation($expectation);
-        $this->dispatcher = $dispatcher;
-        $this->matcher = $matcher;
-        $this->example = $example;
     }
 
     /**

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -20,15 +20,12 @@ use PhpSpec\Wrapper\Subject\WrappedObject;
 
 abstract class DuringCall
 {
-    private Matcher $matcher;
-
     private mixed $subject;
     private array $arguments = [];
     private ?WrappedObject $wrappedObject = null;
 
-    public function __construct(Matcher $matcher)
+    public function __construct(private Matcher $matcher)
     {
-        $this->matcher = $matcher;
     }
 
     /**

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Negative.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Negative.php
@@ -18,11 +18,8 @@ use PhpSpec\Matcher\Matcher;
 
 final class Negative implements Expectation
 {
-    private Matcher $matcher;
-
-    public function __construct(Matcher $matcher)
+    public function __construct(private Matcher $matcher)
     {
-        $this->matcher = $matcher;
     }
 
     public function match(string $alias, mixed $subject, array $arguments = array()): ?DelayedCall

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Positive.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Positive.php
@@ -18,11 +18,8 @@ use PhpSpec\Matcher\Matcher;
 
 final class Positive implements Expectation
 {
-    private Matcher $matcher;
-
-    public function __construct(Matcher $matcher)
+    public function __construct(private Matcher $matcher)
     {
-        $this->matcher = $matcher;
     }
 
     public function match(string $alias, mixed $subject, array $arguments = array()): ?DelayedCall

--- a/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
@@ -18,12 +18,9 @@ use PhpSpec\Wrapper\Unwrapper;
 
 final class UnwrapDecorator extends Decorator implements Expectation
 {
-    private Unwrapper $unwrapper;
-
-    public function __construct(Expectation $expectation, Unwrapper $unwrapper)
+    public function __construct(Expectation $expectation, private Unwrapper $unwrapper)
     {
         parent::__construct($expectation);
-        $this->unwrapper = $unwrapper;
     }
 
     public function match(string $alias, mixed $subject, array $arguments = array()): ?DelayedCall

--- a/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
+++ b/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
@@ -26,15 +26,8 @@ use PhpSpec\Wrapper\Unwrapper;
 
 class ExpectationFactory
 {
-    private ExampleNode $example;
-    private EventDispatcherInterface $dispatcher;
-    private MatcherManager $matchers;
-
-    public function __construct(ExampleNode $example, EventDispatcherInterface $dispatcher, MatcherManager $matchers)
+    public function __construct(private ExampleNode $example, private EventDispatcherInterface $dispatcher, private MatcherManager $matchers)
     {
-        $this->example = $example;
-        $this->dispatcher = $dispatcher;
-        $this->matchers = $matchers;
     }
 
     public function create(string $expectation, mixed $subject, array $arguments = array()): Expectation

--- a/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
+++ b/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
@@ -39,11 +39,11 @@ class ExpectationFactory
 
     public function create(string $expectation, mixed $subject, array $arguments = array()): Expectation
     {
-        if (0 === strpos($expectation, 'shouldNot')) {
+        if (str_starts_with($expectation, 'shouldNot')) {
             return $this->createNegative(lcfirst(substr($expectation, 9)), $subject, $arguments);
         }
 
-        if (0 === strpos($expectation, 'should')) {
+        if (str_starts_with($expectation, 'should')) {
             return $this->createPositive(lcfirst(substr($expectation, 6)), $subject, $arguments);
         }
 

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -101,10 +101,10 @@ class SubjectWithArrayAccess
             sprintf(
                 '%s does not implement %s interface, but should.',
                 $this->presenter->presentValue($this->caller->getWrappedObject()),
-                $this->presenter->presentString('ArrayAccess')
+                $this->presenter->presentString(\ArrayAccess::class)
             ),
             $this->caller->getWrappedObject(),
-            'ArrayAccess'
+            \ArrayAccess::class
         );
     }
 

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -21,18 +21,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class SubjectWithArrayAccess
 {
-    private Caller $caller;
-    private Presenter $presenter;
-    private EventDispatcherInterface $dispatcher;
-
-    public function __construct(
-        Caller $caller,
-        Presenter $presenter,
-        EventDispatcherInterface $dispatcher
-    ) {
-        $this->caller     = $caller;
-        $this->presenter  = $presenter;
-        $this->dispatcher = $dispatcher;
+    public function __construct(private Caller $caller, private Presenter $presenter, private EventDispatcherInterface $dispatcher)
+    {
     }
 
     public function offsetExists(mixed $key): bool

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -80,7 +80,7 @@ class WrappedObject
     public function beConstructedThrough(null|callable|string $factoryMethod, array $arguments = array()): void
     {
 
-        if (\is_string($factoryMethod) && false === strpos($factoryMethod, '::')) {
+        if (\is_string($factoryMethod) && !str_contains($factoryMethod, '::')) {
             if (!$this->classname) {
                 throw new \LogicException('Cannot call factory method on non-obect');
             }

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -35,7 +35,7 @@ class WrappedObject
     public function __construct(private mixed $instance, private Presenter $presenter)
     {
         if (\is_object($this->instance)) {
-            $this->classname = \get_class($this->instance);
+            $this->classname = $this->instance::class;
             $this->isInstantiated = true;
         }
     }

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -30,7 +30,7 @@ class WrappedObject
     /**
      * @var null|callable|string
      */
-    private mixed $factoryMethod;
+    private mixed $factoryMethod = null;
     private array $arguments = array();
     private bool $isInstantiated = false;
 

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -21,8 +21,6 @@ use PhpSpec\Exception\Wrapper\SubjectException;
 
 class WrappedObject
 {
-    private mixed $instance;
-    private Presenter $presenter;
     /**
      * @var ?class-string
      */
@@ -34,10 +32,8 @@ class WrappedObject
     private array $arguments = array();
     private bool $isInstantiated = false;
 
-    public function __construct(mixed $instance, Presenter $presenter)
+    public function __construct(private mixed $instance, private Presenter $presenter)
     {
-        $this->instance = $instance;
-        $this->presenter = $presenter;
         if (\is_object($this->instance)) {
             $this->classname = \get_class($this->instance);
             $this->isInstantiated = true;

--- a/src/PhpSpec/Wrapper/Wrapper.php
+++ b/src/PhpSpec/Wrapper/Wrapper.php
@@ -26,24 +26,8 @@ use PhpSpec\Wrapper\Subject\ExpectationFactory;
 
 class Wrapper
 {
-    private MatcherManager $matchers;
-    private Presenter $presenter;
-    private EventDispatcherInterface $dispatcher;
-    private ExampleNode $example;
-    private AccessInspector $accessInspector;
-
-    public function __construct(
-        MatcherManager $matchers,
-        Presenter $presenter,
-        EventDispatcherInterface $dispatcher,
-        ExampleNode $example,
-        AccessInspector $accessInspector
-    ) {
-        $this->matchers = $matchers;
-        $this->presenter = $presenter;
-        $this->dispatcher = $dispatcher;
-        $this->example = $example;
-        $this->accessInspector = $accessInspector;
+    public function __construct(private MatcherManager $matchers, private Presenter $presenter, private EventDispatcherInterface $dispatcher, private ExampleNode $example, private AccessInspector $accessInspector)
+    {
     }
 
     public function wrap(mixed $value = null): Subject


### PR DESCRIPTION
This uses rector to do a bunch of refactoring

The only deliberate potential BC break is the addition of visibility to class constants, hence this targets the `next` branch