### PR TITLE
Fix compatibility with symfony/console 8.x

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -67,7 +67,7 @@ final class Application extends BaseApplication
         $this->loadConfigurationFile($input, $this->container);
 
         foreach ($this->container->getByTag('console.commands') as $command) {
-            $this->add($command);
+            $this->addCommands([$command]);
         }
 
         $dispatcher = $this->container->get('console_event_dispatcher');


### PR DESCRIPTION
The `add()` method has been removed in Symfony 8.x.

`addCommands()` has been available since long ago and can be used to be cross-version compatible.