### PR TITLE
PHP 8.4 | Fix implicitly nullable parameters (7.x)

### DIFF
--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -111,12 +111,12 @@ class ConsoleIO implements IO
         return $this->lastMessage;
     }
 
-    public function writeln(string $message = '', int $indent = null): void
+    public function writeln(string $message = '', ?int $indent = null): void
     {
         $this->write($message, $indent, true);
     }
 
-    public function writeTemp(string $message, int $indent = null): void
+    public function writeTemp(string $message, ?int $indent = null): void
     {
         $this->write($message, $indent);
         $this->hasTempString = true;
@@ -142,7 +142,7 @@ class ConsoleIO implements IO
         $this->write($this->lastMessage);
     }
 
-    public function write(string $message, int $indent = null, bool $newline = false): void
+    public function write(string $message, ?int $indent = null, bool $newline = false): void
     {
         if ($this->hasTempString) {
             $this->hasTempString = false;
@@ -159,12 +159,12 @@ class ConsoleIO implements IO
         $this->lastMessage = $message.($newline ? "\n" : '');
     }
 
-    public function overwriteln(string $message = '', int $indent = null): void
+    public function overwriteln(string $message = '', ?int $indent = null): void
     {
         $this->overwrite($message, $indent, true);
     }
 
-    public function overwrite(string $message, int $indent = null, bool $newline = false): void
+    public function overwrite(string $message, ?int $indent = null, bool $newline = false): void
     {
         if (null !== $indent) {
             $message = $this->indentText($message, $indent);

--- a/src/PhpSpec/Event/ExampleEvent.php
+++ b/src/PhpSpec/Event/ExampleEvent.php
@@ -63,20 +63,20 @@ class ExampleEvent extends BaseEvent implements PhpSpecEvent
     private $result;
 
     /**
-     * @var \Exception
+     * @var null|\Exception
      */
     private $exception;
 
     /**
-     * @param null|float   $time
-     * @param null|int $result
-     * @param \Exception   $exception
+     * @param float   $time
+     * @param int $result
+     * @param null|\Exception   $exception
      */
     public function __construct(
         ExampleNode $example,
         float $time = 0.0,
         int $result = self::PASSED,
-        \Exception $exception = null
+        ?\Exception $exception = null
     ) {
         $this->example   = $example;
         $this->time      = $time;

--- a/src/PhpSpec/Exception/Example/StopOnFailureException.php
+++ b/src/PhpSpec/Exception/Example/StopOnFailureException.php
@@ -25,7 +25,7 @@ class StopOnFailureException extends ExampleException
      */
     private $result;
 
-    public function __construct($message = "", $code = 0, Exception $previous = null, $result = 0)
+    public function __construct($message = "", $code = 0, ?Exception $previous = null, $result = 0)
     {
         parent::__construct($message, $code, $previous);
         $this->result = $result;

--- a/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
@@ -26,14 +26,14 @@ class CollaboratorNotFoundException extends FractureException
     private $collaboratorName;
 
     /**
-     * @param Exception $previous
+     * @param null|Exception $previous
      */
     public function __construct(
         string $message,
         int $code = 0,
-        Exception $previous = null,
-        ReflectionParameter $reflectionParameter = null,
-        string $className = null
+        ?Exception $previous = null,
+        ?ReflectionParameter $reflectionParameter = null,
+        ?string $className = null
     ) {
         if ($reflectionParameter) {
             $this->collaboratorName = $this->extractCollaboratorName($reflectionParameter);

--- a/src/PhpSpec/Formatter/Html/HtmlIO.php
+++ b/src/PhpSpec/Formatter/Html/HtmlIO.php
@@ -30,7 +30,7 @@ final class HtmlIO implements IO
         return true;
     }
 
-    public function writeln(string $message = '', int $indent = null): void
+    public function writeln(string $message = '', ?int $indent = null): void
     {
         echo $message . "<br>";
     }

--- a/src/PhpSpec/Formatter/TapFormatter.php
+++ b/src/PhpSpec/Formatter/TapFormatter.php
@@ -116,9 +116,9 @@ final class TapFormatter extends ConsoleFormatter
      * Format message as two-space indented YAML when needed outside of a
      * SKIP or TODO directive.
      *
-     * @param int $result
+     * @param null|int $result
      */
-    private function getResultData(ExampleEvent $event, int $result = null): string
+    private function getResultData(ExampleEvent $event, ?int $result = null): string
     {
         if (null === $result) {
             return $this->stripNewlines($event->getException()->getMessage());

--- a/src/PhpSpec/IO/IO.php
+++ b/src/PhpSpec/IO/IO.php
@@ -17,5 +17,5 @@ interface IO
 {
     public function write(string $message): void;
     public function isVerbose(): bool;
-    public function writeln(string $message = '', int $indent = null): void;
+    public function writeln(string $message = '', ?int $indent = null): void;
 }

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -52,7 +52,7 @@ class ResourceLoader
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function load(string $locator = '', int $line = null): Suite
+    public function load(string $locator = '', ?int $line = null): Suite
     {
         $suite = new Suite();
         foreach ($this->manager->locateResources($locator) as $resource) {

--- a/src/PhpSpec/Locator/PSR0/PSR0Locator.php
+++ b/src/PhpSpec/Locator/PSR0/PSR0Locator.php
@@ -51,12 +51,12 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
     private $filesystem;
 
     /**
-     * @var string
+     * @var null|string
      */
     private $psr4Prefix;
 
     /**
-     * @param string     $psr4Prefix
+     * @param null|string $psr4Prefix
      */
     public function __construct(
         Filesystem $filesystem,
@@ -64,7 +64,7 @@ class PSR0Locator implements ResourceLocator, SrcPathLocator
         string $specNamespacePrefix = 'spec',
         string $srcPath = 'src',
         string $specPath = '.',
-        string $psr4Prefix = null
+        ?string $psr4Prefix = null
     ) {
         $this->filesystem = $filesystem;
         $sepr = DIRECTORY_SEPARATOR;

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -61,7 +61,7 @@ final class TriggerMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @return void
      */
-    public function verifyPositive(callable $callable, array $arguments, int $level = null, string $message = null)
+    public function verifyPositive(callable $callable, array $arguments, ?int $level = null, ?string $message = null)
     {
         $triggered = 0;
         $prevHandler = function($type, $str, $file, $line, $context=[]){};
@@ -91,7 +91,7 @@ final class TriggerMatcher implements Matcher
      * @throws \PhpSpec\Exception\Example\FailureException
      * @return void
      */
-    public function verifyNegative(callable $callable, array $arguments, int $level = null, string $message = null)
+    public function verifyNegative(callable $callable, array $arguments, ?int $level = null, ?string $message = null)
     {
         $triggered = 0;
         $prevHandler = function($type, $str, $file, $line, $context=[]){};

--- a/src/PhpSpec/Message/CurrentExampleTracker.php
+++ b/src/PhpSpec/Message/CurrentExampleTracker.php
@@ -17,7 +17,7 @@ final class CurrentExampleTracker
 {
     private $currentExample;
 
-    public function setCurrentExample(string $currentExample = null)
+    public function setCurrentExample(?string $currentExample = null)
     {
         $this->currentExample = $currentExample;
     }

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -144,11 +144,11 @@ final class CollaboratorsMaintainer implements Maintainer
     }
 
     /**
-     * @param string $className
+     * @param null|string $className
      *
      * @throws CollaboratorNotFoundException
      */
-    private function throwCollaboratorNotFound(\Exception $e, \ReflectionParameter $parameter = null, string $className = null): void
+    private function throwCollaboratorNotFound(\Exception $e, ?\ReflectionParameter $parameter = null, ?string $className = null): void
     {
         throw new CollaboratorNotFoundException(
             'Collaborator does not exist',

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -39,9 +39,9 @@ final class Collaborator implements ObjectWrapper
     }
 
     /**
-     * @param array $arguments
+     * @param null|array $arguments
      */
-    public function beConstructedWith(array $arguments = null): void
+    public function beConstructedWith(?array $arguments = null): void
     {
         $this->prophecy->willBeConstructedWith($arguments);
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -29,7 +29,7 @@ final class ConstructorDecorator extends Decorator implements Expectation
      * @throws \PhpSpec\Exception\Example\ErrorException
      * @throws \PhpSpec\Exception\Fracture\FractureException
      */
-    public function match(string $alias, $subject, array $arguments = [], WrappedObject $wrappedObject = null)
+    public function match(string $alias, $subject, array $arguments = [], ?WrappedObject $wrappedObject = null)
     {
         try {
             $wrapped = $subject->getWrappedObject();

--- a/src/PhpSpec/Wrapper/Wrapper.php
+++ b/src/PhpSpec/Wrapper/Wrapper.php
@@ -48,14 +48,14 @@ class Wrapper
     private $accessInspector;
 
     /**
-     * @param AccessInspector $accessInspector
+     * @param null|AccessInspector $accessInspector
      */
     public function __construct(
         MatcherManager $matchers,
         Presenter $presenter,
         EventDispatcherInterface $dispatcher,
         ExampleNode $example,
-        AccessInspector $accessInspector = null
+        ?AccessInspector $accessInspector = null
     ) {
         $this->matchers = $matchers;
         $this->presenter = $presenter;
@@ -65,7 +65,7 @@ class Wrapper
     }
 
     /**
-     * @param object $value
+     * @param null|object $value
      */
     public function wrap($value = null): Subject
     {


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameter with a `null` default value, which are not explicitly declared as nullable.

This commit fixes all found instances of that in the PHPSpec codebase.

Includes updating the documentation to match (where relevant, i.e. only existing documentation has been touched).

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types