### PR TITLE
Allow PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "behat/behat":           "^3.3",
         "symfony/filesystem":    "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "phpunit/phpunit":       "^8.0 || ^9.0",
+        "phpunit/phpunit":       "^8.0 || ^9.0 || ^10.0",
         "vimeo/psalm": "^4.3 || ^5.2"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php":                      "^7.3 || 8.0.* || 8.1.* || 8.2.*",
         "phpspec/prophecy":         "^1.9",
         "phpspec/php-diff":         "^1.0.0",
-        "sebastian/exporter":       "^3.0 || ^4.0",
+        "sebastian/exporter":       "^3.0 || ^4.0 || ^5.0",
         "symfony/console":          "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/event-dispatcher": "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/process":          "^3.4 || ^4.4 || ^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 
     "require": {
         "php":                      "^7.3 || 8.0.* || 8.1.* || 8.2.*",
-        "phpspec/prophecy":         "^1.9",
+        "phpspec/prophecy":         "dev-allow-sebastian-comparator-5 as 1.15",
         "phpspec/php-diff":         "^1.0.0",
         "sebastian/exporter":       "^3.0 || ^4.0 || ^5.0",
         "symfony/console":          "^3.4 || ^4.4 || ^5.0 || ^6.0",
@@ -41,6 +41,13 @@
         "phpunit/phpunit":       "^8.0 || ^9.0 || ^10.0",
         "vimeo/psalm": "^4.3 || ^5.2"
     },
+
+    "repositories": [
+        {
+            "type": "github",
+            "url": "https://github.com/Jean85/prophecy"
+        }
+    ],
 
     "suggest": {
         "phpspec/nyan-formatters": "Adds Nyan formatters"


### PR DESCRIPTION
This is a continuation of #1443 to try and resolve the blockers, /cc @ciaranmcnulty

I expect the CI to have issues due to https://github.com/ramsey/composer-install/issues/241. I also have locally detected some failures, but they are only on test code:

In Behat:
```
001 Scenario: Generating a spec for class with namespace containing reserved keyword # features/code_generation/developer_generates_spec.feature:184
      And there should be no file "spec/Namespace/ClassExample1/MarkdownSpec.php"    # features/code_generation/developer_generates_spec.feature:187
        Fatal error: Call to undefined method PHPUnit\Framework\Assert::assertFileNotExists() (Behat\Testwork\Call\Exception\FatalThrowableError)
```
In PHPSpec:
```
PhpSpec/Formatter/Presenter/Differ/ObjectEngine                                                                                                                                                            
  17  - it is a differ engine                                                                                                                                                                              
      could not reflect class SebastianBergmann\Exporter\Exporter as it is marked final.                                                                                                                   
                                                                                                                                                                                                           
PhpSpec/Formatter/Presenter/Differ/ObjectEngine                                                                                                                                                            
  22  - it does not support scalars                                                                                                                                                                        
      could not reflect class SebastianBergmann\Exporter\Exporter as it is marked final.                                                                                                                   
                                                                                                                                                                                                           
PhpSpec/Formatter/Presenter/Differ/ObjectEngine                                                                                                                                                            
  27  - it only supports objects                                                                                                                                                                           
      could not reflect class SebastianBergmann\Exporter\Exporter as it is marked final.                                                                                                                   
                                                                                                                                                                                                           
PhpSpec/Formatter/Presenter/Differ/ObjectEngine                                                                                                                                                            
  32  - it converts objects to string and diffs the result                                                                                                                                                 
      could not reflect class SebastianBergmann\Exporter\Exporter as it is marked final.                                                                                                                   
```