### PR TITLE
Allow PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php":                      "8.2.* || 8.3.*",
         "phpspec/prophecy":         "^1.16",
         "phpspec/php-diff":         "^1.0",
-        "sebastian/exporter":       "^3.1 || ^4.0 || ^5.0",
+        "sebastian/exporter":       "^3.1 || ^4.0 || ^5.0 || ^6.0",
         "symfony/console":          "^5.4 || ^6.0 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
         "symfony/process":          "^5.4 || ^6.0 || ^7.0",
@@ -38,7 +38,7 @@
     "require-dev": {
         "behat/behat":           "^3.14",
         "symfony/filesystem":    "^5.4  || ^6.0 || ^7.0",
-        "phpunit/phpunit":       "^9.0 || ^10.0",
+        "phpunit/phpunit":       "^9.0 || ^10.0 || ^11.0",
         "vimeo/psalm":           "^4.3 || ^5.2 || ^6.0",
         "bamarni/composer-bin-plugin": "^1.8"
     },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.4.1@09a200c15910905ddc49e5edd37b73f9c78f7580">
+<files psalm-version="6.10.0@9c0add4eb88d4b169ac04acb7c679918cbb9c252">
   <file src="src/PhpSpec/CodeGenerator/Generator/ClassGenerator.php">
     <FalsableReturnStatement>
       <code><![CDATA[file_get_contents(__DIR__.'/templates/class.template')]]></code>
@@ -521,10 +521,30 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="src/PhpSpec/Wrapper/Subject/Expectation/NegativeThrow.php">
+    <UndefinedMagicMethod>
+      <code><![CDATA[during]]></code>
+    </UndefinedMagicMethod>
+  </file>
+  <file src="src/PhpSpec/Wrapper/Subject/Expectation/NegativeTrigger.php">
+    <UndefinedMagicMethod>
+      <code><![CDATA[during]]></code>
+    </UndefinedMagicMethod>
+  </file>
   <file src="src/PhpSpec/Wrapper/Subject/Expectation/Positive.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
+  </file>
+  <file src="src/PhpSpec/Wrapper/Subject/Expectation/PositiveThrow.php">
+    <UndefinedMagicMethod>
+      <code><![CDATA[during]]></code>
+    </UndefinedMagicMethod>
+  </file>
+  <file src="src/PhpSpec/Wrapper/Subject/Expectation/PositiveTrigger.php">
+    <UndefinedMagicMethod>
+      <code><![CDATA[during]]></code>
+    </UndefinedMagicMethod>
   </file>
   <file src="src/PhpSpec/Wrapper/Subject/Expectation/ThrowExpectation.php">
     <PossiblyUnusedMethod>

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,8 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
+    ensureOverrideAttribute="false"
+    strictBinaryOperands="false"
 >
     <projectFiles>
         <directory name="src" />
@@ -14,14 +16,6 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
-        <TypeDoesNotContainType>
-            <errorLevel type="suppress">
-                <!-- Psalm error see https://github.com/vimeo/psalm/issues/5001 -->
-                <file name="src/PhpSpec/CodeAnalysis/TokenizedNamespaceResolver.php"/>
-                <!-- Psalm error see https://github.com/vimeo/psalm/issues/5004 -->
-                <file name="src/PhpSpec/Matcher/TriggerMatcher.php"/>
-            </errorLevel>
-        </TypeDoesNotContainType>
         <RedundantCondition>
             <errorLevel type="suppress">
                 <!-- Psalm error see https://github.com/vimeo/psalm/issues/5004 -->


### PR DESCRIPTION
Same changes as in https://github.com/phpspec/phpspec/pull/1483 but from a more up to date state so that psalm 6 is allowed which enables the installation of PHPUnit 11.

Also updates psalm baseline & configuration due to new errors reported by psalm newest minor versions.