### PR TITLE
Remove legacy Symfony eventdispatcher selection

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -16,12 +16,6 @@
         <MissingParamType><errorLevel type="error"/></MissingParamType>
         <MissingReturnType><errorLevel type="error"/></MissingReturnType>
         <MissingPropertyType><errorLevel type="error"/></MissingPropertyType>
-        <DuplicateClass>
-            <errorLevel type="suppress">
-                <!-- duplicate classes are inside a conditional so not an error -->
-                <file name="src/PhpSpec/Event/BaseEvent.php" />
-            </errorLevel>
-        </DuplicateClass>
         <UndefinedConstant>
             <errorLevel type="suppress">
                 <!-- new token constants in PHP 8 cause an error, despite being behind version detection -->

--- a/src/PhpSpec/Event/BaseEvent.php
+++ b/src/PhpSpec/Event/BaseEvent.php
@@ -7,12 +7,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event as OldEvent;
 use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 
-if (\is_subclass_of(EventDispatcher::class, EventDispatcherInterface::class)) {
-    class BaseEvent extends ContractEvent
-    {
-    }
-} else {
-    class BaseEvent extends OldEvent
-    {
-    }
+class BaseEvent extends ContractEvent
+{
 }

--- a/src/PhpSpec/Event/BaseEvent.php
+++ b/src/PhpSpec/Event/BaseEvent.php
@@ -2,8 +2,6 @@
 
 namespace PhpSpec\Event;
 
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event as OldEvent;
 use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 

--- a/src/PhpSpec/Event/ExpectationEvent.php
+++ b/src/PhpSpec/Event/ExpectationEvent.php
@@ -70,7 +70,7 @@ final class ExpectationEvent extends BaseEvent implements PhpSpecEvent
         return $this->example->getSpecification()->getSuite();
     }
 
-    public function getSubject()
+    public function getSubject() : mixed
     {
         return $this->subject;
     }

--- a/src/PhpSpec/Loader/Node/ExampleNode.php
+++ b/src/PhpSpec/Loader/Node/ExampleNode.php
@@ -17,7 +17,7 @@ use ReflectionFunctionAbstract;
 
 class ExampleNode
 {
-    private ?SpecificationNode $specification;
+    private SpecificationNode $specification;
 
     private bool $isPending = false;
 
@@ -58,7 +58,7 @@ class ExampleNode
         $this->specification = $specification;
     }
 
-    public function getSpecification() : ?SpecificationNode
+    public function getSpecification() : SpecificationNode
     {
         return $this->specification;
     }

--- a/src/PhpSpec/Loader/Node/SpecificationNode.php
+++ b/src/PhpSpec/Loader/Node/SpecificationNode.php
@@ -19,7 +19,7 @@ use ReflectionClass;
 
 class SpecificationNode implements \Countable
 {
-    private ?Suite $suite;
+    private Suite $suite;
 
     /**
      * @var ExampleNode[]
@@ -68,7 +68,7 @@ class SpecificationNode implements \Countable
         $this->suite = $suite;
     }
 
-    public function getSuite() : ?Suite
+    public function getSuite() : Suite
     {
         return $this->suite;
     }

--- a/src/PhpSpec/Util/DispatchTrait.php
+++ b/src/PhpSpec/Util/DispatchTrait.php
@@ -2,10 +2,6 @@
 
 namespace PhpSpec\Util;
 
-use PhpSpec\Wrapper\Collaborator;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-
 /**
  * @internal
  */
@@ -13,21 +9,6 @@ trait DispatchTrait
 {
     private function dispatch(object $eventDispatcher, object $event, string $eventName) : object
     {
-        if ($this->isNewSymfonyContract($eventDispatcher)) {
-            return $eventDispatcher->dispatch($event, $eventName);
-        }
-
-        return $eventDispatcher->dispatch($eventName, $event);
-    }
-
-    private function isNewSymfonyContract(object $eventDispatcher): bool
-    {
-        // This trait may be used with a double, in the tests
-        if ($eventDispatcher instanceof Collaborator) {
-            $eventDispatcher = $eventDispatcher->getWrappedObject();
-        }
-
-        // EventDispatcherInterface contract implemented in Symfony >= 4.3
-        return $eventDispatcher instanceof EventDispatcherInterface;
+        return $eventDispatcher->dispatch($event, $eventName);
     }
 }


### PR DESCRIPTION
We should only need to rely on the new signature