### PR TITLE
Fix `Call to undefined method PhpSpec\Console\Application::add()` in `Application`

### DIFF
--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -66,8 +66,17 @@ final class Application extends BaseApplication
 
         $this->loadConfigurationFile($input, $this->container);
 
-        foreach ($this->container->getByTag('console.commands') as $command) {
-            $this->add($command);
+        $commands = $this->container->getByTag('console.commands');
+
+        if (method_exists($this, 'addCommand')) {
+            foreach ($commands as $command) {
+                $this->addCommand($command);
+            }
+        } elseif (method_exists($this, 'add')) {
+            // For symfony/console < 8.0
+            foreach ($commands as $command) {
+                $this->add($command);
+            }
         }
 
         $dispatcher = $this->container->get('console_event_dispatcher');

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -72,7 +72,7 @@ final class Application extends BaseApplication
             foreach ($commands as $command) {
                 $this->addCommand($command);
             }
-        } elseif (method_exists($this, 'add')) {
+        } else {
             // For symfony/console < 8.0
             foreach ($commands as $command) {
                 $this->add($command);


### PR DESCRIPTION
There is such an error here: https://github.com/phpspec/prophecy/actions/runs/21114065815/job/60726462700
This is because the `add` method was removed in version 8.0 of `symfony/console`.