### PR TITLE
Restore ScalarMatcher's priority order for PHP 8.0+

### DIFF
--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -95,7 +95,7 @@ final class ScalarMatcher implements Matcher
      */
     public function getPriority(): int
     {
-        return 50;
+        return 51;
     }
 
     /**


### PR DESCRIPTION
Fixes issue https://github.com/phpspec/phpspec/issues/1431

We already use this change with a composer patch since June 2022 without any side effect