### PR TITLE
Fix the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
                     ./vendor/bin/box compile
                     ./vendor/bin/behat --profile=phar
 
-            -   uses: actions/upload-artifact@v1
+            -   uses: actions/upload-artifact@v4
                 name: Publish the PHAR
                 if: matrix.publish-phar
                 with:
@@ -96,7 +96,7 @@ jobs:
         needs: tests
         if: github.event_name == 'release'
         steps:
-            -   uses: actions/download-artifact@v1
+            -   uses: actions/download-artifact@v4
                 with:
                     name: phpspec.phar
                     path: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
                 stability: ["stable"]
                 include:
                     -   php: "8.2"
+                        operating-system: ubuntu-latest
                         publish-phar: true
                     -   php: "8.2"
                         composer-flags: --prefer-lowest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
                 run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             -   name: Cache composer dependencies
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 env:
                     cache-name: cache-composer
                 with:


### PR DESCRIPTION
Re https://github.com/phpspec/phpspec/actions/runs/11325136769/job/32545428789#step:1:36

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

The phar was uploaded multiple times (once for each 8.2 build), and the new action doesn't allow that, so I made sure only one action uploads the phar.