### PR TITLE
Allow sebastian/export v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php":                      "^7.3 || 8.0.* || 8.1.* || 8.2.*",
         "phpspec/prophecy":         "^1.9",
         "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "^3.0 || ^4.0",
+        "sebastian/exporter":       "^3.0 || ^4.0 || ^5.0",
         "symfony/console":          "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/event-dispatcher": "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/process":          "^3.4 || ^4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
v5 is required for phpunit 10, which phpspec now blocks.  v5 drops support for PHP 7.3, PHP 7.4 and PHP 8.0 but has no other BC breaks so should work with phpspec.