### PR TITLE
Fix documenation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 phpspec
 =======
 
-The main website with documentation is at `http://www.phpspec.net <http://www.phpspec.net>`_.
+The main website with documentation is at `https://phpspec.net <https://phpspec.net>`_.
 
 .. image:: https://github.com/phpspec/phpspec/workflows/Build/badge.svg
    :target: https://github.com/phpspec/phpspec/actions?query=workflow%3ABuild


### PR DESCRIPTION
The `www` domain gave the following error. It might also be nice to just redirect the `www` domain to the non www version. And while i was at it i updated the link to be https

![image](https://github.com/user-attachments/assets/44c4819f-7cb5-43f2-96a6-d4028828296b)
