### PR TITLE
Add support for doctrine/instantiator 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/process":          "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/finder":           "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/yaml":             "^3.4 || ^4.4 || ^5.0 || ^6.0",
-        "doctrine/instantiator":    "^1.0.5",
+        "doctrine/instantiator":    "^1.0.5 || ^2",
         "ext-tokenizer":            "*"
     },
 


### PR DESCRIPTION
We are not affected by the BC break in it (which is most that some constants that were deprecated for public access are not actually private constants).

This keeps support for doctrine/instantiator 1.x because 2.0 requires PHP 8.1+ (and it makes it easier for projects to avoid dependency conflicts).
