### PR TITLE
PHP 8.4 | Fix implicitly nullable parameters (8.x/main)

### DIFF
--- a/src/PhpSpec/Console/ConsoleIO.php
+++ b/src/PhpSpec/Console/ConsoleIO.php
@@ -79,12 +79,12 @@ class ConsoleIO implements IO
         return $this->lastMessage;
     }
 
-    public function writeln(string $message = '', int $indent = null): void
+    public function writeln(string $message = '', ?int $indent = null): void
     {
         $this->write($message, $indent, true);
     }
 
-    public function writeTemp(string $message, int $indent = null): void
+    public function writeTemp(string $message, ?int $indent = null): void
     {
         $this->write($message, $indent);
         $this->hasTempString = true;
@@ -107,7 +107,7 @@ class ConsoleIO implements IO
         $this->write($this->lastMessage);
     }
 
-    public function write(string $message, int $indent = null, bool $newline = false): void
+    public function write(string $message, ?int $indent = null, bool $newline = false): void
     {
         if ($this->hasTempString) {
             $this->hasTempString = false;
@@ -124,12 +124,12 @@ class ConsoleIO implements IO
         $this->lastMessage = $message.($newline ? "\n" : '');
     }
 
-    public function overwriteln(string $message = '', int $indent = null): void
+    public function overwriteln(string $message = '', ?int $indent = null): void
     {
         $this->overwrite($message, $indent, true);
     }
 
-    public function overwrite(string $message, int $indent = null, bool $newline = false): void
+    public function overwrite(string $message, ?int $indent = null, bool $newline = false): void
     {
         if (null !== $indent) {
             $message = $this->indentText($message, $indent);

--- a/src/PhpSpec/Exception/Example/StopOnFailureException.php
+++ b/src/PhpSpec/Exception/Example/StopOnFailureException.php
@@ -23,7 +23,7 @@ class StopOnFailureException extends ExampleException
     public function __construct(
         string $message = "",
         int $code = 0,
-        Exception $previous = null,
+        ?Exception $previous = null,
         private int $result = 0)
     {
         parent::__construct($message, $code, $previous);

--- a/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
+++ b/src/PhpSpec/Exception/Fracture/CollaboratorNotFoundException.php
@@ -25,9 +25,9 @@ class CollaboratorNotFoundException extends FractureException
     public function __construct(
         string $message,
         int $code = 0,
-        Exception $previous = null,
-        ReflectionParameter $reflectionParameter = null,
-        string $className = null
+        ?Exception $previous = null,
+        ?ReflectionParameter $reflectionParameter = null,
+        ?string $className = null
     ) {
         if ($reflectionParameter) {
             $this->collaboratorName = $this->extractCollaboratorName($reflectionParameter);

--- a/src/PhpSpec/Formatter/Html/HtmlIO.php
+++ b/src/PhpSpec/Formatter/Html/HtmlIO.php
@@ -27,7 +27,7 @@ final class HtmlIO implements IO
         return true;
     }
 
-    public function writeln(string $message = '', int $indent = null): void
+    public function writeln(string $message = '', ?int $indent = null): void
     {
         echo $message . "<br>";
     }

--- a/src/PhpSpec/Formatter/TapFormatter.php
+++ b/src/PhpSpec/Formatter/TapFormatter.php
@@ -110,7 +110,7 @@ final class TapFormatter extends ConsoleFormatter
      * Format message as two-space indented YAML when needed outside of a
      * SKIP or TODO directive.
      */
-    private function getResultData(ExampleEvent $event, int $result = null): string
+    private function getResultData(ExampleEvent $event, ?int $result = null): string
     {
         if (null === $result) {
             return $this->stripNewlines($event->getException()->getMessage());

--- a/src/PhpSpec/IO/IO.php
+++ b/src/PhpSpec/IO/IO.php
@@ -17,5 +17,5 @@ interface IO
 {
     public function write(string $message): void;
     public function isVerbose(): bool;
-    public function writeln(string $message = '', int $indent = null): void;
+    public function writeln(string $message = '', ?int $indent = null): void;
 }

--- a/src/PhpSpec/Loader/ResourceLoader.php
+++ b/src/PhpSpec/Loader/ResourceLoader.php
@@ -35,7 +35,7 @@ class ResourceLoader
     ) {
     }
 
-    public function load(string $locator = '', int $line = null): Suite
+    public function load(string $locator = '', ?int $line = null): Suite
     {
         $suite = new Suite();
         foreach ($this->manager->locateResources($locator) as $resource) {

--- a/src/PhpSpec/Matcher/TriggerMatcher.php
+++ b/src/PhpSpec/Matcher/TriggerMatcher.php
@@ -44,7 +44,7 @@ final class TriggerMatcher implements Matcher
     /**
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function verifyPositive(callable $callable, array $arguments, int $level = null, string $message = null) : void
+    public function verifyPositive(callable $callable, array $arguments, ?int $level = null, ?string $message = null) : void
     {
         $triggered = 0;
         $prevHandler = function($type, $str, $file, $line, $context=[]){};
@@ -73,7 +73,7 @@ final class TriggerMatcher implements Matcher
     /**
      * @throws \PhpSpec\Exception\Example\FailureException
      */
-    public function verifyNegative(callable $callable, array $arguments, int $level = null, string $message = null) : void
+    public function verifyNegative(callable $callable, array $arguments, ?int $level = null, ?string $message = null) : void
     {
         $triggered = 0;
         $prevHandler = function($type, $str, $file, $line, $context=[]){};

--- a/src/PhpSpec/Message/CurrentExampleTracker.php
+++ b/src/PhpSpec/Message/CurrentExampleTracker.php
@@ -17,7 +17,7 @@ final class CurrentExampleTracker
 {
     private ?string $currentExample = null;
 
-    public function setCurrentExample(string $currentExample = null) : void
+    public function setCurrentExample(?string $currentExample = null) : void
     {
         $this->currentExample = $currentExample;
     }

--- a/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
+++ b/src/PhpSpec/Runner/Maintainer/CollaboratorsMaintainer.php
@@ -126,7 +126,7 @@ final class CollaboratorsMaintainer implements Maintainer
     /**
      * @throws CollaboratorNotFoundException
      */
-    private function throwCollaboratorNotFound(\Exception $e, \ReflectionParameter $parameter = null, string $className = null): void
+    private function throwCollaboratorNotFound(\Exception $e, ?\ReflectionParameter $parameter = null, ?string $className = null): void
     {
         throw new CollaboratorNotFoundException(
             'Collaborator does not exist',

--- a/src/PhpSpec/Wrapper/Collaborator.php
+++ b/src/PhpSpec/Wrapper/Collaborator.php
@@ -34,7 +34,7 @@ final class Collaborator implements ObjectWrapper
         }
     }
 
-    public function beConstructedWith(array $arguments = null): void
+    public function beConstructedWith(?array $arguments = null): void
     {
         $this->prophecy->willBeConstructedWith($arguments);
     }

--- a/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
+++ b/src/PhpSpec/Wrapper/Subject/Expectation/ConstructorDecorator.php
@@ -30,7 +30,7 @@ final class ConstructorDecorator extends Decorator implements Expectation
      * @throws \PhpSpec\Exception\Example\ErrorException
      * @throws \PhpSpec\Exception\Fracture\FractureException
      */
-    public function match(string $alias, mixed $subject, array $arguments = [], WrappedObject $wrappedObject = null) : DelayedCall|DuringCall|bool|null
+    public function match(string $alias, mixed $subject, array $arguments = [], ?WrappedObject $wrappedObject = null) : DelayedCall|DuringCall|bool|null
     {
         try {
             $wrapped = $subject->getWrappedObject();


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameter with a `null` default value, which are not explicitly declared as nullable.

This commit fixes all found instances of that in the PHPSpec codebase.

Includes updating the documentation to match (where relevant, i.e. only existing documentation has been touched).

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types