### PR TITLE
Add stricter argument, property, and return types

### DIFF
--- a/features/configuration/developer_adds_extensions.feature
+++ b/features/configuration/developer_adds_extensions.feature
@@ -12,7 +12,7 @@ Feature: Developer enables extensions
 
       class Extension2 implements \PhpSpec\Extension
       {
-          public function load(\PhpSpec\ServiceContainer $container, array $params)
+          public function load(\PhpSpec\ServiceContainer $container, array $params) : void
           {
               throw new \Exception(get_class($this).' enabled'. print_r($params, true));
           }
@@ -38,7 +38,7 @@ Feature: Developer enables extensions
 
       class Extension3 implements \PhpSpec\Extension
       {
-          public function load(\PhpSpec\ServiceContainer $container, array $params)
+          public function load(\PhpSpec\ServiceContainer $container, array $params) : void
           {
               throw new \Exception(get_class($this).' enabled'. print_r($params, true));
           }
@@ -62,7 +62,7 @@ Feature: Developer enables extensions
 
       class NOPE implements \PhpSpec\Extension
       {
-          public function load(\PhpSpec\ServiceContainer $container, array $params)
+          public function load(\PhpSpec\ServiceContainer $container, array $params) : void
           {
               throw new \Exception(get_class($this).' enabled'. print_r($params, true));
           }
@@ -86,7 +86,7 @@ Feature: Developer enables extensions
 
       class Extension4 implements \PhpSpec\Extension
       {
-          public function load(\PhpSpec\ServiceContainer $container, array $params)
+          public function load(\PhpSpec\ServiceContainer $container, array $params) : void
           {
               throw new \Exception(get_class($this).' enabled'. print_r($params, true));
           }

--- a/features/extensions/developer_uses_bootstrap_config_key_in_any_place.feature
+++ b/features/extensions/developer_uses_bootstrap_config_key_in_any_place.feature
@@ -21,7 +21,7 @@ Feature: Developer uses bootstrap config key in any place
 
     class Extension implements PhpSpecExtension
     {
-        public function load(ServiceContainer $container, array $params)
+        public function load(ServiceContainer $container, array $params) : void
         {
             $container->get('console.io');
         }

--- a/features/extensions/developer_uses_extension.feature
+++ b/features/extensions/developer_uses_extension.feature
@@ -19,7 +19,7 @@ Feature: Developer uses extension
 
     class Extension implements PhpSpecExtension
     {
-        public function load(ServiceContainer $container, array $params)
+        public function load(ServiceContainer $container, array $params) : void
         {
             $container->define('matchers.seven', function (ServiceContainer $c) {
                 return new BeSevenMatcher($c->get('formatter.presenter'));
@@ -173,7 +173,7 @@ Feature: Developer uses extension
 
     class EventSubscriberExtension implements PhpSpecExtension
     {
-        public function load(ServiceContainer $compositeContainer, array $params)
+        public function load(ServiceContainer $compositeContainer, array $params) : void
         {
             $io = $compositeContainer->get('console.io');
             $eventDispatcher = $compositeContainer->get('event_dispatcher');

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,9 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
+        <MissingParamType><errorLevel type="error"/></MissingParamType>
+        <MissingReturnType><errorLevel type="error"/></MissingReturnType>
+        <MissingPropertyType><errorLevel type="error"/></MissingPropertyType>
         <DuplicateClass>
             <errorLevel type="suppress">
                 <!-- duplicate classes are inside a conditional so not an error -->

--- a/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/ClassGeneratorSpec.php
@@ -99,7 +99,7 @@ class ClassGeneratorSpec extends ObjectBehavior
         $fs->pathExists('/project/src/Acme/App.php')->willReturn(false);
         $fs->isDirectory('/project/src/Acme')->willReturn(false);
         $fs->makeDirectory('/project/src/Acme')->shouldBeCalled();
-        $fs->putFileContents('/project/src/Acme/App.php', Argument::any())->willReturn(null);
+        $fs->putFileContents('/project/src/Acme/App.php', Argument::any())->shouldBeCalled();
 
         $this->generate($resource);
     }

--- a/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
@@ -106,7 +106,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
         $fs->pathExists('/project/spec/Acme/AppSpec.php')->willReturn(false);
         $fs->isDirectory('/project/spec/Acme')->willReturn(false);
         $fs->makeDirectory('/project/spec/Acme')->shouldBeCalled();
-        $fs->putFileContents('/project/spec/Acme/AppSpec.php', Argument::any())->willReturn(null);
+        $fs->putFileContents('/project/spec/Acme/AppSpec.php', Argument::any())->shouldBeCalled();
 
         $this->generate($resource);
     }

--- a/spec/PhpSpec/Config/OptionsConfigSpec.php
+++ b/spec/PhpSpec/Config/OptionsConfigSpec.php
@@ -39,7 +39,7 @@ class OptionsConfigSpec extends ObjectBehavior
     {
         $this->beConstructedWith(false, false, false, false, false, false);
 
-        $this->getBootstrapPath()->shouldReturn(false);
+        $this->getBootstrapPath()->shouldReturn(null);
     }
 
     function it_returns_bootstrap_path_when_one_is_specified()

--- a/spec/PhpSpec/Event/ExampleEventSpec.php
+++ b/spec/PhpSpec/Event/ExampleEventSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Event;
 
+use PhpSpec\Event\ExampleEvent;
 use PhpSpec\ObjectBehavior;
 
 use PhpSpec\Loader\Node\ExampleNode;
@@ -48,7 +49,7 @@ class ExampleEventSpec extends ObjectBehavior
 
     function it_provides_a_link_to_result()
     {
-        $this->getResult()->shouldReturn($this->FAILED);
+        $this->getResult()->shouldReturn(ExampleEvent::FAILED);
     }
 
     function it_provides_a_link_to_exception($exception)
@@ -60,7 +61,7 @@ class ExampleEventSpec extends ObjectBehavior
     {
         $this->beConstructedWith($example);
 
-        $this->getResult()->shouldReturn($this->PASSED);
+        $this->getResult()->shouldReturn(ExampleEvent::PASSED);
     }
 
     function it_initializes_a_default_time(ExampleNode $example)

--- a/spec/PhpSpec/Event/ExpectationEventSpec.php
+++ b/spec/PhpSpec/Event/ExpectationEventSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Event;
 
+use PhpSpec\Event\ExpectationEvent;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Loader\Suite;
 use PhpSpec\Loader\Node\SpecificationNode;
@@ -66,7 +67,7 @@ class ExpectationEventSpec extends ObjectBehavior
 
     function it_provides_a_link_to_result()
     {
-        $this->getResult()->shouldReturn($this->FAILED);
+        $this->getResult()->shouldReturn(ExpectationEvent::FAILED);
     }
 
     function it_provides_a_link_to_exception($exception)
@@ -81,6 +82,6 @@ class ExpectationEventSpec extends ObjectBehavior
 
         $this->beConstructedWith($example, $matcher, $subject, $method, $arguments);
 
-        $this->getResult()->shouldReturn($this->PASSED);
+        $this->getResult()->shouldReturn(ExpectationEvent::PASSED);
     }
 }

--- a/spec/PhpSpec/Formatter/HtmlFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/HtmlFormatterSpec.php
@@ -2,12 +2,12 @@
 
 namespace spec\PhpSpec\Formatter;
 
+use PhpSpec\Formatter\Html\ReportPassedItem;
 use PhpSpec\IO\IO;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 use PhpSpec\Event\ExampleEvent;
-use PhpSpec\Formatter\Html\ReportItem;
 use PhpSpec\Formatter\Html\ReportItemFactory;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Listener\StatisticsCollector;
@@ -27,7 +27,7 @@ class HtmlFormatterSpec extends ObjectBehavior
     }
 
     function it_delegates_the_reporting_to_the_event_type_line_reporter(
-        ExampleEvent $event, ReportItem $item, ReportItemFactory $factory,
+        ExampleEvent $event, ReportPassedItem $item, ReportItemFactory $factory,
         Presenter $presenter)
     {
         $factory->create($event, $presenter)->willReturn($item);

--- a/spec/PhpSpec/Formatter/JUnitFormatterSpec.php
+++ b/spec/PhpSpec/Formatter/JUnitFormatterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpSpec\Formatter;
 
+use Exception;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\IO\IO;
@@ -55,7 +56,7 @@ class JUnitFormatterSpec extends ObjectBehavior
         $event->getTitle()->willReturn('example title');
         $event->getTime()->willReturn(1337);
 
-        $event->getException()->willReturn(new ExceptionStub('Something went wrong', 'Exception trace'));
+        $event->getException()->willReturn(new Exception('Something went wrong'));
 
         $event->getSpecification()->willReturn($specification);
         $specification->getClassReflection()->willReturn($refClass);
@@ -63,16 +64,18 @@ class JUnitFormatterSpec extends ObjectBehavior
 
         $this->afterExample($event);
 
-        $this->getTestCaseNodes()->shouldReturn(array(
+        $testCaseNode = $this->getTestCaseNodes()[0];
+
+        $testCaseNode->shouldStartWith(
             '<testcase name="example title" time="1337.000000" classname="Acme\Foo\Bar" status="broken">'."\n".
-                '<error type="spec\PhpSpec\Formatter\ExceptionStub" message="Something went wrong" />'."\n".
-                '<system-err>'."\n".
-                    '<![CDATA['."\n".
-                        'Exception trace'."\n".
-                    ']]>'."\n".
-                '</system-err>'."\n".
+                '<error type="Exception" message="Something went wrong" />'."\n".
+                '<system-err>'
+        );
+
+        $testCaseNode->shouldEndWith(
+            '</system-err>'."\n".
             '</testcase>'
-        ));
+        );
     }
 
     function it_stores_a_testcase_node_after_failed_example_run(
@@ -84,7 +87,7 @@ class JUnitFormatterSpec extends ObjectBehavior
         $event->getTitle()->willReturn('example title');
         $event->getTime()->willReturn(1337);
 
-        $event->getException()->willReturn(new ExceptionStub('Something went wrong', 'Exception trace'));
+        $event->getException()->willReturn(new Exception('Something went wrong'));
 
         $event->getSpecification()->willReturn($specification);
         $specification->getClassReflection()->willReturn($refClass);
@@ -92,16 +95,18 @@ class JUnitFormatterSpec extends ObjectBehavior
 
         $this->afterExample($event);
 
-        $this->getTestCaseNodes()->shouldReturn(array(
+        $testCaseNode = $this->getTestCaseNodes()[0];
+
+        $testCaseNode->shouldStartWith(
             '<testcase name="example title" time="1337.000000" classname="Acme\Foo\Bar" status="failed">'."\n".
-                '<failure type="spec\PhpSpec\Formatter\ExceptionStub" message="Something went wrong" />'."\n".
-                '<system-err>'."\n".
-                    '<![CDATA['."\n".
-                        'Exception trace'."\n".
-                    ']]>'."\n".
+                '<failure type="Exception" message="Something went wrong" />'."\n".
+                '<system-err>'
+        );
+
+        $testCaseNode->shouldEndWith(
                 '</system-err>'."\n".
             '</testcase>'
-        ));
+        );
     }
 
     function it_stores_a_testcase_node_after_skipped_example_run(
@@ -199,27 +204,5 @@ class JUnitFormatterSpec extends ObjectBehavior
                 '</testsuite>'."\n".
             '</testsuites>'
         )->shouldBeCalled();
-    }
-}
-
-class ExceptionStub
-{
-    protected $trace;
-    protected $message;
-
-    public function __construct($message, $trace)
-    {
-        $this->message = $message;
-        $this->trace   = $trace;
-    }
-
-    public function getMessage()
-    {
-        return $this->message;
-    }
-
-    public function getTraceAsString()
-    {
-        return $this->trace;
     }
 }

--- a/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
+++ b/spec/PhpSpec/Listener/MethodReturnedNullListenerSpec.php
@@ -14,6 +14,7 @@ use PhpSpec\ObjectBehavior;
 use PhpSpec\Util\MethodAnalyser;
 use Prophecy\Argument;
 use PhpSpec\Exception\Example\MethodFailureException;
+use stdClass;
 
 class MethodReturnedNullListenerSpec extends ObjectBehavior
 {
@@ -33,10 +34,10 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         $methodFailureException->getActual()->willReturn(null);
         $methodFailureException->getExpected()->willReturn(100);
         $methodFailureException->getSubject()->willReturn(null);
-        $methodFailureException->getMethod()->willReturn(null);
+        $methodFailureException->getMethod()->willReturn('');
 
         $methodCallEvent->getMethod()->willReturn('foo');
-        $methodCallEvent->getSubject()->willReturn(new \stdClass);
+        $methodCallEvent->getSubject()->willReturn(new stdClass);
 
         $io->isCodeGenerationEnabled()->willReturn(true);
 
@@ -123,7 +124,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io, ResourceManager $resourceManager, SuiteEvent $event
     ) {
         $resourceManager->createResource(Argument::any())->willThrow(new \RuntimeException());
-        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getSubject()->willReturn(new stdClass());
         $methodCallEvent->getMethod()->willReturn('');
 
         $this->afterMethodCall($methodCallEvent);
@@ -137,7 +138,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io, SuiteEvent $event
     ) {
         $io->isCodeGenerationEnabled()->willReturn(false);
-        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getSubject()->willReturn(new stdClass());
         $methodCallEvent->getMethod()->willReturn('');
 
         $this->afterMethodCall($methodCallEvent);
@@ -175,7 +176,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         $notEqualException->getExpected()->willReturn('foo');
         $notEqualException2->getExpected()->willReturn('bar');
 
-        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getSubject()->willReturn(new stdClass());
         $methodCallEvent->getMethod()->willReturn('');
 
         $this->afterMethodCall($methodCallEvent);
@@ -193,7 +194,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io, SuiteEvent $event
     ) {
         $io->isFakingEnabled()->willReturn(false);
-        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getSubject()->willReturn(new stdClass());
         $methodCallEvent->getMethod()->willReturn('');
 
         $this->afterMethodCall($methodCallEvent);
@@ -206,7 +207,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
     function it_prompts_when_correct_type_of_exception_is_thrown(
         MethodCallEvent $methodCallEvent, ExampleEvent $exampleEvent, ConsoleIO $io, SuiteEvent $event
     ) {
-        $methodCallEvent->getSubject()->willReturn(new \stdClass());
+        $methodCallEvent->getSubject()->willReturn(new stdClass());
         $methodCallEvent->getMethod()->willReturn('');
 
         $this->afterMethodCall($methodCallEvent);
@@ -219,7 +220,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
     function it_prompts_if_no_method_was_called_beforehand_but_subject_and_method_are_set_on_the_exception(
         ExampleEvent $exampleEvent, ConsoleIO $io, SuiteEvent $event, MethodFailureException $methodFailureException
     ) {
-        $methodFailureException->getSubject()->willReturn(new \stdClass());
+        $methodFailureException->getSubject()->willReturn(new stdClass());
         $methodFailureException->getMethod()->willReturn('myMethod');
 
         $this->afterExample($exampleEvent);
@@ -235,7 +236,7 @@ class MethodReturnedNullListenerSpec extends ObjectBehavior
         $io->askConfirmation(Argument::any())->willReturn(true);
         $resourceManager->createResource(Argument::any())->willReturn($resource);
 
-        $methodCallEvent->getSubject()->willReturn(new \StdClass());
+        $methodCallEvent->getSubject()->willReturn(new stdClass());
         $methodCallEvent->getMethod()->willReturn('myMethod');
 
         $this->afterMethodCall($methodCallEvent);

--- a/spec/PhpSpec/Runner/CollaboratorManagerSpec.php
+++ b/spec/PhpSpec/Runner/CollaboratorManagerSpec.php
@@ -9,6 +9,7 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 use ReflectionFunction;
 use ReflectionParameter;
+use stdClass;
 
 class CollaboratorManagerSpec extends ObjectBehavior
 {
@@ -41,28 +42,28 @@ class CollaboratorManagerSpec extends ObjectBehavior
     function it_creates_function_arguments_for_ReflectionFunction(
         ReflectionFunction $function, ReflectionParameter $param1, ReflectionParameter $param2
     ) {
-        $this->set('arg1', '123');
-        $this->set('arg2', '456');
-        $this->set('arg3', '789');
+        $this->set('arg1', $arg1 = new stdClass);
+        $this->set('arg2', new stdClass);
+        $this->set('arg3', $arg3 = new stdClass);
 
         $function->getParameters()->willReturn(array($param1, $param2));
         $param1->getName()->willReturn('arg1');
         $param2->getName()->willReturn('arg3');
 
-        $this->getArgumentsFor($function)->shouldReturn(array('123', '789'));
+        $this->getArgumentsFor($function)->shouldReturn([$arg1, $arg3]);
     }
 
     function it_creates_null_function_arguments_for_ReflectionFunction_if_no_collaborator_found(
         ReflectionFunction $function, ReflectionParameter $param1, ReflectionParameter $param2
     ) {
-        $this->set('arg1', '123');
-        $this->set('arg2', '456');
-        $this->set('arg3', '789');
+        $this->set('arg1', new stdClass);
+        $this->set('arg2', new stdClass);
+        $this->set('arg3', $arg3 = new stdClass);
 
         $function->getParameters()->willReturn(array($param1, $param2));
         $param1->getName()->willReturn('arg4');
         $param2->getName()->willReturn('arg3');
 
-        $this->getArgumentsFor($function)->shouldReturn(array(null, '789'));
+        $this->getArgumentsFor($function)->shouldReturn(array(null, $arg3));
     }
 }

--- a/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
+++ b/spec/PhpSpec/ServiceContainer/IndexedServiceContainerSpec.php
@@ -3,6 +3,7 @@
 namespace spec\PhpSpec\ServiceContainer;
 
 use PhpSpec\ObjectBehavior;
+use stdClass;
 
 class IndexedServiceContainerSpec extends ObjectBehavior
 {
@@ -46,14 +47,14 @@ class IndexedServiceContainerSpec extends ObjectBehavior
 
     function it_returns_services_which_are_set_using_tags($service)
     {
-        $obj = new \StdClass();
+        $obj = new StdClass();
         $this->set('some_service', $obj, ['some_tag']);
         $this->getByTag('some_tag')->shouldReturn([$obj]);
     }
 
     function it_returns_services_which_are_defined_using_tags()
     {
-        $obj = new \StdClass();
+        $obj = new StdClass();
         $this->define('some_service', function () use ($obj) { return $obj; }, ['some_tag']);
         $this->getByTag('some_tag')->shouldReturn([$obj]);
     }
@@ -65,22 +66,30 @@ class IndexedServiceContainerSpec extends ObjectBehavior
 
     function it_evaluates_factory_function_only_once_for_shared_services()
     {
-        $this->define('random_number', function () { return rand(); });
-        $number1 = $this->get('random_number');
-        $number2 = $this->get('random_number');
+        $this->define('random_number', function () {
+            $obj = new stdClass();
+            $obj->num = rand();
+
+            return $obj;
+        });
+        $number1 = $this->get('random_number')->num;
+        $number2 = $this->get('random_number')->num;
 
         $number2->shouldBe($number1);
     }
 
     function it_uses_new_definition_when_a_service_is_redefined()
     {
-        $this->define('some_service', function () { return 1; });
+        $class1 = new stdClass();
+        $class2 = new stdClass();
+
+        $this->define('some_service', fn () => $class1);
         $this->get('some_service');
 
 
-        $this->define('some_service', function () { return 2; });
+        $this->define('some_service', fn () => $class2);
 
-        $this->get('some_service')->shouldBe(2);
+        $this->get('some_service')->shouldBe($class2);
     }
 
 

--- a/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
@@ -14,6 +14,7 @@ use PhpSpec\Wrapper\Subject;
 
 use PhpSpec\Loader\Node\ExampleNode;
 
+use stdClass;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface as Dispatcher;
 
 use PhpSpec\ObjectBehavior;
@@ -33,7 +34,7 @@ class CallerSpec extends ObjectBehavior
         $wrappedObject->isInstantiated()->willReturn(false);
         $wrappedObject->getClassName()->willReturn(null);
         $wrappedObject->getInstance()->willReturn(null);
-        $exceptions->propertyNotFound(Argument::cetera())->willReturn(new PropertyNotFoundException('Message', 'subject', 'prop'));
+        $exceptions->propertyNotFound(Argument::cetera())->willReturn(new PropertyNotFoundException('Message', new stdClass, 'prop'));
 
         $accessInspector->isMethodCallable(Argument::cetera())->willReturn(false);
         $dispatcher->dispatch(Argument::any(), Argument::any())->willReturnArgument(0);

--- a/spec/PhpSpec/Wrapper/Subject/Expectation/DecoratorSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/Expectation/DecoratorSpec.php
@@ -32,7 +32,7 @@ class DecoratorSpec extends ObjectBehavior
 
 class Decorator extends AbstractDecorator
 {
-    public function match(string $alias, $subject, array $arguments = array())
+    public function match(string $alias, $subject, array $arguments = array()) : ?bool
     {
     }
 }

--- a/src/PhpSpec/CodeAnalysis/AccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/AccessInspector.php
@@ -15,18 +15,9 @@ namespace PhpSpec\CodeAnalysis;
 
 interface AccessInspector
 {
-    /**
-     * @param object $object
-     */
-    public function isPropertyReadable($object, string $property): bool;
+    public function isPropertyReadable(object $object, string $property): bool;
 
-    /**
-     * @param object $object
-     */
-    public function isPropertyWritable($object, string $property): bool;
+    public function isPropertyWritable(object $object, string $property): bool;
 
-    /**
-     * @param object $object
-     */
-    public function isMethodCallable($object, string $method): bool;
+    public function isMethodCallable(object $object, string $method): bool;
 }

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -15,37 +15,23 @@ namespace PhpSpec\CodeAnalysis;
 
 final class MagicAwareAccessInspector implements AccessInspector
 {
-    /**
-     * @var AccessInspector
-     */
-    private $accessInspector;
-
-    
-    public function __construct(AccessInspector $accessInspector)
+    public function __construct(
+        private AccessInspector $accessInspector
+    )
     {
-        $this->accessInspector = $accessInspector;
     }
 
-    /**
-     * @param object $object
-     */
-    public function isPropertyReadable($object, string $property): bool
+    public function isPropertyReadable(object $object, string $property): bool
     {
         return method_exists($object, '__get') || $this->accessInspector->isPropertyReadable($object, $property);
     }
 
-    /**
-     * @param object $object
-     */
-    public function isPropertyWritable($object, string $property): bool
+    public function isPropertyWritable(object $object, string $property): bool
     {
         return method_exists($object, '__set') || $this->accessInspector->isPropertyWritable($object, $property);
     }
 
-    /**
-     * @param object $object
-     */
-    public function isMethodCallable($object, string $method): bool
+    public function isMethodCallable(object $object, string $method): bool
     {
         return method_exists($object, '__call') || $this->accessInspector->isMethodCallable($object, $method);
     }

--- a/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/StaticRejectingNamespaceResolver.php
@@ -15,14 +15,10 @@ namespace PhpSpec\CodeAnalysis;
 
 final class StaticRejectingNamespaceResolver implements NamespaceResolver
 {
-    /**
-     * @var NamespaceResolver
-     */
-    private $namespaceResolver;
-
-    public function __construct(NamespaceResolver $namespaceResolver)
+    public function __construct(
+        private NamespaceResolver $namespaceResolver
+    )
     {
-        $this->namespaceResolver = $namespaceResolver;
     }
 
     public function analyse(string $code): void
@@ -39,9 +35,8 @@ final class StaticRejectingNamespaceResolver implements NamespaceResolver
 
     /**
      * @throws \Exception
-     * @return void
      */
-    private function guardNonObjectTypeHints(string $typeAlias)
+    private function guardNonObjectTypeHints(string $typeAlias) : void
     {
         $nonObjectTypes = [
             'int',

--- a/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php
@@ -20,20 +20,19 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
     const STATE_READING_USE = 2;
     const STATE_READING_USE_GROUP = 3;
 
-    private $state = self::STATE_DEFAULT;
+    private int $state = self::STATE_DEFAULT;
 
-    private $currentNamespace;
-    private $currentUseGroup;
-    private $currentUse;
-    private $uses = array();
+    private string $currentNamespace = '';
+    private string $currentUseGroup = '';
+    private string $currentUse = '';
+    private array $uses = [];
 
-    
     public function analyse(string $code): void
     {
         $this->state = self::STATE_DEFAULT;
-        $this->currentUse = null;
-        $this->currentUseGroup = null;
-        $this->uses = array();
+        $this->currentUse = '';
+        $this->currentUseGroup = '';
+        $this->uses = [];
 
         $tokens = token_get_all($code);
 
@@ -52,7 +51,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
                 case self::STATE_READING_USE_GROUP:
                     if ('}' == $token) {
                         $this->state = self::STATE_READING_USE;
-                        $this->currentUseGroup = null;
+                        $this->currentUseGroup = '';
                     }
                     elseif (',' == $token) {
                         $this->storeCurrentUse();
@@ -111,7 +110,7 @@ final class TokenizedNamespaceResolver implements NamespaceResolver
         return $typeAlias;
     }
 
-    private function storeCurrentUse()
+    private function storeCurrentUse() : void
     {
         if (preg_match('/\s*(.*)\s+as\s+(.*)\s*/', $this->currentUse, $matches)) {
             $this->uses[strtolower(trim($matches[2]))] = trim($matches[1]);

--- a/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TokenizedTypeHintRewriter.php
@@ -23,26 +23,19 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
     const STATE_READING_ARGUMENTS = 3;
     const STATE_READING_FUNCTION_BODY = 4;
 
-    private $state = self::STATE_DEFAULT;
+    private int $state = self::STATE_DEFAULT;
 
-    private $currentClass;
-    private $currentFunction;
-    private $currentBodyLevel;
+    private string $currentClass = '';
+    private string $currentFunction = '';
+    private int $currentBodyLevel = 0;
 
-    private $typehintTokens = array(
+    private array $typehintTokens = array(
         T_WHITESPACE, T_STRING, T_NS_SEPARATOR
     );
 
-    /**
-     * @var TypeHintIndex
-     */
-    private $typeHintIndex;
-    /**
-     * @var NamespaceResolver
-     */
-    private $namespaceResolver;
+    private TypeHintIndex $typeHintIndex;
+    private NamespaceResolver $namespaceResolver;
 
-    
     public function __construct(TypeHintIndex $typeHintIndex, NamespaceResolver $namespaceResolver)
     {
         $this->typeHintIndex = $typeHintIndex;
@@ -110,7 +103,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
                     }
                     elseif ('}' == $token && $this->currentClass) {
                         $this->state = self::STATE_DEFAULT;
-                        $this->currentClass = null;
+                        $this->currentClass = '';
                     }
                     elseif ($this->tokenHasType($token, T_STRING) && !$this->currentClass && $this->shouldExtractTokensOfClass($token[1])) {
                         $this->currentClass = $token[1];
@@ -136,7 +129,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         return $tokens;
     }
 
-    
+
     private function tokensToString(array $tokens): string
     {
         return join('', array_map(function ($token) {
@@ -200,7 +193,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         }
     }
 
-    private function haveNotReachedEndOfTypeHint($token) : bool
+    private function haveNotReachedEndOfTypeHint(string|array $token) : bool
     {
         // PHP 8.1 returns the intersection token `&` as an array,
         // while previous versions return it as a string.
@@ -211,10 +204,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         return !\in_array($token[0], $this->typehintTokens);
     }
 
-    /**
-     * @param array|string $token
-     */
-    private function tokenHasType($token, int $type): bool
+    private function tokenHasType(array|string $token, int $type): bool
     {
         return \is_array($token) && $type == $token[0];
     }
@@ -224,10 +214,7 @@ final class TokenizedTypeHintRewriter implements TypeHintRewriter
         return substr($className, -4) == 'Spec';
     }
 
-    /**
-     * @param array|string $token
-     */
-    private function isToken($token, string $string): bool
+    private function isToken(array|string $token, string $string): bool
     {
         return $token == $string || (\is_array($token) && $token[1] == $string);
     }

--- a/src/PhpSpec/CodeAnalysis/TypeHintRewriter.php
+++ b/src/PhpSpec/CodeAnalysis/TypeHintRewriter.php
@@ -15,6 +15,5 @@ namespace PhpSpec\CodeAnalysis;
 
 interface TypeHintRewriter
 {
-    
     public function rewrite(string $classDefinition): string;
 }

--- a/src/PhpSpec/CodeAnalysis/VisibilityAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/VisibilityAccessInspector.php
@@ -18,26 +18,17 @@ use ReflectionProperty;
 
 final class VisibilityAccessInspector implements AccessInspector
 {
-    /**
-     * @param object $object
-     */
-    public function isPropertyReadable($object, string $property): bool
+    public function isPropertyReadable(object $object, string $property): bool
     {
         return $this->isExistingPublicProperty($object, $property);
     }
 
-    /**
-     * @param object $object
-     */
-    public function isPropertyWritable($object, string $property): bool
+    public function isPropertyWritable(object $object, string $property): bool
     {
         return $this->isExistingPublicProperty($object, $property);
     }
 
-    /**
-     * @param object $object
-     */
-    private function isExistingPublicProperty($object, string $property): bool
+    private function isExistingPublicProperty(object $object, string $property): bool
     {
         if (!property_exists($object, $property)) {
             return false;
@@ -48,18 +39,12 @@ final class VisibilityAccessInspector implements AccessInspector
         return $propertyReflection->isPublic();
     }
 
-    /**
-     * @param object $object
-     */
-    public function isMethodCallable($object, string $method): bool
+    public function isMethodCallable(object $object, string $method): bool
     {
         return $this->isExistingPublicMethod($object, $method);
     }
 
-    /**
-     * @param object $object
-     */
-    private function isExistingPublicMethod($object, string $method): bool
+    private function isExistingPublicMethod(object $object, string $method): bool
     {
         if (!method_exists($object, $method)) {
             return false;

--- a/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ConfirmingGenerator.php
@@ -18,26 +18,11 @@ use PhpSpec\Locator\Resource;
 
 final class ConfirmingGenerator implements Generator
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
-     * @var string
-     */
-    private $message;
-
-    /**
-     * @var Generator
-     */
-    private $generator;
-
-    public function __construct(ConsoleIO $io, string $message, Generator $generator)
+    public function __construct(
+        private ConsoleIO $io,
+        private string $message,
+        private Generator $generator)
     {
-        $this->io = $io;
-        $this->message = $message;
-        $this->generator = $generator;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool
@@ -45,9 +30,6 @@ final class ConfirmingGenerator implements Generator
         return $this->generator->supports($resource, $generation, $data);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function generate(Resource $resource, array $data): void
     {
         if ($this->io->askConfirmation($this->composeMessage($resource))) {

--- a/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/CreateObjectTemplate.php
@@ -17,17 +17,13 @@ use PhpSpec\CodeGenerator\TemplateRenderer;
 
 class CreateObjectTemplate
 {
-    private $templates;
-    private $methodName;
-    private $arguments;
-    private $className;
-
-    public function __construct(TemplateRenderer $templates, $methodName, $arguments, $className)
+    public function __construct(
+        private TemplateRenderer $templates,
+        private string $methodName,
+        private array $arguments,
+        private string $className
+    )
     {
-        $this->templates  = $templates;
-        $this->methodName = $methodName;
-        $this->arguments  = $arguments;
-        $this->className  = $className;
     }
 
     public function getContent(): string

--- a/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ExistingConstructorTemplate.php
@@ -18,19 +18,13 @@ use ReflectionMethod;
 
 class ExistingConstructorTemplate
 {
-    private $templates;
-    private $class;
-    private $className;
-    private $arguments;
-    private $methodName;
-
-    public function __construct(TemplateRenderer $templates, string $methodName, array $arguments, string $className, string $class)
+    public function __construct(
+        private TemplateRenderer $templates,
+        private string $methodName,
+        private array $arguments,
+        private string $className,
+        private string $class)
     {
-        $this->templates  = $templates;
-        $this->class      = $class;
-        $this->className  = $className;
-        $this->arguments  = $arguments;
-        $this->methodName = $methodName;
     }
 
     public function getContent(): string
@@ -105,13 +99,13 @@ class ExistingConstructorTemplate
         );
     }
 
-    
+
     private function getCreateObjectTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/named_constructor_create_object.template');
     }
 
-    
+
     private function getExceptionTemplate(): string
     {
         return file_get_contents(__DIR__.'/templates/named_constructor_exception.template');

--- a/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodGenerator.php
@@ -24,33 +24,13 @@ use PhpSpec\Locator\Resource;
  */
 final class MethodGenerator implements Generator
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
-     * @var TemplateRenderer
-     */
-    private $templates;
-
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * @var CodeWriter
-     */
-    private $codeWriter;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(
+        private ConsoleIO $io,
+        private TemplateRenderer $templates,
+        private Filesystem $filesystem,
+        private CodeWriter $codeWriter
+    )
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
-        $this->codeWriter = $codeWriter;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool
@@ -58,7 +38,7 @@ final class MethodGenerator implements Generator
         return 'method' === $generation;
     }
 
-    
+
     public function generate(Resource $resource, array $data = array()): void
     {
         $filepath  = $resource->getSrcFilename();

--- a/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/MethodSignatureGenerator.php
@@ -23,27 +23,12 @@ use PhpSpec\Locator\Resource;
  */
 final class MethodSignatureGenerator implements Generator
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
-     * @var TemplateRenderer
-     */
-    private $templates;
-
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
+    public function __construct(
+        private ConsoleIO $io,
+        private TemplateRenderer $templates,
+        private Filesystem $filesystem
+    )
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool
@@ -84,7 +69,7 @@ final class MethodSignatureGenerator implements Generator
         return file_get_contents(__DIR__.'/templates/interface_method_signature.template');
     }
 
-    private function insertMethodSignature(string $filepath, string $content)
+    private function insertMethodSignature(string $filepath, string $content) : void
     {
         $code = $this->filesystem->getFileContents($filepath);
         $code = preg_replace('/}[ \n]*$/', rtrim($content) . "\n}\n", trim($code));

--- a/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NamedConstructorGenerator.php
@@ -22,32 +22,13 @@ use PhpSpec\Util\Filesystem;
 
 final class NamedConstructorGenerator implements Generator
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
-     * @var TemplateRenderer
-     */
-    private $templates;
-
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-    /**
-     * @var CodeWriter
-     */
-    private $codeWriter;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(
+        private ConsoleIO $io,
+        private TemplateRenderer $templates,
+        private Filesystem $filesystem,
+        private CodeWriter $codeWriter
+    )
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
-        $this->codeWriter = $codeWriter;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool
@@ -55,7 +36,6 @@ final class NamedConstructorGenerator implements Generator
         return 'named_constructor' === $generation;
     }
 
-    
     public function generate(Resource $resource, array $data = array()): void
     {
         $filepath   = $resource->getSrcFilename();

--- a/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/NewFileNotifyingGenerator.php
@@ -12,27 +12,11 @@ final class NewFileNotifyingGenerator implements Generator
 {
     use DispatchTrait;
 
-    /**
-     * @var Generator
-     */
-    private $generator;
-
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    
-    public function __construct(Generator $generator, EventDispatcherInterface $dispatcher, Filesystem $filesystem)
+    public function __construct(
+        private Generator $generator,
+        private EventDispatcherInterface $dispatcher,
+        private Filesystem $filesystem)
     {
-        $this->generator = $generator;
-        $this->dispatcher = $dispatcher;
-        $this->filesystem = $filesystem;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/OneTimeGenerator.php
@@ -17,20 +17,12 @@ use PhpSpec\Locator\Resource;
 
 final class OneTimeGenerator implements Generator
 {
-    /**
-     * @var Generator
-     */
-    private $generator;
+    private array $alreadyGenerated = [];
 
-    /**
-     * @var array
-     */
-    private $alreadyGenerated = array();
-
-    
-    public function __construct(Generator $generator)
+    public function __construct(
+        private Generator $generator
+    )
     {
-        $this->generator = $generator;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool
@@ -38,9 +30,6 @@ final class OneTimeGenerator implements Generator
         return $this->generator->supports($resource, $generation, $data);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function generate(Resource $resource, array $data): void
     {
         $classname = $resource->getSrcClassname();

--- a/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PrivateConstructorGenerator.php
@@ -22,33 +22,13 @@ use PhpSpec\Util\Filesystem;
 
 final class PrivateConstructorGenerator implements Generator
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
-     * @var TemplateRenderer
-     */
-    private $templates;
-
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * @var CodeWriter
-     */
-    private $codeWriter;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, CodeWriter $codeWriter)
+    public function __construct(
+        private ConsoleIO $io,
+        private TemplateRenderer $templates,
+        private Filesystem $filesystem,
+        private CodeWriter $codeWriter
+    )
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
-        $this->codeWriter = $codeWriter;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool
@@ -56,7 +36,7 @@ final class PrivateConstructorGenerator implements Generator
         return 'private-constructor' === $generation;
     }
 
-    
+
     public function generate(Resource $resource, array $data): void
     {
         $filepath  = $resource->getSrcFilename();

--- a/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/PromptingGenerator.php
@@ -24,36 +24,15 @@ use PhpSpec\Locator\Resource;
  */
 abstract class PromptingGenerator implements Generator
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
-     * @var TemplateRenderer
-     */
-    private $templates;
-
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * @var ExecutionContext
-     */
-    private $executionContext;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem, ExecutionContext $executionContext)
+    public function __construct(
+        private ConsoleIO $io,
+        private TemplateRenderer $templates,
+        private Filesystem $filesystem,
+        private ExecutionContext $executionContext
+    )
     {
-        $this->io         = $io;
-        $this->templates  = $templates;
-        $this->filesystem = $filesystem;
-        $this->executionContext = $executionContext;
     }
 
-    
     public function generate(Resource $resource, array $data = array()): void
     {
         $filepath = $this->getFilePath($resource);
@@ -80,7 +59,7 @@ abstract class PromptingGenerator implements Generator
 
     abstract protected function renderTemplate(Resource $resource, string $filepath): string;
 
-    
+
     abstract protected function getGeneratedMessage(Resource $resource, string $filepath): string;
 
     private function fileAlreadyExists(string $filepath): bool
@@ -95,7 +74,7 @@ abstract class PromptingGenerator implements Generator
         return !$this->io->askConfirmation($message, false);
     }
 
-    private function createDirectoryIfItDoesExist(string $filepath)
+    private function createDirectoryIfItDoesExist(string $filepath) : void
     {
         $path = dirname($filepath);
         if (!$this->filesystem->isDirectory($path)) {
@@ -103,7 +82,7 @@ abstract class PromptingGenerator implements Generator
         }
     }
 
-    private function generateFileAndRenderTemplate(Resource $resource, string $filepath)
+    private function generateFileAndRenderTemplate(Resource $resource, string $filepath) : void
     {
         $content = $this->renderTemplate($resource, $filepath);
 

--- a/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ReturnConstantGenerator.php
@@ -20,25 +20,11 @@ use PhpSpec\Util\Filesystem;
 
 final class ReturnConstantGenerator implements Generator
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-    /**
-     * @var TemplateRenderer
-     */
-    private $templates;
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    
-    public function __construct(ConsoleIO $io, TemplateRenderer $templates, Filesystem $filesystem)
+    public function __construct(
+        private ConsoleIO $io,
+        private TemplateRenderer $templates,
+        private Filesystem $filesystem)
     {
-        $this->io = $io;
-        $this->templates = $templates;
-        $this->filesystem = $filesystem;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool
@@ -46,7 +32,7 @@ final class ReturnConstantGenerator implements Generator
         return 'returnConstant' == $generation;
     }
 
-    
+
     public function generate(Resource $resource, array $data): void
     {
         $method = $data['method'];

--- a/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/SpecificationGenerator.php
@@ -32,7 +32,6 @@ final class SpecificationGenerator extends PromptingGenerator
         return 0;
     }
 
-    
     protected function renderTemplate(Resource $resource, string $filepath): string
     {
         $values = array(

--- a/src/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGenerator.php
+++ b/src/PhpSpec/CodeGenerator/Generator/ValidateClassNameSpecificationGenerator.php
@@ -20,16 +20,12 @@ use PhpSpec\Locator\Resource;
 
 final class ValidateClassNameSpecificationGenerator implements Generator
 {
-
-    private $classNameChecker;
-    private $io;
-    private $originalGenerator;
-
-    public function __construct(NameChecker $classNameChecker, ConsoleIO $io, Generator $originalGenerator)
+    public function __construct(
+        private NameChecker $classNameChecker,
+        private ConsoleIO $io,
+        private Generator $originalGenerator
+    )
     {
-        $this->classNameChecker = $classNameChecker;
-        $this->io = $io;
-        $this->originalGenerator = $originalGenerator;
     }
 
     public function supports(Resource $resource, string $generation, array $data): bool

--- a/src/PhpSpec/CodeGenerator/GeneratorManager.php
+++ b/src/PhpSpec/CodeGenerator/GeneratorManager.php
@@ -25,9 +25,8 @@ class GeneratorManager
     /**
      * @var Generator[]
      */
-    private $generators = array();
+    private array $generators = [];
 
-    
     public function registerGenerator(Generator $generator): void
     {
         $this->generators[] = $generator;

--- a/src/PhpSpec/CodeGenerator/TemplateRenderer.php
+++ b/src/PhpSpec/CodeGenerator/TemplateRenderer.php
@@ -21,23 +21,14 @@ use PhpSpec\Util\Filesystem;
  */
 class TemplateRenderer
 {
-    /**
-     * @var array
-     */
-    private $locations = array();
+    private array $locations = [];
 
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    
-    public function __construct(Filesystem $filesystem)
+    public function __construct(
+        private Filesystem $filesystem
+    )
     {
-        $this->filesystem = $filesystem;
     }
 
-    
     public function setLocations(array $locations): void
     {
         $this->locations = array_map(array($this, 'normalizeLocation'), $locations);

--- a/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
+++ b/src/PhpSpec/CodeGenerator/Writer/TokenizedCodeWriter.php
@@ -18,15 +18,10 @@ use PhpSpec\Util\ClassFileAnalyser;
 
 final class TokenizedCodeWriter implements CodeWriter
 {
-    /**
-     * @var ClassFileAnalyser
-     */
-    private $analyser;
-
-    
-    public function __construct(ClassFileAnalyser $analyser)
+    public function __construct(
+        private ClassFileAnalyser $analyser
+    )
     {
-        $this->analyser = $analyser;
     }
 
     public function insertMethodFirstInClass(string $class, string $method): string
@@ -125,10 +120,7 @@ final class TokenizedCodeWriter implements CodeWriter
         throw new GenerationFailed('Could not locate end of class');
     }
 
-    /**
-     * @param $token
-     */
-    private function isWritePoint($token): bool
+    private function isWritePoint(string|array $token): bool
     {
         return \is_array($token) && ($token[1] === "\n" || $token[0] === T_COMMENT);
     }

--- a/src/PhpSpec/Config/OptionsConfig.php
+++ b/src/PhpSpec/Config/OptionsConfig.php
@@ -17,63 +17,21 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class OptionsConfig
 {
-    /**
-     * @var bool
-     */
-    private $stopOnFailureEnabled;
-
-    /**
-     * @var bool
-     */
-    private $codeGenerationEnabled;
-
-    /**
-     * @var bool
-     */
-    private $reRunEnabled;
-
-    /**
-     * @var bool
-     */
-    private $fakingEnabled;
-
-    /**
-     * @var bool|string
-     */
-    private $bootstrapPath;
-
-    /**
-     * @var bool
-     */
-    private $isVerbose;
-
-    /**
-     * @param bool|string $bootstrapPath
-     * @param bool $isVerbose
-     */
     public function __construct(
-        bool $stopOnFailureEnabled,
-        bool $codeGenerationEnabled,
-        bool $reRunEnabled,
-        bool $fakingEnabled,
-        $bootstrapPath,
-        $isVerbose
+        private bool $stopOnFailureEnabled,
+        private bool $codeGenerationEnabled,
+        private bool $reRunEnabled,
+        private bool $fakingEnabled,
+        private ?string $bootstrapPath,
+        private bool $isVerbose
     ) {
-        $this->stopOnFailureEnabled  = $stopOnFailureEnabled;
-        $this->codeGenerationEnabled = $codeGenerationEnabled;
-        $this->reRunEnabled = $reRunEnabled;
-        $this->fakingEnabled = $fakingEnabled;
-        $this->bootstrapPath = $bootstrapPath;
-        $this->isVerbose = $isVerbose;
     }
 
-    
     public function isStopOnFailureEnabled(): bool
     {
         return $this->stopOnFailureEnabled;
     }
 
-    
     public function isCodeGenerationEnabled(): bool
     {
         return $this->codeGenerationEnabled;
@@ -89,9 +47,9 @@ class OptionsConfig
         return $this->fakingEnabled;
     }
 
-    public function getBootstrapPath()
+    public function getBootstrapPath() : ?string
     {
-        return $this->bootstrapPath;
+        return $this->bootstrapPath ? $this->bootstrapPath : null;
     }
 
     public function isVerbose(): bool

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -36,10 +36,7 @@ use RuntimeException;
  */
 final class Application extends BaseApplication
 {
-    /**
-     * @var IndexedServiceContainer
-     */
-    private $container;
+    private IndexedServiceContainer $container;
 
     public function __construct(string $version)
     {
@@ -126,9 +123,8 @@ final class Application extends BaseApplication
 
     /**
      * @throws \RuntimeException
-     * @return void
      */
-    protected function loadConfigurationFile(InputInterface $input, IndexedServiceContainer $container)
+    protected function loadConfigurationFile(InputInterface $input, IndexedServiceContainer $container) : void
     {
         $config = $this->parseConfigurationFile($input);
 
@@ -146,10 +142,7 @@ final class Application extends BaseApplication
         }
     }
 
-    /**
-     * @return void
-     */
-    private function populateContainerParameters(IndexedServiceContainer $container, array $config)
+    private function populateContainerParameters(IndexedServiceContainer $container, array $config) : void
     {
         foreach ($config as $key => $val) {
             if ('extensions' !== $key && 'matchers' !== $key) {
@@ -158,10 +151,7 @@ final class Application extends BaseApplication
         }
     }
 
-    /**
-     * @return void
-     */
-    private function registerCustomMatchers(IndexedServiceContainer $container, array $matchersClassnames)
+    private function registerCustomMatchers(IndexedServiceContainer $container, array $matchersClassnames) : void
     {
         foreach ($matchersClassnames as $class) {
             $this->ensureIsValidMatcherClass($class);
@@ -173,10 +163,7 @@ final class Application extends BaseApplication
         }
     }
 
-    /**
-     * @return void
-     */
-    private function ensureIsValidMatcherClass(string $class)
+    private function ensureIsValidMatcherClass(string $class) : void
     {
         if (!class_exists($class)) {
             throw new InvalidConfigurationException(sprintf('Custom matcher %s does not exist.', $class));
@@ -191,11 +178,7 @@ final class Application extends BaseApplication
         }
     }
 
-    /**
-     * @param mixed $config
-     * @return void
-     */
-    private function loadExtension(ServiceContainer $container, string $extensionClass, $config)
+    private function loadExtension(ServiceContainer $container, string $extensionClass, mixed $config) : void
     {
         if (!class_exists($extensionClass)) {
             throw new InvalidConfigurationException(sprintf('Extension class `%s` does not exist.', $extensionClass));

--- a/src/PhpSpec/Console/Assembler/PresenterAssembler.php
+++ b/src/PhpSpec/Console/Assembler/PresenterAssembler.php
@@ -42,7 +42,7 @@ use SebastianBergmann\Exporter\Exporter;
  */
 final class PresenterAssembler
 {
-    public function assemble(IndexedServiceContainer $container)
+    public function assemble(IndexedServiceContainer $container) : void
     {
         $this->assembleDiffer($container);
         $this->assembleDifferEngines($container);
@@ -51,7 +51,7 @@ final class PresenterAssembler
         $this->assembleHtmlPresenter($container);
     }
 
-    private function assembleDiffer(IndexedServiceContainer $container)
+    private function assembleDiffer(IndexedServiceContainer $container) : void
     {
         $container->define('formatter.presenter.differ', function (IndexedServiceContainer $c) {
             $differ = new Differ();
@@ -65,7 +65,7 @@ final class PresenterAssembler
         });
     }
 
-    private function assembleDifferEngines(IndexedServiceContainer $container)
+    private function assembleDifferEngines(IndexedServiceContainer $container) : void
     {
         $container->define('formatter.presenter.differ.engines.string', function () {
             return new StringEngine();
@@ -83,7 +83,7 @@ final class PresenterAssembler
         }, ['formatter.presenter.differ.engines']);
     }
 
-    private function assembleTypePresenters(IndexedServiceContainer $container)
+    private function assembleTypePresenters(IndexedServiceContainer $container) : void
     {
         $container->define('formatter.presenter.value.array_type_presenter', function () {
             return new ArrayTypePresenter();
@@ -121,7 +121,7 @@ final class PresenterAssembler
         });
     }
 
-    private function assemblePresenter(IndexedServiceContainer $container)
+    private function assemblePresenter(IndexedServiceContainer $container) : void
     {
         $container->define('formatter.presenter', function (IndexedServiceContainer $c) {
             return new TaggingPresenter(
@@ -155,7 +155,7 @@ final class PresenterAssembler
         });
     }
 
-    private function assembleHtmlPresenter(IndexedServiceContainer $container)
+    private function assembleHtmlPresenter(IndexedServiceContainer $container) : void
     {
         $container->define('formatter.presenter.html', function (IndexedServiceContainer $c) {
             return new SimplePresenter(

--- a/src/PhpSpec/Console/Command/DescribeCommand.php
+++ b/src/PhpSpec/Console/Command/DescribeCommand.php
@@ -70,9 +70,6 @@ EOF
         ;
     }
 
-    /**
-     * @return int
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $container = $this->getApplication()->getContainer();
@@ -98,10 +95,8 @@ EOF
 
     /**
      * Get suites namespaces.
-     *
-     * @return array
      */
-    private function getNamespaces()
+    private function getNamespaces() : array
     {
         return $this->getApplication()->getContainer()->get('console.autocomplete_provider')->getNamespaces();
     }

--- a/src/PhpSpec/Console/Command/RunCommand.php
+++ b/src/PhpSpec/Console/Command/RunCommand.php
@@ -45,10 +45,7 @@ final class RunCommand extends Command
         return $application;
     }
 
-    /**
-     * @return void
-     */
-    protected function configure()
+    protected function configure() : void
     {
         $this
             ->setName('run')

--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -27,51 +27,19 @@ class ConsoleIO implements IO
     const COL_DEFAULT_WIDTH = 60;
     const COL_MAX_WIDTH = 80;
 
-    /**
-     * @var InputInterface
-     */
-    private $input;
+    private string $lastMessage = '';
 
-    /**
-     * @var OutputInterface
-     */
-    private $output;
+    private bool $hasTempString = false;
 
-    /**
-     * @var string
-     */
-    private $lastMessage;
-
-    /**
-     * @var bool
-     */
-    private $hasTempString = false;
-
-    /**
-      * @var OptionsConfig
-      */
-    private $config;
-
-    /**
-     * @var int
-     */
-    private $consoleWidth;
-
-    /**
-     * @var Prompter
-     */
-    private $prompter;
+    private int $consoleWidth = 0;
 
     public function __construct(
-        InputInterface $input,
-        OutputInterface $output,
-        OptionsConfig $config,
-        Prompter $prompter
-    ) {
-        $this->input   = $input;
-        $this->output  = $output;
-        $this->config  = $config;
-        $this->prompter = $prompter;
+        private InputInterface $input,
+        private OutputInterface $output,
+        private OptionsConfig $config,
+        private Prompter $prompter
+    )
+    {
     }
 
     public function isInteractive(): bool
@@ -122,13 +90,10 @@ class ConsoleIO implements IO
         $this->hasTempString = true;
     }
 
-    /**
-     * @return ?string
-     */
-    public function cutTemp()
+    public function cutTemp() : ?string
     {
         if (false === $this->hasTempString) {
-            return;
+            return null;
         }
 
         $message = $this->lastMessage;
@@ -248,9 +213,6 @@ class ConsoleIO implements IO
         return $this->input->getOption('fake') || $this->config->isFakingEnabled();
     }
 
-    /**
-     * @return ?string
-     */
     public function getBootstrapPath(): ?string
     {
         if ($path = $this->input->getOption('bootstrap')) {
@@ -280,7 +242,7 @@ class ConsoleIO implements IO
         return $width;
     }
 
-    
+
     public function writeBrokenCodeBlock(string $message, int $indent = 0): void
     {
         $message = wordwrap($message, $this->getBlockWidth() - ($indent * 2), "\n", true);

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -52,7 +52,6 @@ use PhpSpec\Process\Shutdown\Shutdown;
  */
 final class ContainerAssembler
 {
-    
     public function build(IndexedServiceContainer $container): void
     {
         $this->setupParameters($container);
@@ -137,7 +136,7 @@ final class ContainerAssembler
         }, ['console.commands']);
     }
 
-    
+
     private function setupConsoleEventDispatcher(IndexedServiceContainer $container): void
     {
         $container->define('console_event_dispatcher', function (IndexedServiceContainer $c) {
@@ -152,7 +151,7 @@ final class ContainerAssembler
         });
     }
 
-    
+
     private function setupEventDispatcher(IndexedServiceContainer $container): void
     {
         $container->define('event_dispatcher', function () {
@@ -244,7 +243,7 @@ final class ContainerAssembler
         }, ['event_dispatcher.listeners']);
     }
 
-    
+
     private function setupGenerators(IndexedServiceContainer $container): void
     {
         $container->define('code_generator', function (IndexedServiceContainer $c) {
@@ -378,14 +377,14 @@ final class ContainerAssembler
         ));
     }
 
-    
+
     private function setupPresenter(IndexedServiceContainer $container): void
     {
         $presenterAssembler = new PresenterAssembler();
         $presenterAssembler->assemble($container);
     }
 
-    
+
     private function setupLocator(IndexedServiceContainer $container): void
     {
         $container->define('locator.resource_manager', function (IndexedServiceContainer $c) {
@@ -475,7 +474,7 @@ final class ContainerAssembler
         });
     }
 
-    
+
     private function setupLoader(IndexedServiceContainer $container): void
     {
         $container->define('loader.resource_loader', function (IndexedServiceContainer $c) {
@@ -611,7 +610,7 @@ final class ContainerAssembler
         });
     }
 
-    
+
     private function setupRunner(IndexedServiceContainer $container): void
     {
         $container->define('runner.suite', function (IndexedServiceContainer $c) {
@@ -691,7 +690,7 @@ final class ContainerAssembler
         });
     }
 
-    
+
     private function setupMatchers(IndexedServiceContainer $container): void
     {
         $container->define('matchers.identity', function (IndexedServiceContainer $c) {
@@ -765,7 +764,7 @@ final class ContainerAssembler
         }, ['matchers']);
     }
 
-    
+
     private function setupRerunner(IndexedServiceContainer $container): void
     {
         $container->define('process.rerunner', function (IndexedServiceContainer $c) {
@@ -807,7 +806,7 @@ final class ContainerAssembler
         });
     }
 
-    
+
     private function setupSubscribers(IndexedServiceContainer $container): void
     {
         $container->addConfigurator(function (IndexedServiceContainer $c) {
@@ -818,7 +817,7 @@ final class ContainerAssembler
         });
     }
 
-    
+
     private function setupCurrentExample(IndexedServiceContainer $container): void
     {
         $container->define('current_example', function () {
@@ -826,7 +825,7 @@ final class ContainerAssembler
         });
     }
 
-  
+
     private function setupShutdown(IndexedServiceContainer $container): void
     {
         $container->define('process.shutdown', function () {

--- a/src/PhpSpec/Console/Prompter/Question.php
+++ b/src/PhpSpec/Console/Prompter/Question.php
@@ -21,29 +21,14 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 final class Question implements Prompter
 {
-    /**
-     * @var InputInterface
-     */
-    private $input;
-
-    /**
-     * @var OutputInterface
-     */
-    private $output;
-
-    /**
-     * @var QuestionHelper
-     */
-    private $helper;
-
-    public function __construct(InputInterface $input, OutputInterface $output, QuestionHelper $helper)
+    public function __construct(
+        private InputInterface $input,
+        private OutputInterface $output,
+        private QuestionHelper $helper
+    )
     {
-        $this->input = $input;
-        $this->output = $output;
-        $this->helper = $helper;
     }
 
-    
     public function askConfirmation(string $question, bool $default = true): bool
     {
         return (bool)$this->helper->ask($this->input, $this->output, new ConfirmationQuestion($question, $default));

--- a/src/PhpSpec/Console/Provider/NamespacesAutocompleteProvider.php
+++ b/src/PhpSpec/Console/Provider/NamespacesAutocompleteProvider.php
@@ -19,30 +19,26 @@ use Symfony\Component\Finder\Finder;
 
 final class NamespacesAutocompleteProvider
 {
-    /**
-     * @var Finder
-     */
-    private $finder;
+    private array $paths = [];
 
-    private $paths = [];
-
-    public function __construct(Finder $finder, array $locators)
+    public function __construct(
+        private Finder $finder,
+        array $locators
+    )
     {
         foreach ($locators as $locator) {
             if ($locator instanceof SrcPathLocator) {
                 $this->paths[] = $locator->getFullSrcPath();
             }
         }
-
-        $this->finder = $finder;
     }
 
     /**
      * Get namespaces from paths.
      *
-     * @return array of namespases
+     * @return list<string>
      */
-    public function getNamespaces()
+    public function getNamespaces() : array
     {
         $namespaces = [];
         foreach ($this->finder->files()->name('*.php')->in($this->paths) as $phpFile) {

--- a/src/PhpSpec/Console/ResultConverter.php
+++ b/src/PhpSpec/Console/ResultConverter.php
@@ -23,7 +23,7 @@ class ResultConverter
     /**
      * Convert Example result into exit code
      */
-    public function convert($result): int
+    public function convert(int $result): int
     {
         switch ($result) {
             case ExampleEvent::PASSED:

--- a/src/PhpSpec/Event/ExampleEvent.php
+++ b/src/PhpSpec/Event/ExampleEvent.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Event;
 
+use Exception;
 use PhpSpec\Loader\Node\SpecificationNode;
 use PhpSpec\Loader\Suite;
 use PhpSpec\Loader\Node\ExampleNode;
@@ -47,95 +48,56 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
      */
     const BROKEN  = 4;
 
-    /**
-     * @var ExampleNode
-     */
-    private $example;
-
-    /**
-     * @var float
-     */
-    private $time;
-
-    /**
-     * @var int
-     */
-    private $result;
-
-    /**
-     * @var \Exception
-     */
-    private $exception;
-
-    /**
-     * @param null|float   $time
-     * @param null|int $result
-     * @param \Exception   $exception
-     */
     public function __construct(
-        ExampleNode $example,
-        float $time = 0.0,
-        int $result = self::PASSED,
-        \Exception $exception = null
-    ) {
-        $this->example   = $example;
-        $this->time      = $time;
-        $this->result    = $result;
-        $this->exception = $exception;
+        private ExampleNode $example,
+        private float $time = 0.0,
+        private int $result = self::PASSED,
+        private ?Exception $exception = null
+    )
+    {
     }
 
-    
     public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
-    
     public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
-    
     public function getSuite(): Suite
     {
         return $this->getSpecification()->getSuite();
     }
 
-    
     public function getTitle(): string
     {
         return $this->example->getTitle();
     }
 
-    
     public function getMessage(): string
     {
         return $this->exception->getMessage();
     }
 
-    
     public function getBacktrace(): array
     {
         return $this->exception->getTrace();
     }
 
-    
     public function getTime(): float
     {
         return $this->time;
     }
 
-    
     public function getResult(): int
     {
         return $this->result;
     }
 
-    /**
-     * @return null|\Exception
-     */
-    public function getException()
+    public function getException() : ?Exception
     {
         return $this->exception;
     }

--- a/src/PhpSpec/Event/ExpectationEvent.php
+++ b/src/PhpSpec/Event/ExpectationEvent.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Event;
 
+use Exception;
 use PhpSpec\Loader\Node\SpecificationNode;
 use PhpSpec\Loader\Suite;
 use PhpSpec\Loader\Node\ExampleNode;
@@ -38,114 +39,57 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
      */
     const BROKEN  = 2;
 
-    /**
-     * @var ExampleNode
-     */
-    private $example;
-
-    /**
-     * @var Matcher
-     */
-    private $matcher;
-
-    
-    private $subject;
-
-    /**
-     * @var string
-     */
-    private $method;
-
-    /**
-     * @var array
-     */
-    private $arguments;
-
-    /**
-     * @var int
-     */
-    private $result;
-
-    /**
-     * @var \Exception
-     */
-    private $exception;
-
-    /**
-     * @param string           $method
-     * @param array            $arguments
-     * @param int          $result
-     * @param \Exception       $exception
-     */
     public function __construct(
-        ExampleNode $example,
-        Matcher $matcher,
-        $subject,
-        $method,
-        $arguments,
-        $result = self::PASSED,
-        $exception = null
+        private ExampleNode $example,
+        private Matcher $matcher,
+        private mixed $subject,
+        private string $method,
+        private array $arguments,
+        private int $result = self::PASSED,
+        private ?Exception $exception = null
     ) {
-        $this->example = $example;
-        $this->matcher = $matcher;
-        $this->subject = $subject;
-        $this->method = $method;
-        $this->arguments = $arguments;
-        $this->result = $result;
-        $this->exception = $exception;
     }
 
-    
     public function getMatcher(): Matcher
     {
         return $this->matcher;
     }
 
-    
     public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
-    
     public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
-    
     public function getSuite(): Suite
     {
         return $this->example->getSpecification()->getSuite();
     }
 
-    
     public function getSubject()
     {
         return $this->subject;
     }
 
-    
     public function getMethod(): string
     {
         return $this->method;
     }
 
-    
     public function getArguments(): array
     {
         return $this->arguments;
     }
 
-    /**
-     * @return null|\Exception
-     */
-    public function getException()
+    public function getException() : ?Exception
     {
         return $this->exception;
     }
 
-    
     public function getResult(): int
     {
         return $this->result;

--- a/src/PhpSpec/Event/FileCreationEvent.php
+++ b/src/PhpSpec/Event/FileCreationEvent.php
@@ -15,18 +15,11 @@ namespace PhpSpec\Event;
 
 final class FileCreationEvent extends BaseEvent implements PhpSpecEvent
 {
-    /**
-     * @var string
-     */
-    private $filepath;
-
-    public function __construct($filepath)
+    public function __construct(private string $filepath)
     {
-
         $this->filepath = $filepath;
     }
 
-    
     public function getFilePath(): string
     {
         return $this->filepath;

--- a/src/PhpSpec/Event/MethodCallEvent.php
+++ b/src/PhpSpec/Event/MethodCallEvent.php
@@ -22,78 +22,46 @@ use PhpSpec\Loader\Suite;
  */
 class MethodCallEvent extends BaseEvent implements PhpSpecEvent
 {
-    /**
-     * @var ExampleNode
-     */
-    private $example;
-
-    
-    private $subject;
-
-    /**
-     * @var string
-     */
-    private $method;
-
-    /**
-     * @var array
-     */
-    private $arguments;
-
-    
-    private $returnValue;
-
-    /**
-     * @param string      $method
-     * @param array       $arguments
-     */
-    public function __construct(ExampleNode $example, $subject, $method, $arguments, $returnValue = null)
+    public function __construct(
+        private ExampleNode $example,
+        private object $subject,
+        private string $method,
+        private array $arguments,
+        private mixed $returnValue = null)
     {
-        $this->example = $example;
-        $this->subject = $subject;
-        $this->method = $method;
-        $this->arguments = $arguments;
-        $this->returnValue = $returnValue;
     }
 
-    
     public function getExample(): ExampleNode
     {
         return $this->example;
     }
 
-    
     public function getSpecification(): SpecificationNode
     {
         return $this->example->getSpecification();
     }
 
-    
     public function getSuite(): Suite
     {
         return $this->example->getSpecification()->getSuite();
     }
 
-    
-    public function getSubject()
+    public function getSubject() : object
     {
         return $this->subject;
     }
 
-    
     public function getMethod(): string
     {
         return $this->method;
     }
 
-    
     public function getArguments(): array
     {
         return $this->arguments;
     }
 
-    
-    public function getReturnValue()
+    public function getReturnValue() : mixed
     {
         return $this->returnValue;
     }

--- a/src/PhpSpec/Event/ResourceEvent.php
+++ b/src/PhpSpec/Event/ResourceEvent.php
@@ -17,14 +17,10 @@ use PhpSpec\Locator\Resource;
 
 class ResourceEvent extends BaseEvent implements PhpSpecEvent
 {
-    /**
-     * @var Resource
-     */
-    private $resource;
-
-    private function __construct(Resource $resource)
+    private function __construct(
+        private Resource $resource
+    )
     {
-        $this->resource = $resource;
     }
 
     public static function ignored(Resource $resource): self

--- a/src/PhpSpec/Event/SpecificationEvent.php
+++ b/src/PhpSpec/Event/SpecificationEvent.php
@@ -21,54 +21,34 @@ use PhpSpec\Loader\Node\SpecificationNode;
  */
 class SpecificationEvent extends BaseEvent implements PhpSpecEvent
 {
-    /**
-     * @var SpecificationNode
-     */
-    private $specification;
-
-    /**
-     * @var float
-     */
-    private $time;
-
-    /**
-     * @var int
-     */
-    private $result;
-
-    
-    public function __construct(SpecificationNode $specification, float $time = 0.0, int $result = 0)
+    public function __construct(
+        private SpecificationNode $specification,
+        private float $time = 0.0,
+        private int $result = 0
+    )
     {
-        $this->specification = $specification;
-        $this->time          = $time;
-        $this->result        = $result;
     }
 
-    
     public function getSpecification(): SpecificationNode
     {
         return $this->specification;
     }
 
-    
     public function getTitle(): string
     {
         return $this->specification->getTitle();
     }
 
-    
     public function getSuite(): Suite
     {
         return $this->specification->getSuite();
     }
 
-    
     public function getTime(): float
     {
         return $this->time;
     }
 
-    
     public function getResult(): int
     {
         return $this->result;

--- a/src/PhpSpec/Event/SuiteEvent.php
+++ b/src/PhpSpec/Event/SuiteEvent.php
@@ -20,53 +20,31 @@ use PhpSpec\Loader\Suite;
  */
 class SuiteEvent extends BaseEvent implements PhpSpecEvent
 {
-    /**
-     * @var Suite
-     */
-    private $suite;
+    private bool $worthRerunning = false;
 
-    /**
-     * @var float
-     */
-    private $time;
-
-    /**
-     * @var int
-     */
-    private $result;
-
-    /**
-     * @var bool
-     */
-    private $worthRerunning = false;
-
-    
-    public function __construct(Suite $suite, float $time = 0.0, int $result = 0)
+    public function __construct(
+        private Suite $suite,
+        private float $time = 0.0,
+        private int $result = 0
+    )
     {
-        $this->suite  = $suite;
-        $this->time   = $time;
-        $this->result = $result;
     }
 
-    
     public function getSuite(): Suite
     {
         return $this->suite;
     }
 
-    
     public function getTime(): float
     {
         return $this->time;
     }
 
-    
     public function getResult(): int
     {
         return $this->result;
     }
 
-    
     public function isWorthRerunning(): bool
     {
         return $this->worthRerunning;

--- a/src/PhpSpec/Exception/Configuration/InvalidConfigurationException.php
+++ b/src/PhpSpec/Exception/Configuration/InvalidConfigurationException.php
@@ -13,10 +13,8 @@
 
 namespace PhpSpec\Exception\Configuration;
 
-
 use PhpSpec\Exception\Exception;
 
 class InvalidConfigurationException extends Exception
 {
-
 }

--- a/src/PhpSpec/Exception/Example/ErrorException.php
+++ b/src/PhpSpec/Exception/Example/ErrorException.php
@@ -18,10 +18,7 @@ namespace PhpSpec\Exception\Example;
  */
 class ErrorException extends ExampleException
 {
-    /**
-     * @var array
-     */
-    private $levels = array(
+    private array $levels = [
         E_WARNING           => 'warning',
         E_NOTICE            => 'notice',
         E_USER_ERROR        => 'error',
@@ -29,15 +26,10 @@ class ErrorException extends ExampleException
         E_USER_NOTICE       => 'notice',
         E_STRICT            => 'notice',
         E_RECOVERABLE_ERROR => 'error',
-    );
+    ];
 
     /**
      * Initializes error handler exception.
-     *
-     * @param int $level      error level
-     * @param string $message error message
-     * @param string $file    error file
-     * @param int $line       error line
      */
     public function __construct(int $level, string $message, string $file, int $line)
     {

--- a/src/PhpSpec/Exception/Example/MethodFailureException.php
+++ b/src/PhpSpec/Exception/Example/MethodFailureException.php
@@ -15,35 +15,22 @@ namespace PhpSpec\Exception\Example;
 
 class MethodFailureException extends NotEqualException
 {
-    
-    private $subject;
-
-    /**
-     * @var string
-     */
-    private $method;
-
-    /**
-     * @param string $method
-     */
-    public function __construct(string $message, $expected, $actual, $subject, $method)
+    public function __construct(
+        string $message,
+        mixed $expected,
+        mixed $actual,
+        private object $subject,
+        private string $method)
     {
         parent::__construct($message, $expected, $actual);
-
-        $this->subject = $subject;
-        $this->method = $method;
     }
 
-    
-    public function getSubject()
+    public function getSubject() : ?object
     {
         return $this->subject;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+    public function getMethod() : string
     {
         return $this->method;
     }

--- a/src/PhpSpec/Exception/Example/NotEqualException.php
+++ b/src/PhpSpec/Exception/Example/NotEqualException.php
@@ -18,34 +18,25 @@ namespace PhpSpec\Exception\Example;
  */
 class NotEqualException extends FailureException
 {
-    
-    private $expected;
-
-    
-    private $actual;
-
-    
-    public function __construct(string $message, $expected, $actual)
+    public function __construct(
+        string $message,
+        private mixed $expected,
+        private mixed $actual
+    )
     {
         parent::__construct($message);
-
-        $this->expected = $expected;
-        $this->actual   = $actual;
     }
 
-    
-    public function getExpected()
+    public function getExpected() : mixed
     {
         return $this->expected;
     }
 
-    
-    public function getActual()
+    public function getActual() : mixed
     {
         return $this->actual;
     }
 
-    
     public function __toString(): string
     {
         return var_export(array($this->expected, $this->actual), true);

--- a/src/PhpSpec/Exception/Example/PendingException.php
+++ b/src/PhpSpec/Exception/Example/PendingException.php
@@ -18,7 +18,6 @@ namespace PhpSpec\Exception\Example;
  */
 class PendingException extends ExampleException
 {
-    
     public function __construct(string $text = 'write pending example')
     {
         parent::__construct(sprintf('todo: %s', $text));

--- a/src/PhpSpec/Exception/Example/SkippingException.php
+++ b/src/PhpSpec/Exception/Example/SkippingException.php
@@ -15,7 +15,6 @@ namespace PhpSpec\Exception\Example;
 
 class SkippingException extends ExampleException
 {
-    
     public function __construct(string $text)
     {
         parent::__construct(sprintf('skipped: %s', $text));

--- a/src/PhpSpec/Exception/Example/StopOnFailureException.php
+++ b/src/PhpSpec/Exception/Example/StopOnFailureException.php
@@ -20,18 +20,16 @@ use Exception;
  */
 class StopOnFailureException extends ExampleException
 {
-    /**
-     * @var int
-     */
-    private $result;
-
-    public function __construct($message = "", $code = 0, Exception $previous = null, $result = 0)
+    public function __construct(
+        string $message = "",
+        int $code = 0,
+        Exception $previous = null,
+        private int $result = 0)
     {
         parent::__construct($message, $code, $previous);
-        $this->result = $result;
     }
 
-    public function getResult()
+    public function getResult() : int
     {
         return $this->result;
     }

--- a/src/PhpSpec/Exception/Exception.php
+++ b/src/PhpSpec/Exception/Exception.php
@@ -20,18 +20,14 @@ use ReflectionFunctionAbstract;
  */
 class Exception extends \Exception
 {
-    /**
-     * @var ReflectionFunctionAbstract
-     */
-    private $cause;
+    private ?ReflectionFunctionAbstract $cause;
 
-    
-    public function getCause(): ReflectionFunctionAbstract
+    public function getCause(): ?ReflectionFunctionAbstract
     {
         return $this->cause;
     }
 
-    
+
     public function setCause(ReflectionFunctionAbstract $cause): void
     {
         $this->cause = $cause;

--- a/src/PhpSpec/Exception/ExceptionFactory.php
+++ b/src/PhpSpec/Exception/ExceptionFactory.php
@@ -22,18 +22,12 @@ use PhpSpec\Util\Instantiator;
  */
 class ExceptionFactory
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
     public function namedConstructorNotFound(string $classname, string $method, array $arguments = array()): Fracture\NamedConstructorNotFoundException
     {
         $instantiator = new Instantiator();
@@ -49,7 +43,6 @@ class ExceptionFactory
         );
     }
 
-    
     public function methodNotFound(string $classname, string $method, array $arguments = array()): Fracture\MethodNotFoundException
     {
         $instantiator = new Instantiator();
@@ -64,7 +57,6 @@ class ExceptionFactory
         );
     }
 
-    
     public function methodNotVisible(string $classname, string $method, array $arguments = array()): Fracture\MethodNotVisibleException
     {
         $instantiator = new Instantiator();
@@ -79,7 +71,6 @@ class ExceptionFactory
         );
     }
 
-    
     public function classNotFound(string $classname): Fracture\ClassNotFoundException
     {
         $message = sprintf('Class %s does not exist.', $this->presenter->presentString($classname));
@@ -87,17 +78,13 @@ class ExceptionFactory
         return new Fracture\ClassNotFoundException($message, $classname);
     }
 
-    /**
-     * @param string $property
-     */
-    public function propertyNotFound($subject, $property): Fracture\PropertyNotFoundException
+    public function propertyNotFound(object $subject, string $property): Fracture\PropertyNotFoundException
     {
         $message = sprintf('Property %s not found.', $this->presenter->presentString($property));
 
         return new Fracture\PropertyNotFoundException($message, $subject, $property);
     }
 
-    
     public function callingMethodOnNonObject(string $method): SubjectException
     {
         return new SubjectException(sprintf(
@@ -106,7 +93,6 @@ class ExceptionFactory
         ));
     }
 
-    
     public function settingPropertyOnNonObject(string $property): SubjectException
     {
         return new SubjectException(sprintf(
@@ -115,7 +101,6 @@ class ExceptionFactory
         ));
     }
 
-    
     public function gettingPropertyOnNonObject(string $property): SubjectException
     {
         return new SubjectException(sprintf(

--- a/src/PhpSpec/Exception/Fracture/ClassNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/ClassNotFoundException.php
@@ -18,20 +18,13 @@ namespace PhpSpec\Exception\Fracture;
  */
 class ClassNotFoundException extends FractureException
 {
-    /**
-     * @var string
-     */
-    private $classname;
-
-    
-    public function __construct(string $message, string $classname)
+    public function __construct(
+        string $message,
+        private string $classname)
     {
         parent::__construct($message);
-
-        $this->classname = $classname;
     }
 
-    
     public function getClassname(): string
     {
         return $this->classname;

--- a/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
@@ -20,14 +20,8 @@ class CollaboratorNotFoundException extends FractureException
 {
     const CLASSNAME_REGEX = '/\\[.* (?P<classname>[_a-z0-9\\\\]+) .*\\]/i';
 
-    /**
-     * @var string
-     */
-    private $collaboratorName;
+    private string $collaboratorName = '';
 
-    /**
-     * @param Exception $previous
-     */
     public function __construct(
         string $message,
         int $code = 0,
@@ -45,13 +39,11 @@ class CollaboratorNotFoundException extends FractureException
         parent::__construct($message . ': ' . $this->collaboratorName, $code, $previous);
     }
 
-    
     public function getCollaboratorName(): string
     {
         return $this->collaboratorName;
     }
 
-    
     private function extractCollaboratorName(ReflectionParameter $parameter): string
     {
         if (preg_match(self::CLASSNAME_REGEX, (string)$parameter, $matches)) {

--- a/src/PhpSpec/Exception/Fracture/InterfaceNotImplementedException.php
+++ b/src/PhpSpec/Exception/Fracture/InterfaceNotImplementedException.php
@@ -19,32 +19,19 @@ namespace PhpSpec\Exception\Fracture;
  */
 class InterfaceNotImplementedException extends FractureException
 {
-    
-    private $subject;
-
-    /**
-     * @var string
-     */
-    private $interface;
-
-    /**
-     * @param string $interface
-     */
-    public function __construct(string $message, $subject, $interface)
+    public function __construct(
+        string $message,
+        private mixed $subject,
+        private string $interface
+    )
     {
-        parent::__construct($message);
-
-        $this->subject   = $subject;
-        $this->interface = $interface;
     }
 
-    
-    public function getSubject()
+    public function getSubject() : mixed
     {
         return $this->subject;
     }
 
-    
     public function getInterface(): string
     {
         return $this->interface;

--- a/src/PhpSpec/Exception/Fracture/MethodInvocationException.php
+++ b/src/PhpSpec/Exception/Fracture/MethodInvocationException.php
@@ -19,44 +19,27 @@ namespace PhpSpec\Exception\Fracture;
  */
 abstract class MethodInvocationException extends FractureException
 {
-    
-    private $subject;
-
-    /**
-     * @var string
-     */
-    private $method;
-
-    /**
-     * @var array
-     */
-    private $arguments;
-
-    /**
-     * @param string $method
-     */
-    public function __construct(string $message, $subject, $method, array $arguments = array())
+    public function __construct(
+        string $message,
+        private object $subject,
+        private string $method,
+        private array $arguments = array()
+    )
     {
         parent::__construct($message);
-
-        $this->subject   = $subject;
-        $this->method    = $method;
-        $this->arguments = $arguments;
     }
 
-    
-    public function getSubject()
+    public function getSubject() : object
     {
         return $this->subject;
     }
 
-    
     public function getMethodName(): string
     {
         return $this->method;
     }
 
-    
+
     public function getArguments(): array
     {
         return $this->arguments;

--- a/src/PhpSpec/Exception/Fracture/PropertyNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/PropertyNotFoundException.php
@@ -19,32 +19,20 @@ namespace PhpSpec\Exception\Fracture;
  */
 class PropertyNotFoundException extends FractureException
 {
-    
-    private $subject;
-
-    /**
-     * @var string
-     */
-    private $property;
-
-    /**
-     * @param string $property
-     */
-    public function __construct(string $message, $subject, $property)
+    public function __construct(
+        string $message,
+        private object $subject,
+        private string $property
+    )
     {
         parent::__construct($message);
-
-        $this->subject = $subject;
-        $this->property  = $property;
     }
 
-    
-    public function getSubject()
+    public function getSubject() : object
     {
         return $this->subject;
     }
 
-    
     public function getProperty(): string
     {
         return $this->property;

--- a/src/PhpSpec/Exception/Wrapper/MatcherNotFoundException.php
+++ b/src/PhpSpec/Exception/Wrapper/MatcherNotFoundException.php
@@ -21,42 +21,26 @@ use PhpSpec\Exception\Exception;
  */
 class MatcherNotFoundException extends Exception
 {
-    /**
-     * @var string
-     */
-    private $keyword;
-
-    
-    private $subject;
-
-    /**
-     * @var array
-     */
-    private $arguments;
-
-    
-    public function __construct(string $message, string $keyword, $subject, array $arguments)
+    public function __construct(
+        string $message,
+        private string $keyword,
+        private string $subject,
+        private array $arguments
+    )
     {
         parent::__construct($message);
-
-        $this->keyword   = $keyword;
-        $this->subject   = $subject;
-        $this->arguments = $arguments;
     }
 
-    
     public function getKeyword(): string
     {
         return $this->keyword;
     }
 
-    
-    public function getSubject()
+    public function getSubject() : string
     {
         return $this->subject;
     }
 
-    
     public function getArguments(): array
     {
         return $this->arguments;

--- a/src/PhpSpec/Extension.php
+++ b/src/PhpSpec/Extension.php
@@ -19,6 +19,5 @@ namespace PhpSpec;
  */
 interface Extension
 {
-    
-    public function load(ServiceContainer $container, array $params);
+    public function load(ServiceContainer $container, array $params) : void;
 }

--- a/src/PhpSpec/Factory/ObjectFactory.php
+++ b/src/PhpSpec/Factory/ObjectFactory.php
@@ -25,7 +25,8 @@ class ObjectFactory
     public function instantiateFromCallable(
         callable $callable,
         array $arguments = []
-    ) {
+    ) : object
+    {
         $instance = \call_user_func_array($callable, $arguments);
 
         if (!\is_object($instance)) {

--- a/src/PhpSpec/Factory/ReflectionFactory.php
+++ b/src/PhpSpec/Factory/ReflectionFactory.php
@@ -19,10 +19,7 @@ namespace PhpSpec\Factory;
  */
 class ReflectionFactory
 {
-    /**
-     * @param $class
-     */
-    public function create($class): \ReflectionClass
+    public function create(object $class): \ReflectionClass
     {
         return new \ReflectionClass($class);
     }

--- a/src/PhpSpec/Formatter/BasicFormatter.php
+++ b/src/PhpSpec/Formatter/BasicFormatter.php
@@ -23,29 +23,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 abstract class BasicFormatter implements EventSubscriberInterface
 {
-    /**
-     * @var IO
-     */
-    private $io;
-
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    /**
-     * @var StatisticsCollector
-     */
-    private $stats;
-
-    public function __construct(Presenter $presenter, IO $io, StatisticsCollector $stats)
+    public function __construct(
+        private Presenter $presenter,
+        private IO $io,
+        private StatisticsCollector $stats
+    )
     {
-        $this->presenter = $presenter;
-        $this->io = $io;
-        $this->stats = $stats;
     }
 
-    
     public static function getSubscribedEvents(): array
     {
         $events = array(
@@ -57,51 +42,42 @@ abstract class BasicFormatter implements EventSubscriberInterface
         return array_combine($events, $events);
     }
 
-    
     protected function getIO(): IO
     {
         return $this->io;
     }
 
-    
     protected function getPresenter(): Presenter
     {
         return $this->presenter;
     }
 
-    
     protected function getStatisticsCollector(): StatisticsCollector
     {
         return $this->stats;
     }
 
-    
-    public function beforeSuite(SuiteEvent $event)
+    public function beforeSuite(SuiteEvent $event) : void
     {
     }
 
-    
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
     }
 
-    
-    public function beforeExample(ExampleEvent $event)
+    public function beforeExample(ExampleEvent $event) : void
     {
     }
 
-    
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
     }
 
-    
-    public function beforeSpecification(SpecificationEvent $event)
+    public function beforeSpecification(SpecificationEvent $event) : void
     {
     }
 
-    
-    public function afterSpecification(SpecificationEvent $event)
+    public function afterSpecification(SpecificationEvent $event) : void
     {
     }
 }

--- a/src/PhpSpec/Formatter/ConsoleFormatter.php
+++ b/src/PhpSpec/Formatter/ConsoleFormatter.php
@@ -26,22 +26,15 @@ use PhpSpec\Message\CurrentExampleTracker;
 
 abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    
-    public function __construct(Presenter $presenter, ConsoleIO $io, StatisticsCollector $stats)
+    public function __construct(
+        Presenter $presenter,
+        private ConsoleIO $io,
+        StatisticsCollector $stats)
     {
         parent::__construct($presenter, $io, $stats);
-        $this->io = $io;
     }
 
-    /**
-     * @return ConsoleIO
-     */
-    protected function getIO(): IO
+    protected function getIO(): ConsoleIO
     {
         return $this->io;
     }
@@ -98,7 +91,7 @@ abstract class ConsoleFormatter extends BasicFormatter implements FatalPresenter
         $this->io->writeln();
     }
 
-    public function displayFatal(CurrentExampleTracker $currentExample, $error): void
+    public function displayFatal(CurrentExampleTracker $currentExample, ?array $error): void
     {
         if (
             (null !== $error && ($currentExample->getCurrentExample() || $error['type'] == E_ERROR)) ||

--- a/src/PhpSpec/Formatter/DotFormatter.php
+++ b/src/PhpSpec/Formatter/DotFormatter.php
@@ -18,19 +18,14 @@ use PhpSpec\Event\ExampleEvent;
 
 final class DotFormatter extends ConsoleFormatter
 {
-    /**
-     * @var int
-     */
-    private $examplesCount = 0;
+    private int $examplesCount = 0;
 
-    
-    public function beforeSuite(SuiteEvent $event)
+    public function beforeSuite(SuiteEvent $event) : void
     {
         $this->examplesCount = \count($event->getSuite());
     }
 
-    
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         $io = $this->getIO();
 
@@ -77,8 +72,7 @@ final class DotFormatter extends ConsoleFormatter
         }
     }
 
-    
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         $this->getIO()->writeln("\n");
 
@@ -114,7 +108,7 @@ final class DotFormatter extends ConsoleFormatter
         $this->getIO()->writeln(sprintf("\n%sms", round($event->getTime() * 1000)));
     }
 
-    private function plural($count)
+    private function getPluralSuffix(int $count) : string
     {
         return $count > 1 ? 's' : '';
     }
@@ -123,7 +117,7 @@ final class DotFormatter extends ConsoleFormatter
     {
         $stats = $this->getStatisticsCollector();
         $count = $stats->getTotalSpecs();
-        $line = sprintf("%d spec%s", $count, $this->plural($count));
+        $line = sprintf("%d spec%s", $count, $this->getPluralSuffix($count));
 
         if (($ignoredCount = count($stats->getIgnoredResourceEvents())) > 0) {
             $line .= sprintf(' (%d ignored)', $ignoredCount);
@@ -134,7 +128,7 @@ final class DotFormatter extends ConsoleFormatter
     private function outputTotalExamplesCount(): void
     {
         $count = $this->getStatisticsCollector()->getEventsCount();
-        $this->getIO()->write(sprintf("%d example%s ", $count, $this->plural($count)));
+        $this->getIO()->write(sprintf("%d example%s ", $count, $this->getPluralSuffix($count)));
     }
 
     private function outputSpecificExamplesCount(): void

--- a/src/PhpSpec/Formatter/FatalPresenter.php
+++ b/src/PhpSpec/Formatter/FatalPresenter.php
@@ -17,5 +17,5 @@ use PhpSpec\Message\CurrentExampleTracker;
 
 interface FatalPresenter
 {
-    public function displayFatal(CurrentExampleTracker $currentExample, $error): void;
+    public function displayFatal(CurrentExampleTracker $currentExample, ?array $error): void;
 }

--- a/src/PhpSpec/Formatter/Html/HtmlIO.php
+++ b/src/PhpSpec/Formatter/Html/HtmlIO.php
@@ -17,14 +17,11 @@ use PhpSpec\IO\IO;
 
 final class HtmlIO implements IO
 {
-    /**
-     * @param $message
-     */
     public function write(string $message): void
     {
         echo $message;
     }
-    
+
     public function isVerbose(): bool
     {
         return true;

--- a/src/PhpSpec/Formatter/Html/ReportFailedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportFailedItem.php
@@ -19,32 +19,15 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportFailedItem
 {
-    /**
-     * @var TemplateInterface
-     */
-    private $template;
-    /**
-     * @var ExampleEvent
-     */
-    private $event;
-    /**
-     * @var int
-     */
-    private static $failingExamplesCount = 1;
-    /**
-     * @var Presenter
-     */
-    private $presenter;
+    private static int $failingExamplesCount = 1;
 
-    
-    public function __construct(TemplateInterface $template, ExampleEvent $event, Presenter $presenter)
+    public function __construct(
+        private TemplateInterface $template,
+        private ExampleEvent $event,
+        private Presenter $presenter)
     {
-        $this->template = $template;
-        $this->event = $event;
-        $this->presenter = $presenter;
     }
 
-    
     public function write(int $index): void
     {
         $code = $this->presenter->presentException($this->event->getException(), true);
@@ -61,7 +44,6 @@ class ReportFailedItem
         );
     }
 
-    
     private function formatBacktrace() : string
     {
         $backtrace = '';

--- a/src/PhpSpec/Formatter/Html/ReportItemFactory.php
+++ b/src/PhpSpec/Formatter/Html/ReportItemFactory.php
@@ -19,21 +19,13 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportItemFactory
 {
-    /**
-     * @var TemplateInterface
-     */
-    private $template;
-
-    
-    public function __construct(TemplateInterface $template)
+    public function __construct(
+        private TemplateInterface $template
+    )
     {
-        $this->template = $template;
     }
 
-    /**
-     * @return ReportFailedItem|ReportPassedItem|ReportPendingItem|ReportSkippedItem
-     */
-    public function create(ExampleEvent $event, Presenter $presenter)
+    public function create(ExampleEvent $event, Presenter $presenter) : ReportFailedItem|ReportPassedItem|ReportPendingItem|ReportSkippedItem
     {
         switch ($result = $event->getResult()) {
             case ExampleEvent::PASSED:

--- a/src/PhpSpec/Formatter/Html/ReportPassedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPassedItem.php
@@ -18,20 +18,11 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportPassedItem
 {
-    /**
-     * @var TemplateInterface
-     */
-    private $template;
-    /**
-     * @var ExampleEvent
-     */
-    private $event;
-
-    
-    public function __construct(TemplateInterface $template, ExampleEvent $event)
+    public function __construct(
+        private TemplateInterface $template,
+        private ExampleEvent $event
+    )
     {
-        $this->template = $template;
-        $this->event = $event;
     }
 
     public function write(): void

--- a/src/PhpSpec/Formatter/Html/ReportPendingItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportPendingItem.php
@@ -18,24 +18,12 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportPendingItem
 {
-    /**
-     * @var TemplateInterface
-     */
-    private $template;
-    /**
-     * @var ExampleEvent
-     */
-    private $event;
-    /**
-     * @var int
-     */
-    private static $pendingExamplesCount = 1;
+    private static int $pendingExamplesCount = 1;
 
-    
-    public function __construct(TemplateInterface $template, ExampleEvent $event)
+    public function __construct(
+        private TemplateInterface $template,
+        private ExampleEvent $event)
     {
-        $this->template = $template;
-        $this->event = $event;
     }
 
     public function write(): void

--- a/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
+++ b/src/PhpSpec/Formatter/Html/ReportSkippedItem.php
@@ -18,20 +18,11 @@ use PhpSpec\Formatter\Template as TemplateInterface;
 
 class ReportSkippedItem
 {
-    /**
-     * @var TemplateInterface
-     */
-    private $template;
-    /**
-     * @var ExampleEvent
-     */
-    private $event;
-
-    
-    public function __construct(TemplateInterface $template, ExampleEvent $event)
+    public function __construct(
+        private TemplateInterface $template,
+        private ExampleEvent $event
+    )
     {
-        $this->template = $template;
-        $this->event    = $event;
     }
 
     public function write(): void

--- a/src/PhpSpec/Formatter/Html/Template.php
+++ b/src/PhpSpec/Formatter/Html/Template.php
@@ -20,18 +20,12 @@ final class Template implements TemplateInterface
 {
     const DIR = __DIR__;
 
-    /**
-     * @var IO
-     */
-    private $io;
-
-    
-    public function __construct(IO $io)
+    public function __construct(
+        private IO $io
+    )
     {
-        $this->io = $io;
     }
 
-    
     public function render(string $text, array $templateVars = array()): void
     {
         if (file_exists($text)) {
@@ -42,7 +36,6 @@ final class Template implements TemplateInterface
         $this->io->write($output);
     }
 
-    
     private function extractKeys(array $templateVars): array
     {
         return array_map(function ($e) {

--- a/src/PhpSpec/Formatter/HtmlFormatter.php
+++ b/src/PhpSpec/Formatter/HtmlFormatter.php
@@ -22,35 +22,25 @@ use PhpSpec\Listener\StatisticsCollector;
 
 final class HtmlFormatter extends BasicFormatter
 {
-    /**
-     * @var Html\ReportItemFactory
-     */
-    private $reportItemFactory;
-
-    /**
-     * @var int
-     */
-    private $index = 1;
+    private int $index = 1;
 
     public function __construct(
-        Html\ReportItemFactory $reportItemFactory,
+        private Html\ReportItemFactory $reportItemFactory,
         Presenter $presenter,
         IO $io,
         StatisticsCollector $stats
     ) {
-        $this->reportItemFactory = $reportItemFactory;
-
         parent::__construct($presenter, $io, $stats);
     }
 
 
-    public function beforeSuite(SuiteEvent $event)
+    public function beforeSuite(SuiteEvent $event) : void
     {
         include __DIR__."/Html/Template/ReportHeader.html";
     }
 
 
-    public function beforeSpecification(SpecificationEvent $event)
+    public function beforeSpecification(SpecificationEvent $event) : void
     {
         $index = $this->index++;
         $name = $event->getTitle();
@@ -58,13 +48,13 @@ final class HtmlFormatter extends BasicFormatter
     }
 
 
-    public function afterSpecification(SpecificationEvent $event)
+    public function afterSpecification(SpecificationEvent $event) : void
     {
         include __DIR__."/Html/Template/ReportSpecificationEnds.html";
     }
 
 
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         $reportLine = $this->reportItemFactory->create($event, $this->getPresenter());
         $reportLine->write($this->index - 1);
@@ -72,7 +62,7 @@ final class HtmlFormatter extends BasicFormatter
     }
 
 
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         include __DIR__."/Html/Template/ReportSummary.html";
         include __DIR__."/Html/Template/ReportFooter.html";

--- a/src/PhpSpec/Formatter/JUnitFormatter.php
+++ b/src/PhpSpec/Formatter/JUnitFormatter.php
@@ -27,30 +27,25 @@ use PhpSpec\Event\SpecificationEvent;
  */
 final class JUnitFormatter extends BasicFormatter
 {
-    /** @var array */
-    protected $testCaseNodes = array();
+    protected array $testCaseNodes = [];
 
-    /** @var array */
-    protected $testSuiteNodes = array();
+    protected array $testSuiteNodes = [];
 
-    /** @var array */
-    protected $exampleStatusCounts = array();
+    protected array $exampleStatusCounts = [];
 
-    /** @var array */
-    protected $jUnitStatuses = array(
+    protected array $jUnitStatuses = [
         ExampleEvent::PASSED  => 'passed',
         ExampleEvent::PENDING => 'pending',
         ExampleEvent::SKIPPED => 'skipped',
         ExampleEvent::FAILED  => 'failed',
         ExampleEvent::BROKEN  => 'broken',
-    );
+    ];
 
-    /** @var array */
-    protected $resultTags = array(
+    protected array $resultTags = [
         ExampleEvent::FAILED  => 'failure',
         ExampleEvent::BROKEN  => 'error',
         ExampleEvent::SKIPPED => 'skipped',
-    );
+    ];
 
     public function __construct(Presenter $presenter, IO $io, StatisticsCollector $stats)
     {
@@ -78,7 +73,7 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Set testsuite nodes
      */
-    public function setTestSuiteNodes(array $testSuiteNodes)
+    public function setTestSuiteNodes(array $testSuiteNodes) : void
     {
         $this->testSuiteNodes = $testSuiteNodes;
     }
@@ -94,7 +89,7 @@ final class JUnitFormatter extends BasicFormatter
     /**
      * Set example status counts
      */
-    public function setExampleStatusCounts(array $exampleStatusCounts)
+    public function setExampleStatusCounts(array $exampleStatusCounts) : void
     {
         $this->exampleStatusCounts = $exampleStatusCounts;
     }
@@ -107,10 +102,7 @@ final class JUnitFormatter extends BasicFormatter
         return $this->exampleStatusCounts;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         $testCaseNode = sprintf(
             '<testcase name="%s" time="%F" classname="%s" status="%s"',
@@ -152,10 +144,7 @@ final class JUnitFormatter extends BasicFormatter
         $this->testCaseNodes[] = $testCaseNode;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function afterSpecification(SpecificationEvent $event)
+    public function afterSpecification(SpecificationEvent $event) : void
     {
         $this->testSuiteNodes[] = sprintf(
             '<testsuite name="%s" time="%F" tests="%s" failures="%s" errors="%s" skipped="%s">'."\n".
@@ -173,10 +162,7 @@ final class JUnitFormatter extends BasicFormatter
         $this->initTestCaseNodes();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         $stats = $this->getStatisticsCollector();
 

--- a/src/PhpSpec/Formatter/JsonFormatter.php
+++ b/src/PhpSpec/Formatter/JsonFormatter.php
@@ -9,7 +9,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
- 
+
 namespace PhpSpec\Formatter;
 
 use PhpSpec\Event\ExampleEvent;
@@ -18,7 +18,7 @@ use PhpSpec\Event\SuiteEvent;
 
 final class JsonFormatter extends BasicFormatter
 {
-    private $data = [
+    private array $data = [
         'status' => '',
         'time' => 0,
         'specifications' => [],
@@ -32,7 +32,7 @@ final class JsonFormatter extends BasicFormatter
         ExampleEvent::BROKEN  => 'broken',
     ];
 
-    public function beforeSpecification(SpecificationEvent $event)
+    public function beforeSpecification(SpecificationEvent $event) : void
     {
         $this->data['specifications'][$event->getSpecification()->getTitle()] = [
             'status' => '',
@@ -41,7 +41,7 @@ final class JsonFormatter extends BasicFormatter
         ];
     }
 
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         $specification = $event->getSpecification()->getTitle();
         $example = $event->getTitle();
@@ -63,15 +63,15 @@ final class JsonFormatter extends BasicFormatter
         ];
     }
 
-    public function afterSpecification(SpecificationEvent $event)
+    public function afterSpecification(SpecificationEvent $event) : void
     {
         $specification = $event->getSpecification()->getTitle();
-        
+
         $this->data['specifications'][$specification]['status'] = self::STATUS_NAME[$event->getResult()];
         $this->data['specifications'][$specification]['time'] = $event->getTime();
     }
 
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         $this->data['status'] = self::STATUS_NAME[$event->getResult()];
         $this->data['time'] = $event->getTime();

--- a/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ArrayEngine.php
@@ -21,19 +21,18 @@ final class ArrayEngine extends StringEngine
 
     private const PAD_STRING = ' ';
 
-    private $exporter;
-
-    public function __construct(Exporter $exporter)
+    public function __construct(
+        private Exporter $exporter
+    )
     {
-        $this->exporter = $exporter;
     }
 
-    public function supports($expected, $actual): bool
+    public function supports(mixed $expected, mixed $actual): bool
     {
         return \is_array($expected) && \is_array($actual);
     }
 
-    public function compare($expected, $actual): string
+    public function compare(mixed $expected, mixed $actual): string
     {
         $expectedString = $this->convertArrayToString($expected);
         $actualString = $this->convertArrayToString($actual);
@@ -41,7 +40,7 @@ final class ArrayEngine extends StringEngine
         return parent::compare($expectedString, $actualString);
     }
 
-    private function convertArrayToString(array $a, $pad = 1): string
+    private function convertArrayToString(array $a, int $pad = 1): string
     {
         $str = str_pad('', $pad * self::PAD_SIZE, self::PAD_STRING) . '[';
         foreach ($a as $key => $val) {

--- a/src/PhpSpec/Formatter/Presenter/Differ/Differ.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/Differ.php
@@ -15,11 +15,10 @@ namespace PhpSpec\Formatter\Presenter\Differ;
 
 class Differ
 {
-    private $engines = array();
-
-    public function __construct(array $engines = array())
+    public function __construct(
+        private array $engines = []
+    )
     {
-        $this->engines = $engines;
     }
 
     public function addEngine(DifferEngine $engine): void
@@ -27,12 +26,14 @@ class Differ
         $this->engines[] = $engine;
     }
 
-    public function compare($expected, $actual)
+    public function compare(mixed $expected, mixed $actual) : ?string
     {
         foreach ($this->engines as $engine) {
             if ($engine->supports($expected, $actual)) {
                 return rtrim($engine->compare($expected, $actual));
             }
         }
+
+        return null;
     }
 }

--- a/src/PhpSpec/Formatter/Presenter/Differ/DifferEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/DifferEngine.php
@@ -15,9 +15,7 @@ namespace PhpSpec\Formatter\Presenter\Differ;
 
 interface DifferEngine
 {
-    
-    public function supports($expected, $actual): bool;
+    public function supports(mixed $expected, mixed $actual): bool;
 
-    
-    public function compare($expected, $actual): string;
+    public function compare(mixed $expected, mixed $actual): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/ObjectEngine.php
@@ -17,33 +17,19 @@ use SebastianBergmann\Exporter\Exporter;
 
 final class ObjectEngine implements DifferEngine
 {
-    /**
-     * @var Exporter
-     */
-    private $exporter;
-    /**
-     * @var StringEngine
-     */
-    private $stringDiffer;
-
-    
-    public function __construct(Exporter $exporter, StringEngine $stringDiffer)
+    public function __construct(
+        private Exporter $exporter,
+        private StringEngine $stringDiffer
+    )
     {
-        $this->exporter = $exporter;
-        $this->stringDiffer = $stringDiffer;
     }
 
-    
-    public function supports($expected, $actual): bool
+    public function supports(mixed $expected, mixed $actual): bool
     {
         return \is_object($expected) && \is_object($actual);
     }
 
-    /**
-     * @param object $expected
-     * @param object $actual
-     */
-    public function compare($expected, $actual): string
+    public function compare(mixed $expected, mixed$actual): string
     {
         return $this->stringDiffer->compare(
             $this->exporter->export($expected),

--- a/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
+++ b/src/PhpSpec/Formatter/Presenter/Differ/StringEngine.php
@@ -15,12 +15,12 @@ namespace PhpSpec\Formatter\Presenter\Differ;
 
 class StringEngine implements DifferEngine
 {
-    public function supports($expected, $actual): bool
+    public function supports(mixed $expected, mixed $actual): bool
     {
         return \is_string($expected) && \is_string($actual);
     }
 
-    public function compare($expected, $actual): string
+    public function compare(mixed $expected, mixed $actual): string
     {
         $expected = explode("\n", (string) $expected);
         $actual   = explode("\n", (string) $actual);

--- a/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/CallArgumentsPresenter.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Formatter\Presenter\Exception;
 
+use PhpParser\Builder\Method;
 use PhpSpec\Formatter\Presenter\Differ\Differ;
 use Prophecy\Argument\Token\ExactValueToken;
 use Prophecy\Exception\Call\UnexpectedCallException;
@@ -20,18 +21,12 @@ use Prophecy\Prophecy\MethodProphecy;
 
 class CallArgumentsPresenter
 {
-    /**
-     * @var Differ
-     */
-    private $differ;
-
-    
-    public function __construct(Differ $differ)
+    public function __construct(
+        private Differ $differ
+    )
     {
-        $this->differ = $differ;
     }
 
-    
     public function presentDifference(UnexpectedCallException $exception): string
     {
         $actualArguments = $exception->getArguments();
@@ -67,13 +62,12 @@ class CallArgumentsPresenter
 
     /**
      * @param MethodProphecy[] $methodProphecies
-     *
-     * @return null|MethodProphecy
      */
     private function findFirstUnexpectedArgumentsCallProphecy(
         array $methodProphecies,
         UnexpectedCallException $exception
-    ){
+    ) : ?MethodProphecy
+    {
         $objectProphecy = $exception->getObjectProphecy();
 
         foreach ($methodProphecies as $methodProphecy) {
@@ -92,13 +86,13 @@ class CallArgumentsPresenter
         return null;
     }
 
-    
+
     private function parametersCountMismatch(array $expectedTokens, array $actualArguments): bool
     {
         return \count($expectedTokens) !== \count($actualArguments);
     }
 
-    
+
     private function convertArgumentTokensToDiffableValues(array $tokens): array
     {
         $values = array();
@@ -113,7 +107,7 @@ class CallArgumentsPresenter
         return $values;
     }
 
-    
+
     private function generateArgumentsDifferenceText(array $actualArguments, array $expectedArguments): string
     {
         $text = '';

--- a/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/GenericPhpSpecExceptionPresenter.php
@@ -15,18 +15,12 @@ namespace PhpSpec\Formatter\Presenter\Exception;
 
 final class GenericPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresenter implements PhpSpecExceptionPresenter
 {
-    /**
-     * @var ExceptionElementPresenter
-     */
-    private $exceptionElementPresenter;
-
-    
-    public function __construct(ExceptionElementPresenter $exceptionElementPresenter)
+    public function __construct(
+        private ExceptionElementPresenter $exceptionElementPresenter
+    )
     {
-        $this->exceptionElementPresenter = $exceptionElementPresenter;
     }
 
-    
     protected function presentFileCode(string $file, int $lineno, int $context = 6): string
     {
         $lines  = explode(PHP_EOL, file_get_contents($file));

--- a/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/HtmlPhpSpecExceptionPresenter.php
@@ -15,7 +15,6 @@ namespace PhpSpec\Formatter\Presenter\Exception;
 
 final class HtmlPhpSpecExceptionPresenter extends AbstractPhpSpecExceptionPresenter implements PhpSpecExceptionPresenter
 {
-    
     protected function presentFileCode(string $file, int $lineno, int $context = 6): string
     {
         $lines  = explode(PHP_EOL, file_get_contents($file));

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionElementPresenter.php
@@ -18,24 +18,13 @@ use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
 {
-    /**
-     * @var ExceptionTypePresenter
-     */
-    private $exceptionTypePresenter;
-
-    /**
-     * @var ValuePresenter
-     */
-    private $valuePresenter;
-
-    
-    public function __construct(ExceptionTypePresenter $exceptionTypePresenter, ValuePresenter $valuePresenter)
+    public function __construct(
+        private ExceptionTypePresenter $exceptionTypePresenter,
+        private ValuePresenter $valuePresenter
+    )
     {
-        $this->exceptionTypePresenter = $exceptionTypePresenter;
-        $this->valuePresenter = $valuePresenter;
     }
 
-    
     public function presentExceptionThrownMessage(\Exception $exception): string
     {
         return sprintf(
@@ -44,37 +33,31 @@ final class SimpleExceptionElementPresenter implements ExceptionElementPresenter
         );
     }
 
-    
     public function presentCodeLine(string $number, string $line): string
     {
         return sprintf('%s %s', $number, $line);
     }
 
-    
     public function presentHighlight(string $line): string
     {
         return $line;
     }
 
-    
     public function presentExceptionTraceHeader(string $header): string
     {
         return $header;
     }
 
-    
     public function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         return sprintf('   %s%s%s(%s)', $class, $type, $method, $this->presentExceptionTraceArguments($args));
     }
 
-    
     public function presentExceptionTraceFunction(string $function, array $args): string
     {
         return sprintf('   %s(%s)', $function, $this->presentExceptionTraceArguments($args));
     }
 
-    
     private function presentExceptionTraceArguments(array $args): string
     {
         return implode(', ', array_map(array($this->valuePresenter, 'presentValue'), $args));

--- a/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/SimpleExceptionPresenter.php
@@ -24,53 +24,21 @@ use Prophecy\Exception\Exception as ProphecyException;
 
 final class SimpleExceptionPresenter implements ExceptionPresenter
 {
-    /**
-     * @var Differ
-     */
-    private $differ;
+    private string $phpspecPath;
 
-    /**
-     * @var string
-     */
-    private $phpspecPath;
+    private string $runnerPath;
 
-    /**
-     * @var string
-     */
-    private $runnerPath;
-
-    /**
-     * @var ExceptionElementPresenter
-     */
-    private $exceptionElementPresenter;
-
-    /**
-     * @var CallArgumentsPresenter
-     */
-    private $callArgumentsPresenter;
-
-    /**
-     * @var PhpSpecExceptionPresenter
-     */
-    private $phpspecExceptionPresenter;
-
-    
     public function __construct(
-        Differ $differ,
-        ExceptionElementPresenter $exceptionElementPresenter,
-        CallArgumentsPresenter $callArgumentsPresenter,
-        PhpSpecExceptionPresenter $phpspecExceptionPresenter
+        private Differ $differ,
+        private ExceptionElementPresenter $exceptionElementPresenter,
+        private CallArgumentsPresenter $callArgumentsPresenter,
+        private PhpSpecExceptionPresenter $phpspecExceptionPresenter
     ) {
-        $this->differ = $differ;
-        $this->exceptionElementPresenter = $exceptionElementPresenter;
-        $this->callArgumentsPresenter = $callArgumentsPresenter;
-        $this->phpspecExceptionPresenter = $phpspecExceptionPresenter;
-
         $this->phpspecPath = dirname(dirname(__DIR__));
         $this->runnerPath  = $this->phpspecPath.DIRECTORY_SEPARATOR.'Runner';
     }
 
-    
+
     public function presentException(\Exception $exception, bool $verbose = false): string
     {
         if ($exception instanceof PhpSpecException) {
@@ -88,7 +56,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return $this->getVerbosePresentation($exception, $presentation);
     }
 
-    
+
     private function getVerbosePresentation(\Exception $exception, string $presentation): string
     {
         // displaying skipped exception trace is not necessary and too verbose
@@ -113,7 +81,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return $presentation . $this->presentExceptionStackTrace($exception);
     }
 
-    
+
     private function presentExceptionDifference(NotEqualException $exception): string
     {
         $diff = $this->differ->compare($exception->getExpected(), $exception->getActual());
@@ -121,7 +89,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return $diff === null ? '' : $diff;
     }
 
-    
+
     private function presentExceptionStackTrace(\Exception $exception): string
     {
         $offset = 0;
@@ -148,25 +116,25 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return empty($text) ? $text : PHP_EOL . $text;
     }
 
-    
+
     private function presentExceptionTraceHeader(string $header): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceHeader($header) . PHP_EOL;
     }
 
-    
+
     private function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceMethod($class, $type, $method, $args) . PHP_EOL;
     }
 
-    
+
     private function presentExceptionTraceFunction(string $function, array $args): string
     {
         return $this->exceptionElementPresenter->presentExceptionTraceFunction($function, $args) . PHP_EOL;
     }
 
-    
+
     private function presentExceptionTraceLocation(int $offset, string $file, int $line): string
     {
         return $this->presentExceptionTraceHeader(sprintf(
@@ -177,13 +145,13 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         ));
     }
 
-    
+
     private function shouldStopTracePresentation(array $call): bool
     {
         return isset($call['file']) && false !== strpos($call['file'], $this->runnerPath);
     }
 
-    
+
     private function shouldSkipTracePresentation(array $call): bool
     {
         if (isset($call['file']) && 0 === strpos($call['file'], $this->phpspecPath)) {
@@ -193,7 +161,7 @@ final class SimpleExceptionPresenter implements ExceptionPresenter
         return isset($call['class']) && 0 === strpos($call['class'], "PhpSpec\\");
     }
 
-    
+
     private function presentExceptionTraceDetails(array $call, int $offset): string
     {
         $text = '';

--- a/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Exception/TaggingExceptionElementPresenter.php
@@ -18,24 +18,13 @@ use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 final class TaggingExceptionElementPresenter implements ExceptionElementPresenter
 {
-    /**
-     * @var ExceptionTypePresenter
-     */
-    private $exceptionTypePresenter;
-
-    /**
-     * @var ValuePresenter
-     */
-    private $valuePresenter;
-
-    
-    public function __construct(ExceptionTypePresenter $exceptionTypePresenter, ValuePresenter $valuePresenter)
+    public function __construct(
+        private ExceptionTypePresenter $exceptionTypePresenter,
+        private ValuePresenter $valuePresenter
+    )
     {
-        $this->exceptionTypePresenter = $exceptionTypePresenter;
-        $this->valuePresenter = $valuePresenter;
     }
 
-    
     public function presentExceptionThrownMessage(\Exception $exception): string
     {
         return sprintf(
@@ -44,25 +33,21 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
         );
     }
 
-    
     public function presentCodeLine(string $number, string $line): string
     {
         return sprintf('<lineno>%s</lineno> <code>%s</code>', $number, $line);
     }
 
-    
     public function presentHighlight(string $line): string
     {
         return sprintf('<hl>%s</hl>', $line);
     }
 
-    
     public function presentExceptionTraceHeader(string $header): string
     {
         return sprintf('<trace>%s</trace>', $header);
     }
 
-    
     public function presentExceptionTraceMethod(string $class, string $type, string $method, array $args): string
     {
         $template = '   <trace><trace-class>%s</trace-class><trace-type>%s</trace-type>'.
@@ -71,7 +56,6 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
         return sprintf($template, $class, $type, $method, $this->presentExceptionTraceArguments($args));
     }
 
-    
     public function presentExceptionTraceFunction(string $function, array $args): string
     {
         $template = '   <trace><trace-func>%s</trace-func>(<trace-args>%s</trace-args>)</trace>';
@@ -79,7 +63,6 @@ final class TaggingExceptionElementPresenter implements ExceptionElementPresente
         return sprintf($template, $function, $this->presentExceptionTraceArguments($args));
     }
 
-    
     private function presentExceptionTraceArguments(array $args): string
     {
         $valuePresenter = $this->valuePresenter;

--- a/src/PhpSpec/Formatter/Presenter/Presenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Presenter.php
@@ -18,6 +18,5 @@ use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 interface Presenter extends ExceptionPresenter, ValuePresenter
 {
-    
     public function presentString(string $string): string;
 }

--- a/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/SimplePresenter.php
@@ -18,36 +18,23 @@ use PhpSpec\Formatter\Presenter\Value\ValuePresenter;
 
 final class SimplePresenter implements Presenter
 {
-    /**
-     * @var ValuePresenter
-     */
-    private $valuePresenter;
-
-    /**
-     * @var ExceptionPresenter
-     */
-    private $exceptionPresenter;
-
-    
-    public function __construct(ValuePresenter $valuePresenter, ExceptionPresenter $exceptionPresenter)
+    public function __construct(
+        private ValuePresenter $valuePresenter,
+        private ExceptionPresenter $exceptionPresenter
+    )
     {
-        $this->valuePresenter = $valuePresenter;
-        $this->exceptionPresenter = $exceptionPresenter;
     }
 
-    
-    public function presentValue($value): string
+    public function presentValue(mixed $value): string
     {
         return $this->valuePresenter->presentValue($value);
     }
 
-    
     public function presentException(\Exception $exception, bool $verbose = false): string
     {
         return $this->exceptionPresenter->presentException($exception, $verbose);
     }
 
-    
     public function presentString(string $string): string
     {
         return $string;

--- a/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/TaggingPresenter.php
@@ -15,31 +15,23 @@ namespace PhpSpec\Formatter\Presenter;
 
 final class TaggingPresenter implements Presenter
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
     public function presentException(\Exception $exception, bool $verbose = false): string
     {
         return $this->presenter->presentException($exception, $verbose);
     }
 
-    
     public function presentString(string $string): string
     {
         return sprintf('<value>%s</value>', $string);
     }
 
-    
-    public function presentValue($value): string
+    public function presentValue(mixed $value): string
     {
         return $this->presentString($this->presenter->presentValue($value));
     }

--- a/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ArrayTypePresenter.php
@@ -15,19 +15,16 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class ArrayTypePresenter implements TypePresenter
 {
-    
-    public function supports($value): bool
+    public function supports(mixed $value): bool
     {
         return 'array' === strtolower(\gettype($value));
     }
 
-    
-    public function present($value): string
+    public function present(mixed $value): string
     {
         return sprintf('[array:%d]', \count($value));
     }
 
-    
     public function getPriority(): int
     {
         return 20;

--- a/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BaseExceptionTypePresenter.php
@@ -17,14 +17,12 @@ use PhpSpec\Exception\ErrorException;
 
 final class BaseExceptionTypePresenter implements ExceptionTypePresenter
 {
-    
-    public function supports($value): bool
+    public function supports(mixed $value): bool
     {
         return $value instanceof \Exception;
     }
 
-    
-    public function present($value): string
+    public function present(mixed $value): string
     {
         $label = 'exc';
         $message = $value->getMessage();
@@ -51,7 +49,7 @@ final class BaseExceptionTypePresenter implements ExceptionTypePresenter
         );
     }
 
-    
+
     public function getPriority(): int
     {
         return 60;

--- a/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/BooleanTypePresenter.php
@@ -15,19 +15,16 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class BooleanTypePresenter implements TypePresenter
 {
-    
-    public function supports($value): bool
+    public function supports(mixed $value): bool
     {
         return 'boolean' === strtolower(\gettype($value));
     }
 
-    
-    public function present($value): string
+    public function present(mixed $value): string
     {
         return $value ? 'true' : 'false';
     }
 
-    
     public function getPriority(): int
     {
         return 40;

--- a/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/CallableTypePresenter.php
@@ -17,25 +17,18 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class CallableTypePresenter implements TypePresenter
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports($value): bool
+    public function supports(mixed $value): bool
     {
         return is_callable($value);
     }
 
-    
-    public function present($value): string
+    public function present(mixed $value): string
     {
         if (\is_array($value)) {
             $type = \is_object($value[0]) ? $this->presenter->presentValue($value[0]) : $value[0];
@@ -53,7 +46,6 @@ final class CallableTypePresenter implements TypePresenter
         return sprintf('[%s()]', $value);
     }
 
-    
     public function getPriority(): int
     {
         return 70;

--- a/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ComposedValuePresenter.php
@@ -18,10 +18,9 @@ final class ComposedValuePresenter implements ValuePresenter
     /**
      * @var TypePresenter[]
      */
-    private $typePresenters = array();
+    private array $typePresenters = [];
 
-    
-    public function addTypePresenter(TypePresenter $typePresenter)
+    public function addTypePresenter(TypePresenter $typePresenter) : void
     {
         $this->typePresenters[] = $typePresenter;
 
@@ -30,8 +29,7 @@ final class ComposedValuePresenter implements ValuePresenter
         });
     }
 
-    
-    public function presentValue($value): string
+    public function presentValue(mixed $value): string
     {
         foreach ($this->typePresenters as $typePresenter) {
             if ($typePresenter->supports($value)) {

--- a/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/NullTypePresenter.php
@@ -15,19 +15,16 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class NullTypePresenter implements TypePresenter
 {
-    
-    public function supports($value): bool
+    public function supports(mixed $value): bool
     {
         return null === $value;
     }
 
-    
-    public function present($value): string
+    public function present(mixed $value): string
     {
         return 'null';
     }
 
-    
     public function getPriority(): int
     {
         return 50;

--- a/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ObjectTypePresenter.php
@@ -15,19 +15,16 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class ObjectTypePresenter implements TypePresenter
 {
-    
-    public function supports($value): bool
+    public function supports(mixed $value): bool
     {
         return 'object' === strtolower(\gettype($value));
     }
 
-    
-    public function present($value): string
+    public function present(mixed $value): string
     {
         return sprintf('[obj:%s]', \get_class($value));
     }
 
-    
     public function getPriority(): int
     {
         return 30;

--- a/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/QuotingStringTypePresenter.php
@@ -15,19 +15,16 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class QuotingStringTypePresenter implements StringTypePresenter
 {
-    
-    public function supports($value): bool
+    public function supports(mixed $value): bool
     {
         return 'string' === strtolower(\gettype($value));
     }
 
-    
-    public function present($value): string
+    public function present(mixed $value): string
     {
         return sprintf('"%s"', $value);
     }
 
-    
     public function getPriority(): int
     {
         return 10;

--- a/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TruncatingStringTypePresenter.php
@@ -15,24 +15,18 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 final class TruncatingStringTypePresenter implements StringTypePresenter
 {
-    /**
-     * @var StringTypePresenter
-     */
-    private $stringTypePresenter;
-
-    public function __construct(StringTypePresenter $stringTypePresenter)
+    public function __construct(
+        private StringTypePresenter $stringTypePresenter
+    )
     {
-        $this->stringTypePresenter = $stringTypePresenter;
     }
 
-    
-    public function supports($value): bool
+    public function supports(mixed $value): bool
     {
         return $this->stringTypePresenter->supports($value);
     }
 
-    
-    public function present($value): string
+    public function present(mixed $value): string
     {
         if (25 > \strlen($value) && false === strpos($value, "\n")) {
             return $this->stringTypePresenter->present($value);
@@ -42,7 +36,6 @@ final class TruncatingStringTypePresenter implements StringTypePresenter
         return $this->stringTypePresenter->present(sprintf('%s...', substr($lines[0], 0, 25)));
     }
 
-    
     public function getPriority(): int
     {
         return $this->stringTypePresenter->getPriority();

--- a/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/TypePresenter.php
@@ -16,12 +16,9 @@ namespace PhpSpec\Formatter\Presenter\Value;
 
 interface TypePresenter
 {
-    
-    public function supports($value): bool;
+    public function supports(mixed $value): bool;
 
-    
-    public function present($value): string;
+    public function present(mixed $value): string;
 
-    
     public function getPriority(): int;
 }

--- a/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
+++ b/src/PhpSpec/Formatter/Presenter/Value/ValuePresenter.php
@@ -13,9 +13,7 @@
 
 namespace PhpSpec\Formatter\Presenter\Value;
 
-
 interface ValuePresenter
 {
-    
-    public function presentValue($value): string;
+    public function presentValue(mixed $value): string;
 }

--- a/src/PhpSpec/Formatter/PrettyFormatter.php
+++ b/src/PhpSpec/Formatter/PrettyFormatter.php
@@ -19,12 +19,12 @@ use PhpSpec\Event\ExampleEvent;
 
 final class PrettyFormatter extends ConsoleFormatter
 {
-    public function beforeSpecification(SpecificationEvent $event)
+    public function beforeSpecification(SpecificationEvent $event) : void
     {
         $this->getIO()->writeln(sprintf("\n      %s\n", $event->getSpecification()->getTitle()), 0);
     }
 
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         $io = $this->getIO();
         $line  = $event->getExample()->getFunctionReflection()->getStartLine();
@@ -56,7 +56,7 @@ final class PrettyFormatter extends ConsoleFormatter
         $this->printException($event);
     }
 
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         $io = $this->getIO();
         $io->writeln();
@@ -98,7 +98,7 @@ final class PrettyFormatter extends ConsoleFormatter
         $io->writeln(sprintf("\n%sms", round($event->getTime() * 1000)));
     }
 
-    protected function printSlowTime(ExampleEvent $event)
+    protected function printSlowTime(ExampleEvent $event) : void
     {
         $io = $this->getIO();
         $ms = $event->getTime() * 1000;
@@ -109,7 +109,7 @@ final class PrettyFormatter extends ConsoleFormatter
         }
     }
 
-    protected function printException(ExampleEvent $event, $depth = null): void
+    protected function printException(ExampleEvent $event, ?int $depth = null): void
     {
         $io = $this->getIO();
 

--- a/src/PhpSpec/Formatter/ProgressFormatter.php
+++ b/src/PhpSpec/Formatter/ProgressFormatter.php
@@ -21,9 +21,9 @@ final class ProgressFormatter extends ConsoleFormatter
 {
     const FPS = 10;
 
-    private $lastDraw;
+    private ?float $lastDraw = null;
 
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         $this->printException($event);
 
@@ -52,7 +52,7 @@ final class ProgressFormatter extends ConsoleFormatter
         }
     }
 
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         $this->drawStats();
 
@@ -83,11 +83,7 @@ final class ProgressFormatter extends ConsoleFormatter
         $io->writeln();
     }
 
-    /**
-     * @param $total
-     * @param $counts
-     */
-    private function getPercentages($total, $counts): array
+    private function getPercentages(int $total, array $counts): array
     {
         return array_map(
             function ($count) use ($total) {
@@ -103,7 +99,6 @@ final class ProgressFormatter extends ConsoleFormatter
         );
     }
 
-    
     private function getBarLengths(array $counts): array
     {
         $stats = $this->getStatisticsCollector();
@@ -119,7 +114,6 @@ final class ProgressFormatter extends ConsoleFormatter
         return $barLengths;
     }
 
-    
     private function formatProgressOutput(array $barLengths, array $percents, bool $isDecorated): array
     {
         $size = $this->getIO()->getBlockWidth();
@@ -152,7 +146,6 @@ final class ProgressFormatter extends ConsoleFormatter
         return $progress;
     }
 
-    
     private function updateProgressBar(ConsoleIO $io, array $progress, int $total): void
     {
         if ($io->isDecorated()) {

--- a/src/PhpSpec/Formatter/TapFormatter.php
+++ b/src/PhpSpec/Formatter/TapFormatter.php
@@ -42,17 +42,11 @@ final class TapFormatter extends ConsoleFormatter
 
     const UNDEFINED_RESULT = -1;
 
-    /**
-     * @var int
-     */
-    private $examplesCount = 0;
+    private int $examplesCount = 0;
 
-    /**
-     * @var string
-     */
-    private $currentSpecificationTitle;
+    private string $currentSpecificationTitle = '';
 
-    public function beforeSuite(SuiteEvent $event)
+    public function beforeSuite(SuiteEvent $event) : void
     {
         $this->getIO()->writeln(self::VERSION);
         foreach ($this->getStatisticsCollector()->getIgnoredResourceEvents() as $event) {
@@ -65,12 +59,12 @@ final class TapFormatter extends ConsoleFormatter
         }
     }
 
-    public function beforeSpecification(SpecificationEvent $event)
+    public function beforeSpecification(SpecificationEvent $event) : void
     {
         $this->currentSpecificationTitle = $event->getSpecification()->getTitle();
     }
 
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         $this->examplesCount++;
         $desc = sprintf(
@@ -104,7 +98,7 @@ final class TapFormatter extends ConsoleFormatter
         $this->getIO()->writeln($result);
     }
 
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         $this->getIO()->writeln(sprintf(
             self::PLAN,
@@ -115,8 +109,6 @@ final class TapFormatter extends ConsoleFormatter
     /**
      * Format message as two-space indented YAML when needed outside of a
      * SKIP or TODO directive.
-     *
-     * @param int $result
      */
     private function getResultData(ExampleEvent $event, int $result = null): string
     {

--- a/src/PhpSpec/Formatter/TeamCityFormatter.php
+++ b/src/PhpSpec/Formatter/TeamCityFormatter.php
@@ -11,12 +11,11 @@ use PhpSpec\Event\SuiteEvent;
 
 class TeamCityFormatter extends BasicFormatter
 {
-    /** @var string|null */
-    private $startedTestName = null;
-    /** @var bool */
-    private $isSummaryTestCountPrinted = false;
-    /** @var false|int */
-    private $flowId;
+    private ?string $startedTestName = null;
+
+    private bool $isSummaryTestCountPrinted = false;
+
+    private int|false $flowId = false;
 
     private function startTest(ExampleEvent $event): void
     {
@@ -94,9 +93,6 @@ class TeamCityFormatter extends BasicFormatter
         );
     }
 
-    /**
-     * @param float $time microseconds
-     */
     private function toMilliseconds(float $time): int
     {
         return (int)round($time * 1000);
@@ -168,9 +164,6 @@ class TeamCityFormatter extends BasicFormatter
         );
     }
 
-    /**
-     * @param SuiteEvent $event
-     */
     public function afterSuite(SuiteEvent $event): void
     {
         $this->printEvent(
@@ -189,9 +182,6 @@ class TeamCityFormatter extends BasicFormatter
         $this->startTest($event);
     }
 
-    /**
-     * @param ExampleEvent $event
-     */
     public function afterExample(ExampleEvent $event): void
     {
         switch ($event->getResult()) {
@@ -231,9 +221,6 @@ class TeamCityFormatter extends BasicFormatter
         $this->endTest($event);
     }
 
-    /**
-     * @param SpecificationEvent $event
-     */
     public function beforeSpecification(SpecificationEvent $event): void
     {
         $suiteName = $event->getSpecification()->getResource()->getSpecClassname();
@@ -249,9 +236,6 @@ class TeamCityFormatter extends BasicFormatter
         $this->printEvent('testSuiteStarted', $parameters);
     }
 
-    /**
-     * @param SpecificationEvent $event
-     */
     public function afterSpecification(SpecificationEvent $event): void
     {
         $suiteName = $event->getSpecification()->getResource()->getSpecClassname();

--- a/src/PhpSpec/Listener/BootstrapListener.php
+++ b/src/PhpSpec/Listener/BootstrapListener.php
@@ -7,17 +7,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class BootstrapListener implements EventSubscriberInterface
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    public function __construct(ConsoleIO $io)
+    public function __construct(
+        private ConsoleIO $io
+    )
     {
-        $this->io = $io;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents() : array
     {
         return array('beforeSuite' => array('beforeSuite', 1100));
     }

--- a/src/PhpSpec/Listener/ClassNotFoundListener.php
+++ b/src/PhpSpec/Listener/ClassNotFoundListener.php
@@ -24,20 +24,15 @@ use Prophecy\Exception\Doubler\ClassNotFoundException as ProphecyClassException;
 
 final class ClassNotFoundListener implements EventSubscriberInterface
 {
-    private $io;
-    private $resources;
-    private $generator;
-    private $classes = array();
+    private array $classes = [];
 
-    
-    public function __construct(ConsoleIO $io, ResourceManager $resources, GeneratorManager $generator)
+    public function __construct(
+        private ConsoleIO $io,
+        private ResourceManager $resources,
+        private GeneratorManager $generator)
     {
-        $this->io        = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
     }
 
-    
     public static function getSubscribedEvents(): array
     {
         return array(
@@ -46,8 +41,7 @@ final class ClassNotFoundListener implements EventSubscriberInterface
         );
     }
 
-    
-    public function afterExample(ExampleEvent $event)
+    public function afterExample(ExampleEvent $event) : void
     {
         if (null === $exception = $event->getException()) {
             return;
@@ -61,8 +55,7 @@ final class ClassNotFoundListener implements EventSubscriberInterface
         $this->classes[$exception->getClassname()] = true;
     }
 
-    
-    public function afterSuite(SuiteEvent $event)
+    public function afterSuite(SuiteEvent $event) : void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
             return;

--- a/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
+++ b/src/PhpSpec/Listener/CollaboratorNotFoundListener.php
@@ -25,34 +25,18 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 final class CollaboratorNotFoundListener implements EventSubscriberInterface
 {
     /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    /**
      * @var CollaboratorNotFoundException[]
      */
-    private $exceptions = array();
+    private array $exceptions = [];
 
-    /**
-     * @var ResourceManager
-     */
-    private $resources;
-
-    /**
-     * @var GeneratorManager
-     */
-    private $generator;
-
-    
-    public function __construct(ConsoleIO $io, ResourceManager $resources, GeneratorManager $generator)
+    public function __construct(
+        private ConsoleIO $io,
+        private ResourceManager $resources,
+        private GeneratorManager $generator
+    )
     {
-        $this->io = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
     }
 
-    
     public static function getSubscribedEvents(): array
     {
         return array(
@@ -61,7 +45,6 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
         );
     }
 
-    
     public function afterExample(ExampleEvent $event): void
     {
         if (($exception = $event->getException()) &&
@@ -70,7 +53,6 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
         }
     }
 
-    
     public function afterSuite(SuiteEvent $event): void
     {
         if (!$this->io->isCodeGenerationEnabled()) {
@@ -93,7 +75,6 @@ final class CollaboratorNotFoundListener implements EventSubscriberInterface
         }
     }
 
-    
     private function resourceIsInSpecNamespace(CollaboratorNotFoundException $exception, Resource $resource): bool
     {
         return strpos($exception->getCollaboratorName(), $resource->getSpecNamespace()) === 0;

--- a/src/PhpSpec/Listener/CurrentExampleListener.php
+++ b/src/PhpSpec/Listener/CurrentExampleListener.php
@@ -20,23 +20,19 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class CurrentExampleListener implements EventSubscriberInterface {
 
-    /**
-     * @var CurrentExampleTracker
-     */
-    private $currentExample;
+    public function __construct(
+        private CurrentExampleTracker $currentExample
+    )
+    {
+    }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents() : array
     {
         return array(
             'beforeExample' => array('beforeCurrentExample', -20),
             'afterExample' => array('afterCurrentExample', -20),
             'afterSuite' => array('afterSuiteEvent', -20),
         );
-    }
-
-    public function __construct(CurrentExampleTracker $currentExample)
-    {
-        $this->currentExample = $currentExample;
     }
 
     public function beforeCurrentExample(ExampleEvent $event): void

--- a/src/PhpSpec/Listener/MethodNotFoundListener.php
+++ b/src/PhpSpec/Listener/MethodNotFoundListener.php
@@ -24,30 +24,19 @@ use PhpSpec\Exception\Fracture\MethodNotFoundException;
 
 final class MethodNotFoundListener implements EventSubscriberInterface
 {
-    private $io;
-    private $resources;
-    private $generator;
-    private $methods = array();
-    private $wrongMethodNames = array();
-    /**
-     * @var NameChecker
-     */
-    private $nameChecker;
+    private array $methods = [];
+    private array $wrongMethodNames = [];
 
-    
     public function __construct(
-        ConsoleIO $io,
-        ResourceManager $resources,
-        GeneratorManager $generator,
-        NameChecker $nameChecker
-    ) {
-        $this->io        = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
-        $this->nameChecker = $nameChecker;
+        private ConsoleIO $io,
+        private ResourceManager $resources,
+        private GeneratorManager $generator,
+        private NameChecker $nameChecker
+    )
+    {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents() : array
     {
         return array(
             'afterExample' => array('afterExample', 10),
@@ -107,7 +96,7 @@ final class MethodNotFoundListener implements EventSubscriberInterface
         }
     }
 
-    private function checkIfMethodNameAllowed($methodName): void
+    private function checkIfMethodNameAllowed(string $methodName): void
     {
         if (!$this->nameChecker->isNameValid($methodName)) {
             $this->wrongMethodNames[] = $methodName;

--- a/src/PhpSpec/Listener/MethodReturnedNullListener.php
+++ b/src/PhpSpec/Listener/MethodReturnedNullListener.php
@@ -26,47 +26,20 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class MethodReturnedNullListener implements EventSubscriberInterface
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
+    private array $nullMethods = [];
 
-    private $nullMethods = array();
+    private ?MethodCallEvent $lastMethodCallEvent = null;
 
-    /**
-     * @var null|MethodCallEvent
-     */
-    private $lastMethodCallEvent = null;
-    /**
-     * @var ResourceManager
-     */
-    private $resources;
-    /**
-     * @var GeneratorManager
-     */
-    private $generator;
-    /**
-     * @var MethodAnalyser
-     */
-    private $methodAnalyser;
-
-    
     public function __construct(
-        ConsoleIO $io,
-        ResourceManager $resources,
-        GeneratorManager $generator,
-        MethodAnalyser $methodAnalyser
-    ) {
-        $this->io = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
-        $this->methodAnalyser = $methodAnalyser;
+        private ConsoleIO $io,
+        private ResourceManager $resources,
+        private GeneratorManager $generator,
+        private MethodAnalyser $methodAnalyser
+    )
+    {
     }
 
-    /**
-     * @{inheritdoc}
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents() : array
     {
         return array(
             'afterExample' => array('afterExample', 10),
@@ -107,7 +80,7 @@ final class MethodReturnedNullListener implements EventSubscriberInterface
 
             $subject = $exception->getSubject();
             $method = $exception->getMethod();
-            if (is_null($subject) || is_null($method)) {
+            if (is_null($subject)) {
                 return;
             }
             $class = \get_class($subject);

--- a/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
+++ b/src/PhpSpec/Listener/NamedConstructorNotFoundListener.php
@@ -23,19 +23,17 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class NamedConstructorNotFoundListener implements EventSubscriberInterface
 {
-    private $io;
-    private $resources;
-    private $generator;
-    private $methods = array();
+    private array $methods = array();
 
-    public function __construct(ConsoleIO $io, ResourceManager $resources, GeneratorManager $generator)
+    public function __construct(
+        private ConsoleIO $io,
+        private ResourceManager $resources,
+        private GeneratorManager $generator
+    )
     {
-        $this->io        = $io;
-        $this->resources = $resources;
-        $this->generator = $generator;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents() : array
     {
         return array(
             'afterExample' => array('afterExample', 10),

--- a/src/PhpSpec/Listener/RerunListener.php
+++ b/src/PhpSpec/Listener/RerunListener.php
@@ -20,27 +20,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class RerunListener implements EventSubscriberInterface
 {
-    /**
-     * @var ReRunner
-     */
-    private $reRunner;
-
-    /**
-     * @var PrerequisiteTester
-     */
-    private $suitePrerequisites;
-
-    
-    public function __construct(ReRunner $reRunner, PrerequisiteTester $suitePrerequisites)
+    public function __construct(
+        private ReRunner $reRunner,
+        private PrerequisiteTester $suitePrerequisites
+    )
     {
-        $this->reRunner = $reRunner;
-        $this->suitePrerequisites = $suitePrerequisites;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents() : array
     {
         return array(
             'beforeSuite' => array('beforeSuite', 1000),
@@ -48,13 +35,13 @@ final class RerunListener implements EventSubscriberInterface
         );
     }
 
-    
+
     public function beforeSuite(SuiteEvent $suiteEvent): void
     {
         $this->suitePrerequisites->guardPrerequisites();
     }
 
-    
+
     public function afterSuite(SuiteEvent $suiteEvent): void
     {
         if ($suiteEvent->isWorthRerunning()) {

--- a/src/PhpSpec/Listener/StatisticsCollector.php
+++ b/src/PhpSpec/Listener/StatisticsCollector.php
@@ -21,18 +21,18 @@ use PhpSpec\Event\SpecificationEvent;
 
 class StatisticsCollector implements EventSubscriberInterface
 {
-    private $globalResult = 0;
-    private $totalSpecs = 0;
-    private $totalSpecsCount = 0;
+    private int $globalResult = 0;
+    private int $totalSpecs = 0;
+    private int $totalSpecsCount = 0;
 
-    private $passedEvents = array();
-    private $pendingEvents = array();
-    private $skippedEvents = array();
-    private $failedEvents = array();
-    private $brokenEvents = array();
-    private $resourceIgnoredEvents = array();
+    private array $passedEvents = [];
+    private array $pendingEvents = [];
+    private array $skippedEvents = [];
+    private array $failedEvents = [];
+    private array $brokenEvents = [];
+    private array $resourceIgnoredEvents = [];
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents() : array
     {
         return array(
             'afterSpecification' => array('afterSpecification', 10),
@@ -75,7 +75,7 @@ class StatisticsCollector implements EventSubscriberInterface
         $this->totalSpecsCount = \count($suiteEvent->getSuite()->getSpecifications());
     }
 
-    public function onResourceIgnored(ResourceEvent $resourceEvent)
+    public function onResourceIgnored(ResourceEvent $resourceEvent) : void
     {
         $this->resourceIgnoredEvents[] = $resourceEvent;
     }

--- a/src/PhpSpec/Listener/StopOnFailureListener.php
+++ b/src/PhpSpec/Listener/StopOnFailureListener.php
@@ -20,18 +20,12 @@ use PhpSpec\Console\ConsoleIO;
 
 final class StopOnFailureListener implements EventSubscriberInterface
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-
-    
-    public function __construct(ConsoleIO $io)
+    public function __construct(
+        private ConsoleIO $io
+    )
     {
-        $this->io = $io;
     }
 
-    
     public static function getSubscribedEvents(): array
     {
         return array(

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -17,75 +17,52 @@ use ReflectionFunctionAbstract;
 
 class ExampleNode
 {
-    /**
-     * @var string
-     */
-    private $title;
-    /**
-     * @var \ReflectionFunctionAbstract
-     */
-    private $function;
-    /**
-     * @var null|SpecificationNode
-     */
-    private $specification;
-    /**
-     * @var bool
-     */
-    private $isPending = false;
+    private ?SpecificationNode $specification;
 
-    
-    public function __construct(string $title, ReflectionFunctionAbstract $function)
+    private bool $isPending = false;
+
+    public function __construct(
+        private string $title,
+        private ReflectionFunctionAbstract $function
+    )
     {
-        $this->setTitle($title);
-        $this->function = $function;
     }
 
-    
-    public function setTitle(string $title)
+    public function setTitle(string $title) : void
     {
       $this->title = $title;
     }
 
-    
     public function getTitle(): string
     {
         return $this->title;
     }
 
-    
     public function markAsPending(bool $isPending = true): void
     {
         $this->isPending = $isPending;
     }
 
-    
     public function isPending(): bool
     {
         return $this->isPending;
     }
 
-    
     public function getFunctionReflection(): ReflectionFunctionAbstract
     {
         return $this->function;
     }
 
-    
     public function setSpecification(SpecificationNode $specification): void
     {
         $this->specification = $specification;
     }
 
-    /**
-     * @return null|SpecificationNode
-     */
-    public function getSpecification()
+    public function getSpecification() : ?SpecificationNode
     {
         return $this->specification;
     }
 
-    
     public function getLineNumber(): int
     {
         return $this->function->isClosure() ? 0 : $this->function->getStartLine();

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -19,54 +19,36 @@ use ReflectionClass;
 
 class SpecificationNode implements \Countable
 {
-    /**
-     * @var string
-     */
-    private $title;
-    /**
-     * @var \ReflectionClass
-     */
-    private $class;
-    /**
-     * @var Resource
-     */
-    private $resource;
-    /**
-     * @var Suite
-     */
-    private $suite;
+    private ?Suite $suite;
+
     /**
      * @var ExampleNode[]
      */
-    private $examples = array();
+    private array $examples = [];
 
-    
-    public function __construct(string $title, ReflectionClass $class, Resource $resource)
+    public function __construct(
+        private string $title,
+        private ReflectionClass $class,
+        private Resource $resource
+    )
     {
-        $this->title    = $title;
-        $this->class    = $class;
-        $this->resource = $resource;
     }
 
-    
     public function getTitle(): string
     {
         return $this->title;
     }
 
-    
     public function getClassReflection(): ReflectionClass
     {
         return $this->class;
     }
 
-    
     public function getResource(): Resource
     {
         return $this->resource;
     }
 
-    
     public function addExample(ExampleNode $example): void
     {
         $this->examples[] = $example;
@@ -81,21 +63,16 @@ class SpecificationNode implements \Countable
         return $this->examples;
     }
 
-    
-    public function setSuite(Suite $suite)
+    public function setSuite(Suite $suite) : void
     {
         $this->suite = $suite;
     }
 
-    /**
-     * @return null|Suite
-     */
-    public function getSuite()
+    public function getSuite() : ?Suite
     {
         return $this->suite;
     }
 
-    
     public function count(): int
     {
         return \count($this->examples);

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -27,29 +27,11 @@ class ResourceLoader
 {
     use DispatchTrait;
 
-    /**
-     * @var ResourceManager
-     */
-    private $manager;
-
-    /**
-     * @var MethodAnalyser
-     */
-    private $methodAnalyser;
-
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $eventDispatcher;
-
     public function __construct(
-        ResourceManager $manager,
-        MethodAnalyser $methodAnalyser,
-        EventDispatcherInterface $eventDispatcher
+        private ResourceManager $manager,
+        private MethodAnalyser $methodAnalyser,
+        private EventDispatcherInterface $eventDispatcher
     ) {
-        $this->manager = $manager;
-        $this->methodAnalyser = $methodAnalyser;
-        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function load(string $locator = '', int $line = null): Suite
@@ -117,7 +99,7 @@ class ResourceLoader
         return $line >= $method->getStartLine() && $line <= $method->getEndLine();
     }
 
-    private function addErrorThrowingExampleToSuite(Resource $resource, Suite $suite, \Error $error)
+    private function addErrorThrowingExampleToSuite(Resource $resource, Suite $suite, \Error $error) : void
     {
         $reflection = new ReflectionClass(ErrorSpecification::class);
         $spec = new Node\SpecificationNode($resource->getSrcClassname(), $reflection, $resource);

--- a/src/PhpSpec/Loader/StreamWrapper.php
+++ b/src/PhpSpec/Loader/StreamWrapper.php
@@ -15,12 +15,15 @@ namespace PhpSpec\Loader;
 
 class StreamWrapper
 {
-    private $realPath;
-    private $fileResource;
+    private string $realPath;
 
-    private static $specTransformers = array();
+    /** @var resource */
+    private mixed $fileResource;
 
-    public $context;
+    private static array $specTransformers = [];
+
+    /** set by PHP */
+    public mixed $context;
 
     public static function register(): void
     {
@@ -40,7 +43,7 @@ class StreamWrapper
         static::$specTransformers[] = $specTransformer;
     }
 
-    public static function wrapPath($path): string
+    public static function wrapPath(string $path): string
     {
         if (!\defined('HHVM_VERSION'))
         {
@@ -50,7 +53,7 @@ class StreamWrapper
         return $path;
     }
 
-    public function stream_open($path, $mode, $options, &$opened_path): bool
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
     {
         if ($mode != 'rb') {
             throw new \RuntimeException('Cannot open phpspec url in mode "$mode"');
@@ -81,7 +84,7 @@ class StreamWrapper
         return stat($this->realPath);
     }
 
-    public function stream_read($count)
+    public function stream_read(int $count) : string|false
     {
         return fread($this->fileResource, $count);
     }

--- a/src/PhpSpec/Loader/Suite.php
+++ b/src/PhpSpec/Loader/Suite.php
@@ -15,12 +15,8 @@ namespace PhpSpec\Loader;
 
 class Suite implements \Countable
 {
-    /**
-     * @var array
-     */
-    private $specs = array();
+    private array $specs = [];
 
-    
     public function addSpecification(Node\SpecificationNode $spec): void
     {
         $this->specs[] = $spec;
@@ -35,7 +31,6 @@ class Suite implements \Countable
         return $this->specs;
     }
 
-    
     public function count(): int
     {
         return array_sum(array_map('count', $this->specs));

--- a/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/InMemoryTypeHintIndex.php
@@ -13,27 +13,23 @@
 
 namespace PhpSpec\Loader\Transformer;
 
+use Exception;
+
 final class InMemoryTypeHintIndex implements TypeHintIndex
 {
-    /**
-     * @var array
-     */
-    private $typehints = array();
+    private array $typehints = [];
 
-    
     public function add(string $class, string $method, string $argument, string $typehint): void
     {
         $this->store($class, $method, $argument, $typehint);
     }
 
-    
-    public function addInvalid(string $class, string $method, string $argument, \Exception $exception): void
+    public function addInvalid(string $class, string $method, string $argument, Exception $exception): void
     {
         $this->store($class, $method, $argument, $exception);
     }
 
-    
-    private function store(string $class, string $method, string $argument, $typehint): void
+    private function store(string $class, string $method, string $argument, string|Exception $typehint): void
     {
         $class = strtolower($class);
         $method = strtolower($method);
@@ -49,10 +45,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
         $this->typehints[$class][$method][$argument] = $typehint;
     }
 
-    /**
-     * @return ?string
-     */
-    public function lookup(string $class, string $method, string $argument)
+    public function lookup(string $class, string $method, string $argument) : ?string
     {
         $class = strtolower($class);
         $method = strtolower($method);
@@ -62,7 +55,7 @@ final class InMemoryTypeHintIndex implements TypeHintIndex
             return null;
         }
 
-        if ($this->typehints[$class][$method][$argument] instanceof \Exception) {
+        if ($this->typehints[$class][$method][$argument] instanceof Exception) {
             throw $this->typehints[$class][$method][$argument];
         };
 

--- a/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintIndex.php
@@ -15,14 +15,9 @@ namespace PhpSpec\Loader\Transformer;
 
 interface TypeHintIndex
 {
-    
     public function add(string $class, string $method, string $argument, string $typehint): void;
 
-    
     public function addInvalid(string $class, string $method, string $argument, \Exception $exception): void;
 
-    /**
-     * @return null|string
-     */
-    public function lookup(string $class, string $method, string $argument);
+    public function lookup(string $class, string $method, string $argument) : ?string;
 }

--- a/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
+++ b/src/PhpSpec/Loader/Transformer/TypeHintRewriter.php
@@ -18,18 +18,12 @@ use PhpSpec\CodeAnalysis\TypeHintRewriter as TypeHintRewriterInterface;
 
 final class TypeHintRewriter implements SpecTransformer
 {
-    /**
-     * @var TypeHintRewriterInterface
-     */
-    private $rewriter;
-
-    
-    public function __construct(TypeHintRewriterInterface $rewriter)
+    public function __construct(
+        private TypeHintRewriterInterface $rewriter
+    )
     {
-        $this->rewriter = $rewriter;
     }
 
-    
     public function transform(string $spec): string
     {
         return $this->rewriter->rewrite($spec);

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -21,52 +21,28 @@ use InvalidArgumentException;
 
 class PSR0Locator implements ResourceLocator, SrcPathLocator
 {
-    /**
-     * @var string
-     */
-    private $srcPath;
-    /**
-     * @var string
-     */
-    private $specPath;
-    /**
-     * @var string
-     */
-    private $srcNamespace;
-    /**
-     * @var string
-     */
-    private $specNamespace;
-    /**
-     * @var string
-     */
-    private $fullSrcPath;
-    /**
-     * @var string
-     */
-    private $fullSpecPath;
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
+    private string $srcPath;
 
-    /**
-     * @var string
-     */
-    private $psr4Prefix;
+    private string $specPath;
 
-    /**
-     * @param string     $psr4Prefix
-     */
+    private string $srcNamespace;
+
+    private string $specNamespace;
+
+    private string $fullSrcPath;
+
+    private string $fullSpecPath;
+
+    private ?string $psr4Prefix;
+
     public function __construct(
-        Filesystem $filesystem,
+        private Filesystem $filesystem,
         string $srcNamespace = '',
         string $specNamespacePrefix = 'spec',
         string $srcPath = 'src',
         string $specPath = '.',
-        string $psr4Prefix = null
+        ?string $psr4Prefix = null
     ) {
-        $this->filesystem = $filesystem;
         $sepr = DIRECTORY_SEPARATOR;
 
         $this->srcPath       = rtrim(realpath($srcPath), '/\\').$sepr;
@@ -104,25 +80,25 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         }
     }
 
-    
+
     public function getFullSrcPath(): string
     {
         return $this->fullSrcPath;
     }
 
-    
+
     public function getFullSpecPath(): string
     {
         return $this->fullSpecPath;
     }
 
-    
+
     public function getSrcNamespace(): string
     {
         return $this->srcNamespace;
     }
 
-    
+
     public function getSpecNamespace(): string
     {
         return $this->specNamespace;
@@ -136,7 +112,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return $this->findSpecResources($this->fullSpecPath);
     }
 
-    
+
     public function supportsQuery(string $query): bool
     {
         $path = $this->getQueryPath($query);
@@ -154,7 +130,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     /**
      * @return Resource[]
      */
-    public function findResources(string $query)
+    public function findResources(string $query) : array
     {
         $path = $this->getQueryPath($query);
 
@@ -183,7 +159,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return array();
     }
 
-    
+
     public function supportsClass(string $classname): bool
     {
         $classname = str_replace('/', '\\', $classname);
@@ -194,10 +170,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         ;
     }
 
-    /**
-     * @return null|PSR0Resource
-     */
-    public function createResource(string $classname)
+    public function createResource(string $classname) : ?PSR0Resource
     {
         $classname = ltrim($classname, '\\');
         $this->validatePsr0Classname($classname);
@@ -219,7 +192,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return null;
     }
 
-    
+
     public function getPriority(): int
     {
         return 0;
@@ -228,7 +201,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     /**
      * @return PSR0Resource[]
      */
-    protected function findSpecResources(string $path)
+    protected function findSpecResources(string $path) : array
     {
         if (!$this->filesystem->pathExists($path)) {
             return array();
@@ -246,12 +219,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return $resources;
     }
 
-    /**
-     * @param $path
-     *
-     * @return null|string
-     */
-    private function findSpecClassname($path)
+    private function findSpecClassname(string $path) : ?string
     {
         // Find namespace and class name
         $namespace = '';
@@ -284,7 +252,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return null;
     }
 
-    
+
     private function createResourceFromSpecFile(string $path): PSR0Resource
     {
         $classname = $this->findSpecClassname($path);
@@ -316,7 +284,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     /**
      * @throws InvalidArgumentException
      */
-    private function validatePsr0Classname(string $classname)
+    private function validatePsr0Classname(string $classname) : void
     {
         $pattern = '/\A([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*[\/\\\\]?)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\z/';
 
@@ -329,7 +297,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         }
     }
 
-    
+
     private function getQueryPath(string $query): string
     {
         $sepr = DIRECTORY_SEPARATOR;
@@ -350,19 +318,19 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         return rtrim(realpath($replacedQuery), $sepr);
     }
 
-    
+
     private function queryContainsQualifiedClassName(string $query): bool
     {
         return $this->queryContainsBlackslashes($query) && !$this->isWindowsPath($query);
     }
 
-    
+
     private function queryContainsBlackslashes(string $query): bool
     {
         return false !== strpos($query, '\\');
     }
 
-    
+
     private function isWindowsPath(string $query): bool
     {
         return (bool) preg_match('/^\w:/', $query);

--- a/src/PhpSpec/Locator/PSR0/PSR0Resource.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Resource.php
@@ -17,35 +17,23 @@ use PhpSpec\Locator\Resource;
 
 final class PSR0Resource implements Resource
 {
-    /**
-     * @var array
-     */
-    private $parts;
-    /**
-     * @var PSR0Locator
-     */
-    private $locator;
-
-    
-    public function __construct(array $parts, PSR0Locator $locator)
+    public function __construct(
+        private array $parts,
+        private PSR0Locator $locator
+    )
     {
-        $this->parts   = $parts;
-        $this->locator = $locator;
     }
 
-    
     public function getName(): string
     {
         return end($this->parts);
     }
 
-    
     public function getSpecName(): string
     {
         return $this->getName().'Spec';
     }
 
-    
     public function getSrcFilename(): string
     {
         if ($this->locator->isPSR4()) {
@@ -59,7 +47,6 @@ final class PSR0Resource implements Resource
         return $this->locator->getFullSrcPath().implode(DIRECTORY_SEPARATOR, $parts).'.php';
     }
 
-    
     public function getSrcNamespace(): string
     {
         $nsParts = $this->parts;
@@ -68,13 +55,11 @@ final class PSR0Resource implements Resource
         return rtrim($this->locator->getSrcNamespace().implode('\\', $nsParts), '\\');
     }
 
-    
     public function getSrcClassname(): string
     {
         return $this->locator->getSrcNamespace().implode('\\', $this->parts);
     }
 
-    
     public function getSpecFilename(): string
     {
         if ($this->locator->isPSR4()) {
@@ -90,7 +75,6 @@ final class PSR0Resource implements Resource
             implode(DIRECTORY_SEPARATOR, $parts).'Spec.php';
     }
 
-    
     public function getSpecNamespace(): string
     {
         $nsParts = $this->parts;
@@ -99,7 +83,6 @@ final class PSR0Resource implements Resource
         return rtrim($this->locator->getSpecNamespace().implode('\\', $nsParts), '\\');
     }
 
-    
     public function getSpecClassname(): string
     {
         return $this->locator->getSpecNamespace().implode('\\', $this->parts).'Spec';

--- a/src/PhpSpec/Locator/PrioritizedResourceManager.php
+++ b/src/PhpSpec/Locator/PrioritizedResourceManager.php
@@ -20,10 +20,9 @@ final class PrioritizedResourceManager implements ResourceManager
     /**
      * @var ResourceLocator[]
      */
-    private $locators = array();
+    private array $locators = [];
 
-    
-    public function registerLocator(ResourceLocator $locator)
+    public function registerLocator(ResourceLocator $locator) : void
     {
         $this->locators[] = $locator;
 

--- a/src/PhpSpec/Locator/ResourceLocator.php
+++ b/src/PhpSpec/Locator/ResourceLocator.php
@@ -20,22 +20,16 @@ interface ResourceLocator
      */
     public function getAllResources(): array;
 
-    
     public function supportsQuery(string $query): bool;
 
     /**
      * @return Resource[]
      */
-    public function findResources(string $query);
+    public function findResources(string $query) : array;
 
-    
     public function supportsClass(string $classname): bool;
 
-    /**
-     * @return null|Resource
-     */
-    public function createResource(string $classname);
+    public function createResource(string $classname) : ?Resource;
 
-    
     public function getPriority(): int;
 }

--- a/src/PhpSpec/Locator/ResourceManager.php
+++ b/src/PhpSpec/Locator/ResourceManager.php
@@ -20,6 +20,5 @@ interface ResourceManager
      */
     public function locateResources(string $query): array;
 
-    
     public function createResource(string $classname): \PhpSpec\Locator\Resource;
 }

--- a/src/PhpSpec/Matcher/ApproximatelyMatcher.php
+++ b/src/PhpSpec/Matcher/ApproximatelyMatcher.php
@@ -19,30 +19,20 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class ApproximatelyMatcher extends BasicMatcher
 {
-
-    /**
-     * @var array
-     */
-    private static $keywords = array(
+    private static array $keywords = [
         'beApproximately',
         'beEqualToApproximately',
         'equalApproximately',
         'returnApproximately'
-    );
+    ];
 
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         if (!\in_array($name, self::$keywords) || 2 != \count($arguments)) {
             return false;
@@ -58,8 +48,7 @@ final class ApproximatelyMatcher extends BasicMatcher
         return true;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         [$expected, $precision] = $arguments;
 
@@ -81,8 +70,7 @@ final class ApproximatelyMatcher extends BasicMatcher
         return true;
     }
 
-
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new NotEqualException(sprintf(
             'Expected an approximated value of %s, but got %s',
@@ -91,7 +79,7 @@ final class ApproximatelyMatcher extends BasicMatcher
         ), $arguments[0], $subject);
     }
 
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Did Not expect an approximated value of %s, but got %s',

--- a/src/PhpSpec/Matcher/ArrayContainMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayContainMatcher.php
@@ -18,19 +18,13 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class ArrayContainMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'contain' === $name
             && 1 == \count($arguments)
@@ -38,14 +32,12 @@ final class ArrayContainMatcher extends BasicMatcher
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return \in_array($arguments[0], $subject, true);
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to contain %s, but it does not.',
@@ -54,8 +46,7 @@ final class ArrayContainMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to contain %s, but it does.',

--- a/src/PhpSpec/Matcher/ArrayCountMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayCountMatcher.php
@@ -18,19 +18,13 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class ArrayCountMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'haveCount' === $name
             && 1 == \count($arguments)
@@ -38,14 +32,12 @@ final class ArrayCountMatcher extends BasicMatcher
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return $arguments[0] === \count($subject);
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to have %s items, but got %s.',
@@ -55,8 +47,7 @@ final class ArrayCountMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have %s items, but got it.',

--- a/src/PhpSpec/Matcher/ArrayKeyMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyMatcher.php
@@ -19,19 +19,13 @@ use ArrayAccess;
 
 final class ArrayKeyMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'haveKey' === $name
             && 1 == \count($arguments)
@@ -39,8 +33,7 @@ final class ArrayKeyMatcher extends BasicMatcher
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         $key = $arguments[0];
 
@@ -51,8 +44,7 @@ final class ArrayKeyMatcher extends BasicMatcher
         return isset($subject[$key]) || array_key_exists($arguments[0], $subject);
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to have %s key, but it does not.',
@@ -61,8 +53,7 @@ final class ArrayKeyMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have %s key, but it does.',

--- a/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/ArrayKeyValueMatcher.php
@@ -19,19 +19,13 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class ArrayKeyValueMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return
             (\is_array($subject) || $subject instanceof \ArrayAccess) &&
@@ -40,10 +34,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * @param array|ArrayAccess $subject
-     */
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         $key = $arguments[0];
         $value  = $arguments[1];
@@ -55,8 +46,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
         return (isset($subject[$key]) || array_key_exists($arguments[0], $subject)) && $subject[$key] === $value;
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         $key = $arguments[0];
 
@@ -76,8 +66,8 @@ final class ArrayKeyValueMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have %s key, but it does.',
@@ -86,7 +76,7 @@ final class ArrayKeyValueMatcher extends BasicMatcher
         ));
     }
 
-    private function offsetExists($key, $subject): bool
+    private function offsetExists(mixed $key, mixed $subject): bool
     {
         if ($subject instanceof ArrayAccess && $subject->offsetExists($key)) {
             return true;

--- a/src/PhpSpec/Matcher/BasicMatcher.php
+++ b/src/PhpSpec/Matcher/BasicMatcher.php
@@ -21,7 +21,7 @@ abstract class BasicMatcher implements Matcher
     /**
      * @throws FailureException
      */
-    final public function positiveMatch(string $name, $subject, array $arguments): ?DelayedCall
+    final public function positiveMatch(string $name, mixed $subject, array $arguments): ?DelayedCall
     {
         if (false === $this->matches($subject, $arguments)) {
             throw $this->getFailureException($name, $subject, $arguments);
@@ -33,7 +33,7 @@ abstract class BasicMatcher implements Matcher
     /**
      * @throws FailureException
      */
-    final public function negativeMatch(string $name, $subject, array $arguments): ?DelayedCall
+    final public function negativeMatch(string $name, mixed $subject, array $arguments): ?DelayedCall
     {
         if (true === $this->matches($subject, $arguments)) {
             throw $this->getNegativeFailureException($name, $subject, $arguments);
@@ -42,18 +42,14 @@ abstract class BasicMatcher implements Matcher
         return null;
     }
 
-    
     public function getPriority(): int
     {
         return 100;
     }
 
-    
-    abstract protected function matches($subject, array $arguments): bool;
+    abstract protected function matches(mixed $subject, array $arguments): bool;
 
-    
-    abstract protected function getFailureException(string $name, $subject, array $arguments): FailureException;
+    abstract protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException;
 
-    
-    abstract protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException;
+    abstract protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException;
 }

--- a/src/PhpSpec/Matcher/CallbackMatcher.php
+++ b/src/PhpSpec/Matcher/CallbackMatcher.php
@@ -18,43 +18,31 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class CallbackMatcher extends BasicMatcher
 {
-    /**
-     * @var string
-     */
-    private $name;
-    /**
-     * @var callable
-     */
-    private $callback;
-    /**
-     * @var Presenter
-     */
-    private $presenter;
+    /** @var callable */
+    private mixed $callback;
 
-    
-    public function __construct(string $name, callable $callback, Presenter $presenter)
+    public function __construct(
+        private string $name,
+        callable $callback,
+        private Presenter $presenter
+    )
     {
-        $this->name      = $name;
-        $this->callback  = $callback;
-        $this->presenter = $presenter;
+        $this->callback = $callback;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return $name === $this->name;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         array_unshift($arguments, $subject);
 
         return (Boolean) \call_user_func_array($this->callback, $arguments);
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             '%s expected to %s(%s), but it is not.',
@@ -64,8 +52,7 @@ final class CallbackMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             '%s not expected to %s(%s), but it did.',

--- a/src/PhpSpec/Matcher/ComparisonMatcher.php
+++ b/src/PhpSpec/Matcher/ComparisonMatcher.php
@@ -19,35 +19,25 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class ComparisonMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'beLike' === $name
             && 1 == \count($arguments)
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return $subject == $arguments[0];
     }
 
-    /**
-     * @return NotEqualException
-     */
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): NotEqualException
     {
         return new NotEqualException(sprintf(
             'Expected %s, but got %s.',
@@ -56,8 +46,7 @@ final class ComparisonMatcher extends BasicMatcher
         ), $arguments[0], $subject);
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Did not expect %s, but got one.',

--- a/src/PhpSpec/Matcher/IdentityMatcher.php
+++ b/src/PhpSpec/Matcher/IdentityMatcher.php
@@ -19,42 +19,32 @@ use PhpSpec\Exception\Example\NotEqualException;
 
 final class IdentityMatcher extends BasicMatcher
 {
-    /**
-     * @var array
-     */
-    private static $keywords = array(
+    private static array $keywords = [
         'return',
         'be',
         'equal',
         'beEqualTo'
-    );
-    /**
-     * @var Presenter
-     */
-    private $presenter;
+    ];
 
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return \in_array($name, self::$keywords)
             && 1 == \count($arguments)
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return $subject === $arguments[0];
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new NotEqualException(sprintf(
             'Expected %s, but got %s.',
@@ -63,8 +53,7 @@ final class IdentityMatcher extends BasicMatcher
         ), $arguments[0], $subject);
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Did not expect %s, but got one.',

--- a/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
+++ b/src/PhpSpec/Matcher/Iterate/IterablesMatcher.php
@@ -3,30 +3,23 @@
 namespace PhpSpec\Matcher\Iterate;
 
 use PhpSpec\Formatter\Presenter\Presenter;
+use Traversable;
 
 final class IterablesMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
     /**
-     * @param array|\Traversable $subject
-     * @param array|\Traversable $expected
-     *
      * @throws \InvalidArgumentException
      * @throws SubjectElementDoesNotMatchException
      * @throws SubjectHasFewerElementsException
      * @throws SubjectHasMoreElementsException
      */
-    public function match($subject, $expected, bool $strict = true): void
+    public function match(mixed $subject, mixed $expected, bool $strict = true): void
     {
         if (!$this->isIterable($subject)) {
             throw new \InvalidArgumentException('Subject value should be an array or implement \Traversable.');
@@ -63,16 +56,12 @@ final class IterablesMatcher
         }
     }
 
-    
-    private function isIterable($variable): bool
+    private function isIterable(mixed $variable): bool
     {
         return \is_array($variable) || $variable instanceof \Traversable;
     }
 
-    /**
-     * @param array|\Traversable $iterable
-     */
-    private function createIteratorFromIterable($iterable): \Iterator
+    private function createIteratorFromIterable(iterable $iterable): \Iterator
     {
         if (\is_array($iterable)) {
             return new \ArrayIterator($iterable);
@@ -84,7 +73,7 @@ final class IterablesMatcher
         return $iterator;
     }
 
-    private function valueIsEqual($expected, $value, bool $strict): bool
+    private function valueIsEqual(mixed $expected, mixed $value, bool $strict): bool
     {
         return $strict ? $expected === $value : $expected == $value;
     }

--- a/src/PhpSpec/Matcher/IterateAsMatcher.php
+++ b/src/PhpSpec/Matcher/IterateAsMatcher.php
@@ -20,21 +20,14 @@ use PhpSpec\Wrapper\DelayedCall;
 
 final class IterateAsMatcher implements Matcher
 {
-    /**
-     * @var IterablesMatcher
-     */
-    private $iterablesMatcher;
+    private IterablesMatcher $iterablesMatcher;
 
-    
     public function __construct(Presenter $presenter)
     {
         $this->iterablesMatcher = new IterablesMatcher($presenter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return \in_array($name, ['iterateAs', 'yield'])
             && 1 === \count($arguments)
@@ -43,10 +36,7 @@ final class IterateAsMatcher implements Matcher
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function positiveMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0]);
@@ -59,10 +49,7 @@ final class IterateAsMatcher implements Matcher
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function negativeMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
@@ -73,9 +60,6 @@ final class IterateAsMatcher implements Matcher
         throw new FailureException('Expected subject not to iterate the same as matched value, but it does.');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         return 100;

--- a/src/PhpSpec/Matcher/IterateLikeMatcher.php
+++ b/src/PhpSpec/Matcher/IterateLikeMatcher.php
@@ -20,21 +20,14 @@ use PhpSpec\Wrapper\DelayedCall;
 
 final class IterateLikeMatcher implements Matcher
 {
-    /**
-     * @var IterablesMatcher
-     */
-    private $iterablesMatcher;
+    private IterablesMatcher $iterablesMatcher;
 
-    
     public function __construct(Presenter $presenter)
     {
         $this->iterablesMatcher = new IterablesMatcher($presenter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return \in_array($name, ['iterateLike', 'yieldLike'])
             && 1 === \count($arguments)
@@ -43,10 +36,7 @@ final class IterateLikeMatcher implements Matcher
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function positiveMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0], false);
@@ -59,10 +49,7 @@ final class IterateLikeMatcher implements Matcher
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function negativeMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
@@ -73,9 +60,6 @@ final class IterateLikeMatcher implements Matcher
         throw new FailureException('Expected subject not to iterate the same as matched value, but it does.');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         return 100;

--- a/src/PhpSpec/Matcher/Matcher.php
+++ b/src/PhpSpec/Matcher/Matcher.php
@@ -20,17 +20,17 @@ interface Matcher
     /**
      * Checks if matcher supports provided subject and matcher name.
      */
-    public function supports(string $name, $subject, array $arguments): bool;
+    public function supports(string $name, mixed $subject, array $arguments): bool;
 
     /**
      * Evaluates positive match.
      */
-    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall;
+    public function positiveMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall;
 
     /**
      * Evaluates negative match.
      */
-    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall;
+    public function negativeMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall;
 
     /**
      * Returns matcher priority.

--- a/src/PhpSpec/Matcher/ObjectStateMatcher.php
+++ b/src/PhpSpec/Matcher/ObjectStateMatcher.php
@@ -20,23 +20,15 @@ use PhpSpec\Wrapper\DelayedCall;
 
 final class ObjectStateMatcher implements Matcher
 {
-    /**
-     * @var string
-     */
-    private static $regex = '/(be|have)(.+)/';
-    /**
-     * @var Presenter
-     */
-    private $presenter;
+    private static string $regex = '/(be|have)(.+)/';
 
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return \is_object($subject) && !is_callable($subject)
             && (0 === strpos($name, 'be') || 0 === strpos($name, 'have'))
@@ -47,7 +39,7 @@ final class ObjectStateMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\MethodFailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      */
-    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function positiveMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         preg_match(self::$regex, $name, $matches);
         $method   = ('be' === $matches[1] ? 'is' : 'has').ucfirst($matches[2]);
@@ -71,7 +63,7 @@ final class ObjectStateMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\MethodFailureException
      * @throws \PhpSpec\Exception\Fracture\MethodNotFoundException
      */
-    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function negativeMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         preg_match(self::$regex, $name, $matches);
         $method   = ('be' === $matches[1] ? 'is' : 'has').ucfirst($matches[2]);
@@ -91,13 +83,12 @@ final class ObjectStateMatcher implements Matcher
         return null;
     }
 
-    
     public function getPriority(): int
     {
         return 50;
     }
 
-    private function getMethodFailureExceptionFor(array $callable, bool $expectedBool, $result): MethodFailureException
+    private function getMethodFailureExceptionFor(array $callable, bool $expectedBool, mixed $result): MethodFailureException
     {
         return new MethodFailureException(sprintf(
             "Expected %s to return %s, but got %s.",

--- a/src/PhpSpec/Matcher/ScalarMatcher.php
+++ b/src/PhpSpec/Matcher/ScalarMatcher.php
@@ -19,21 +19,16 @@ use PhpSpec\Wrapper\DelayedCall;
 
 final class ScalarMatcher implements Matcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
     /**
      * Checks if matcher supports provided subject and matcher name.
      */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         $checkerName = $this->getCheckerName($name);
 
@@ -43,10 +38,9 @@ final class ScalarMatcher implements Matcher
     /**
      * Evaluates positive match.
      *
-     *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function positiveMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         $checker = $this->getCheckerName($name);
 
@@ -71,7 +65,7 @@ final class ScalarMatcher implements Matcher
      *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function negativeMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         $checker = $this->getCheckerName($name);
 
@@ -98,10 +92,7 @@ final class ScalarMatcher implements Matcher
         return 51;
     }
 
-    /**
-     * @return false|string
-     */
-    private function getCheckerName(string $name)
+    private function getCheckerName(string $name) : string|false
     {
         if (0 !== strpos($name, 'be')) {
             return false;

--- a/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
+++ b/src/PhpSpec/Matcher/StartIteratingAsMatcher.php
@@ -20,21 +20,14 @@ use PhpSpec\Wrapper\DelayedCall;
 
 final class StartIteratingAsMatcher implements Matcher
 {
-    /**
-     * @var IterablesMatcher
-     */
-    private $iterablesMatcher;
+    private IterablesMatcher $iterablesMatcher;
 
-    
     public function __construct(Presenter $presenter)
     {
         $this->iterablesMatcher = new IterablesMatcher($presenter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return \in_array($name, ['startIteratingAs', 'startYielding'])
             && 1 === \count($arguments)
@@ -43,10 +36,7 @@ final class StartIteratingAsMatcher implements Matcher
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function positiveMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->iterablesMatcher->match($subject, $arguments[0]);
@@ -59,10 +49,7 @@ final class StartIteratingAsMatcher implements Matcher
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function negativeMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         try {
             $this->positiveMatch($name, $subject, $arguments);
@@ -73,9 +60,6 @@ final class StartIteratingAsMatcher implements Matcher
         throw new FailureException('Expected subject not to start iterating the same as matched value, but it does.');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         return 100;

--- a/src/PhpSpec/Matcher/StringContainMatcher.php
+++ b/src/PhpSpec/Matcher/StringContainMatcher.php
@@ -18,21 +18,13 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class StringContainMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'contain' === $name
             && \is_string($subject)
@@ -40,18 +32,12 @@ final class StringContainMatcher extends BasicMatcher
             && \is_string($arguments[0]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return false !== strpos($subject, $arguments[0]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to contain %s, but it does not.',
@@ -60,10 +46,7 @@ final class StringContainMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to contain %s, but it does.',

--- a/src/PhpSpec/Matcher/StringEndMatcher.php
+++ b/src/PhpSpec/Matcher/StringEndMatcher.php
@@ -18,19 +18,13 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class StringEndMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'endWith' === $name
             && \is_string($subject)
@@ -38,14 +32,12 @@ final class StringEndMatcher extends BasicMatcher
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return $arguments[0] === substr($subject, 0 - \strlen($arguments[0]));
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to end with %s, but it does not.',
@@ -54,8 +46,7 @@ final class StringEndMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to end with %s, but it does.',

--- a/src/PhpSpec/Matcher/StringRegexMatcher.php
+++ b/src/PhpSpec/Matcher/StringRegexMatcher.php
@@ -18,19 +18,13 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class StringRegexMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'match' === $name
             && \is_string($subject)
@@ -38,14 +32,12 @@ final class StringRegexMatcher extends BasicMatcher
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return (Boolean) preg_match($arguments[0], $subject);
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to match %s regex, but it does not.',
@@ -54,8 +46,7 @@ final class StringRegexMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to match %s regex, but it does.',

--- a/src/PhpSpec/Matcher/StringStartMatcher.php
+++ b/src/PhpSpec/Matcher/StringStartMatcher.php
@@ -18,19 +18,13 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class StringStartMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'startWith' === $name
             && \is_string($subject)
@@ -38,14 +32,12 @@ final class StringStartMatcher extends BasicMatcher
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return 0 === strpos($subject, $arguments[0]);
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to start with %s, but it does not.',
@@ -54,8 +46,7 @@ final class StringStartMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to start with %s, but it does.',

--- a/src/PhpSpec/Matcher/ThrowMatcher.php
+++ b/src/PhpSpec/Matcher/ThrowMatcher.php
@@ -24,58 +24,38 @@ use PhpSpec\Exception\Fracture\MethodNotFoundException;
 
 final class ThrowMatcher implements Matcher
 {
-    /**
-     * @var array
-     */
-    private static $ignoredProperties = array('file', 'line', 'string', 'trace', 'previous');
+    private static array $ignoredProperties = [
+        'file', 'line', 'string', 'trace', 'previous'
+    ];
 
-    /**
-     * @var Unwrapper
-     */
-    private $unwrapper;
-
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    /**
-     * @var ReflectionFactory
-     */
-    private $factory;
-
-    public function __construct(Unwrapper $unwrapper, Presenter $presenter, ReflectionFactory $factory)
+    public function __construct(
+        private Unwrapper $unwrapper,
+        private Presenter $presenter,
+        private ReflectionFactory $factory
+    )
     {
-        $this->unwrapper = $unwrapper;
-        $this->presenter = $presenter;
-        $this->factory   = $factory;
     }
 
-
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'throw' === $name;
     }
 
-
-    public function positiveMatch(string $name, $subject, array $arguments): DelayedCall
+    public function positiveMatch(string $name, mixed $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyPositive'), $subject, $arguments);
     }
 
-
-    public function negativeMatch(string $name, $subject, array $arguments): DelayedCall
+    public function negativeMatch(string $name, mixed $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyNegative'), $subject, $arguments);
     }
 
     /**
-     * @param null|object|string $exception
-     *
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \PhpSpec\Exception\Example\NotEqualException
      */
-    public function verifyPositive(callable $callable, array $arguments, $exception = null)
+    public function verifyPositive(callable $callable, array $arguments, object|string|null $exception = null) : void
     {
         $exceptionThrown = null;
 
@@ -146,11 +126,9 @@ final class ThrowMatcher implements Matcher
     }
 
     /**
-     * @param null|object|string $exception
-     *
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function verifyNegative(callable $callable, array $arguments, $exception = null)
+    public function verifyNegative(callable $callable, array $arguments, object|null|string $exception = null) : void
     {
         $exceptionThrown = null;
 
@@ -221,14 +199,12 @@ final class ThrowMatcher implements Matcher
         }
     }
 
-
     public function getPriority(): int
     {
         return 1;
     }
 
-
-    private function getDelayedCall(callable $check, $subject, array $arguments): DelayedCall
+    private function getDelayedCall(callable $check, mixed $subject, array $arguments): DelayedCall
     {
         $exception = $this->getException($arguments);
         $unwrapper = $this->unwrapper;
@@ -257,11 +233,9 @@ final class ThrowMatcher implements Matcher
     }
 
     /**
-     * @return null|string|\Throwable
-     *
      * @throws \PhpSpec\Exception\Example\MatcherException
      */
-    private function getException(array $arguments)
+    private function getException(array $arguments) : null|string|\Throwable
     {
         if (0 === \count($arguments)) {
             return null;

--- a/src/PhpSpec/Matcher/TraversableContainMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableContainMatcher.php
@@ -18,21 +18,13 @@ use PhpSpec\Formatter\Presenter\Presenter;
 
 final class TraversableContainMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'contain' === $name
             && 1 === \count($arguments)
@@ -40,18 +32,12 @@ final class TraversableContainMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         return 101;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         foreach ($subject as $value) {
             if ($value === $arguments[0]) {
@@ -62,10 +48,7 @@ final class TraversableContainMatcher extends BasicMatcher
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to contain %s, but it does not.',
@@ -74,10 +57,7 @@ final class TraversableContainMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to contain %s, but it does.',

--- a/src/PhpSpec/Matcher/TraversableCountMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableCountMatcher.php
@@ -23,21 +23,13 @@ final class TraversableCountMatcher implements Matcher
     const EQUAL = 1;
     const MORE_THAN = 2;
 
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'haveCount' === $name
             && 1 === \count($arguments)
@@ -45,10 +37,7 @@ final class TraversableCountMatcher implements Matcher
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function positiveMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function positiveMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         $countDifference = $this->countDifference($subject, (int) $arguments[0]);
 
@@ -64,10 +53,7 @@ final class TraversableCountMatcher implements Matcher
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function negativeMatch(string $name, $subject, array $arguments) : ?DelayedCall
+    public function negativeMatch(string $name, mixed $subject, array $arguments) : ?DelayedCall
     {
         $count = $this->countDifference($subject, (int) $arguments[0]);
 
@@ -82,9 +68,6 @@ final class TraversableCountMatcher implements Matcher
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         return 101;

--- a/src/PhpSpec/Matcher/TraversableKeyMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyMatcher.php
@@ -19,21 +19,13 @@ use ArrayAccess;
 
 final class TraversableKeyMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'haveKey' === $name
             && 1 === \count($arguments)
@@ -41,18 +33,12 @@ final class TraversableKeyMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         return 101;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         foreach ($subject as $key => $value) {
             if ($key === $arguments[0]) {
@@ -63,10 +49,7 @@ final class TraversableKeyMatcher extends BasicMatcher
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to have %s key, but it does not.',
@@ -75,10 +58,7 @@ final class TraversableKeyMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have %s key, but it does.',

--- a/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
+++ b/src/PhpSpec/Matcher/TraversableKeyValueMatcher.php
@@ -19,21 +19,13 @@ use ArrayAccess;
 
 final class TraversableKeyValueMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-
-
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'haveKeyWithValue' === $name
             && 2 === \count($arguments)
@@ -41,18 +33,12 @@ final class TraversableKeyValueMatcher extends BasicMatcher
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         return 101;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         foreach ($subject as $key => $value) {
             if ($key === $arguments[0] && $value === $arguments[1]) {
@@ -63,10 +49,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s to have an element with %s key and %s value, but it does not.',
@@ -76,10 +59,7 @@ final class TraversableKeyValueMatcher extends BasicMatcher
         ));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected %s not to have an element with %s key and %s value, but it does.',

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -21,47 +21,30 @@ use PhpSpec\Exception\Fracture\MethodNotFoundException;
 
 final class TriggerMatcher implements Matcher
 {
-    /**
-     * @var Unwrapper
-     */
-    private $unwrapper;
-
-
-    public function __construct(Unwrapper $unwrapper)
+    public function __construct(
+        private Unwrapper $unwrapper
+    )
     {
-        $this->unwrapper = $unwrapper;
     }
 
-
-    /**
-     * @param mixed $subject
-     */
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return 'trigger' === $name;
     }
-
-    /**
-     * @param mixed $subject
-     */
-    public function positiveMatch(string $name, $subject, array $arguments): DelayedCall
+    public function positiveMatch(string $name, mixed $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyPositive'), $subject, $arguments);
     }
 
-    /**
-     * @param mixed $subject
-     */
-    public function negativeMatch(string $name, $subject, array $arguments): DelayedCall
+    public function negativeMatch(string $name, mixed $subject, array $arguments): DelayedCall
     {
         return $this->getDelayedCall(array($this, 'verifyNegative'), $subject, $arguments);
     }
 
     /**
      * @throws \PhpSpec\Exception\Example\FailureException
-     * @return void
      */
-    public function verifyPositive(callable $callable, array $arguments, int $level = null, string $message = null)
+    public function verifyPositive(callable $callable, array $arguments, int $level = null, string $message = null) : void
     {
         $triggered = 0;
         $prevHandler = function($type, $str, $file, $line, $context=[]){};
@@ -89,9 +72,8 @@ final class TriggerMatcher implements Matcher
 
     /**
      * @throws \PhpSpec\Exception\Example\FailureException
-     * @return void
      */
-    public function verifyNegative(callable $callable, array $arguments, int $level = null, string $message = null)
+    public function verifyNegative(callable $callable, array $arguments, int $level = null, string $message = null) : void
     {
         $triggered = 0;
         $prevHandler = function($type, $str, $file, $line, $context=[]){};
@@ -129,21 +111,13 @@ final class TriggerMatcher implements Matcher
         return 1;
     }
 
-    /**
-     * @param mixed $subject
-     */
-    private function getDelayedCall(callable $check, $subject, array $arguments): DelayedCall
+    private function getDelayedCall(callable $check, mixed $subject, array $arguments): DelayedCall
     {
         $unwrapper = $this->unwrapper;
         list($level, $message) = $this->unpackArguments($arguments);
 
         return new DelayedCall(
-            /**
-             * @param mixed $method
-             * @param mixed $arguments
-             * @return mixed
-             */
-            function ($method, $arguments) use ($check, $subject, $level, $message, $unwrapper) {
+            function (mixed $method, mixed $arguments) use ($check, $subject, $level, $message, $unwrapper) : mixed {
                 $arguments = $unwrapper->unwrapAll($arguments);
 
                 $methodName = $arguments[0];
@@ -164,7 +138,6 @@ final class TriggerMatcher implements Matcher
             }
         );
     }
-
 
     private function unpackArguments(array $arguments): array
     {

--- a/src/PhpSpec/Matcher/TypeMatcher.php
+++ b/src/PhpSpec/Matcher/TypeMatcher.php
@@ -18,42 +18,32 @@ use PhpSpec\Exception\Example\FailureException;
 
 final class TypeMatcher extends BasicMatcher
 {
-    /**
-     * @var array
-     */
-    private static $keywords = array(
+    private static array $keywords = [
         'beAnInstanceOf',
         'returnAnInstanceOf',
         'haveType',
         'implement'
-    );
-    /**
-     * @var Presenter
-     */
-    private $presenter;
+    ];
 
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
-    public function supports(string $name, $subject, array $arguments): bool
+    public function supports(string $name, mixed $subject, array $arguments): bool
     {
         return \in_array($name, self::$keywords)
             && 1 == \count($arguments)
         ;
     }
 
-    
-    protected function matches($subject, array $arguments): bool
+    protected function matches(mixed $subject, array $arguments): bool
     {
         return (null !== $subject) && ($subject instanceof $arguments[0]);
     }
 
-    
-    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Expected an instance of %s, but got %s.',
@@ -62,8 +52,7 @@ final class TypeMatcher extends BasicMatcher
         ));
     }
 
-    
-    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    protected function getNegativeFailureException(string $name, mixed $subject, array $arguments): FailureException
     {
         return new FailureException(sprintf(
             'Did not expect instance of %s, but got %s.',

--- a/src/PhpSpec/Message/CurrentExampleTracker.php
+++ b/src/PhpSpec/Message/CurrentExampleTracker.php
@@ -15,9 +15,9 @@ namespace PhpSpec\Message;
 
 final class CurrentExampleTracker
 {
-    private $currentExample;
+    private ?string $currentExample = null;
 
-    public function setCurrentExample(string $currentExample = null)
+    public function setCurrentExample(string $currentExample = null) : void
     {
         $this->currentExample = $currentExample;
     }

--- a/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
+++ b/src/PhpSpec/NamespaceProvider/ComposerPsrNamespaceProvider.php
@@ -9,20 +9,11 @@ use Composer\Autoload\ClassLoader;
  */
 class ComposerPsrNamespaceProvider
 {
-    /**
-     * @var string path to the root directory of the project, without a trailing slash
-     */
-    private $rootDirectory;
-
-    /**
-     * @var string prefix of the specifications namespace
-     */
-    private $specPrefix;
-
-    public function __construct(string $rootDirectory, string $specPrefix)
+    public function __construct(
+        private string $rootDirectory,
+        private string $specPrefix
+    )
     {
-        $this->rootDirectory = $rootDirectory;
-        $this->specPrefix = $specPrefix;
     }
 
     /**
@@ -61,7 +52,7 @@ class ComposerPsrNamespaceProvider
         return $namespaces;
     }
 
-    private function getNamespacesFromPrefixes(array $prefixes, array $vendors, $standard) : array
+    private function getNamespacesFromPrefixes(array $prefixes, array $vendors, string $standard) : array
     {
         $namespaces = array();
         foreach ($prefixes as $namespace => $psrPrefix) {
@@ -85,7 +76,7 @@ class ComposerPsrNamespaceProvider
         return $namespaces;
     }
 
-    private function normaliseLocation($location)
+    private function normaliseLocation(string $location) : string
     {
         return strpos(realpath($location), realpath($this->rootDirectory)) === 0 ?
             substr(

--- a/src/PhpSpec/NamespaceProvider/NamespaceLocation.php
+++ b/src/PhpSpec/NamespaceProvider/NamespaceLocation.php
@@ -6,28 +6,25 @@ use Composer\Autoload\ClassLoader;
 
 final class NamespaceLocation
 {
-    private $namespace;
-    private $location;
-    private $autoloadingStandard;
-
-    public function __construct($namespace, $location, $autoloadingStandard)
+    public function __construct(
+        private string $namespace,
+        private string $location,
+        private string $autoloadingStandard
+    )
     {
-        $this->namespace = $namespace;
-        $this->location = $location;
-        $this->autoloadingStandard = $autoloadingStandard;
     }
 
-    public function getNamespace()
+    public function getNamespace() : string
     {
         return $this->namespace;
     }
 
-    public function getLocation()
+    public function getLocation() : string
     {
         return $this->location;
     }
 
-    public function getAutoloadingStandard()
+    public function getAutoloadingStandard() : string
     {
         return $this->autoloadingStandard;
     }

--- a/src/PhpSpec/ObjectBehavior.php
+++ b/src/PhpSpec/ObjectBehavior.php
@@ -72,17 +72,12 @@ abstract class ObjectBehavior implements
     ObjectWrapper,
     Specification
 {
-    /**
-     * @var Subject
-     */
-    protected $object;
+    protected Subject $object;
 
     /**
      * Override this method to provide your own inline matchers
      *
      * @link http://phpspec.net/cookbook/matchers.html Matchers cookbook
-     *
-     * @return array a list of inline matchers
      */
     public function getMatchers(): array
     {
@@ -101,10 +96,8 @@ abstract class ObjectBehavior implements
 
     /**
      * Gets the unwrapped proxied object from PhpSpec subject
-     *
-     * @return ?object
      */
-    public function getWrappedObject()
+    public function getWrappedObject() : ?object
     {
         return $this->object->getWrappedObject();
     }
@@ -113,9 +106,8 @@ abstract class ObjectBehavior implements
      * Checks if a key exists in case object implements ArrayAccess
      *
      * @psalm-param TKey $key
-     * @param int|string $key
      */
-    public function offsetExists($key): bool
+    public function offsetExists(mixed $key): bool
     {
         return $this->object->offsetExists($key);
     }
@@ -124,10 +116,9 @@ abstract class ObjectBehavior implements
      * Gets the value in a particular position in the ArrayAccess object
      *
      * @psalm-param TKey $key
-     * @param int|string $key
      * @psalm-suppress ImplementedReturnTypeMismatch
      */
-    public function offsetGet($key): Subject
+    public function offsetGet(mixed $key): Subject
     {
         return $this->object->offsetGet($key);
     }
@@ -136,12 +127,10 @@ abstract class ObjectBehavior implements
      * Sets the value in a particular position in the ArrayAccess object
      *
      * @psalm-param TKey $offset
-     * @param int|string $offset
-     * @param mixed $value
      * @psalm-suppress InvalidAttribute
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value)
     {
         $this->object->offsetSet($offset, $value);
     }
@@ -150,11 +139,10 @@ abstract class ObjectBehavior implements
      * Unsets a position in the ArrayAccess object
      *
      * @psalm-param TKey $key
-     * @param int|string $key
      * @psalm-suppress InvalidAttribute
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($key)
+    public function offsetUnset(mixed $key)
     {
         $this->object->offsetUnset($key);
     }
@@ -169,10 +157,8 @@ abstract class ObjectBehavior implements
 
     /**
      * Proxies setting to the PhpSpec subject
-     *
-     * @param mixed $value
      */
-    public function __set(string $property, $value)
+    public function __set(string $property, mixed $value)
     {
         $this->object->$property = $value;
     }

--- a/src/PhpSpec/Process/Context/ExecutionContext.php
+++ b/src/PhpSpec/Process/Context/ExecutionContext.php
@@ -15,12 +15,9 @@ namespace PhpSpec\Process\Context;
 
 interface ExecutionContext
 {
-    
-    public function addGeneratedType(string $type);
+    public function addGeneratedType(string $type) : void;
 
-    
     public function getGeneratedTypes(): array;
 
-    
     public function asEnv(): array;
 }

--- a/src/PhpSpec/Process/Context/JsonExecutionContext.php
+++ b/src/PhpSpec/Process/Context/JsonExecutionContext.php
@@ -16,11 +16,8 @@ namespace PhpSpec\Process\Context;
 final class JsonExecutionContext implements ExecutionContext
 {
     const ENV_NAME = 'PHPSPEC_EXECUTION_CONTEXT';
-    /**
-     * @var array
-     */
-    private $generatedTypes;
 
+    private array $generatedTypes;
 
     public static function fromEnv(array $env): JsonExecutionContext
     {
@@ -37,18 +34,15 @@ final class JsonExecutionContext implements ExecutionContext
         return $executionContext;
     }
 
-
-    public function addGeneratedType(string $type)
+    public function addGeneratedType(string $type) : void
     {
         $this->generatedTypes[] = $type;
     }
-
 
     public function getGeneratedTypes(): array
     {
         return $this->generatedTypes;
     }
-
 
     public function asEnv(): array
     {

--- a/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
+++ b/src/PhpSpec/Process/Prerequisites/SuitePrerequisites.php
@@ -17,15 +17,10 @@ use PhpSpec\Process\Context\ExecutionContext;
 
 final class SuitePrerequisites implements PrerequisiteTester
 {
-    /**
-     * @var ExecutionContext
-     */
-    private $executionContext;
-
-    
-    public function __construct(ExecutionContext $executionContext)
+    public function __construct(
+        private ExecutionContext $executionContext
+    )
     {
-        $this->executionContext = $executionContext;
     }
 
     /**

--- a/src/PhpSpec/Process/ReRunner/CompositeReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/CompositeReRunner.php
@@ -17,10 +17,7 @@ use PhpSpec\Process\ReRunner;
 
 final class CompositeReRunner implements ReRunner
 {
-    /**
-     * @var ReRunner
-     */
-    private $reRunner;
+    private ReRunner $reRunner;
 
     /**
      * @param PlatformSpecificReRunner[] $reRunners

--- a/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/OptionalReRunner.php
@@ -18,20 +18,11 @@ use PhpSpec\Process\ReRunner;
 
 final class OptionalReRunner implements ReRunner
 {
-    /**
-     * @var ConsoleIO
-     */
-    private $io;
-    /**
-     * @var ReRunner
-     */
-    private $decoratedRerunner;
-
-    
-    public function __construct(ReRunner $decoratedRerunner, ConsoleIO $io)
+    public function __construct(
+        private ReRunner $decoratedRerunner,
+        private ConsoleIO $io
+    )
     {
-        $this->io = $io;
-        $this->decoratedRerunner = $decoratedRerunner;
     }
 
     public function reRunSuite(): void

--- a/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PcntlReRunner.php
@@ -18,15 +18,9 @@ use Symfony\Component\Process\PhpExecutableFinder;
 
 final class PcntlReRunner extends PhpExecutableReRunner
 {
-    /**
-     * @var ExecutionContext
-     */
-    private $executionContext;
+    private ExecutionContext $executionContext;
 
-    /**
-     * @return static
-     */
-    public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext)
+    public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext) : static
     {
         $reRunner = new static($phpExecutableFinder);
         $reRunner->executionContext = $executionContext;
@@ -34,7 +28,6 @@ final class PcntlReRunner extends PhpExecutableReRunner
         return $reRunner;
     }
 
-    
     public function isSupported(): bool
     {
         return (php_sapi_name() == 'cli')
@@ -49,7 +42,7 @@ final class PcntlReRunner extends PhpExecutableReRunner
     public function reRunSuite(): void
     {
         $args = $_SERVER['argv'];
-        $env = $this->executionContext ? $this->executionContext->asEnv() : array();
+        $env = $this->executionContext->asEnv();
 
         $env = array_filter(
             array_merge($env, $_SERVER),

--- a/src/PhpSpec/Process/ReRunner/PhpExecutableReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/PhpExecutableReRunner.php
@@ -17,27 +17,18 @@ use Symfony\Component\Process\PhpExecutableFinder;
 
 abstract class PhpExecutableReRunner implements PlatformSpecificReRunner
 {
-    /**
-     * @var PhpExecutableFinder
-     */
-    private $executableFinder;
+    private string|false|null $executablePath = null;
 
-    /**
-     * @var null|false|string
-     */
-    private $executablePath;
-
-
-    public function __construct(PhpExecutableFinder $executableFinder)
+    public function __construct(
+        private PhpExecutableFinder $executableFinder
+    )
     {
-        $this->executableFinder = $executableFinder;
     }
 
     /**
-     * @return false|string
      * @psalm-suppress ReservedWord
      */
-    protected function getExecutablePath()
+    protected function getExecutablePath() : false|string
     {
         if (null === $this->executablePath) {
             $this->executablePath = $this->executableFinder->find();

--- a/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/ProcOpenReRunner.php
@@ -18,15 +18,9 @@ use Symfony\Component\Process\PhpExecutableFinder;
 
 final class ProcOpenReRunner extends PhpExecutableReRunner
 {
-    /**
-     * @var ExecutionContext
-     */
-    private $executionContext;
+    private ExecutionContext $executionContext;
 
-    /**
-     * @return static
-     */
-    public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext)
+    public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext) : static
     {
         $reRunner = new static($phpExecutableFinder);
         $reRunner->executionContext = $executionContext;

--- a/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
+++ b/src/PhpSpec/Process/ReRunner/WindowsPassthruReRunner.php
@@ -18,15 +18,9 @@ use Symfony\Component\Process\PhpExecutableFinder;
 
 final class WindowsPassthruReRunner extends PhpExecutableReRunner
 {
-    /**
-     * @var ExecutionContext
-     */
-    private $executionContext;
+    private ExecutionContext $executionContext;
 
-    /**
-     * @return static
-     */
-    public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext)
+    public static function withExecutionContext(PhpExecutableFinder $phpExecutableFinder, ExecutionContext $executionContext) : static
     {
         $reRunner = new static($phpExecutableFinder);
         $reRunner->executionContext = $executionContext;

--- a/src/PhpSpec/Process/Shutdown/Shutdown.php
+++ b/src/PhpSpec/Process/Shutdown/Shutdown.php
@@ -15,12 +15,7 @@ namespace PhpSpec\Process\Shutdown;
 
 final class Shutdown
 {
-    protected $actions;
-
-    public function __construct()
-    {
-        $this->actions = array();
-    }
+    protected array $actions = [];
 
     public function registerShutdown(): void
     {
@@ -42,7 +37,7 @@ final class Shutdown
         }
     }
 
-    private function getFatalError()
+    private function getFatalError() : ?array
     {
         $error = error_get_last();
 

--- a/src/PhpSpec/Process/Shutdown/ShutdownAction.php
+++ b/src/PhpSpec/Process/Shutdown/ShutdownAction.php
@@ -15,5 +15,5 @@ namespace PhpSpec\Process\Shutdown;
 
 interface ShutdownAction
 {
-    public function runAction($error): void;
+    public function runAction(?array $error): void;
 }

--- a/src/PhpSpec/Process/Shutdown/UpdateConsoleAction.php
+++ b/src/PhpSpec/Process/Shutdown/UpdateConsoleAction.php
@@ -18,23 +18,13 @@ use PhpSpec\Message\CurrentExampleTracker;
 
 final class UpdateConsoleAction implements ShutdownAction
 {
-    /**
-     * @var CurrentExampleTracker
-     */
-    private $currentExample;
-
-    /**
-     * @var FatalPresenter
-     */
-    private $currentExampleWriter;
-
-    public function __construct(CurrentExampleTracker $currentExample, FatalPresenter $currentExampleWriter)
+    public function __construct(
+        private CurrentExampleTracker $currentExample,
+        private FatalPresenter $currentExampleWriter)
     {
-        $this->currentExample = $currentExample;
-        $this->currentExampleWriter = $currentExampleWriter;
     }
 
-    public function runAction($error): void
+    public function runAction(?array $error): void
     {
         $this->currentExampleWriter->displayFatal($this->currentExample, $error);
     }

--- a/src/PhpSpec/Runner/CollaboratorManager.php
+++ b/src/PhpSpec/Runner/CollaboratorManager.php
@@ -21,40 +21,30 @@ use ReflectionFunctionAbstract;
 class CollaboratorManager
 {
     /**
-     * @var Presenter
-     */
-    private $presenter;
-    /**
      * @var Collaborator[]
      */
-    private $collaborators = array();
+    private array $collaborators = [];
 
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    /**
-     * @param object $collaborator
-     */
-    public function set(string $name, $collaborator): void
+    public function set(string $name, object $collaborator): void
     {
         $this->collaborators[$name] = $collaborator;
     }
 
-    
     public function has(string $name): bool
     {
         return isset($this->collaborators[$name]);
     }
 
     /**
-     * @return object
-     *
      * @throws \PhpSpec\Exception\Wrapper\CollaboratorException
      */
-    public function get(string $name)
+    public function get(string $name) : object
     {
         if (!$this->has($name)) {
             throw new CollaboratorException(
@@ -65,7 +55,6 @@ class CollaboratorManager
         return $this->collaborators[$name];
     }
 
-    
     public function getArgumentsFor(ReflectionFunctionAbstract $function): array
     {
         $parameters = array();

--- a/src/PhpSpec/Runner/ExampleRunner.php
+++ b/src/PhpSpec/Runner/ExampleRunner.php
@@ -32,27 +32,15 @@ class ExampleRunner
 {
     use DispatchTrait;
 
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-    /**
-     * @var Maintainer[]
-     */
-    private $maintainers = array();
+    private array $maintainers = [];
 
-    
-    public function __construct(EventDispatcherInterface $dispatcher, Presenter $presenter)
+    public function __construct(
+        private EventDispatcherInterface $dispatcher,
+        private Presenter $presenter
+    )
     {
-        $this->dispatcher = $dispatcher;
-        $this->presenter  = $presenter;
     }
 
-    
     public function registerMaintainer(Maintainer $maintainer): void
     {
         $this->maintainers[] = $maintainer;
@@ -62,7 +50,6 @@ class ExampleRunner
         });
     }
 
-    
     public function run(ExampleNode $example): int
     {
         $startTime = microtime(true);
@@ -182,7 +169,7 @@ class ExampleRunner
      *
      * @return Maintainer[]
      */
-    private function searchExceptionMaintainers(array $maintainers)
+    private function searchExceptionMaintainers(array $maintainers) : array
     {
         return array_filter(
             $maintainers,

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -30,37 +30,21 @@ use ReflectionNamedType;
 
 final class CollaboratorsMaintainer implements Maintainer
 {
-    /**
-     * @var string
-     */
-    private static $docex = '#@param *([^ ]*) *\$([^ ]*)#';
-    /**
-     * @var Unwrapper
-     */
-    private $unwrapper;
-    /**
-     * @var Prophet
-     */
-    private $prophet;
+    private static string $docex = '#@param *([^ ]*) *\$([^ ]*)#';
 
-    /**
-     * @var TypeHintIndex
-     */
-    private $typeHintIndex;
+    private Prophet $prophet;
 
-
-    public function __construct(Unwrapper $unwrapper, TypeHintIndex $typeHintIndex)
+    public function __construct(
+        private Unwrapper $unwrapper,
+        private TypeHintIndex $typeHintIndex
+    )
     {
-        $this->unwrapper = $unwrapper;
-        $this->typeHintIndex = $typeHintIndex;
     }
-
 
     public function supports(ExampleNode $example): bool
     {
         return true;
     }
-
 
     public function prepare(
         ExampleNode $example,
@@ -79,7 +63,6 @@ final class CollaboratorsMaintainer implements Maintainer
         $this->generateCollaborators($collaborators, $example->getFunctionReflection(), $classRefl);
     }
 
-
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -89,12 +72,10 @@ final class CollaboratorsMaintainer implements Maintainer
         $this->prophet->checkPredictions();
     }
 
-
     public function getPriority(): int
     {
         return 50;
     }
-
 
     private function generateCollaborators(CollaboratorManager $collaborators, \ReflectionFunctionAbstract $function, \ReflectionClass $classRefl): void
     {
@@ -132,7 +113,6 @@ final class CollaboratorsMaintainer implements Maintainer
         return !$type instanceof ReflectionNamedType || in_array($type->getName(), ['array', 'callable'], true);
     }
 
-
     private function getOrCreateCollaborator(CollaboratorManager $collaborators, string $name): Collaborator
     {
         if (!$collaborators->has($name)) {
@@ -144,8 +124,6 @@ final class CollaboratorsMaintainer implements Maintainer
     }
 
     /**
-     * @param string $className
-     *
      * @throws CollaboratorNotFoundException
      */
     private function throwCollaboratorNotFound(\Exception $e, \ReflectionParameter $parameter = null, string $className = null): void
@@ -157,7 +135,6 @@ final class CollaboratorsMaintainer implements Maintainer
             $className
         );
     }
-
 
     private function getParameterTypeFromIndex(\ReflectionClass $classRefl, \ReflectionParameter $parameter): ?string
     {

--- a/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/ErrorMaintainer.php
@@ -22,26 +22,20 @@ use PhpSpec\Exception\Example as ExampleException;
 final class ErrorMaintainer implements Maintainer
 {
     /**
-     * @var int
-     */
-    private $errorLevel;
-    /**
      * @var null|callable
      */
-    private $errorHandler;
+    private mixed $errorHandler;
 
-
-    public function __construct(int $errorLevel)
+    public function __construct(
+        private int $errorLevel
+    )
     {
-        $this->errorLevel = $errorLevel;
     }
-
 
     public function supports(ExampleNode $example): bool
     {
         return true;
     }
-
 
     public function prepare(
         ExampleNode $example,
@@ -51,7 +45,6 @@ final class ErrorMaintainer implements Maintainer
     ): void {
         $this->errorHandler = set_error_handler(array($this, 'errorHandler'), $this->errorLevel);
     }
-
 
     public function teardown(
         ExampleNode $example,
@@ -63,7 +56,6 @@ final class ErrorMaintainer implements Maintainer
             set_error_handler($this->errorHandler);
         }
     }
-
 
     public function getPriority(): int
     {

--- a/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/MatchersMaintainer.php
@@ -25,34 +25,23 @@ use PhpSpec\Formatter\Presenter\Presenter;
 final class MatchersMaintainer implements Maintainer
 {
     /**
-     * @var Presenter
-     */
-    private $presenter;
-
-    /**
-     * @var Matcher[]
-     */
-    private $defaultMatchers = array();
-
-    /**
      * @param Matcher[] $matchers
      */
-    public function __construct(Presenter $presenter, array $matchers)
+    public function __construct(
+        private Presenter $presenter,
+        private array $matchers
+    )
     {
-        $this->presenter = $presenter;
-        $this->defaultMatchers = $matchers;
-        @usort($this->defaultMatchers, function (Matcher $matcher1, Matcher $matcher2) {
+        @usort($this->matchers, function (Matcher $matcher1, Matcher $matcher2) {
             return $matcher2->getPriority() - $matcher1->getPriority();
         });
     }
 
-    
     public function supports(ExampleNode $example): bool
     {
         return true;
     }
 
-    
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -60,7 +49,7 @@ final class MatchersMaintainer implements Maintainer
         CollaboratorManager $collaborators
     ): void {
 
-        $matchers->replace($this->defaultMatchers);
+        $matchers->replace($this->matchers);
 
         if (!$context instanceof MatchersProvider) {
             return;
@@ -79,7 +68,6 @@ final class MatchersMaintainer implements Maintainer
         }
     }
 
-    
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -88,7 +76,6 @@ final class MatchersMaintainer implements Maintainer
     ): void {
     }
 
-    
     public function getPriority(): int
     {
         return 50;

--- a/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/SubjectMaintainer.php
@@ -26,37 +26,14 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class SubjectMaintainer implements Maintainer
 {
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-    /**
-     * @var Unwrapper
-     */
-    private $unwrapper;
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-    /**
-     * @var AccessInspector
-     */
-    private $accessInspector;
-
-    
     public function __construct(
-        Presenter $presenter,
-        Unwrapper $unwrapper,
-        EventDispatcherInterface $dispatcher,
-        AccessInspector $accessInspector
+        private Presenter $presenter,
+        private Unwrapper $unwrapper,
+        private EventDispatcherInterface $dispatcher,
+        private AccessInspector $accessInspector
     ) {
-        $this->presenter = $presenter;
-        $this->unwrapper = $unwrapper;
-        $this->dispatcher = $dispatcher;
-        $this->accessInspector = $accessInspector;
     }
 
-    
     public function supports(ExampleNode $example): bool
     {
         return $example->getSpecification()->getClassReflection()->implementsInterface(
@@ -64,7 +41,6 @@ final class SubjectMaintainer implements Maintainer
         );
     }
 
-    
     public function prepare(
         ExampleNode $example,
         Specification $context,
@@ -82,7 +58,6 @@ final class SubjectMaintainer implements Maintainer
         }
     }
 
-    
     public function teardown(
         ExampleNode $example,
         Specification $context,
@@ -91,7 +66,6 @@ final class SubjectMaintainer implements Maintainer
     ): void {
     }
 
-    
     public function getPriority(): int
     {
         return 100;

--- a/src/PhpSpec/Runner/MatcherManager.php
+++ b/src/PhpSpec/Runner/MatcherManager.php
@@ -20,21 +20,16 @@ use PhpSpec\Formatter\Presenter\Presenter;
 class MatcherManager
 {
     /**
-     * @var Presenter
-     */
-    private $presenter;
-    /**
      * @var Matcher[]
      */
-    private $matchers = array();
+    private array $matchers = [];
 
-    
-    public function __construct(Presenter $presenter)
+    public function __construct(
+        private Presenter $presenter
+    )
     {
-        $this->presenter = $presenter;
     }
 
-    
     public function add(Matcher $matcher): void
     {
         $this->matchers[] = $matcher;
@@ -56,7 +51,7 @@ class MatcherManager
     /**
      * @throws \PhpSpec\Exception\Wrapper\MatcherNotFoundException
      */
-    public function find(string $keyword, $subject, array $arguments): Matcher
+    public function find(string $keyword, mixed $subject, array $arguments): Matcher
     {
         foreach ($this->matchers as $matcher) {
             if (true === $matcher->supports($keyword, $subject, $arguments)) {

--- a/src/PhpSpec/Runner/SpecificationRunner.php
+++ b/src/PhpSpec/Runner/SpecificationRunner.php
@@ -22,25 +22,13 @@ class SpecificationRunner
 {
     use DispatchTrait;
 
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-    /**
-     * @var ExampleRunner
-     */
-    private $exampleRunner;
-
-    
-    public function __construct(EventDispatcherInterface $dispatcher, ExampleRunner $exampleRunner)
+    public function __construct(
+        private EventDispatcherInterface $dispatcher,
+        private ExampleRunner $exampleRunner
+    )
     {
-        $this->dispatcher    = $dispatcher;
-        $this->exampleRunner = $exampleRunner;
     }
 
-    /**
-     * @return int
-     */
     public function run(SpecificationNode $specification): int
     {
         $startTime = microtime(true);

--- a/src/PhpSpec/Runner/SuiteRunner.php
+++ b/src/PhpSpec/Runner/SuiteRunner.php
@@ -23,23 +23,13 @@ class SuiteRunner
 {
     use DispatchTrait;
 
-    /**
-     * @var EventDispatcher
-     */
-    private $dispatcher;
-    /**
-     * @var SpecificationRunner
-     */
-    private $specRunner;
-
-    
-    public function __construct(EventDispatcher $dispatcher, SpecificationRunner $specRunner)
+    public function __construct(
+        private EventDispatcher $dispatcher,
+        private SpecificationRunner $specRunner
+    )
     {
-        $this->dispatcher = $dispatcher;
-        $this->specRunner = $specRunner;
     }
 
-    
     public function run(Suite $suite): int
     {
         $this->dispatch($this->dispatcher, new SuiteEvent($suite), 'beforeSuite');

--- a/src/PhpSpec/ServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer.php
@@ -11,21 +11,19 @@ interface ServiceContainer
     /**
      * Sets a param in the container
      */
-    public function setParam(string $id, $value): void;
+    public function setParam(string $id, mixed $value): void;
 
     /**
      * Gets a param from the container or a default value.
      */
-    public function getParam(string $id, $default = null);
+    public function getParam(string $id, mixed $default = null) : mixed;
 
     /**
      * Sets a object to be used as a service
      *
-     * @param object $service
-     *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set(string $id, $service, array $tags = []): void;
+    public function set(string $id, object $service, array $tags = []): void;
 
     /**
      * Sets a factory for the service creation. The same service will
@@ -39,12 +37,9 @@ interface ServiceContainer
     /**
      * Retrieves a service from the container
      *
-     *
-     * @return object
-     *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function get(string $id);
+    public function get(string $id) : object;
 
     /**
      * Determines whether a service is defined

--- a/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
+++ b/src/PhpSpec/ServiceContainer/IndexedServiceContainer.php
@@ -22,35 +22,20 @@ use PhpSpec\ServiceContainer;
  */
 final class IndexedServiceContainer implements ServiceContainer
 {
-    /**
-     * @var array
-     */
-    private $parameters = [];
+    private array $parameters = [];
 
-    /**
-     * @var array
-     */
-    private $definitions = [];
+    private array $definitions = [];
 
-    /**
-     * @var array
-     */
-    private $services = [];
+    private array $services = [];
 
-    /**
-     * @var array
-     */
-    private $tags = [];
+    private array $tags = [];
 
-    /**
-     * @var array
-     */
-    private $configurators = [];
+    private array $configurators = [];
 
     /**
      * Sets a param in the container
      */
-    public function setParam(string $id, $value): void
+    public function setParam(string $id, mixed $value): void
     {
         $this->parameters[$id] = $value;
     }
@@ -58,7 +43,7 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Gets a param from the container or a default value.
      */
-    public function getParam(string $id, $default = null)
+    public function getParam(string $id, mixed $default = null) : mixed
     {
         return $this->parameters[$id] ?? $default;
     }
@@ -66,19 +51,10 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Sets a object to be used as a service
      *
-     * @param object $service
-     *
      * @throws \InvalidArgumentException if service is not an object
      */
-    public function set(string $id, $service, array $tags = []): void
+    public function set(string $id, object $service, array $tags = []): void
     {
-        if (!\is_object($service)) {
-            throw new InvalidArgumentException(sprintf(
-                'Service should be an object, but %s given.',
-                \gettype($service)
-            ));
-        }
-
         $this->services[$id] = $service;
         unset($this->definitions[$id]);
 
@@ -100,12 +76,9 @@ final class IndexedServiceContainer implements ServiceContainer
     /**
      * Retrieves a service from the container
      *
-     *
-     * @return object
-     *
      * @throws \InvalidArgumentException if service is not defined
      */
-    public function get(string $id)
+    public function get(string $id) : object
     {
         if (!array_key_exists($id, $this->services)) {
             if (!array_key_exists($id, $this->definitions)) {

--- a/src/PhpSpec/Util/ClassFileAnalyser.php
+++ b/src/PhpSpec/Util/ClassFileAnalyser.php
@@ -18,9 +18,8 @@ use PhpSpec\Exception\Generator\NoMethodFoundInClass;
 
 final class ClassFileAnalyser
 {
-    private $tokenLists = array();
+    private array $tokenLists = [];
 
-    
     public function getStartLineOfFirstMethod(string $class): int
     {
         $tokens = $this->getTokensForClass($class);
@@ -28,7 +27,6 @@ final class ClassFileAnalyser
         return $tokens[$index][2];
     }
 
-    
     public function getEndLineOfLastMethod(string $class): int
     {
         $tokens = $this->getTokensForClass($class);
@@ -36,7 +34,6 @@ final class ClassFileAnalyser
         return $tokens[$index][2];
     }
 
-    
     public function classHasMethods(string $class): bool
     {
         foreach ($this->getTokensForClass($class) as $token) {
@@ -52,7 +49,6 @@ final class ClassFileAnalyser
         return false;
     }
 
-    
     public function getEndLineOfNamedMethod(string $class, string $methodName): int
     {
         $tokens = $this->getTokensForClass($class);
@@ -61,7 +57,6 @@ final class ClassFileAnalyser
         return $tokens[$index][2];
     }
 
-    
     private function findIndexOfFirstMethod(array $tokens): int
     {
         for ($i = 0, $max = \count($tokens); $i < $max; $i++) {
@@ -73,7 +68,6 @@ final class ClassFileAnalyser
         throw new \RuntimeException('Could not find index of first method');
     }
 
-    
     private function offsetForDocblock(array $tokens, int $index): int
     {
         $allowedTokens = array(
@@ -107,10 +101,7 @@ final class ClassFileAnalyser
         throw new \RuntimeException('Could not find index of for docblock');
     }
 
-    /**
-     * @param $class
-     */
-    private function getTokensForClass($class): array
+    private function getTokensForClass(string $class): array
     {
         $hash = md5($class);
 
@@ -121,7 +112,7 @@ final class ClassFileAnalyser
         return $this->tokenLists[$hash];
     }
 
-    
+
     private function findIndexOfNamedMethodEnd(array $tokens, string $methodName): int
     {
         $index = $this->findIndexOfNamedMethod($tokens, $methodName);
@@ -162,7 +153,7 @@ final class ClassFileAnalyser
         throw new NamedMethodNotFoundException('Target method not found');
     }
 
-    
+
     private function findIndexOfMethodOrClassEnd(array $tokens, int $index): int
     {
         $braceCount = 0;
@@ -186,7 +177,7 @@ final class ClassFileAnalyser
         throw new \RuntimeException('Could not find last method or class end');
     }
 
-    private function isSpecialBraceToken($token): bool
+    private function isSpecialBraceToken(string|array $token): bool
     {
         if (!\is_array($token)) {
             return false;
@@ -195,13 +186,13 @@ final class ClassFileAnalyser
         return $token[1] === "{";
     }
 
-    
-    private function tokenIsFunction($token): bool
+
+    private function tokenIsFunction(string|array $token): bool
     {
         return \is_array($token) && $token[0] === T_FUNCTION;
     }
 
-    
+
     private function findIndexOfClassEnd(array $tokens): int
     {
         $classTokens = array_filter($tokens, function ($token) {
@@ -211,7 +202,7 @@ final class ClassFileAnalyser
         return $this->findIndexOfMethodOrClassEnd($tokens, $classTokenIndex) - 1;
     }
 
-    
+
     public function findEndOfLastMethod(array $tokens, int $index): int
     {
         for ($i = $index - 1; $i > 0; $i--) {

--- a/src/PhpSpec/Util/ClassNameChecker.php
+++ b/src/PhpSpec/Util/ClassNameChecker.php
@@ -16,7 +16,7 @@ namespace PhpSpec\Util;
 
 final class ClassNameChecker implements NameChecker
 {
-    private $reservedKeywordsForClassNamespaceParts = [
+    private array $reservedKeywordsForClassNamespaceParts = [
         '__halt_compiler',
         'abstract',
         'and',

--- a/src/PhpSpec/Util/DispatchTrait.php
+++ b/src/PhpSpec/Util/DispatchTrait.php
@@ -11,12 +11,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 trait DispatchTrait
 {
-    /**
-     * @param EventDispatcher $eventDispatcher
-     * @param object $event
-     * @param string $eventName
-     */
-    private function dispatch($eventDispatcher, $event, $eventName)
+    private function dispatch(object $eventDispatcher, object $event, string $eventName) : object
     {
         if ($this->isNewSymfonyContract($eventDispatcher)) {
             return $eventDispatcher->dispatch($event, $eventName);
@@ -25,7 +20,7 @@ trait DispatchTrait
         return $eventDispatcher->dispatch($eventName, $event);
     }
 
-    private function isNewSymfonyContract($eventDispatcher): bool
+    private function isNewSymfonyContract(object $eventDispatcher): bool
     {
         // This trait may be used with a double, in the tests
         if ($eventDispatcher instanceof Collaborator) {

--- a/src/PhpSpec/Util/Filesystem.php
+++ b/src/PhpSpec/Util/Filesystem.php
@@ -17,31 +17,31 @@ use Symfony\Component\Finder\Finder;
 
 class Filesystem
 {
-    
+
     public function pathExists(string $path): bool
     {
         return file_exists($path);
     }
 
-    
+
     public function getFileContents(string $path): string
     {
         return file_get_contents($path);
     }
 
-    
-    public function putFileContents(string $path, string $content)
+
+    public function putFileContents(string $path, string $content) : void
     {
         file_put_contents($path, $content);
     }
 
-    
+
     public function isDirectory(string $path): bool
     {
         return is_dir($path);
     }
 
-    
+
     public function makeDirectory(string $path): void
     {
         mkdir($path, 0777, true);

--- a/src/PhpSpec/Util/Instantiator.php
+++ b/src/PhpSpec/Util/Instantiator.php
@@ -17,10 +17,7 @@ use PhpSpec\Exception\Fracture\ClassNotFoundException;
 
 class Instantiator
 {
-    /**
-     * @return object
-     */
-    public function instantiate(string $className)
+    public function instantiate(string $className) : object
     {
         if (!class_exists($className)) {
             throw new ClassNotFoundException("Class $className does not exist.", $className);

--- a/src/PhpSpec/Util/MethodAnalyser.php
+++ b/src/PhpSpec/Util/MethodAnalyser.php
@@ -17,13 +17,13 @@ use PhpSpec\Loader\StreamWrapper;
 
 class MethodAnalyser
 {
-    
+
     public function methodIsEmpty(string $class, string $method): bool
     {
         return $this->reflectionMethodIsEmpty(new \ReflectionMethod($class, $method));
     }
 
-    
+
     public function reflectionMethodIsEmpty(\ReflectionMethod $method): bool
     {
         if ($this->isNotImplementedInPhp($method)) {
@@ -36,7 +36,7 @@ class MethodAnalyser
         return $this->codeIsOnlyBlocksAndWhitespace($codeWithoutComments);
     }
 
-    
+
     public function getMethodOwnerName(string $class, string $method): string
     {
         $reflectionMethod = new \ReflectionMethod($class, $method);
@@ -47,7 +47,7 @@ class MethodAnalyser
         return $reflectionClass->getName();
     }
 
-    
+
     private function getCodeBody(\ReflectionMethod $reflectionMethod): string
     {
         $endLine = $reflectionMethod->getEndLine();
@@ -61,7 +61,7 @@ class MethodAnalyser
         return preg_replace('/.*function[^{]+{/s', '', $code);
     }
 
-    
+
     private function getMethodOwner(\ReflectionMethod $reflectionMethod, int $methodStartLine, int $methodEndLine): \ReflectionClass
     {
         $reflectionClass = $reflectionMethod->getDeclaringClass();
@@ -89,7 +89,7 @@ class MethodAnalyser
         return null;
     }
 
-    
+
     private function stripComments(string $code): string
     {
         $tokens = token_get_all('<?php ' . $code);
@@ -110,13 +110,13 @@ class MethodAnalyser
         return $commentless;
     }
 
-    
+
     private function codeIsOnlyBlocksAndWhitespace(string $codeWithoutComments): bool
     {
         return (bool) preg_match('/^[\s{}]*$/s', $codeWithoutComments);
     }
 
-    
+
     private function isNotImplementedInPhp(\ReflectionMethod $method): bool
     {
         $filename = $method->getDeclaringClass()->getFileName();

--- a/src/PhpSpec/Util/ReservedWordsMethodNameChecker.php
+++ b/src/PhpSpec/Util/ReservedWordsMethodNameChecker.php
@@ -15,13 +15,10 @@ namespace PhpSpec\Util;
 
 final class ReservedWordsMethodNameChecker implements NameChecker
 {
-    private $reservedWords = [
+    private array $reservedWords = [
         '__halt_compiler',
     ];
 
-    /**
-     * {@inheritdoc}
-     */
     public function isNameValid(string $name): bool
     {
         return !\in_array(strtolower($name), $this->reservedWords);

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -17,18 +17,11 @@ use Prophecy\Prophecy\ObjectProphecy;
 
 final class Collaborator implements ObjectWrapper
 {
-    /**
-     * @var ObjectProphecy
-     */
-    private $prophecy;
-
-    
-    public function __construct(ObjectProphecy $prophecy)
+    public function __construct(
+        private ObjectProphecy $prophecy)
     {
-        $this->prophecy  = $prophecy;
     }
 
-    
     public function beADoubleOf(string $classOrInterface): void
     {
         if (interface_exists($classOrInterface)) {
@@ -38,42 +31,32 @@ final class Collaborator implements ObjectWrapper
         }
     }
 
-    /**
-     * @param array $arguments
-     */
     public function beConstructedWith(array $arguments = null): void
     {
         $this->prophecy->willBeConstructedWith($arguments);
     }
 
-    
     public function implement(string $interface): void
     {
         $this->prophecy->willImplement($interface);
     }
 
-    
     public function __call(string $method, array $arguments)
     {
         return \call_user_func_array(array($this->prophecy, '__call'), array($method, $arguments));
     }
 
-    
-    public function __set(string $parameter, $value)
+    public function __set(string $parameter, mixed $value)
     {
         $this->prophecy->$parameter = $value;
     }
 
-    
     public function __get(string $parameter)
     {
         return $this->prophecy->$parameter;
     }
 
-    /**
-     * @return object
-     */
-    public function getWrappedObject()
+    public function getWrappedObject() : object
     {
         return $this->prophecy->reveal();
     }

--- a/src/PhpSpec/Wrapper/DelayedCall.php
+++ b/src/PhpSpec/Wrapper/DelayedCall.php
@@ -15,18 +15,13 @@ namespace PhpSpec\Wrapper;
 
 class DelayedCall
 {
-    /**
-     * @var callable
-     */
-    private $callable;
+    private mixed $callable;
 
-    
     public function __construct(callable $callable)
     {
         $this->callable = $callable;
     }
 
-    
     public function __call(string $method, array $arguments)
     {
         return \call_user_func($this->callable, $method, $arguments);

--- a/src/PhpSpec/Wrapper/ObjectWrapper.php
+++ b/src/PhpSpec/Wrapper/ObjectWrapper.php
@@ -15,6 +15,5 @@ namespace PhpSpec\Wrapper;
 
 interface ObjectWrapper
 {
-    
-    public function getWrappedObject();
+    public function getWrappedObject() : mixed;
 }

--- a/src/PhpSpec/Wrapper/Subject.php
+++ b/src/PhpSpec/Wrapper/Subject.php
@@ -111,76 +111,32 @@ use ArrayAccess;
  */
 class Subject implements ArrayAccess, ObjectWrapper
 {
-    /**
-     * @var mixed
-     */
-    private $subject;
-    /**
-     * @var Subject\WrappedObject
-     */
-    private $wrappedObject;
-    /**
-     * @var Subject\Caller
-     */
-    private $caller;
-    /**
-     * @var Subject\SubjectWithArrayAccess
-     */
-    private $arrayAccess;
-    /**
-     * @var Wrapper
-     */
-    private $wrapper;
-    /**
-     * @var Subject\ExpectationFactory
-     */
-    private $expectationFactory;
-
-    /**
-     * @param mixed $subject
-     */
     public function __construct(
-        $subject,
-        Wrapper $wrapper,
-        WrappedObject $wrappedObject,
-        Caller $caller,
-        SubjectWithArrayAccess $arrayAccess,
-        ExpectationFactory $expectationFactory
+        private mixed $subject,
+        private Wrapper $wrapper,
+        private WrappedObject $wrappedObject,
+        private Caller $caller,
+        private SubjectWithArrayAccess $arrayAccess,
+        private ExpectationFactory $expectationFactory
     ) {
-        $this->subject            = $subject;
-        $this->wrapper            = $wrapper;
-        $this->wrappedObject      = $wrappedObject;
-        $this->caller             = $caller;
-        $this->arrayAccess        = $arrayAccess;
-        $this->expectationFactory = $expectationFactory;
     }
-
 
     public function beAnInstanceOf(string $className, array $arguments = array()): void
     {
         $this->wrappedObject->beAnInstanceOf($className, $arguments);
     }
 
-    /**
-     * @param mixed ...$arguments
-     */
     public function beConstructedWith(): void
     {
         $this->wrappedObject->beConstructedWith(\func_get_args());
     }
 
-    /**
-     * @param array|string $factoryMethod
-     */
-    public function beConstructedThrough($factoryMethod, array $arguments = array()): void
+    public function beConstructedThrough(string|array $factoryMethod, array $arguments = array()): void
     {
         $this->wrappedObject->beConstructedThrough($factoryMethod, $arguments);
     }
 
-    /**
-     * @return ?object
-     */
-    public function getWrappedObject()
+    public function getWrappedObject() : mixed
     {
         if ($this->subject) {
             return $this->subject;
@@ -195,65 +151,50 @@ class Subject implements ArrayAccess, ObjectWrapper
         return $this->caller->call($method, $arguments);
     }
 
-    /**
-     * @param mixed $value
-     * @return void
-     */
-    public function setToWrappedObject(string $property, $value = null)
+    public function setToWrappedObject(string $property, mixed $value = null) : void
     {
         $this->caller->set($property, $value);
     }
 
-    /**
-     * @return string|Subject
-     */
-    public function getFromWrappedObject(string $property)
+    public function getFromWrappedObject(string $property) : string|Subject
     {
         return $this->caller->get($property);
     }
 
     /**
      * @psalm-param TKey $key
-     * @param int|string $key
      */
-    public function offsetExists($key): bool
+    public function offsetExists(mixed $key): bool
     {
         return $this->arrayAccess->offsetExists($key);
     }
 
     /**
-     * @param int|string $key
      * @psalm-param TKey $key
      * @psalm-suppress ImplementedReturnTypeMismatch
      */
-    public function offsetGet($key): Subject
+    public function offsetGet(mixed $key): Subject
     {
         return $this->wrap($this->arrayAccess->offsetGet($key));
     }
 
     /**
-     * @param mixed $value
      * @psalm-param TKey $offset
-     * @param int|string $offset
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->arrayAccess->offsetSet($offset, $value);
     }
 
     /**
      * @psalm-param TKey $key
-     * @param int|string $key
      */
-    public function offsetUnset($key): void
+    public function offsetUnset(mixed $key): void
     {
         $this->arrayAccess->offsetUnset($key);
     }
 
-    /**
-     * @return mixed|Subject
-     */
-    public function __call(string $method, array $arguments = array())
+    public function __call(string $method, array $arguments = array()) : mixed
     {
         if (0 === strpos($method, 'should')) {
             return $this->callExpectation($method, $arguments);
@@ -276,35 +217,22 @@ class Subject implements ArrayAccess, ObjectWrapper
         return $this->caller->call('__invoke', \func_get_args());
     }
 
-
-    /**
-     * @param mixed $value
-     */
-    public function __set(string $property, $value = null)
+    public function __set(string $property, mixed $value = null)
     {
         return $this->caller->set($property, $value);
     }
 
-    /**
-     * @return string|Subject
-     */
-    public function __get(string $property)
+    public function __get(string $property) : string|Subject
     {
         return $this->caller->get($property);
     }
 
-    /**
-     * @param mixed $value
-     */
-    private function wrap($value): Subject
+    private function wrap(mixed $value): Subject
     {
         return $this->wrapper->wrap($value);
     }
 
-    /**
-     * @return mixed
-     */
-    private function callExpectation(string $method, array $arguments)
+    private function callExpectation(string $method, array $arguments) : mixed
     {
         $subject = $this->makeSureWeHaveASubject();
 
@@ -317,10 +245,7 @@ class Subject implements ArrayAccess, ObjectWrapper
         return $expectation->match(lcfirst(substr($method, 6)), $this, $arguments, $this->wrappedObject);
     }
 
-    /**
-     * @return object
-     */
-    private function makeSureWeHaveASubject()
+    private function makeSureWeHaveASubject() : mixed
     {
         if (null === $this->subject && $this->wrappedObject->getClassName()) {
             $instantiator = new Instantiator();

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -15,10 +15,11 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 use PhpSpec\Util\Instantiator;
 use PhpSpec\Wrapper\Subject\WrappedObject;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class ConstructorDecorator extends Decorator implements Expectation
 {
-    
+
     public function __construct(Expectation $expectation)
     {
         $this->setExpectation($expectation);
@@ -29,7 +30,7 @@ final class ConstructorDecorator extends Decorator implements Expectation
      * @throws \PhpSpec\Exception\Example\ErrorException
      * @throws \PhpSpec\Exception\Fracture\FractureException
      */
-    public function match(string $alias, $subject, array $arguments = [], WrappedObject $wrappedObject = null)
+    public function match(string $alias, mixed $subject, array $arguments = [], WrappedObject $wrappedObject = null) : DelayedCall|DuringCall|bool|null
     {
         try {
             $wrapped = $subject->getWrappedObject();

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Decorator.php
@@ -15,30 +15,22 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 abstract class Decorator implements Expectation
 {
-    /**
-     * @var Expectation
-     */
-    private $expectation;
-
-    
-    public function __construct(Expectation $expectation)
+    public function __construct(
+        private Expectation $expectation
+    )
     {
-        $this->expectation = $expectation;
     }
 
-    
     public function getExpectation(): Expectation
     {
         return $this->expectation;
     }
 
-    
     protected function setExpectation(Expectation $expectation): void
     {
         $this->expectation = $expectation;
     }
 
-    
     public function getNestedExpectation(): Expectation
     {
         $expectation = $this->getExpectation();

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DispatcherDecorator.php
@@ -18,6 +18,7 @@ use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\Matcher\Matcher;
 use PhpSpec\Util\DispatchTrait;
+use PhpSpec\Wrapper\DelayedCall;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Exception;
 
@@ -25,30 +26,13 @@ final class DispatcherDecorator extends Decorator implements Expectation
 {
     use DispatchTrait;
 
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-    /**
-     * @var Matcher
-     */
-    private $matcher;
-    /**
-     * @var ExampleNode
-     */
-    private $example;
-
-    
     public function __construct(
         Expectation $expectation,
-        EventDispatcherInterface $dispatcher,
-        Matcher $matcher,
-        ExampleNode $example
+        private EventDispatcherInterface $dispatcher,
+        private Matcher $matcher,
+        private ExampleNode $example
     ) {
         $this->setExpectation($expectation);
-        $this->dispatcher = $dispatcher;
-        $this->matcher = $matcher;
-        $this->example = $example;
     }
 
     /**
@@ -56,7 +40,7 @@ final class DispatcherDecorator extends Decorator implements Expectation
      * @throws \PhpSpec\Exception\Example\FailureException
      * @throws \Exception
      */
-    public function match(string $alias, $subject, array $arguments = array())
+    public function match(string $alias, mixed $subject, array $arguments = array()) : DelayedCall|DuringCall|bool|null
     {
         $this->dispatch(
             $this->dispatcher,

--- a/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/DuringCall.php
@@ -20,33 +20,22 @@ use PhpSpec\Wrapper\Subject\WrappedObject;
 
 abstract class DuringCall
 {
-    /**
-     * @var Matcher
-     */
-    private $matcher;
+    private mixed $subject;
 
-    private $subject;
-    /**
-     * @var array
-     */
-    private $arguments;
-    /**
-     * @var WrappedObject
-     */
-    private $wrappedObject;
+    private array $arguments;
 
+    private WrappedObject $wrappedObject;
 
-    public function __construct(Matcher $matcher)
+    public function __construct(
+        private Matcher $matcher
+    )
     {
-        $this->matcher = $matcher;
     }
 
     /**
-     * @param null|WrappedObject $wrappedObject
-     *
      * @return $this
      */
-    public function match(string $alias, $subject, array $arguments = array(), $wrappedObject = null)
+    public function match(string $alias, mixed $subject, array $arguments = array(), ?WrappedObject $wrappedObject = null) : static
     {
         $this->subject = $subject;
         $this->arguments = $arguments;
@@ -55,22 +44,23 @@ abstract class DuringCall
         return $this;
     }
 
-
-    public function during(string $method, array $arguments = array())
+    public function during(string $method, array $arguments = array()) : void
     {
         if ($method === '__construct') {
             $this->subject->beAnInstanceOf($this->wrappedObject->getClassName(), $arguments);
 
-            return $this->duringInstantiation();
+            $this->duringInstantiation();
+
+            return;
         }
 
         $object = $this->wrappedObject->instantiate();
 
-        return $this->runDuring($object, $method, $arguments);
+        $this->runDuring($object, $method, $arguments);
     }
 
 
-    public function duringInstantiation()
+    public function duringInstantiation() : void
     {
         if ($factoryMethod = $this->wrappedObject->getFactoryMethod()) {
             $method = \is_array($factoryMethod) ? $factoryMethod[1] : $factoryMethod;
@@ -80,7 +70,7 @@ abstract class DuringCall
         $instantiator = new Instantiator();
         $object = $instantiator->instantiate($this->wrappedObject->getClassName());
 
-        return $this->runDuring($object, $method, $this->wrappedObject->getArguments());
+        $this->runDuring($object, $method, $this->wrappedObject->getArguments());
     }
 
     /**
@@ -112,9 +102,5 @@ abstract class DuringCall
         return $this->matcher;
     }
 
-    /**
-     * @param object $object
-     * @param string $method
-     */
-    abstract protected function runDuring($object, $method, array $arguments = array());
+    abstract protected function runDuring(object $object, string $method, array $arguments = array()) : void;
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Expectation.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Expectation.php
@@ -13,8 +13,10 @@
 
 namespace PhpSpec\Wrapper\Subject\Expectation;
 
+use PhpSpec\Wrapper\DelayedCall;
+use PhpSpec\Wrapper\Subject\Expectation\DuringCall;
+
 interface Expectation
 {
-    
-    public function match(string $alias, $subject, array $arguments = array());
+    public function match(string $alias, mixed $subject, array $arguments = array()) : DuringCall|DelayedCall|bool|null;
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Negative.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Negative.php
@@ -14,22 +14,17 @@
 namespace PhpSpec\Wrapper\Subject\Expectation;
 
 use PhpSpec\Matcher\Matcher;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class Negative implements Expectation
 {
-    /**
-     * @var Matcher
-     */
-    private $matcher;
-
-    
-    public function __construct(Matcher $matcher)
+    public function __construct(
+        private Matcher $matcher
+    )
     {
-        $this->matcher = $matcher;
     }
 
-    
-    public function match(string $alias, $subject, array $arguments = array())
+    public function match(string $alias, mixed $subject, array $arguments = array()) : ?DelayedCall
     {
         return $this->matcher->negativeMatch($alias, $subject, $arguments);
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/NegativeThrow.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/NegativeThrow.php
@@ -15,13 +15,9 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 final class NegativeThrow extends DuringCall implements ThrowExpectation
 {
-    /**
-     * @param object $object
-     * @param string $method
-     */
-    protected function runDuring($object, $method, array $arguments = array())
+    protected function runDuring(object $object, string $method, array $arguments = array()) : void
     {
-        return $this->getMatcher()->negativeMatch('throw', $object, $this->getArguments())
+        $this->getMatcher()->negativeMatch('throw', $object, $this->getArguments())
             ->during($method, $arguments);
     }
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php
@@ -15,13 +15,9 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 final class NegativeTrigger extends DuringCall implements ThrowExpectation
 {
-    /**
-     * @param object $object
-     * @param string $method
-     */
-    protected function runDuring($object, $method, array $arguments = array())
+    protected function runDuring(object $object, string $method, array $arguments = array()) : void
     {
-        return $this->getMatcher()->negativeMatch('trigger', $object, $this->getArguments())
+        $this->getMatcher()->negativeMatch('trigger', $object, $this->getArguments())
             ->during($method, $arguments);
     }
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/Positive.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/Positive.php
@@ -14,22 +14,17 @@
 namespace PhpSpec\Wrapper\Subject\Expectation;
 
 use PhpSpec\Matcher\Matcher;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class Positive implements Expectation
 {
-    /**
-     * @var Matcher
-     */
-    private $matcher;
-
-    
-    public function __construct(Matcher $matcher)
+    public function __construct(
+        private Matcher $matcher
+    )
     {
-        $this->matcher = $matcher;
     }
 
-    
-    public function match(string $alias, $subject, array $arguments = array())
+    public function match(string $alias, mixed $subject, array $arguments = array()) : ?DelayedCall
     {
         return $this->matcher->positiveMatch($alias, $subject, $arguments);
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/PositiveThrow.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/PositiveThrow.php
@@ -15,13 +15,9 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 final class PositiveThrow extends DuringCall implements ThrowExpectation
 {
-    /**
-     * @param object $object
-     * @param string $method
-     */
-    protected function runDuring($object, $method, array $arguments = array())
+    protected function runDuring(object $object, string $method, array $arguments = array()) : void
     {
-        return $this->getMatcher()->positiveMatch('throw', $object, $this->getArguments())
+        $this->getMatcher()->positiveMatch('throw', $object, $this->getArguments())
             ->during($method, $arguments);
     }
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php
@@ -15,13 +15,9 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 final class PositiveTrigger extends DuringCall implements ThrowExpectation
 {
-    /**
-     * @param object $object
-     * @param string $method
-     */
-    protected function runDuring($object, $method, array $arguments = array())
+    protected function runDuring(object $object, string $method, array $arguments = array()) : void
     {
-        return $this->getMatcher()->positiveMatch('trigger', $object, $this->getArguments())
+        $this->getMatcher()->positiveMatch('trigger', $object, $this->getArguments())
             ->during($method, $arguments);
     }
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ThrowExpectation.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ThrowExpectation.php
@@ -15,6 +15,5 @@ namespace PhpSpec\Wrapper\Subject\Expectation;
 
 interface ThrowExpectation extends Expectation
 {
-    
-    public function during(string $method, array $arguments = array());
+    public function during(string $method, array $arguments = array()) : void;
 }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/UnwrapDecorator.php
@@ -14,23 +14,19 @@
 namespace PhpSpec\Wrapper\Subject\Expectation;
 
 use PhpSpec\Wrapper\Unwrapper;
+use PhpSpec\Wrapper\DelayedCall;
 
 final class UnwrapDecorator extends Decorator implements Expectation
 {
-    /**
-     * @var Unwrapper
-     */
-    private $unwrapper;
-
-    
-    public function __construct(Expectation $expectation, Unwrapper $unwrapper)
+    public function __construct(
+        Expectation $expectation,
+        private Unwrapper $unwrapper
+    )
     {
         parent::__construct($expectation);
-        $this->unwrapper = $unwrapper;
     }
 
-    
-    public function match(string $alias, $subject, array $arguments = array())
+    public function match(string $alias, mixed $subject, array $arguments = array()) : DuringCall|DelayedCall|bool|null
     {
         $arguments = $this->unwrapper->unwrapAll($arguments);
 

--- a/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
+++ b/src/PhpSpec/Wrapper/Subject/ExpectationFactory.php
@@ -26,29 +26,15 @@ use PhpSpec\Wrapper\Unwrapper;
 
 class ExpectationFactory
 {
-    /**
-     * @var ExampleNode
-     */
-    private $example;
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-    /**
-     * @var MatcherManager
-     */
-    private $matchers;
-
-    
-    public function __construct(ExampleNode $example, EventDispatcherInterface $dispatcher, MatcherManager $matchers)
+    public function __construct(
+        private ExampleNode $example,
+        private EventDispatcherInterface $dispatcher,
+        private MatcherManager $matchers
+    )
     {
-        $this->example = $example;
-        $this->dispatcher = $dispatcher;
-        $this->matchers = $matchers;
     }
 
-    
-    public function create(string $expectation, $subject, array $arguments = array()): Expectation
+    public function create(string $expectation, mixed $subject, array $arguments = array()): Expectation
     {
         if (0 === strpos($expectation, 'shouldNot')) {
             return $this->createNegative(lcfirst(substr($expectation, 9)), $subject, $arguments);
@@ -61,8 +47,7 @@ class ExpectationFactory
         throw new \RuntimeException('Could not create match');
     }
 
-    
-    private function createPositive(string $name, $subject, array $arguments = array()): Expectation
+    private function createPositive(string $name, mixed $subject, array $arguments = array()): Expectation
     {
         if (strtolower($name) === 'throw') {
             return $this->createDecoratedExpectation("PositiveThrow", $name, $subject, $arguments);
@@ -75,8 +60,7 @@ class ExpectationFactory
         return $this->createDecoratedExpectation("Positive", $name, $subject, $arguments);
     }
 
-    
-    private function createNegative(string $name, $subject, array $arguments = array()): Expectation
+    private function createNegative(string $name, mixed $subject, array $arguments = array()): Expectation
     {
         if (strtolower($name) === 'throw') {
             return $this->createDecoratedExpectation("NegativeThrow", $name, $subject, $arguments);
@@ -89,8 +73,7 @@ class ExpectationFactory
         return $this->createDecoratedExpectation("Negative", $name, $subject, $arguments);
     }
 
-    
-    private function createDecoratedExpectation(string $expectation, string $name, $subject, array $arguments): Expectation
+    private function createDecoratedExpectation(string $expectation, string $name, mixed $subject, array $arguments): Expectation
     {
         $matcher = $this->findMatcher($name, $subject, $arguments);
         $expectation = "\\PhpSpec\\Wrapper\\Subject\\Expectation\\".$expectation;
@@ -104,8 +87,7 @@ class ExpectationFactory
         return $this->decoratedExpectation($expectation, $matcher);
     }
 
-    
-    private function findMatcher(string $name, $subject, array $arguments = array()): Matcher
+    private function findMatcher(string $name, mixed $subject, array $arguments = array()): Matcher
     {
         $unwrapper = new Unwrapper();
         $arguments = $unwrapper->unwrapAll($arguments);
@@ -113,7 +95,6 @@ class ExpectationFactory
         return $this->matchers->find($name, $subject, $arguments);
     }
 
-    
     private function decoratedExpectation(Expectation $expectation, Matcher $matcher): ConstructorDecorator
     {
         $dispatcherDecorator = new DispatcherDecorator($expectation, $this->dispatcher, $matcher, $this->example);

--- a/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
+++ b/src/PhpSpec/Wrapper/Subject/SubjectWithArrayAccess.php
@@ -21,34 +21,15 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class SubjectWithArrayAccess
 {
-    /**
-     * @var Caller
-     */
-    private $caller;
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-
-    
     public function __construct(
-        Caller $caller,
-        Presenter $presenter,
-        EventDispatcherInterface $dispatcher
-    ) {
-        $this->caller     = $caller;
-        $this->presenter  = $presenter;
-        $this->dispatcher = $dispatcher;
+        private Caller $caller,
+        private Presenter $presenter,
+        private EventDispatcherInterface $dispatcher
+    )
+    {
     }
 
-    /**
-     * @param int|string $key
-     */
-    public function offsetExists($key): bool
+    public function offsetExists(int|string $key): bool
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -60,10 +41,7 @@ class SubjectWithArrayAccess
         return isset($subject[$key]);
     }
 
-    /**
-     * @param int|string $key
-     */
-    public function offsetGet($key)
+    public function offsetGet(int|string $key) : mixed
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -75,10 +53,7 @@ class SubjectWithArrayAccess
         return $subject[$key];
     }
 
-    /**
-     * @param int|string $key
-     */
-    public function offsetSet($key, $value): void
+    public function offsetSet(int|string $key, mixed $value): void
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -91,10 +66,7 @@ class SubjectWithArrayAccess
         $subject[$key] = $value;
     }
 
-    /**
-     * @param int|string $key
-     */
-    public function offsetUnset($key): void
+    public function offsetUnset(int|string $key): void
     {
         $unwrapper = new Unwrapper();
         $subject = $this->caller->getWrappedObject();
@@ -110,7 +82,7 @@ class SubjectWithArrayAccess
      * @throws \PhpSpec\Exception\Wrapper\SubjectException
      * @throws \PhpSpec\Exception\Fracture\InterfaceNotImplementedException
      */
-    private function checkIfSubjectImplementsArrayAccess($subject): void
+    private function checkIfSubjectImplementsArrayAccess(mixed $subject): void
     {
         if (\is_object($subject) && !($subject instanceof \ArrayAccess)) {
             throw $this->interfaceNotImplemented();
@@ -119,7 +91,6 @@ class SubjectWithArrayAccess
         }
     }
 
-    
     private function interfaceNotImplemented(): InterfaceNotImplementedException
     {
         return new InterfaceNotImplementedException(
@@ -133,8 +104,7 @@ class SubjectWithArrayAccess
         );
     }
 
-    
-    private function cantUseAsArray($subject): SubjectException
+    private function cantUseAsArray(mixed $subject): SubjectException
     {
         return new SubjectException(sprintf(
             'Can not use %s as array.',

--- a/src/PhpSpec/Wrapper/Subject/WrappedObject.php
+++ b/src/PhpSpec/Wrapper/Subject/WrappedObject.php
@@ -13,6 +13,7 @@
 
 namespace PhpSpec\Wrapper\Subject;
 
+use Closure;
 use PhpSpec\Factory\ObjectFactory;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Wrapper\Unwrapper;
@@ -20,38 +21,22 @@ use PhpSpec\Exception\Wrapper\SubjectException;
 
 class WrappedObject
 {
-    /**
-     * @var object
-     */
-    private $instance;
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-    /**
-     * @var string
-     */
-    private $classname;
+    private ?string $classname = null;
+
     /**
      * @var null|callable
      */
-    private $factoryMethod;
-    /**
-     * @var array
-     */
-    private $arguments = array();
-    /**
-     * @var bool
-     */
-    private $isInstantiated = false;
+    private mixed $factoryMethod;
 
-    /**
-     * @param null|object        $instance
-     */
-    public function __construct($instance, Presenter $presenter)
+    private array $arguments =[];
+
+    private bool $isInstantiated = false;
+
+    public function __construct(
+        private mixed $instance,
+        private Presenter $presenter
+    )
     {
-        $this->instance = $instance;
-        $this->presenter = $presenter;
         if (\is_object($this->instance)) {
             $this->classname = \get_class($this->instance);
             $this->isInstantiated = true;
@@ -89,10 +74,7 @@ class WrappedObject
         $this->beAnInstanceOf($this->classname, $args);
     }
 
-    /**
-     * @param null|callable|string $factoryMethod
-     */
-    public function beConstructedThrough($factoryMethod, array $arguments = array()): void
+    public function beConstructedThrough(callable|array|string|null $factoryMethod, array $arguments = array()): void
     {
         if (\is_string($factoryMethod) &&
             false === strpos($factoryMethod, '::') &&
@@ -110,66 +92,47 @@ class WrappedObject
         $this->arguments     = $unwrapper->unwrapAll($arguments);
     }
 
-    /**
-     * @return null|callable
-     */
-    public function getFactoryMethod()
+    public function getFactoryMethod() : callable|array|string|null
     {
         return $this->factoryMethod;
     }
 
-    
     public function isInstantiated(): bool
     {
         return $this->isInstantiated;
     }
 
-    
     public function setInstantiated(bool $instantiated): void
     {
         $this->isInstantiated = $instantiated;
     }
 
-    /**
-     * @return null|string
-     */
-    public function getClassName()
+    public function getClassName() : ?string
     {
         return $this->classname;
     }
 
-    
     public function setClassName(string $classname): void
     {
         $this->classname = $classname;
     }
 
-    
     public function getArguments(): array
     {
         return $this->arguments;
     }
 
-    /**
-     * @return null|object
-     */
-    public function getInstance()
+    public function getInstance() : mixed
     {
         return $this->instance;
     }
 
-    /**
-     * @param object $instance
-     */
-    public function setInstance($instance): void
+    public function setInstance(object $instance): void
     {
         $this->instance = $instance;
     }
 
-    /**
-     * @return object
-     */
-    public function instantiate()
+    public function instantiate() : object
     {
         if ($this->isInstantiated()) {
             return $this->instance;

--- a/src/PhpSpec/Wrapper/Unwrapper.php
+++ b/src/PhpSpec/Wrapper/Unwrapper.php
@@ -18,14 +18,12 @@ use Prophecy\Prophecy\ProphecyInterface;
 
 class Unwrapper implements RevealerInterface
 {
-    
     public function unwrapAll(array $arguments): array
     {
         return array_map(array($this, 'unwrapOne'), $arguments);
     }
 
-    
-    public function unwrapOne($argument)
+    public function unwrapOne(mixed $argument) : mixed
     {
         if (\is_array($argument)) {
             return array_map(array($this, 'unwrapOne'), $argument);
@@ -46,8 +44,7 @@ class Unwrapper implements RevealerInterface
         return $argument;
     }
 
-    
-    public function reveal($value)
+    public function reveal(mixed $value) : mixed
     {
         return $this->unwrapOne($value);
     }

--- a/src/PhpSpec/Wrapper/Wrapper.php
+++ b/src/PhpSpec/Wrapper/Wrapper.php
@@ -26,48 +26,17 @@ use PhpSpec\Wrapper\Subject\ExpectationFactory;
 
 class Wrapper
 {
-    /**
-     * @var MatcherManager
-     */
-    private $matchers;
-    /**
-     * @var Presenter
-     */
-    private $presenter;
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-    /**
-     * @var ExampleNode
-     */
-    private $example;
-    /**
-     * @var AccessInspector
-     */
-    private $accessInspector;
-
-    /**
-     * @param AccessInspector $accessInspector
-     */
     public function __construct(
-        MatcherManager $matchers,
-        Presenter $presenter,
-        EventDispatcherInterface $dispatcher,
-        ExampleNode $example,
-        AccessInspector $accessInspector = null
-    ) {
-        $this->matchers = $matchers;
-        $this->presenter = $presenter;
-        $this->dispatcher = $dispatcher;
-        $this->example = $example;
-        $this->accessInspector = $accessInspector;
+        private MatcherManager $matchers,
+        private Presenter $presenter,
+        private EventDispatcherInterface $dispatcher,
+        private ExampleNode $example,
+        private ?AccessInspector $accessInspector = null
+    )
+    {
     }
 
-    /**
-     * @param object $value
-     */
-    public function wrap($value = null): Subject
+    public function wrap(mixed $value = null): Subject
     {
         $wrappedObject = new WrappedObject($value, $this->presenter);
         $caller = $this->createCaller($wrappedObject);
@@ -84,7 +53,6 @@ class Wrapper
         );
     }
 
-    
     private function createCaller(WrappedObject $wrappedObject): Caller
     {
         $exceptionFactory = new ExceptionFactory($this->presenter);


### PR DESCRIPTION
Used existing docblocks to populate types, and added obvious narrower types where there was no docblock. Used wide types where it was not clear what the real types should be.

Did not attempt to fix types in this PR, just to tried to ensure that everywhere has a declared type of some sort.