### PR TITLE
Add per-example JSON coverage report and CLI options for mutation testing (#1514)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,16 +142,22 @@ bin/phpspec run --format=junit > results.xml
 | Option | Description |
 |---|---|
 | `--filter=PATTERN` | Only run spec files whose path contains PATTERN |
+| `--paths-from=FILE` | Read spec/feature paths to run from a file, one per line |
 | `--stop-on-failure` | Stop execution after the first spec file with a failure or error |
 | `--order=ORDER` | Run order: `default` or `random` |
 | `--seed=SEED` | Seed for random ordering (for reproducibility) |
 
 ```bash
 bin/phpspec run --filter Calculator              # Only specs with "Calculator" in path
+bin/phpspec run --paths-from specs.txt            # Run the specs listed in specs.txt
 bin/phpspec run --stop-on-failure                 # Stop on first failing spec
 bin/phpspec run --order random                    # Randomize spec order
 bin/phpspec run --order random --seed 42          # Reproducible random order
 ```
+
+`--paths-from` is designed for tools that drive PhpSpec programmatically (such as
+mutation testing frameworks): a long list of spec paths passed as arguments can
+exceed the operating system's argument size limit, while a file cannot.
 
 ### Bootstrap
 
@@ -162,6 +168,22 @@ bin/phpspec run --order random --seed 42          # Reproducible random order
 ```bash
 bin/phpspec run --bootstrap tests/bootstrap.php
 ```
+
+### Configuration File
+
+| Option | Description |
+|---|---|
+| `-c`, `--config=FILE` | Path to a phpspec configuration file (overrides the working directory lookup) |
+
+```bash
+bin/phpspec run --config custom/phpspec.ci.yaml
+```
+
+By default PhpSpec looks for `phpspec.yaml`, `phpspec.yml`, `phpspec.json` or
+`phpspec.php` in the working directory. With `--config` exactly the given file
+is loaded instead (its format is resolved from the extension), and the command
+fails if the file does not exist. The option is available on every command and
+is forwarded to worker processes in `--parallel` runs.
 
 ### Code Generation
 
@@ -182,16 +204,62 @@ bin/phpspec run --fake
 | `--coverage` | Show text coverage report in terminal |
 | `--coverage-html=DIR` | Generate HTML coverage report in the specified directory |
 | `--coverage-clover=FILE` | Generate Clover XML coverage report |
+| `--coverage-json=FILE` | Generate JSON coverage report with per-example detail (experimental) |
+| `--coverage-src=DIR` | Source directory to scope coverage reports to (overrides config `src_path`) |
 | `--coverage-min=PCT` | Fail if coverage is below the threshold (0-100) |
 
 ```bash
 bin/phpspec run --coverage                       # Text report
 bin/phpspec run --coverage-html coverage/        # HTML report
 bin/phpspec run --coverage-clover clover.xml     # Clover XML
+bin/phpspec run --coverage-json coverage.json    # JSON report (per-example detail)
 bin/phpspec run --coverage-min 90                # Fail below 90%
+bin/phpspec run --coverage --coverage-src lib    # Scope the report to lib/
 ```
 
-Coverage requires the xdebug extension with `xdebug.mode=coverage`.
+Coverage requires the xdebug extension with `xdebug.mode=coverage`. Coverage
+options can be combined with `--parallel`: workers collect coverage per example
+and the parent process merges their results before rendering the reports.
+
+#### JSON Coverage Report (experimental)
+
+The JSON report is designed for tools that need to know **which example covers
+which source line** — most notably mutation testing frameworks such as
+[Infection](https://infection.github.io/). Its schema is experimental and may
+change while the integration is being finalised.
+
+```json
+{
+    "version": 1,
+    "tests": {
+        "spec/App/Calculator.spec.php::Calculator > adds two numbers": {
+            "time": 0.0021,
+            "memory": 524288,
+            "spec_file": "spec/App/Calculator.spec.php",
+            "spec_checksum": "9b4f1af43ee97a2924b320db64067458"
+        }
+    },
+    "sources": {
+        "src/App/Calculator.php": {
+            "checksum": "ac4a5f10068b3a275d47b87df2d78d59",
+            "lines": {
+                "9": ["spec/App/Calculator.spec.php::Calculator > adds two numbers"]
+            }
+        }
+    }
+}
+```
+
+- **Test identifiers** are `<spec file>::<context titles joined with " > ">`,
+  at example granularity. All paths are relative to the project root.
+- **`time`** is the example's wall-clock duration in seconds and **`memory`**
+  its peak memory usage in bytes, both measured across the example *and* its
+  `let`/`beforeEach`/`afterEach` hooks, so setup code counts as covered by the
+  example that ran it.
+- **`checksum`**/**`spec_checksum`** are MD5 hashes of the file contents,
+  letting consumers detect stale coverage data.
+- Code executed only in `beforeAll`/`afterAll` hooks is not attributed to any
+  example.
 
 ## Exit Codes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,17 @@ PhpSpec can be configured via a config file in the project root. The following f
 
 The first file found wins. If none exists, defaults are used.
 
+Alternatively, pass an explicit path with `--config` (or `-c`) to load exactly
+that file and skip the working directory lookup entirely:
+
+```bash
+bin/phpspec run --config custom/phpspec.ci.yaml
+```
+
+The format is resolved from the file extension, and the command fails if the
+file does not exist. Because the path is explicit, several processes can run
+side by side in the same directory with different configurations.
+
 ## phpspec.yaml
 
 ```yaml

--- a/features/scenarios/cli/cli-options.feature
+++ b/features/scenarios/cli/cli-options.feature
@@ -362,3 +362,47 @@ Feature: CLI options
     Then the exit code should be 0
     And the output should contain "1 scenario"
     And the output should not contain "example"
+
+  Scenario: Run only the specs listed in a paths file
+    Given a spec file "spec/App/Listed.spec.php":
+      """
+      <?php
+      describe('Listed', function () {
+          it('runs from the paths file', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    And a spec file "spec/App/AlsoListed.spec.php":
+      """
+      <?php
+      describe('AlsoListed', function () {
+          it('also runs from the paths file', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    And a spec file "spec/App/Unlisted.spec.php":
+      """
+      <?php
+      describe('Unlisted', function () {
+          it('must not run', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    And a file "paths.txt":
+      """
+      spec/App/Listed.spec.php
+      spec/App/AlsoListed.spec.php
+      """
+    When I run phpspec run with option "--paths-from=paths.txt"
+    Then the exit code should be 0
+    And the output should contain "Listed"
+    And the output should contain "AlsoListed"
+    And the output should not contain "Unlisted"
+
+  Scenario: Error when the paths file does not exist
+    When I run phpspec run with option "--paths-from=missing.txt"
+    Then the exit code should be 1
+    And the output should contain "missing.txt"

--- a/features/scenarios/cli/configuration.feature
+++ b/features/scenarios/cli/configuration.feature
@@ -276,3 +276,28 @@ Feature: Configuration
       """
     When I run phpspec run
     Then all examples should pass
+
+  Scenario: Load configuration from an explicit path
+    Given a file "custom/my-config.json":
+      """
+      {
+          "format": "dot"
+      }
+      """
+    And a spec file "spec/App/ExplicitConfig.spec.php":
+      """
+      <?php
+      describe('ExplicitConfig', function () {
+          it('passes', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    When I run phpspec run with option "--config=custom/my-config.json"
+    Then the output should contain "."
+    And all examples should pass
+
+  Scenario: Error when the explicit config file does not exist
+    When I run phpspec run with option "--config=nope.yaml"
+    Then the exit code should not be 0
+    And the output should contain "nope.yaml"

--- a/features/scenarios/cli/coverage.feature
+++ b/features/scenarios/cli/coverage.feature
@@ -1,0 +1,143 @@
+Feature: JSON coverage report
+  As a mutation testing tool author
+  I want a machine-readable coverage report with per-example detail
+  So that I can exercise only the tests that cover a mutated line
+
+  Background:
+    Given a PSR-4 project with "spec" and "src" directories
+    And a class "src/App/Calculator.php":
+      """
+      <?php
+
+      namespace App;
+
+      class Calculator
+      {
+          public function add(int $a, int $b): int
+          {
+              return $a + $b;
+          }
+      }
+      """
+    And a spec file "spec/App/Calculator.spec.php":
+      """
+      <?php
+
+      use App\Calculator;
+
+      describe('Calculator', function () {
+          it('adds two numbers', function () {
+              expect((new Calculator())->add(1, 2))->toBe(3);
+          });
+      });
+      """
+
+  Scenario: Generate a JSON coverage report file
+    When I run phpspec run with coverage options "--coverage-json=coverage.json"
+    Then a file "coverage.json" should be generated
+    And the file "coverage.json" should contain:
+      """
+      "version": 1
+      """
+    And the file "coverage.json" should contain "spec/App/Calculator.spec.php::Calculator > adds two numbers"
+
+  Scenario: The report maps covered source lines to the examples that cover them
+    When I run phpspec run with coverage options "--coverage-json=coverage.json"
+    Then the file "coverage.json" should contain "src/App/Calculator.php"
+    And the file "coverage.json" should contain:
+      """
+      "lines"
+      """
+
+  Scenario: The report includes per-test timing and memory usage
+    When I run phpspec run with coverage options "--coverage-json=coverage.json"
+    Then the file "coverage.json" should contain:
+      """
+      "time"
+      """
+    And the file "coverage.json" should contain:
+      """
+      "memory"
+      """
+
+  Scenario: The report includes source and spec file checksums
+    When I run phpspec run with coverage options "--coverage-json=coverage.json"
+    Then the file "coverage.json" should contain:
+      """
+      "checksum"
+      """
+    And the file "coverage.json" should contain:
+      """
+      "spec_checksum"
+      """
+
+  Scenario: Combining the JSON report with a Clover report produces both
+    When I run phpspec run with coverage options "--coverage-json=coverage.json --coverage-clover=clover.xml"
+    Then a file "coverage.json" should be generated
+    And a file "clover.xml" should be generated
+    And the file "clover.xml" should contain "App/Calculator.php"
+
+  Scenario: Scope the coverage report to another source directory from the CLI
+    Given a class "lib/Acme/Multiplier.php":
+      """
+      <?php
+
+      namespace Acme;
+
+      class Multiplier
+      {
+          public function multiply(int $a, int $b): int
+          {
+              return $a * $b;
+          }
+      }
+      """
+    And a spec file "spec/Acme/Multiplier.spec.php":
+      """
+      <?php
+
+      use Acme\Multiplier;
+
+      describe('Multiplier', function () {
+          it('multiplies two numbers', function () {
+              expect((new Multiplier())->multiply(2, 3))->toBe(6);
+          });
+      });
+      """
+    When I run phpspec run with coverage options "--coverage-json=coverage.json --coverage-src=lib"
+    Then the file "coverage.json" should contain "lib/Acme/Multiplier.php"
+    And the file "coverage.json" should contain "spec/Acme/Multiplier.spec.php::Multiplier > multiplies two numbers"
+
+  Scenario: Parallel runs produce the same JSON coverage report
+    Given a class "src/App/Greeter.php":
+      """
+      <?php
+
+      namespace App;
+
+      class Greeter
+      {
+          public function greet(string $name): string
+          {
+              return "Hello, $name!";
+          }
+      }
+      """
+    And a spec file "spec/App/Greeter.spec.php":
+      """
+      <?php
+
+      use App\Greeter;
+
+      describe('Greeter', function () {
+          it('greets by name', function () {
+              expect((new Greeter())->greet('Marcello'))->toBe('Hello, Marcello!');
+          });
+      });
+      """
+    When I run phpspec run with coverage options "--coverage-json=coverage.json --parallel=2"
+    Then a file "coverage.json" should be generated
+    And the file "coverage.json" should contain "spec/App/Calculator.spec.php::Calculator > adds two numbers"
+    And the file "coverage.json" should contain "spec/App/Greeter.spec.php::Greeter > greets by name"
+    And the file "coverage.json" should contain "src/App/Calculator.php"
+    And the file "coverage.json" should contain "src/App/Greeter.php"

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -118,6 +118,16 @@ then('the class {string} should contain {string}', function (string $path, strin
     expect($content)->toContain($text);
 });
 
+then('the file {string} should contain {string}', function (string $path, string $text) {
+    $content = file_get_contents($this->projectDir . '/' . $path);
+    expect($content)->toContain($text);
+});
+
+then('the file {string} should contain:', function (string $path, string $text) {
+    $content = file_get_contents($this->projectDir . '/' . $path);
+    expect($content)->toContain($text);
+});
+
 then('the class should have a {string} method stub', function (string $method) {
     $content = file_get_contents($this->lastFile);
     expect($content)->toContain("function {$method}");

--- a/features/steps/runner.steps.php
+++ b/features/steps/runner.steps.php
@@ -30,9 +30,9 @@ if (!function_exists('_phpspec_exec')) {
         _phpspec_exec_subprocess($world, $args, $interactive);
     }
 
-    function _phpspec_exec_subprocess(object $world, string $args, bool $interactive = false): void
+    function _phpspec_exec_subprocess(object $world, string $args, bool $interactive = false, string $xdebugMode = 'off'): void
     {
-        $cmd = [$world->phpBin, '-d', 'xdebug.mode=off', $world->phpspecBin, ...preg_split('/\s+/', $args)];
+        $cmd = [$world->phpBin, '-d', 'xdebug.mode=' . $xdebugMode, $world->phpspecBin, ...preg_split('/\s+/', $args)];
 
         $descriptors = [
             0 => ['pipe', 'r'],
@@ -73,6 +73,15 @@ when('I run phpspec run with option {string}', function (string $options) {
 
 when('I run phpspec run {string}', function (string $path) {
     _phpspec_exec($this, 'run ' . $path);
+});
+
+// -- Coverage runs (subprocess so xdebug.mode=coverage can be forced) ---
+
+when('I run phpspec run with coverage options {string}', function (string $options) {
+    if (!extension_loaded('xdebug')) {
+        skip('Xdebug is not available');
+    }
+    _phpspec_exec_subprocess($this, 'run ' . $options, xdebugMode: 'coverage');
 });
 
 // -- Describe command --------------------------------------------------

--- a/spec/PhpSpec/Configuration.spec.php
+++ b/spec/PhpSpec/Configuration.spec.php
@@ -326,4 +326,27 @@ describe(Configuration::class, function () {
         expect($config->getPsr4Prefix())->toBe('App');
     });
 
+    it("loads an explicit config file instead of the working directory cascade", function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => $path === 'custom/my-config.json');
+        allow($fs->read())->toReturn(json_encode(['format' => 'dot']));
+
+        $config = new Configuration('/app', $fs, configFile: 'custom/my-config.json');
+
+        expect($config->getFormat())->toBe('dot');
+    });
+
+    it("throws when the explicit config file does not exist", function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+
+        expect(fn() => new Configuration('/app', $fs, configFile: 'nope.yaml'))
+            ->toThrow(RuntimeException::class);
+    });
+
+    it("resolves the config path from argv tokens", function () {
+        expect(Configuration::configPathFromArgv(['phpspec', 'run', '--config=a.yaml']))->toBe('a.yaml');
+        expect(Configuration::configPathFromArgv(['phpspec', 'run', '--config', 'b.json']))->toBe('b.json');
+        expect(Configuration::configPathFromArgv(['phpspec', 'run', '-c', 'c.yml']))->toBe('c.yml');
+        expect(Configuration::configPathFromArgv(['phpspec', 'run']))->toBeNull();
+    });
+
 });

--- a/spec/PhpSpec/Console/Command/Run.spec.php
+++ b/spec/PhpSpec/Console/Command/Run.spec.php
@@ -115,6 +115,43 @@ describe(Run::class, function () {
             expect($exitCode)->toBe(1);
         });
 
+        it('runs with the parallel option on an empty suite', function (Filesystem $execFs) {
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader($execFs), new Runner(), $config);
+
+            $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+            $exitCode = $tester->execute(['--parallel' => '2']);
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('No specs found');
+        });
+
+        it('errors when the paths file does not exist', function (Filesystem $execFs) {
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader($execFs), new Runner(), $config);
+
+            $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+            $exitCode = $tester->execute(['--paths-from' => 'missing.txt']);
+            expect($exitCode)->toBe(1);
+            expect($tester->getDisplay())->toContain('missing.txt');
+        });
+
+        it('reads spec paths from the paths file', function (Filesystem $execFs) {
+            $pathsFile = tempnam(sys_get_temp_dir(), 'phpspec_paths_') . '.txt';
+            file_put_contents($pathsFile, "spec/App/NotThere.spec.php\n\n");
+
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader($execFs), new Runner(), $config);
+
+            try {
+                $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+                $exitCode = $tester->execute(['--paths-from' => $pathsFile]);
+                expect($exitCode)->toBe(0);
+                expect($tester->getDisplay())->toContain('No specs found');
+            } finally {
+                unlink($pathsFile);
+            }
+        });
+
         it('registers PSR-4 autoloader from config', function (Filesystem $execFs) {
             allow($execFs->exists())->toReturnUsing(fn($p) => str_ends_with($p, 'phpspec.json'));
             allow($execFs->read())->toReturn(json_encode(['autoload' => ['TestNs\\' => 'src/']]));

--- a/spec/PhpSpec/Console/Command/Run/CoverageReporter.spec.php
+++ b/spec/PhpSpec/Console/Command/Run/CoverageReporter.spec.php
@@ -2,6 +2,10 @@
 
 use PhpSpec\Console\Command\Run\CoverageReporter;
 use PhpSpec\Coverage\CoverageCollector;
+use PhpSpec\Coverage\CoverageDriver;
+use PhpSpec\Coverage\CoverageOptions;
+use PhpSpec\Coverage\CoverageRegistry;
+use PhpSpec\Coverage\PerExampleCollector;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 describe(CoverageReporter::class, function () {
@@ -10,10 +14,33 @@ describe(CoverageReporter::class, function () {
 
         if (CoverageCollector::isAvailable()) {
 
-            it('returns true when Xdebug coverage is available', function () {
+            // Starting/stopping a real collection would clobber a live
+            // whole-suite collection (xdebug coverage state is process-global).
+            if (!CoverageCollector::isCollecting()) {
+
+                it('returns true when Xdebug coverage is available', function () {
+                    $output = new BufferedOutput();
+                    $reporter = new CoverageReporter();
+
+                    expect($reporter->start($output))->toBeTrue();
+
+                    // Stop the collection so no state leaks into later examples
+                    $reporter->report($output, new CoverageOptions(srcPath: 'src'));
+                    expect(CoverageCollector::isCollecting())->toBeFalse();
+                });
+
+            }
+
+            it('activates the per-example coverage registry in per-example mode', function () {
                 $output = new BufferedOutput();
                 $reporter = new CoverageReporter();
-                expect($reporter->start($output))->toBeTrue();
+
+                try {
+                    expect($reporter->start($output, perExample: true))->toBeTrue();
+                    expect(CoverageRegistry::collector())->toBeAnInstanceOf(PerExampleCollector::class);
+                } finally {
+                    CoverageRegistry::reset();
+                }
             });
 
         } else {
@@ -22,6 +49,12 @@ describe(CoverageReporter::class, function () {
                 $output = new BufferedOutput();
                 $reporter = new CoverageReporter();
                 expect($reporter->start($output))->toBeFalse();
+            });
+
+            it('returns false in per-example mode when Xdebug coverage is not available', function () {
+                $output = new BufferedOutput();
+                $reporter = new CoverageReporter();
+                expect($reporter->start($output, perExample: true))->toBeFalse();
             });
 
             it('writes error message when Xdebug coverage is not available', function () {
@@ -34,4 +67,137 @@ describe(CoverageReporter::class, function () {
         }
 
     });
+
+    context('report', function () {
+
+        it('reports nothing when collection was never started', function () {
+            $output = new BufferedOutput();
+            $reporter = new CoverageReporter();
+            $options = new CoverageOptions(srcPath: 'src');
+
+            expect($reporter->report($output, $options))->toBeNull();
+            expect($output->fetch())->toBe('');
+        });
+
+        it('renders the requested reports from a per-example collection', function (CoverageDriver $driver) {
+            $fixture = (string) realpath(__DIR__ . '/../../../Coverage/Driver/fixtures/covered_probe.php');
+            allow($driver->stop())->toReturn([$fixture => [3 => 1]]);
+            $collector = new PerExampleCollector($driver);
+            $collector->beginSpec('spec/PhpSpec/Coverage/JsonReport.spec.php');
+            $collector->beginExample();
+            $collector->endExample('probes');
+            CoverageRegistry::activate($collector);
+
+            $dir = sys_get_temp_dir() . '/phpspec_reports_' . uniqid();
+            $output = new BufferedOutput();
+            $reporter = new CoverageReporter();
+
+            try {
+                $exitCode = $reporter->report($output, new CoverageOptions(
+                    srcPath: dirname($fixture),
+                    showText: true,
+                    cloverPath: $dir . '/clover.xml',
+                    htmlPath: $dir . '/html',
+                    jsonPath: $dir . '/coverage.json',
+                    coverageMin: '100',
+                ));
+
+                expect($exitCode)->toBeNull();
+                expect(file_exists($dir . '/clover.xml'))->toBeTrue();
+                expect(file_exists($dir . '/html/index.html'))->toBeTrue();
+                expect(file_exists($dir . '/coverage.json'))->toBeTrue();
+                expect($output->fetch())->toContain('meets the required');
+                expect((string) file_get_contents($dir . '/coverage.json'))
+                    ->toContain('spec/PhpSpec/Coverage/JsonReport.spec.php::probes');
+            } finally {
+                CoverageRegistry::reset();
+                @unlink($dir . '/clover.xml');
+                @unlink($dir . '/coverage.json');
+                array_map('unlink', glob($dir . '/html/*') ?: []);
+                @rmdir($dir . '/html');
+                @rmdir($dir);
+            }
+        });
+
+        it('returns exit code 1 when coverage is below the minimum', function (CoverageDriver $driver) {
+            $fixture = (string) realpath(__DIR__ . '/../../../Coverage/Driver/fixtures/covered_probe.php');
+            allow($driver->stop())->toReturn([$fixture => [3 => 1, 4 => -1]]);
+            $collector = new PerExampleCollector($driver);
+            $collector->beginSpec('spec/PhpSpec/Coverage/JsonReport.spec.php');
+            $collector->beginExample();
+            $collector->endExample('probes');
+            CoverageRegistry::activate($collector);
+
+            $output = new BufferedOutput();
+            $reporter = new CoverageReporter();
+
+            try {
+                $exitCode = $reporter->report($output, new CoverageOptions(
+                    srcPath: dirname($fixture),
+                    coverageMin: '90',
+                ));
+
+                expect($exitCode)->toBe(1);
+                expect($output->fetch())->toContain('below the required');
+            } finally {
+                CoverageRegistry::reset();
+            }
+        });
+
+        it('writes the raw collector state to the partial path instead of rendering reports', function (CoverageDriver $driver) {
+            allow($driver->stop())->toReturn(['/project/src/App/Calculator.php' => [12 => 1]]);
+            $collector = new PerExampleCollector($driver);
+            $collector->beginSpec('spec/App/Calculator.spec.php');
+            $collector->beginExample();
+            $collector->endExample('adds');
+            CoverageRegistry::activate($collector);
+
+            $partialPath = sys_get_temp_dir() . '/phpspec_partial_' . uniqid() . '.json';
+            $output = new BufferedOutput();
+            $reporter = new CoverageReporter();
+
+            try {
+                $exitCode = $reporter->report($output, new CoverageOptions(srcPath: 'src', partialPath: $partialPath));
+
+                expect($exitCode)->toBeNull();
+                $state = json_decode((string) file_get_contents($partialPath), true);
+                expect($state['tests'])->toHaveKey('spec/App/Calculator.spec.php::adds');
+                expect($state['aggregate'])->toHaveKey('/project/src/App/Calculator.php');
+                expect(CoverageRegistry::collector())->toBeNull();
+            } finally {
+                CoverageRegistry::reset();
+                if (file_exists($partialPath)) {
+                    unlink($partialPath);
+                }
+            }
+        });
+
+        it('merges partial state files into the active collector and removes them', function (CoverageDriver $driver, CoverageDriver $workerDriver) {
+            allow($workerDriver->stop())->toReturn(['/project/src/App/Greeter.php' => [8 => 1]]);
+            $workerCollector = new PerExampleCollector($workerDriver);
+            $workerCollector->beginSpec('spec/App/Greeter.spec.php');
+            $workerCollector->beginExample();
+            $workerCollector->endExample('greets');
+
+            $partialPath = sys_get_temp_dir() . '/phpspec_partial_' . uniqid() . '.json';
+            file_put_contents($partialPath, json_encode($workerCollector->toArray()));
+
+            CoverageRegistry::activate(new PerExampleCollector($driver));
+            $reporter = new CoverageReporter();
+
+            try {
+                $reporter->mergePartials([$partialPath]);
+
+                expect(CoverageRegistry::collector()->getTests())->toHaveKey('spec/App/Greeter.spec.php::greets');
+                expect(file_exists($partialPath))->toBeFalse();
+            } finally {
+                CoverageRegistry::reset();
+                if (file_exists($partialPath)) {
+                    unlink($partialPath);
+                }
+            }
+        });
+
+    });
+
 });

--- a/spec/PhpSpec/Coverage/CoverageCollector.spec.php
+++ b/spec/PhpSpec/Coverage/CoverageCollector.spec.php
@@ -23,6 +23,21 @@ describe(CoverageCollector::class, function () {
         expect($result['executable'])->toBe(0);
     });
 
+    if (CoverageCollector::isAvailable() && !CoverageCollector::isCollecting()) {
+
+        it('tracks whether a whole-suite collection is in progress', function () {
+            $collector = new CoverageCollector();
+            expect(CoverageCollector::isCollecting())->toBeFalse();
+
+            $collector->start();
+            expect(CoverageCollector::isCollecting())->toBeTrue();
+
+            $collector->stop();
+            expect(CoverageCollector::isCollecting())->toBeFalse();
+        });
+
+    }
+
     it('filter excludes eval\'d code paths', function () {
         $collector = new CoverageCollector();
 

--- a/spec/PhpSpec/Coverage/CoverageCollector.spec.php
+++ b/spec/PhpSpec/Coverage/CoverageCollector.spec.php
@@ -38,6 +38,15 @@ describe(CoverageCollector::class, function () {
 
     }
 
+    it('filterData matches Windows-style backslash paths', function () {
+        $realSrc = (string) realpath('src');
+        $windowsStyleFile = str_replace('/', '\\', $realSrc . '/PhpSpec/Loader.php');
+
+        $filtered = CoverageCollector::filterData([$windowsStyleFile => [1 => 1]], 'src');
+
+        expect($filtered)->toHaveKey('PhpSpec/Loader.php');
+    });
+
     it('filter excludes eval\'d code paths', function () {
         $collector = new CoverageCollector();
 

--- a/spec/PhpSpec/Coverage/CoverageRegistry.spec.php
+++ b/spec/PhpSpec/Coverage/CoverageRegistry.spec.php
@@ -1,0 +1,32 @@
+<?php
+
+use PhpSpec\Coverage\CoverageDriver;
+use PhpSpec\Coverage\CoverageRegistry;
+use PhpSpec\Coverage\PerExampleCollector;
+
+describe(CoverageRegistry::class, function () {
+
+    afterEach(function () {
+        CoverageRegistry::reset();
+    });
+
+    it('has no collector by default', function () {
+        expect(CoverageRegistry::collector())->toBeNull();
+    });
+
+    it('exposes the collector once activated', function (CoverageDriver $driver) {
+        $collector = new PerExampleCollector($driver);
+
+        CoverageRegistry::activate($collector);
+
+        expect(CoverageRegistry::collector())->toBe($collector);
+    });
+
+    it('clears the collector on reset', function (CoverageDriver $driver) {
+        CoverageRegistry::activate(new PerExampleCollector($driver));
+
+        CoverageRegistry::reset();
+
+        expect(CoverageRegistry::collector())->toBeNull();
+    });
+});

--- a/spec/PhpSpec/Coverage/Driver/XdebugDriver.spec.php
+++ b/spec/PhpSpec/Coverage/Driver/XdebugDriver.spec.php
@@ -1,0 +1,41 @@
+<?php
+
+use PhpSpec\Coverage\CoverageCollector;
+use PhpSpec\Coverage\CoverageDriver;
+use PhpSpec\Coverage\Driver\XdebugDriver;
+
+describe(XdebugDriver::class, function () {
+
+    it('is a coverage driver', function () {
+        expect(new XdebugDriver())->toBeAnInstanceOf(CoverageDriver::class);
+    });
+
+    // Cycling xdebug start/stop would clobber a live whole-suite collection
+    // (xdebug coverage state is process-global), so skip these when one is running.
+    if (CoverageCollector::isAvailable() && !CoverageCollector::isCollecting()) {
+
+        it('collects line hits between start and stop', function () {
+            $driver = new XdebugDriver();
+
+            $driver->start();
+            $probe = require __DIR__ . '/fixtures/covered_probe.php';
+            $data = $driver->stop();
+
+            expect($probe)->toBe('covered');
+            expect($data)->toHaveKey(realpath(__DIR__ . '/fixtures/covered_probe.php'));
+        });
+
+        it('starts a fresh cycle each time', function () {
+            $driver = new XdebugDriver();
+
+            $driver->start();
+            $driver->stop();
+            $driver->start();
+            $data = $driver->stop();
+
+            expect($data)->not()->toHaveKey(realpath(__DIR__ . '/fixtures/covered_probe.php'));
+        });
+
+    }
+
+});

--- a/spec/PhpSpec/Coverage/Driver/fixtures/covered_probe.php
+++ b/spec/PhpSpec/Coverage/Driver/fixtures/covered_probe.php
@@ -1,0 +1,3 @@
+<?php
+
+return 'covered';

--- a/spec/PhpSpec/Coverage/JsonReport.spec.php
+++ b/spec/PhpSpec/Coverage/JsonReport.spec.php
@@ -1,0 +1,48 @@
+<?php
+
+use PhpSpec\Coverage\JsonReport;
+
+describe(JsonReport::class, function () {
+
+    beforeEach(function () {
+        $this->filePath = sys_get_temp_dir() . '/phpspec_json_report_' . uniqid() . '/coverage.json';
+        $this->tests = [
+            'spec/App/Calculator.spec.php::Calculator > adds two numbers' => [
+                'time' => 0.0021,
+                'memory' => 524288,
+                'spec_file' => 'spec/App/Calculator.spec.php',
+                'spec_checksum' => 'abc123',
+            ],
+        ];
+        $this->sources = [
+            'src/App/Calculator.php' => [
+                'checksum' => 'def456',
+                'lines' => [
+                    12 => ['spec/App/Calculator.spec.php::Calculator > adds two numbers'],
+                ],
+            ],
+        ];
+    });
+
+    afterEach(function () {
+        if (file_exists($this->filePath)) {
+            unlink($this->filePath);
+            rmdir(dirname($this->filePath));
+        }
+    });
+
+    it('writes the report to the given file path, creating parent directories', function () {
+        (new JsonReport())->render($this->tests, $this->sources, $this->filePath);
+
+        expect(file_exists($this->filePath))->toBeTrue();
+    });
+
+    it('renders a version 1 document with tests and sources sections', function () {
+        (new JsonReport())->render($this->tests, $this->sources, $this->filePath);
+
+        $document = json_decode((string) file_get_contents($this->filePath), true);
+        expect($document['version'])->toBe(1);
+        expect($document['tests'])->toBe($this->tests);
+        expect($document['sources'])->toBe($this->sources);
+    });
+});

--- a/spec/PhpSpec/Coverage/JsonReportBuilder.spec.php
+++ b/spec/PhpSpec/Coverage/JsonReportBuilder.spec.php
@@ -39,6 +39,23 @@ describe(JsonReportBuilder::class, function () {
         ]);
     });
 
+    it('handles Windows-style backslash paths', function (CoverageDriver $winDriver, Filesystem $filesystem) {
+        allow($winDriver->stop())->toReturn([
+            'C:\\project\\src\\App\\Calculator.php' => [12 => 1],
+        ]);
+        allow($filesystem->read())->toReturn('code');
+        $collector = new PerExampleCollector($winDriver);
+        $collector->beginSpec('spec\\App\\Calculator.spec.php');
+        $collector->beginExample();
+        $collector->endExample('adds');
+        $builder = new JsonReportBuilder($filesystem);
+
+        $report = $builder->build($collector, 'C:\\project\\src', 'C:\\project');
+
+        expect($report['sources'])->toHaveKey('src/App/Calculator.php');
+        expect($report['tests'])->toHaveKey('spec/App/Calculator.spec.php::adds');
+    });
+
     it('adds a checksum of each spec file to the test metadata', function (Filesystem $filesystem) {
         allow($filesystem->read())->toReturnUsing(
             fn(string $path) => $path === 'spec/App/Calculator.spec.php' ? 'spec code' : 'other',

--- a/spec/PhpSpec/Coverage/JsonReportBuilder.spec.php
+++ b/spec/PhpSpec/Coverage/JsonReportBuilder.spec.php
@@ -1,0 +1,56 @@
+<?php
+
+use PhpSpec\Coverage\CoverageDriver;
+use PhpSpec\Coverage\JsonReportBuilder;
+use PhpSpec\Coverage\PerExampleCollector;
+use PhpSpec\Filesystem;
+
+describe(JsonReportBuilder::class, function () {
+
+    beforeEach(function (CoverageDriver $driver) {
+        allow($driver->stop())->toReturn([
+            '/project/src/App/Calculator.php' => [12 => 1, 13 => -1],
+            '/project/spec/App/Calculator.spec.php' => [5 => 1],
+            '/project/vendor/lib/functions.php' => [3 => 1],
+        ]);
+
+        $this->collector = new PerExampleCollector($driver);
+        $this->collector->beginSpec('spec/App/Calculator.spec.php');
+        $this->collector->pushContext('Calculator');
+        $this->collector->beginExample();
+        $this->collector->endExample('adds two numbers');
+    });
+
+    it('keeps only sources under the src path, relative to the project root, with checksums', function (Filesystem $filesystem) {
+        allow($filesystem->read())->toReturnUsing(
+            fn(string $path) => $path === '/project/src/App/Calculator.php' ? 'source code' : 'other',
+        );
+        $builder = new JsonReportBuilder($filesystem);
+
+        $report = $builder->build($this->collector, '/project/src', '/project');
+
+        expect($report['sources'])->toBe([
+            'src/App/Calculator.php' => [
+                'checksum' => md5('source code'),
+                'lines' => [
+                    12 => ['spec/App/Calculator.spec.php::Calculator > adds two numbers'],
+                ],
+            ],
+        ]);
+    });
+
+    it('adds a checksum of each spec file to the test metadata', function (Filesystem $filesystem) {
+        allow($filesystem->read())->toReturnUsing(
+            fn(string $path) => $path === 'spec/App/Calculator.spec.php' ? 'spec code' : 'other',
+        );
+        $builder = new JsonReportBuilder($filesystem);
+
+        $report = $builder->build($this->collector, '/project/src', '/project');
+
+        $test = $report['tests']['spec/App/Calculator.spec.php::Calculator > adds two numbers'];
+        expect($test['spec_file'])->toBe('spec/App/Calculator.spec.php');
+        expect($test['spec_checksum'])->toBe(md5('spec code'));
+        expect($test['time'])->toBeGreaterThan(0);
+        expect($test['memory'])->toBeGreaterThan(0);
+    });
+});

--- a/spec/PhpSpec/Coverage/PerExampleCollector.spec.php
+++ b/spec/PhpSpec/Coverage/PerExampleCollector.spec.php
@@ -1,0 +1,120 @@
+<?php
+
+use PhpSpec\Coverage\CoverageDriver;
+use PhpSpec\Coverage\PerExampleCollector;
+
+describe(PerExampleCollector::class, function () {
+
+    it('attributes executed lines to the running example', function (CoverageDriver $driver) {
+        allow($driver->stop())->toReturn([
+            '/project/src/App/Calculator.php' => [12 => 1, 13 => -1, 14 => -2],
+        ]);
+        $collector = new PerExampleCollector($driver);
+
+        $collector->beginSpec('spec/App/Calculator.spec.php');
+        $collector->pushContext('Calculator');
+        $collector->beginExample();
+        $collector->endExample('adds two numbers');
+
+        expect($collector->getLines())->toBe([
+            '/project/src/App/Calculator.php' => [
+                12 => ['spec/App/Calculator.spec.php::Calculator > adds two numbers'],
+            ],
+        ]);
+    });
+
+    it('records timing, peak memory and spec file per test', function (CoverageDriver $driver) {
+        allow($driver->stop())->toReturn([]);
+        $collector = new PerExampleCollector($driver);
+
+        $collector->beginSpec('spec/App/Calculator.spec.php');
+        $collector->pushContext('Calculator');
+        $collector->beginExample();
+        str_repeat('x', 1000);
+        $collector->endExample('adds two numbers');
+
+        $tests = $collector->getTests();
+        $test = $tests['spec/App/Calculator.spec.php::Calculator > adds two numbers'];
+        expect($test['time'])->toBeGreaterThan(0);
+        expect($test['memory'])->toBeGreaterThan(0);
+        expect($test['spec_file'])->toBe('spec/App/Calculator.spec.php');
+    });
+
+    it('merges each cycle into an aggregate usable by the other reports', function (CoverageDriver $driver) {
+        allow($driver->stop())->toReturnUsing(function () {
+            static $cycle = 0;
+            $cycle++;
+            return $cycle === 1
+                ? ['/project/src/App/Calculator.php' => [12 => 1, 13 => -1, 14 => -2]]
+                : ['/project/src/App/Calculator.php' => [12 => -1, 13 => 1, 14 => -2]];
+        });
+        $collector = new PerExampleCollector($driver);
+        $collector->beginSpec('spec/App/Calculator.spec.php');
+
+        $collector->beginExample();
+        $collector->endExample('adds');
+        $collector->beginExample();
+        $collector->endExample('subtracts');
+
+        expect($collector->getAggregate())->toBe([
+            '/project/src/App/Calculator.php' => [12 => 1, 13 => 1, 14 => -2],
+        ]);
+    });
+
+    it('normalises away a leading ./ from the spec path in test identifiers', function (CoverageDriver $driver) {
+        allow($driver->stop())->toReturn(['/project/src/App/Calculator.php' => [12 => 1]]);
+        $collector = new PerExampleCollector($driver);
+
+        $collector->beginSpec('./spec/App/Calculator.spec.php');
+        $collector->beginExample();
+        $collector->endExample('adds');
+
+        expect($collector->getLines()['/project/src/App/Calculator.php'][12])->toBe([
+            'spec/App/Calculator.spec.php::adds',
+        ]);
+        expect($collector->getTests()['spec/App/Calculator.spec.php::adds']['spec_file'])
+            ->toBe('spec/App/Calculator.spec.php');
+    });
+
+    it('attributes a line to every example that executes it, without duplicates', function (CoverageDriver $driver) {
+        allow($driver->stop())->toReturn(['/project/src/App/Calculator.php' => [12 => 1]]);
+        $collector = new PerExampleCollector($driver);
+        $collector->beginSpec('spec/App/Calculator.spec.php');
+
+        $collector->beginExample();
+        $collector->endExample('adds');
+        $collector->beginExample();
+        $collector->endExample('adds');
+        $collector->beginExample();
+        $collector->endExample('subtracts');
+
+        expect($collector->getLines()['/project/src/App/Calculator.php'][12])->toBe([
+            'spec/App/Calculator.spec.php::adds',
+            'spec/App/Calculator.spec.php::subtracts',
+        ]);
+    });
+
+    it('exports its state and merges state from another collector', function (CoverageDriver $driver, CoverageDriver $otherDriver) {
+        allow($driver->stop())->toReturn(['/project/src/App/Calculator.php' => [12 => 1, 13 => -1]]);
+        $collector = new PerExampleCollector($driver);
+        $collector->beginSpec('spec/App/Calculator.spec.php');
+        $collector->beginExample();
+        $collector->endExample('adds');
+
+        allow($otherDriver->stop())->toReturn(['/project/src/App/Calculator.php' => [12 => 1, 13 => 1]]);
+        $other = new PerExampleCollector($otherDriver);
+        $other->beginSpec('spec/App/Greeter.spec.php');
+        $other->beginExample();
+        $other->endExample('greets');
+
+        $collector->applyState($other->toArray());
+
+        expect($collector->getLines()['/project/src/App/Calculator.php'][12])->toBe([
+            'spec/App/Calculator.spec.php::adds',
+            'spec/App/Greeter.spec.php::greets',
+        ]);
+        expect($collector->getAggregate()['/project/src/App/Calculator.php'])->toBe([12 => 1, 13 => 1]);
+        expect($collector->getTests())->toHaveKey('spec/App/Greeter.spec.php::greets');
+        expect($collector->getTests())->toHaveKey('spec/App/Calculator.spec.php::adds');
+    });
+});

--- a/spec/PhpSpec/InProcessRunner.spec.php
+++ b/spec/PhpSpec/InProcessRunner.spec.php
@@ -1,8 +1,11 @@
 <?php
 
-use PhpSpec\InProcessRunner;
-use PhpSpec\InProcessResult;
 use PhpSpec\ClassConflictException;
+use PhpSpec\Coverage\CoverageDriver;
+use PhpSpec\Coverage\CoverageRegistry;
+use PhpSpec\Coverage\PerExampleCollector;
+use PhpSpec\InProcessResult;
+use PhpSpec\InProcessRunner;
 
 describe(InProcessRunner::class, function () {
     let("inProcessRunner", fn() => new InProcessRunner());
@@ -167,6 +170,45 @@ describe(InProcessRunner::class, function () {
             @rmdir($dir . '/spec');
             @rmdir($dir . '/src');
             @rmdir($dir);
+        });
+
+        it('isolates the coverage registry from the inner run and restores it', function (CoverageDriver $driver) {
+            $cycles = [];
+            allow($driver->start())->toReturnUsing(function () use (&$cycles) {
+                $cycles[] = 'start';
+            });
+            allow($driver->stop())->toReturnUsing(function () use (&$cycles) {
+                $cycles[] = 'stop';
+                return [];
+            });
+            $outerCollector = new PerExampleCollector($driver);
+            CoverageRegistry::activate($outerCollector);
+
+            $dir = sys_get_temp_dir() . '/phpspec_inprocess_cov_' . uniqid();
+            mkdir($dir . '/spec/App', 0777, true);
+            mkdir($dir . '/src', 0777, true);
+            file_put_contents($dir . '/spec/App/Inner.spec.php', <<<'PHP'
+            <?php
+            describe('Inner', function () {
+                it('passes', function () {
+                    expect(true)->toBeTrue();
+                });
+            });
+            PHP);
+
+            try {
+                InProcessRunner::run($dir, 'run');
+
+                expect(CoverageRegistry::collector())->toBe($outerCollector);
+                expect($cycles)->toBe([]);
+            } finally {
+                CoverageRegistry::reset();
+                @unlink($dir . '/spec/App/Inner.spec.php');
+                @rmdir($dir . '/spec/App');
+                @rmdir($dir . '/spec');
+                @rmdir($dir . '/src');
+                @rmdir($dir);
+            }
         });
     });
 });

--- a/spec/PhpSpec/Parallel/WorkerProcess.spec.php
+++ b/spec/PhpSpec/Parallel/WorkerProcess.spec.php
@@ -272,6 +272,31 @@ describe(WorkerProcess::class, function () {
         });
     });
 
+    context('buildCommand', function () {
+        it('disables xdebug and produces junit output by default', function () {
+            $worker = new WorkerProcess(['spec/A.spec.php'], '/path/to/phpspec');
+            $command = $worker->buildCommand();
+
+            expect($command)->toContain('xdebug.mode=off');
+            expect($command)->toContain('spec/A.spec.php');
+        });
+
+        it('enables xdebug coverage and requests a partial dump when a coverage partial path is set', function () {
+            $worker = new WorkerProcess(['spec/A.spec.php'], '/path/to/phpspec', '/tmp/partial-0.json');
+            $command = $worker->buildCommand();
+
+            expect($command)->toContain('xdebug.mode=coverage');
+            expect($command)->toContain('--coverage-partial=/tmp/partial-0.json');
+        });
+
+        it('forwards the explicit config path to the worker', function () {
+            $worker = new WorkerProcess(['spec/A.spec.php'], '/path/to/phpspec', configPath: 'custom/my-config.json');
+            $command = $worker->buildCommand();
+
+            expect($command)->toContain('--config=custom/my-config.json');
+        });
+    });
+
     context('getExitCode', function () {
         it('returns null before process runs', function () {
             $worker = new WorkerProcess([], '/dev/null');

--- a/spec/PhpSpec/Specification.spec.php
+++ b/spec/PhpSpec/Specification.spec.php
@@ -47,7 +47,9 @@ describe(Specification::class, function() {
             unlink($file);
         }
 
-        expect($collector->getTests())->toHaveKey($file . '::Sample > works');
+        // Test identifiers always use forward slashes, also on Windows
+        $expectedId = str_replace('\\', '/', $file) . '::Sample > works';
+        expect($collector->getTests())->toHaveKey($expectedId);
     });
 
 });

--- a/spec/PhpSpec/Specification.spec.php
+++ b/spec/PhpSpec/Specification.spec.php
@@ -1,5 +1,8 @@
 <?php
 
+use PhpSpec\Coverage\CoverageDriver;
+use PhpSpec\Coverage\CoverageRegistry;
+use PhpSpec\Coverage\PerExampleCollector;
 use PhpSpec\Specification;
 use PhpSpec\Specification\Example;
 
@@ -27,6 +30,24 @@ describe(Specification::class, function() {
     it("returns the path", function() {
         $spec = new Specification('/some/path/MyClass.spec.php');
         expect($spec->getPath())->toBe('/some/path/MyClass.spec.php');
+    });
+
+    it("announces the spec file to the active coverage collector", function (CoverageDriver $driver) {
+        allow($driver->stop())->toReturn([]);
+        $collector = new PerExampleCollector($driver);
+        CoverageRegistry::activate($collector);
+
+        $file = sys_get_temp_dir() . '/phpspec_spec_coverage_' . uniqid() . '.spec.php';
+        file_put_contents($file, '<?php describe("Sample", function () { it("works", function () {}); });');
+
+        try {
+            (new Specification($file))->run();
+        } finally {
+            CoverageRegistry::reset();
+            unlink($file);
+        }
+
+        expect($collector->getTests())->toHaveKey($file . '::Sample > works');
     });
 
 });

--- a/spec/PhpSpec/Specification/Context.spec.php
+++ b/spec/PhpSpec/Specification/Context.spec.php
@@ -1,5 +1,8 @@
 <?php
 
+use PhpSpec\Coverage\CoverageDriver;
+use PhpSpec\Coverage\CoverageRegistry;
+use PhpSpec\Coverage\PerExampleCollector;
 use PhpSpec\Specification\Context;
 use PhpSpec\Specification\Subject;
 use PhpSpec\Result\ContextResult;
@@ -418,6 +421,43 @@ describe(Context::class, function() {
         $ctx->setWorld(new Subject(__FILE__));
         $ctx->run();
         expect($log)->toBe([]);
+    });
+
+    it("cycles the active coverage collector around each example including hooks", function (CoverageDriver $driver) {
+        $log = [];
+        allow($driver->start())->toReturnUsing(function() use (&$log) {
+            $log[] = 'coverage start';
+        });
+        allow($driver->stop())->toReturnUsing(function() use (&$log) {
+            $log[] = 'coverage stop';
+            return ['/project/src/App/Calculator.php' => [12 => 1]];
+        });
+        $collector = new PerExampleCollector($driver);
+        $collector->beginSpec('spec/App/Calculator.spec.php');
+        CoverageRegistry::activate($collector);
+
+        try {
+            $ctx = new Context("Calculator", function() use (&$log) {
+                beforeEach(function() use (&$log) {
+                    $log[] = 'beforeEach';
+                });
+                afterEach(function() use (&$log) {
+                    $log[] = 'afterEach';
+                });
+                it("adds two numbers", function() use (&$log) {
+                    $log[] = 'example';
+                });
+            });
+            $ctx->setWorld(new Subject(__FILE__));
+            $ctx->run();
+        } finally {
+            CoverageRegistry::reset();
+        }
+
+        expect($log)->toBe(['coverage start', 'beforeEach', 'example', 'afterEach', 'coverage stop']);
+        expect($collector->getLines()['/project/src/App/Calculator.php'][12])->toBe([
+            'spec/App/Calculator.spec.php::Calculator > adds two numbers',
+        ]);
     });
 
 });

--- a/spec/PhpSpec/StoryBDD/Feature.spec.php
+++ b/spec/PhpSpec/StoryBDD/Feature.spec.php
@@ -110,6 +110,33 @@ describe(Feature::class, function () {
         expect($steps[1]->isSkipped())->toBeTrue();
     });
 
+    it("skips remaining steps after a skipped step", function () {
+        $registry = new StepRegistry();
+        $registry->addStep("a skipped step", function () {
+            skip("environment not available");
+        });
+        $ran = false;
+        $registry->addStep("a following step", function () use (&$ran) {
+            $ran = true;
+        });
+
+        $feature = new Feature('test.feature', new FeatureNode(
+            'Skipping',
+            '',
+            null,
+            [new ScenarioNode('Skips', [
+                new StepNode('When', 'a skipped step'),
+                new StepNode('Then', 'a following step'),
+            ])]
+        ), $registry, new HookRegistry());
+
+        $result = $feature->run();
+        $steps = $result->getResults()[0]->getResults();
+        expect($steps[0]->isSkipped())->toBeTrue();
+        expect($steps[1]->isSkipped())->toBeTrue();
+        expect($ran)->toBeFalse();
+    });
+
     it("shares world across steps in a scenario", function () {
         $registry = new StepRegistry();
         $registry->addStep("I set name to {string}", function ($name) {

--- a/src/PhpSpec/Configuration.php
+++ b/src/PhpSpec/Configuration.php
@@ -14,11 +14,13 @@
 
 namespace PhpSpec;
 
+use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
  * Reads and provides access to project configuration from phpspec.yaml, phpspec.yml,
- * phpspec.json, or phpspec.php (in priority order).
+ * phpspec.json, or phpspec.php (in priority order), or from an explicit config
+ * file passed with --config.
  */
 final class Configuration
 {
@@ -28,20 +30,63 @@ final class Configuration
     /**
      * @param string $rootDir project root directory containing config files
      * @param Filesystem|null $filesystem injectable filesystem for testability
+     * @param string|null $configFile explicit config file path; when set, the working directory cascade is skipped
      */
     private Filesystem $fs;
 
-    public function __construct(private string $rootDir, ?Filesystem $filesystem = null)
-    {
+    public function __construct(
+        private string $rootDir,
+        ?Filesystem $filesystem = null,
+        private readonly ?string $configFile = null,
+    ) {
         $this->fs = $filesystem ?? new RealFilesystem();
         $this->load();
     }
 
     /**
-     * Loads configuration from the first config file found: yaml > yml > json > php.
+     * Extracts the --config option value from raw argv tokens, supporting the
+     * "--config=FILE", "--config FILE" and "-c FILE" forms.
+     *
+     * @param array<int, mixed> $argv raw argv tokens
+     * @return string|null the config file path, or null when not given
+     */
+    public static function configPathFromArgv(array $argv): ?string
+    {
+        $tokens = array_values($argv);
+
+        foreach ($tokens as $i => $token) {
+            if (!is_string($token)) {
+                continue;
+            }
+
+            if (str_starts_with($token, '--config=')) {
+                return substr($token, strlen('--config='));
+            }
+
+            if ($token === '--config' || $token === '-c') {
+                $next = $tokens[$i + 1] ?? null;
+
+                if (is_string($next) && $next !== '' && !str_starts_with($next, '-')) {
+                    return $next;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Loads the explicit config file when given, otherwise the first config
+     * file found in the root directory: yaml > yml > json > php.
      */
     private function load(): void
     {
+        if ($this->configFile !== null) {
+            $this->loadFile($this->configFile);
+
+            return;
+        }
+
         $yamlPath = $this->rootDir . '/phpspec.yaml';
         $ymlPath = $this->rootDir . '/phpspec.yml';
         $jsonPath = $this->rootDir . '/phpspec.json';
@@ -57,6 +102,27 @@ final class Configuration
         } elseif ($this->fs->exists($phpPath)) {
             $this->config = $this->fs->requirePhp($phpPath);
         }
+    }
+
+    /**
+     * Loads configuration from an explicit file, resolving the parser from
+     * the file extension.
+     *
+     * @param string $path the config file path
+     * @throws RuntimeException when the file does not exist or has an unsupported extension
+     */
+    private function loadFile(string $path): void
+    {
+        if (!$this->fs->exists($path)) {
+            throw new RuntimeException("Configuration file not found: $path");
+        }
+
+        $this->config = match (pathinfo($path, PATHINFO_EXTENSION)) {
+            'yaml', 'yml' => Yaml::parse($this->fs->read($path)) ?? [],
+            'json' => json_decode($this->fs->read($path), true) ?? [],
+            'php' => $this->fs->requirePhp($path),
+            default => throw new RuntimeException("Unsupported configuration file type: $path"),
+        };
     }
 
     /**

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -28,6 +28,8 @@ use PhpSpec\Loader;
 use PhpSpec\Runner;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @internal
@@ -36,6 +38,39 @@ use Symfony\Component\Console\Command\Command;
  */
 final class Application extends BaseApplication
 {
+    /** @var array<int, string> raw argv tokens, used to resolve --config before commands are built */
+    private readonly array $argv;
+
+    /**
+     * @param string $version the application version
+     * @param array<int, string>|null $argv raw argv tokens; defaults to the process argv (in-process runners pass their own)
+     */
+    public function __construct(string $version = 'UNKNOWN', ?array $argv = null)
+    {
+        $globalArgv = $_SERVER['argv'] ?? null;
+        $this->argv = $argv ?? (is_array($globalArgv) ? $globalArgv : []);
+
+        parent::__construct($version);
+    }
+
+    /**
+     * Adds the application-level --config option so every command accepts it.
+     *
+     * @return InputDefinition the default input definition
+     */
+    public function getDefaultInputDefinition(): InputDefinition
+    {
+        $definition = parent::getDefaultInputDefinition();
+        $definition->addOption(new InputOption(
+            'config',
+            'c',
+            InputOption::VALUE_REQUIRED,
+            'Path to a phpspec configuration file (overrides the working directory lookup)',
+        ));
+
+        return $definition;
+    }
+
     /**
      * Returns the default commands including the PhpSpec run and describe commands.
      *
@@ -43,7 +78,7 @@ final class Application extends BaseApplication
      */
     public function getDefaultCommands(): array
     {
-        $config = new Configuration('.');
+        $config = new Configuration('.', configFile: Configuration::configPathFromArgv($this->argv));
 
         $config->registerAutoloaders();
         $extensionLoader = new ExtensionLoader($config);

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -18,6 +18,7 @@ use DOMException;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Run\CodeGenerator;
 use PhpSpec\Console\Command\Run\CoverageReporter;
+use PhpSpec\Coverage\CoverageOptions;
 use PhpSpec\Extensions\ExtensionLoader;
 use PhpSpec\Extensions\FormatterBridge;
 use PhpSpec\Loader;
@@ -44,6 +45,9 @@ use Symfony\Component\Console\Output\OutputInterface as Output;
  */
 final class Run extends Command
 {
+    /** @var array<int, string> partial coverage state files written by parallel workers */
+    private array $coveragePartials = [];
+
     /**
      * @param Loader $loader the spec/feature file loader
      * @param Runner $runner the spec runner
@@ -77,6 +81,7 @@ final class Run extends Command
             ->addOption('stop-on-skipped', null, Option::VALUE_NONE, 'Stop on first skipped example')
             ->addOption('stop-on-problems', null, Option::VALUE_NONE, 'Stop on any non-pass result')
             ->addOption('filter', null, Option::VALUE_REQUIRED, 'Run only specs matching pattern')
+            ->addOption('paths-from', null, Option::VALUE_REQUIRED, 'Read spec/feature paths to run from a file, one per line')
             ->addOption('format', 'f', Option::VALUE_REQUIRED, 'Output format (pretty, dot, tap, junit)', 'pretty')
             ->addOption('order', null, Option::VALUE_REQUIRED, 'Run order (default, random)', 'default')
             ->addOption('seed', null, Option::VALUE_REQUIRED, 'Seed for random order')
@@ -89,6 +94,9 @@ final class Run extends Command
             ->addOption('coverage-clover', null, Option::VALUE_REQUIRED, 'Generate Clover XML coverage report to file')
             ->addOption('coverage-html', null, Option::VALUE_REQUIRED, 'Generate HTML coverage report to directory')
             ->addOption('coverage-min', null, Option::VALUE_REQUIRED, 'Fail if coverage is below this percentage')
+            ->addOption('coverage-json', null, Option::VALUE_REQUIRED, 'Generate JSON coverage report with per-example detail, for mutation testing tools (experimental)')
+            ->addOption('coverage-src', null, Option::VALUE_REQUIRED, 'Source directory to scope coverage reports to (overrides config src_path)')
+            ->addOption('coverage-partial', null, Option::VALUE_REQUIRED, 'Dump raw coverage state to a file (internal, used by parallel workers)')
             ->addOption('parallel', null, Option::VALUE_OPTIONAL, 'Run specs in parallel processes (--parallel=N for N workers)', false)
             ->setDescription('Runs specifications');
     }
@@ -115,7 +123,8 @@ final class Run extends Command
      * 6. If --profile was given, prints the N slowest examples with their durations.
      *
      * 7. If coverage was collected, stops collection and renders reports (text,
-     *    clover XML, HTML). Enforces --coverage-min threshold, returning code 2
+     *    clover XML, HTML, JSON). In parallel runs, worker partial states are
+     *    merged first. Enforces --coverage-min threshold, returning code 2
      *    if coverage is below the minimum.
      *
      * 8. Runs interactive code generation: scans results for missing types, undefined
@@ -138,6 +147,14 @@ final class Run extends Command
             return 1;
         }
         $this->registerAutoloader();
+
+        $pathsFrom = $input->getOption('paths-from');
+
+        if ($pathsFrom !== null && !is_file($pathsFrom)) {
+            $output->writeln("<fg=red>Paths file not found: $pathsFrom</>");
+
+            return 1;
+        }
 
         $coverageReporter = $this->startCoverage($input, $output);
 
@@ -203,20 +220,39 @@ final class Run extends Command
      */
     private function startCoverage(Input $input, Output $output): CoverageReporter|null|false
     {
-        $wantsCoverage = $input->getOption('coverage')
-            || $input->getOption('coverage-clover')
-            || $input->getOption('coverage-html')
-            || $input->getOption('coverage-min') !== null;
-
-        if (!$wantsCoverage) {
+        if (!$this->wantsCoverage($input)) {
             return null;
         }
 
+        // Parallel runs also collect per example: workers dump raw per-example
+        // state and the parent merges it, which serves every report format.
+        $perExample = $input->getOption('coverage-json') !== null
+            || $input->getOption('coverage-partial') !== null
+            || $input->getOption('parallel') !== false;
+
         $reporter = new CoverageReporter();
-        if (!$reporter->start($output)) {
+
+        if (!$reporter->start($output, perExample: $perExample)) {
             return false;
         }
+
         return $reporter;
+    }
+
+    /**
+     * Checks whether any coverage option was given.
+     *
+     * @param Input $input the console input to check coverage options
+     * @return bool true if any coverage report or the partial dump was requested
+     */
+    private function wantsCoverage(Input $input): bool
+    {
+        return $input->getOption('coverage')
+            || $input->getOption('coverage-clover')
+            || $input->getOption('coverage-html')
+            || $input->getOption('coverage-json')
+            || $input->getOption('coverage-partial')
+            || $input->getOption('coverage-min') !== null;
     }
 
     /**
@@ -238,6 +274,13 @@ final class Run extends Command
         if ($parallel !== false && is_string($parallel) && !ctype_digit($parallel)) {
             $paths[] = $parallel;
             $input->setOption('parallel', null);
+        }
+
+        $pathsFrom = $input->getOption('paths-from');
+
+        if ($pathsFrom !== null) {
+            $listed = file($pathsFrom, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            $paths = array_merge($paths, array_filter(array_map('trim', $listed ?: [])));
         }
 
         if (!empty($paths)) {
@@ -285,15 +328,35 @@ final class Run extends Command
                     $paths[] = $spec->getPath();
                 }
             }
-            $parallelRunner = new ParallelRunner($paths, $workers, $stop);
+
+            $coveragePartialDir = $this->wantsCoverage($input)
+                ? sys_get_temp_dir() . '/phpspec_coverage_' . uniqid()
+                : null;
+
+            // --config is defined at the application level, absent when the
+            // command runs standalone (e.g. under CommandTester)
+            $configPath = $input->hasOption('config') ? $input->getOption('config') : null;
+
+            $parallelRunner = new ParallelRunner(
+                $paths,
+                $workers,
+                $stop,
+                coveragePartialDir: $coveragePartialDir,
+                configPath: $configPath,
+            );
             $stream = $parallelRunner->stream();
         } else {
+            $parallelRunner = null;
             $stream = $this->runner->stream($suite, $stop, $seed);
         }
 
         foreach ($stream as $result) {
             $formatter->printResult($result);
             $accumulated[] = $result;
+        }
+
+        if ($parallelRunner !== null) {
+            $this->coveragePartials = $parallelRunner->getCoveragePartials();
         }
 
         $results = new SuiteResult($accumulated);
@@ -374,14 +437,20 @@ final class Run extends Command
      */
     private function reportCoverage(Input $input, Output $output, CoverageReporter $reporter): ?int
     {
-        return $reporter->report(
-            $output,
-            $this->config->getSrcPath(),
-            (bool) $input->getOption('coverage'),
-            $input->getOption('coverage-clover'),
-            $input->getOption('coverage-html'),
-            $input->getOption('coverage-min'),
-        );
+        if ($this->coveragePartials !== []) {
+            $reporter->mergePartials($this->coveragePartials);
+            $this->coveragePartials = [];
+        }
+
+        return $reporter->report($output, new CoverageOptions(
+            srcPath: $input->getOption('coverage-src') ?? $this->config->getSrcPath(),
+            showText: (bool) $input->getOption('coverage'),
+            cloverPath: $input->getOption('coverage-clover'),
+            htmlPath: $input->getOption('coverage-html'),
+            jsonPath: $input->getOption('coverage-json'),
+            coverageMin: $input->getOption('coverage-min'),
+            partialPath: $input->getOption('coverage-partial'),
+        ));
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Run/CoverageReporter.php
+++ b/src/PhpSpec/Console/Command/Run/CoverageReporter.php
@@ -17,14 +17,24 @@ namespace PhpSpec\Console\Command\Run;
 use DOMException;
 use PhpSpec\Coverage\CloverReport;
 use PhpSpec\Coverage\CoverageCollector;
+use PhpSpec\Coverage\CoverageOptions;
+use PhpSpec\Coverage\CoverageRegistry;
+use PhpSpec\Coverage\Driver\XdebugDriver;
 use PhpSpec\Coverage\HtmlReport;
+use PhpSpec\Coverage\JsonReport;
+use PhpSpec\Coverage\JsonReportBuilder;
+use PhpSpec\Coverage\PerExampleCollector;
 use PhpSpec\Coverage\TextReport;
+use PhpSpec\RealFilesystem;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 
 /**
  * @internal
- * Manages the complete code coverage lifecycle: availability check, collection start/stop,
- * report rendering (text, Clover XML, HTML), and minimum threshold enforcement.
+ * Manages the complete code coverage lifecycle: availability check, collection
+ * start/stop, report rendering (text, Clover XML, HTML, JSON), and minimum
+ * threshold enforcement. Collection runs in one of two modes: whole-suite
+ * (one aggregate collection around the entire run) or per-example (the runner
+ * cycles collection around each example so coverage can be attributed to it).
  */
 final class CoverageReporter
 {
@@ -33,76 +43,196 @@ final class CoverageReporter
     /**
      * Checks Xdebug availability and starts coverage collection.
      *
+     * In per-example mode no collection is started here; instead a collector
+     * is activated in the CoverageRegistry and the runner cycles it around
+     * each example.
+     *
      * @param Output $output the console output for error messages
+     * @param bool $perExample whether to collect coverage per example
      * @return bool true if collection started, false if unavailable
      */
-    public function start(Output $output): bool
+    public function start(Output $output, bool $perExample = false): bool
     {
         if (!CoverageCollector::isAvailable()) {
             $output->writeln('<fg=red>Code coverage requires Xdebug with coverage mode enabled</>');
+
             return false;
         }
+
+        if ($perExample) {
+            CoverageRegistry::activate(new PerExampleCollector(new XdebugDriver()));
+
+            return true;
+        }
+
         $this->collector = new CoverageCollector();
         $this->collector->start();
+
         return true;
     }
 
     /**
      * Stops collection and renders all requested coverage reports.
      *
+     * When a per-example collector is active and a partial path is set (the
+     * parallel worker case), the raw collector state is dumped there instead
+     * of rendering any report.
+     *
      * @param Output $output the console output
-     * @param string $srcPath the source directory to filter coverage data
-     * @param bool $showText whether to render the text coverage report
-     * @param string|null $cloverPath path for Clover XML report, or null to skip
-     * @param string|null $htmlPath directory for HTML report, or null to skip
-     * @param string|null $coverageMin minimum coverage percentage threshold, or null to skip
+     * @param CoverageOptions $options the requested reports and their destinations
      * @return int|null returns 1 if below minimum threshold, null otherwise
      * @throws DOMException
      */
-    public function report(
-        Output $output,
-        string $srcPath,
-        bool $showText,
-        ?string $cloverPath,
-        ?string $htmlPath,
-        ?string $coverageMin,
-    ): ?int {
+    public function report(Output $output, CoverageOptions $options): ?int
+    {
+        $perExampleCollector = CoverageRegistry::collector();
+
+        if ($perExampleCollector !== null) {
+            CoverageRegistry::reset();
+
+            if ($options->partialPath !== null) {
+                $this->writePartial($perExampleCollector, $options->partialPath);
+
+                return null;
+            }
+
+            $covData = CoverageCollector::filterData($perExampleCollector->getAggregate(), $options->srcPath);
+
+            if ($options->jsonPath !== null) {
+                $this->renderJson($output, $perExampleCollector, $options->srcPath, $options->jsonPath);
+            }
+
+            return $this->renderReports($output, $covData, $options);
+        }
+
         if ($this->collector === null) {
             return null;
         }
 
         $this->collector->stop();
-        $covData = $this->collector->filter($srcPath);
+        $covData = $this->collector->filter($options->srcPath);
 
-        if ($showText) {
+        return $this->renderReports($output, $covData, $options);
+    }
+
+    /**
+     * Merges partial collector state files produced by parallel workers into
+     * the active per-example collector, removing each file once applied.
+     *
+     * @param array<int, string> $paths partial state file paths written by workers
+     */
+    public function mergePartials(array $paths): void
+    {
+        $collector = CoverageRegistry::collector();
+
+        if ($collector === null) {
+            return;
+        }
+
+        foreach ($paths as $path) {
+            if (!is_file($path)) {
+                continue;
+            }
+
+            $state = json_decode((string) file_get_contents($path), true);
+
+            if (is_array($state)) {
+                $collector->applyState($state);
+            }
+
+            unlink($path);
+        }
+    }
+
+    /**
+     * Dumps the raw collector state as JSON for the parent process to merge.
+     *
+     * @param PerExampleCollector $collector the collector holding this worker's coverage
+     * @param string $partialPath the file path to write the state to
+     */
+    private function writePartial(PerExampleCollector $collector, string $partialPath): void
+    {
+        $dir = dirname($partialPath);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        file_put_contents($partialPath, json_encode($collector->toArray()));
+    }
+
+    /**
+     * Builds and writes the JSON coverage report from the per-example collection.
+     *
+     * @param Output $output the console output
+     * @param PerExampleCollector $collector the collector holding per-example coverage
+     * @param string $srcPath the source directory to scope the report to
+     * @param string $jsonPath the file path to write the JSON report to
+     */
+    private function renderJson(Output $output, PerExampleCollector $collector, string $srcPath, string $jsonPath): void
+    {
+        $realSrcPath = realpath($srcPath);
+        $projectRoot = getcwd();
+
+        $report = (new JsonReportBuilder(new RealFilesystem()))->build(
+            $collector,
+            $realSrcPath !== false ? $realSrcPath : $srcPath,
+            $projectRoot !== false ? $projectRoot : '.',
+        );
+        (new JsonReport())->render($report['tests'], $report['sources'], $jsonPath);
+
+        $output->writeln("  JSON coverage report: $jsonPath");
+    }
+
+    /**
+     * Renders the text, Clover and HTML reports and enforces the minimum
+     * coverage threshold.
+     *
+     * @param Output $output the console output
+     * @param array<string, array<int, int>> $covData filtered coverage data, relative file paths mapped to line hits
+     * @param CoverageOptions $options the requested reports and their destinations
+     * @return int|null returns 1 if below minimum threshold, null otherwise
+     * @throws DOMException
+     */
+    private function renderReports(Output $output, array $covData, CoverageOptions $options): ?int
+    {
+        if ($options->showText) {
             (new TextReport())->render($covData, $output);
         }
-        if ($cloverPath !== null) {
-            (new CloverReport())->render($covData, $cloverPath);
-            $output->writeln("  Clover report: $cloverPath");
+
+        if ($options->cloverPath !== null) {
+            (new CloverReport())->render($covData, $options->cloverPath);
+            $output->writeln("  Clover report: {$options->cloverPath}");
         }
-        if ($htmlPath !== null) {
-            (new HtmlReport())->render($covData, $htmlPath);
-            $output->writeln("  HTML report: $htmlPath/index.html");
+
+        if ($options->htmlPath !== null) {
+            (new HtmlReport())->render($covData, $options->htmlPath);
+            $output->writeln("  HTML report: {$options->htmlPath}/index.html");
         }
-        if ($coverageMin !== null) {
+
+        if ($options->coverageMin !== null) {
             $totalCovered = 0;
             $totalExecutable = 0;
+
             foreach ($covData as $lines) {
                 $counts = CoverageCollector::countLines($lines);
                 $totalCovered += $counts['covered'];
                 $totalExecutable += $counts['executable'];
             }
+
             $pct = $totalExecutable > 0 ? ($totalCovered / $totalExecutable) * 100 : 0;
-            $min = (float) $coverageMin;
+            $min = (float) $options->coverageMin;
+
             if ($pct < $min) {
                 $output->writeln(sprintf(
                     '<fg=red>Code coverage %.1f%% is below the required %.1f%%</>',
                     $pct,
                     $min,
                 ));
+
                 return 1;
             }
+
             $output->writeln(sprintf('<fg=green>Code coverage %.1f%% meets the required %.1f%%</>', $pct, $min));
         }
 

--- a/src/PhpSpec/Coverage/CoverageCollector.php
+++ b/src/PhpSpec/Coverage/CoverageCollector.php
@@ -118,7 +118,8 @@ final class CoverageCollector
 
     /**
      * Filters raw coverage data to only include files under the given source path.
-     * Returns relative paths sorted alphabetically.
+     * Returns relative paths sorted alphabetically, using forward slashes on
+     * every platform (Xdebug and realpath() report backslash paths on Windows).
      *
      * @param array<string, array<int, int>> $data raw coverage data keyed by absolute file path
      * @param string $srcPath the source directory path to filter by
@@ -131,11 +132,13 @@ final class CoverageCollector
         if ($realSrcPath === false) {
             return [];
         }
-        $realSrcPath = rtrim($realSrcPath, '/') . '/';
+        $realSrcPath = rtrim(str_replace('\\', '/', $realSrcPath), '/') . '/';
 
         $filtered = [];
 
         foreach ($data as $file => $lines) {
+            $file = str_replace('\\', '/', $file);
+
             if (str_starts_with($file, $realSrcPath)
                 && !str_contains($file, "eval()'d code")
             ) {

--- a/src/PhpSpec/Coverage/CoverageCollector.php
+++ b/src/PhpSpec/Coverage/CoverageCollector.php
@@ -24,6 +24,9 @@ final class CoverageCollector
     /** @var array<string, array<int, int>> raw coverage data keyed by file path */
     private array $data = [];
 
+    /** @var bool whether a whole-suite collection is currently in progress */
+    private static bool $collecting = false;
+
     /**
      * Checks whether Xdebug is loaded with coverage mode enabled.
      *
@@ -36,10 +39,23 @@ final class CoverageCollector
     }
 
     /**
+     * Checks whether a whole-suite collection is currently in progress.
+     * Xdebug coverage state is process-global, so cycling it (as the
+     * per-example driver does) would clobber a live whole-suite collection.
+     *
+     * @return bool true if a collection has been started and not yet stopped
+     */
+    public static function isCollecting(): bool
+    {
+        return self::$collecting;
+    }
+
+    /**
      * Starts Xdebug code coverage collection with unused and dead code analysis.
      */
     public function start(): void
     {
+        self::$collecting = true;
         xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
     }
 
@@ -50,6 +66,7 @@ final class CoverageCollector
     {
         $this->data = xdebug_get_code_coverage();
         xdebug_stop_code_coverage();
+        self::$collecting = false;
     }
 
     /**
@@ -96,14 +113,29 @@ final class CoverageCollector
      */
     public function filter(string $srcPath): array
     {
+        return self::filterData($this->data, $srcPath);
+    }
+
+    /**
+     * Filters raw coverage data to only include files under the given source path.
+     * Returns relative paths sorted alphabetically.
+     *
+     * @param array<string, array<int, int>> $data raw coverage data keyed by absolute file path
+     * @param string $srcPath the source directory path to filter by
+     * @return array<string, array<int, int>> relative file paths mapped to line-level hit counts
+     */
+    public static function filterData(array $data, string $srcPath): array
+    {
         $realSrcPath = realpath($srcPath);
+
         if ($realSrcPath === false) {
             return [];
         }
         $realSrcPath = rtrim($realSrcPath, '/') . '/';
 
         $filtered = [];
-        foreach ($this->data as $file => $lines) {
+
+        foreach ($data as $file => $lines) {
             if (str_starts_with($file, $realSrcPath)
                 && !str_contains($file, "eval()'d code")
             ) {

--- a/src/PhpSpec/Coverage/CoverageDriver.php
+++ b/src/PhpSpec/Coverage/CoverageDriver.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Coverage;
+
+/**
+ * @internal
+ * Abstracts the underlying line coverage engine so collectors can be
+ * exercised in specs without a live Xdebug extension.
+ */
+interface CoverageDriver
+{
+    /**
+     * Starts a fresh line coverage collection cycle.
+     */
+    public function start(): void;
+
+    /**
+     * Stops the current collection cycle and returns the collected data.
+     *
+     * @return array<string, array<int, int>> file paths mapped to line-level hit counts
+     */
+    public function stop(): array;
+}

--- a/src/PhpSpec/Coverage/CoverageOptions.php
+++ b/src/PhpSpec/Coverage/CoverageOptions.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Coverage;
+
+/**
+ * @internal
+ * Value object describing which coverage reports were requested and where
+ * they should be written, resolved from the run command CLI options.
+ */
+final readonly class CoverageOptions
+{
+    /**
+     * @param string $srcPath the source directory to scope the reports to
+     * @param bool $showText whether to render the text coverage report
+     * @param string|null $cloverPath path for the Clover XML report, or null to skip
+     * @param string|null $htmlPath directory for the HTML report, or null to skip
+     * @param string|null $jsonPath path for the JSON coverage report, or null to skip
+     * @param string|null $coverageMin minimum coverage percentage threshold, or null to skip
+     * @param string|null $partialPath path to dump raw collector state to instead of rendering reports; used internally by parallel workers
+     */
+    public function __construct(
+        public string $srcPath,
+        public bool $showText = false,
+        public ?string $cloverPath = null,
+        public ?string $htmlPath = null,
+        public ?string $jsonPath = null,
+        public ?string $coverageMin = null,
+        public ?string $partialPath = null,
+    ) {}
+}

--- a/src/PhpSpec/Coverage/CoverageRegistry.php
+++ b/src/PhpSpec/Coverage/CoverageRegistry.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Coverage;
+
+/**
+ * @internal
+ * Holds the active per-example coverage collector for the current run.
+ * The runner consults this registry at example boundaries; when no collector
+ * is active (the normal case) those consultations are no-ops.
+ */
+final class CoverageRegistry
+{
+    private static ?PerExampleCollector $collector = null;
+
+    /**
+     * Activates per-example coverage collection for the current run.
+     *
+     * @param PerExampleCollector $collector the collector to notify at example boundaries
+     */
+    public static function activate(PerExampleCollector $collector): void
+    {
+        self::$collector = $collector;
+    }
+
+    /**
+     * Returns the active collector, or null when per-example coverage is off.
+     */
+    public static function collector(): ?PerExampleCollector
+    {
+        return self::$collector;
+    }
+
+    /**
+     * Deactivates per-example coverage collection.
+     */
+    public static function reset(): void
+    {
+        self::$collector = null;
+    }
+}

--- a/src/PhpSpec/Coverage/Driver/XdebugDriver.php
+++ b/src/PhpSpec/Coverage/Driver/XdebugDriver.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Coverage\Driver;
+
+use PhpSpec\Coverage\CoverageDriver;
+
+/**
+ * @internal
+ * Xdebug-backed coverage driver. Each start()/stop() pair is a fresh
+ * collection cycle, including unused and dead code analysis so that
+ * executable-but-unexecuted lines are reported.
+ * Requires Xdebug with coverage mode enabled.
+ */
+final class XdebugDriver implements CoverageDriver
+{
+    /**
+     * Starts a fresh Xdebug coverage collection cycle with unused and
+     * dead code analysis.
+     */
+    public function start(): void
+    {
+        xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+    }
+
+    /**
+     * Stops the current Xdebug collection cycle and returns the collected data.
+     *
+     * @return array<string, array<int, int>> file paths mapped to line-level hit counts
+     */
+    public function stop(): array
+    {
+        $data = xdebug_get_code_coverage();
+        xdebug_stop_code_coverage();
+
+        return $data;
+    }
+}

--- a/src/PhpSpec/Coverage/JsonReport.php
+++ b/src/PhpSpec/Coverage/JsonReport.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Coverage;
+
+use RuntimeException;
+
+/**
+ * @internal
+ * Renders a machine-readable JSON code coverage report designed for mutation
+ * testing tools such as Infection. The document maps each source line to the
+ * examples that cover it, and records per-example timing, memory usage and
+ * source/spec file checksums. The schema is experimental (version 1).
+ */
+final class JsonReport
+{
+    /**
+     * Renders the coverage data as a version 1 JSON document and writes it
+     * to the specified file path. Creates parent directories if they do not exist.
+     *
+     * @param array<string, array{time: float, memory: int, spec_file: string, spec_checksum: string}> $tests per-example metadata keyed by test identifier
+     * @param array<string, array{checksum: string, lines: array<int, array<int, string>>}> $sources per-file checksums and line-to-test-identifier coverage, keyed by relative file path
+     * @param string $filePath the absolute path to write the JSON file to
+     * @throws RuntimeException when the document cannot be encoded as JSON
+     */
+    public function render(array $tests, array $sources, string $filePath): void
+    {
+        $document = [
+            'version' => 1,
+            'tests' => $tests,
+            'sources' => $sources,
+        ];
+
+        $json = json_encode($document, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            throw new RuntimeException('Failed to encode coverage data as JSON: ' . json_last_error_msg());
+        }
+
+        $dir = dirname($filePath);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        file_put_contents($filePath, $json);
+    }
+}

--- a/src/PhpSpec/Coverage/JsonReportBuilder.php
+++ b/src/PhpSpec/Coverage/JsonReportBuilder.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Coverage;
+
+use PhpSpec\Filesystem;
+
+/**
+ * @internal
+ * Assembles the data for the JSON coverage report from a per-example
+ * collection: filters covered files down to the source path, relativizes
+ * paths against the project root, and adds source/spec file checksums so
+ * consumers can detect stale coverage data.
+ */
+final class JsonReportBuilder
+{
+    public function __construct(private readonly Filesystem $filesystem) {}
+
+    /**
+     * Builds the tests and sources sections of the JSON coverage report.
+     *
+     * @param PerExampleCollector $collector the collector holding per-example coverage
+     * @param string $srcPath absolute path to the source directory to include
+     * @param string $projectRoot absolute path to the project root used to relativize paths
+     * @return array{tests: array<string, array{time: float, memory: int, spec_file: string, spec_checksum: string}>, sources: array<string, array{checksum: string, lines: array<int, array<int, string>>}>}
+     */
+    public function build(PerExampleCollector $collector, string $srcPath, string $projectRoot): array
+    {
+        return [
+            'tests' => $this->buildTests($collector->getTests()),
+            'sources' => $this->buildSources($collector->getLines(), $srcPath, $projectRoot),
+        ];
+    }
+
+    /**
+     * Adds a content checksum of each spec file to the per-test metadata.
+     *
+     * @param array<string, array{time: float, memory: int, spec_file: string}> $tests per-test metadata keyed by test identifier
+     * @return array<string, array{time: float, memory: int, spec_file: string, spec_checksum: string}>
+     */
+    private function buildTests(array $tests): array
+    {
+        $checksums = [];
+        $result = [];
+
+        foreach ($tests as $testId => $test) {
+            $specFile = $test['spec_file'];
+            $checksums[$specFile] ??= md5($this->filesystem->read($specFile));
+            $result[$testId] = $test + ['spec_checksum' => $checksums[$specFile]];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Filters covered files down to the source path, relativizes them against
+     * the project root and pairs each with a content checksum.
+     *
+     * @param array<string, array<int, array<int, string>>> $lines file path => line number => test identifiers
+     * @param string $srcPath absolute path to the source directory to include
+     * @param string $projectRoot absolute path to the project root used to relativize paths
+     * @return array<string, array{checksum: string, lines: array<int, array<int, string>>}>
+     */
+    private function buildSources(array $lines, string $srcPath, string $projectRoot): array
+    {
+        $srcPrefix = rtrim($srcPath, '/') . '/';
+        $rootPrefix = rtrim($projectRoot, '/') . '/';
+        $sources = [];
+
+        foreach ($lines as $file => $fileLines) {
+            if (!str_starts_with($file, $srcPrefix) || str_contains($file, "eval()'d code")) {
+                continue;
+            }
+
+            $relative = str_starts_with($file, $rootPrefix) ? substr($file, strlen($rootPrefix)) : $file;
+            $sources[$relative] = [
+                'checksum' => md5($this->filesystem->read($file)),
+                'lines' => $fileLines,
+            ];
+        }
+
+        ksort($sources);
+
+        return $sources;
+    }
+}

--- a/src/PhpSpec/Coverage/JsonReportBuilder.php
+++ b/src/PhpSpec/Coverage/JsonReportBuilder.php
@@ -65,7 +65,9 @@ final class JsonReportBuilder
 
     /**
      * Filters covered files down to the source path, relativizes them against
-     * the project root and pairs each with a content checksum.
+     * the project root and pairs each with a content checksum. Paths are
+     * normalised to forward slashes on every platform (Xdebug and realpath()
+     * report backslash paths on Windows).
      *
      * @param array<string, array<int, array<int, string>>> $lines file path => line number => test identifiers
      * @param string $srcPath absolute path to the source directory to include
@@ -74,16 +76,18 @@ final class JsonReportBuilder
      */
     private function buildSources(array $lines, string $srcPath, string $projectRoot): array
     {
-        $srcPrefix = rtrim($srcPath, '/') . '/';
-        $rootPrefix = rtrim($projectRoot, '/') . '/';
+        $srcPrefix = rtrim(str_replace('\\', '/', $srcPath), '/') . '/';
+        $rootPrefix = rtrim(str_replace('\\', '/', $projectRoot), '/') . '/';
         $sources = [];
 
         foreach ($lines as $file => $fileLines) {
-            if (!str_starts_with($file, $srcPrefix) || str_contains($file, "eval()'d code")) {
+            $normalized = str_replace('\\', '/', $file);
+
+            if (!str_starts_with($normalized, $srcPrefix) || str_contains($normalized, "eval()'d code")) {
                 continue;
             }
 
-            $relative = str_starts_with($file, $rootPrefix) ? substr($file, strlen($rootPrefix)) : $file;
+            $relative = str_starts_with($normalized, $rootPrefix) ? substr($normalized, strlen($rootPrefix)) : $normalized;
             $sources[$relative] = [
                 'checksum' => md5($this->filesystem->read($file)),
                 'lines' => $fileLines,

--- a/src/PhpSpec/Coverage/PerExampleCollector.php
+++ b/src/PhpSpec/Coverage/PerExampleCollector.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Coverage;
+
+/**
+ * @internal
+ * Collects line coverage attributed to individual examples by cycling the
+ * coverage driver around each example run. Tracks the current spec file and
+ * context titles to build stable test identifiers of the form
+ * "spec/App/Calculator.spec.php::Calculator > adds two numbers".
+ */
+final class PerExampleCollector
+{
+    /** @var array<string, array<int, array<string, true>>> file path => line number => set of test identifiers */
+    private array $lines = [];
+
+    /** @var array<string, array<int, int>> line hit data merged across all cycles, in raw driver shape */
+    private array $aggregate = [];
+
+    /** @var array<string, array{time: float, memory: int, spec_file: string}> per-test metadata keyed by test identifier */
+    private array $tests = [];
+
+    private ?string $specPath = null;
+
+    /** @var array<int, string> stack of context titles for the currently running spec */
+    private array $contextTitles = [];
+
+    /** @var float example start time from hrtime(), in nanoseconds */
+    private float $startTime = 0.0;
+
+    public function __construct(private readonly CoverageDriver $driver) {}
+
+    /**
+     * Records the spec file that examples are about to run from.
+     * A leading "./" is stripped so test identifiers use clean relative paths.
+     *
+     * @param string $path the spec file path
+     */
+    public function beginSpec(string $path): void
+    {
+        $this->specPath = str_starts_with($path, './') ? substr($path, 2) : $path;
+        $this->contextTitles = [];
+    }
+
+    /**
+     * Pushes a describe/context title onto the current title stack.
+     *
+     * @param string $title the context title
+     */
+    public function pushContext(string $title): void
+    {
+        $this->contextTitles[] = $title;
+    }
+
+    /**
+     * Pops the innermost context title off the current title stack.
+     */
+    public function popContext(): void
+    {
+        array_pop($this->contextTitles);
+    }
+
+    /**
+     * Starts a coverage collection cycle for a single example, resetting the
+     * peak memory watermark and recording the start time.
+     */
+    public function beginExample(): void
+    {
+        memory_reset_peak_usage();
+        $this->startTime = hrtime(true);
+        $this->driver->start();
+    }
+
+    /**
+     * Stops the current collection cycle, attributes every executed line
+     * to the example identified by the current spec path, context titles and
+     * title, and records the example's duration and peak memory usage.
+     *
+     * @param string $title the example title
+     */
+    public function endExample(string $title): void
+    {
+        $data = $this->driver->stop();
+        $elapsed = (hrtime(true) - $this->startTime) / 1e9;
+        $testId = $this->testId($title);
+
+        $this->tests[$testId] = [
+            'time' => $elapsed,
+            'memory' => memory_get_peak_usage(),
+            'spec_file' => (string) $this->specPath,
+        ];
+
+        foreach ($data as $file => $lines) {
+            foreach ($lines as $lineNumber => $hit) {
+                if ($hit >= 1) {
+                    $this->lines[$file][$lineNumber][$testId] = true;
+                }
+                $this->aggregate[$file][$lineNumber] = max($this->aggregate[$file][$lineNumber] ?? $hit, $hit);
+            }
+        }
+    }
+
+    /**
+     * Returns executed lines mapped to the test identifiers that covered them.
+     *
+     * @return array<string, array<int, array<int, string>>> file path => line number => test identifiers
+     */
+    public function getLines(): array
+    {
+        $result = [];
+        foreach ($this->lines as $file => $lines) {
+            foreach ($lines as $lineNumber => $testIds) {
+                $result[$file][$lineNumber] = array_keys($testIds);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns line hit data merged across all example cycles, in the same
+     * shape as a whole-suite collection, so the text, Clover and HTML reports
+     * can be rendered from a per-example run.
+     *
+     * @return array<string, array<int, int>> file paths mapped to line-level hit counts
+     */
+    public function getAggregate(): array
+    {
+        return $this->aggregate;
+    }
+
+    /**
+     * Builds the stable test identifier for the currently running example.
+     *
+     * @param string $title the example title
+     * @return string identifier such as "spec/App/Calculator.spec.php::Calculator > adds two numbers"
+     */
+    private function testId(string $title): string
+    {
+        $titles = [...$this->contextTitles, $title];
+
+        return $this->specPath . '::' . implode(' > ', $titles);
+    }
+
+    /**
+     * Returns per-test timing, memory and spec file metadata.
+     *
+     * @return array<string, array{time: float, memory: int, spec_file: string}> metadata keyed by test identifier
+     */
+    public function getTests(): array
+    {
+        return $this->tests;
+    }
+
+    /**
+     * Exports the collector state for transfer between processes.
+     *
+     * @return array{tests: array<string, array{time: float, memory: int, spec_file: string}>, lines: array<string, array<int, array<int, string>>>, aggregate: array<string, array<int, int>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'tests' => $this->tests,
+            'lines' => $this->getLines(),
+            'aggregate' => $this->aggregate,
+        ];
+    }
+
+    /**
+     * Merges state exported by another collector (e.g. from a parallel worker)
+     * into this one. Line attributions are unioned without duplicates and
+     * aggregate hits are merged keeping the highest value per line.
+     *
+     * @param array{tests?: array<string, array{time: float, memory: int, spec_file: string}>, lines?: array<string, array<int, array<int, string>>>, aggregate?: array<string, array<int, int>>} $state state produced by toArray()
+     */
+    public function applyState(array $state): void
+    {
+        foreach ($state['tests'] ?? [] as $testId => $test) {
+            $this->tests[$testId] = $test;
+        }
+
+        foreach ($state['lines'] ?? [] as $file => $lines) {
+            foreach ($lines as $lineNumber => $testIds) {
+                foreach ($testIds as $testId) {
+                    $this->lines[$file][$lineNumber][$testId] = true;
+                }
+            }
+        }
+
+        foreach ($state['aggregate'] ?? [] as $file => $lines) {
+            foreach ($lines as $lineNumber => $hit) {
+                $this->aggregate[$file][$lineNumber] = max($this->aggregate[$file][$lineNumber] ?? $hit, $hit);
+            }
+        }
+    }
+}

--- a/src/PhpSpec/Coverage/PerExampleCollector.php
+++ b/src/PhpSpec/Coverage/PerExampleCollector.php
@@ -44,12 +44,15 @@ final class PerExampleCollector
 
     /**
      * Records the spec file that examples are about to run from.
-     * A leading "./" is stripped so test identifiers use clean relative paths.
+     * A leading "./" is stripped and backslashes are normalised to forward
+     * slashes, so test identifiers use the same clean relative paths on
+     * every platform.
      *
      * @param string $path the spec file path
      */
     public function beginSpec(string $path): void
     {
+        $path = str_replace('\\', '/', $path);
         $this->specPath = str_starts_with($path, './') ? substr($path, 2) : $path;
         $this->contextTitles = [];
     }

--- a/src/PhpSpec/InProcessRunner.php
+++ b/src/PhpSpec/InProcessRunner.php
@@ -16,6 +16,7 @@ namespace PhpSpec;
 
 use PhpSpec\Browser\BrowserRegistry;
 use PhpSpec\Console\Application;
+use PhpSpec\Coverage\CoverageRegistry;
 use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\Mock\Double;
 use PhpSpec\Mock\Expectation as MockExpectation;
@@ -53,6 +54,7 @@ final class InProcessRunner
         $savedAutoloaders = spl_autoload_functions();
         $savedStoryBDD = StoryBDDRegistry::saveState();
         $savedBrowser = BrowserRegistry::saveState();
+        $savedCoverage = CoverageRegistry::collector();
 
         // Reset for inner run — fresh Dispatcher for the nested Application
         DispatcherRegistry::reset();
@@ -63,12 +65,14 @@ final class InProcessRunner
         MockExpectation::$registry = [];
         StoryBDDRegistry::init();
         BrowserRegistry::reset();
+        CoverageRegistry::reset();
 
         $savedCwdStr = is_string($savedCwd) ? $savedCwd : $projectDir;
         chdir($projectDir);
 
         try {
-            $app = new Application('9.0.0');
+            $argv = preg_split('/\s+/', trim($args));
+            $app = new Application('9.0.0', $argv !== false ? $argv : []);
             $app->setAutoExit(false);
             $app->setCatchExceptions(true);
 
@@ -88,6 +92,12 @@ final class InProcessRunner
             MockExpectation::$registry = $savedRegistry;
             StoryBDDRegistry::restoreState($savedStoryBDD);
             BrowserRegistry::restoreState($savedBrowser);
+
+            if ($savedCoverage !== null) {
+                CoverageRegistry::activate($savedCoverage);
+            } else {
+                CoverageRegistry::reset();
+            }
 
             // Unregister any autoloaders added by the inner run
             $currentAutoloaders = spl_autoload_functions();

--- a/src/PhpSpec/Parallel/ParallelRunner.php
+++ b/src/PhpSpec/Parallel/ParallelRunner.php
@@ -31,20 +31,38 @@ final class ParallelRunner
     private readonly int $workers;
     private readonly string $phpspecBin;
 
+    /** @var array<int, string> partial coverage state files assigned to workers */
+    private array $coveragePartials = [];
+
     /**
      * @param string[] $paths spec file paths to run
      * @param int|null $workers number of worker processes (null = auto-detect CPU count)
      * @param StopConditions $stop conditions under which to halt early
      * @param string|null $phpspecBin absolute path to phpspec binary (null = auto-detect)
+     * @param string|null $coveragePartialDir directory for workers to dump raw coverage state to, or null to run without coverage
+     * @param string|null $configPath explicit config file path to forward to workers, or null to use the working directory lookup
      */
     public function __construct(
         private readonly array $paths,
         ?int $workers = null,
         private readonly StopConditions $stop = new StopConditions(),
         ?string $phpspecBin = null,
+        private readonly ?string $coveragePartialDir = null,
+        private readonly ?string $configPath = null,
     ) {
         $this->workers = max(1, $workers ?? self::detectCpuCount());
         $this->phpspecBin = $phpspecBin ?? self::findPhpspecBin();
+    }
+
+    /**
+     * Returns the partial coverage state files assigned to workers, for the
+     * parent process to merge once the stream has been fully consumed.
+     *
+     * @return array<int, string> partial state file paths
+     */
+    public function getCoveragePartials(): array
+    {
+        return $this->coveragePartials;
     }
 
     /**
@@ -68,8 +86,15 @@ final class ParallelRunner
         $processes = [];
         $fibers = [];
 
-        foreach ($partitions as $partition) {
-            $process = new WorkerProcess($partition, $this->phpspecBin);
+        foreach ($partitions as $i => $partition) {
+            $coveragePartial = null;
+
+            if ($this->coveragePartialDir !== null) {
+                $coveragePartial = $this->coveragePartialDir . '/partial-' . $i . '.json';
+                $this->coveragePartials[] = $coveragePartial;
+            }
+
+            $process = new WorkerProcess($partition, $this->phpspecBin, $coveragePartial, $this->configPath);
             $processes[] = $process;
 
             $fiber = new \Fiber(function () use ($process) {

--- a/src/PhpSpec/Parallel/WorkerProcess.php
+++ b/src/PhpSpec/Parallel/WorkerProcess.php
@@ -43,27 +43,52 @@ final class WorkerProcess
     /**
      * @param string[] $paths spec file paths to run in this worker
      * @param string $phpspecBin absolute path to the phpspec binary
+     * @param string|null $coveragePartial file path for the worker to dump raw coverage state to, or null to run without coverage
+     * @param string|null $configPath explicit config file path to forward to the worker, or null to use the working directory lookup
      */
     public function __construct(
         private readonly array $paths,
         private readonly string $phpspecBin,
+        private readonly ?string $coveragePartial = null,
+        private readonly ?string $configPath = null,
     ) {}
 
     /**
-     * Spawns the child phpspec process with non-blocking stdout/stderr pipes.
+     * Builds the child process command line. Coverage-enabled workers run with
+     * xdebug coverage mode and dump their raw coverage state to the partial path.
+     *
+     * @return list<string> the command and its arguments
      */
-    public function start(): void
+    public function buildCommand(): array
     {
-        $command = array_values([
+        $command = [
             PHP_BINARY,
-            '-d', 'xdebug.mode=off',
+            '-d', 'xdebug.mode=' . ($this->coveragePartial !== null ? 'coverage' : 'off'),
             $this->phpspecBin,
             'run',
             ...$this->paths,
             '-f', 'junit',
             '--no-ansi',
             '--no-interaction',
-        ]);
+        ];
+
+        if ($this->coveragePartial !== null) {
+            $command[] = '--coverage-partial=' . $this->coveragePartial;
+        }
+
+        if ($this->configPath !== null) {
+            $command[] = '--config=' . $this->configPath;
+        }
+
+        return array_values($command);
+    }
+
+    /**
+     * Spawns the child phpspec process with non-blocking stdout/stderr pipes.
+     */
+    public function start(): void
+    {
+        $command = $this->buildCommand();
 
         $descriptors = [
             0 => ['pipe', 'r'],

--- a/src/PhpSpec/Specification.php
+++ b/src/PhpSpec/Specification.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec;
 
+use PhpSpec\Coverage\CoverageRegistry;
 use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\EventDispatcher\Event\SpecificationFinished;
 use PhpSpec\EventDispatcher\Event\SpecificationStarted;
@@ -49,6 +50,7 @@ class Specification implements ExampleRegistry, SpecBlock
     public function run(): Results
     {
         DispatcherRegistry::dispatcher()->dispatch(new SpecificationStarted($this->path), SpecificationStarted::NAME);
+        CoverageRegistry::collector()?->beginSpec($this->path);
 
         // loads the specification file from the Subject constructor
         // so $this in the examples refers to Subject

--- a/src/PhpSpec/Specification/Context.php
+++ b/src/PhpSpec/Specification/Context.php
@@ -15,6 +15,7 @@
 namespace PhpSpec\Specification;
 
 use Closure;
+use PhpSpec\Coverage\CoverageRegistry;
 use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\EventDispatcher\Event\ContextRan;
 use PhpSpec\EventDispatcher\Event\ContextStarted;
@@ -111,6 +112,8 @@ class Context implements ExampleRegistry, SpecBlock
     public function run(): Results
     {
         $results = [];
+        CoverageRegistry::collector()?->pushContext($this->context);
+
         try {
             DispatcherRegistry::dispatcher()->dispatch(new ContextStarted($this->context), ContextStarted::NAME);
             DispatcherRegistry::dispatcher()->pushScope($this);
@@ -129,24 +132,15 @@ class Context implements ExampleRegistry, SpecBlock
                 if ($this->pending && ($block instanceof Context || $block instanceof Example)) {
                     $block->setPending(true);
                 }
+
                 if ($block instanceof Context) {
                     $block->setWorld($this->world);
                     $block->inheritHooks($this->beforeEachHooks, $this->afterEachHooks, $this->letBindings);
                 }
-                if ($block instanceof Example && !$block->isPending()) {
-                    $this->reapplyLets();
-                    foreach ($this->beforeEachHooks as $hook) {
-                        $hook(...$this->resolveClosureArgs($hook));
-                    }
-                    $this->world->__phpspec_let_mocks = $this->letMocks;
-                }
-                $result = $block->run();
-                if ($block instanceof Example && !$block->isPending()) {
-                    foreach ($this->afterEachHooks as $hook) {
-                        $hook(...$this->resolveClosureArgs($hook));
-                    }
-                }
-                $results[] = $result;
+
+                $results[] = $block instanceof Example && !$block->isPending()
+                    ? $this->runExampleWithHooks($block)
+                    : $block->run();
             }
 
             if (!$this->pending) {
@@ -161,10 +155,46 @@ class Context implements ExampleRegistry, SpecBlock
             $result->setError($error);
             $contextResult = new ContextResult($this->context, [$result]);
             $contextResult->setError($error);
+
             return $contextResult;
+        } finally {
+            CoverageRegistry::collector()?->popContext();
         }
+
         DispatcherRegistry::dispatcher()->dispatch(new ContextRan($this->context, $this), ContextRan::NAME);
+
         return new ContextResult($this->context, $results);
+    }
+
+    /**
+     * Runs a single example surrounded by its beforeEach/afterEach hooks and
+     * let bindings. When per-example coverage is active, the whole sequence
+     * (setup, example, teardown) is collected and attributed to the example,
+     * so that code exercised only during setup still counts as covered by it.
+     *
+     * @param Example $example the example to run
+     * @return Results the example result
+     * @throws ReflectionException
+     */
+    private function runExampleWithHooks(Example $example): Results
+    {
+        $coverage = CoverageRegistry::collector();
+        $coverage?->beginExample();
+
+        $this->reapplyLets();
+        foreach ($this->beforeEachHooks as $hook) {
+            $hook(...$this->resolveClosureArgs($hook));
+        }
+        $this->world->__phpspec_let_mocks = $this->letMocks;
+
+        $result = $example->run();
+
+        foreach ($this->afterEachHooks as $hook) {
+            $hook(...$this->resolveClosureArgs($hook));
+        }
+        $coverage?->endExample($result->getTitle());
+
+        return $result;
     }
 
     /**

--- a/src/PhpSpec/Specification/Example.php
+++ b/src/PhpSpec/Specification/Example.php
@@ -95,9 +95,9 @@ class Example implements ExampleResultRegistry, SpecBlock
      * Executes the example closure, dispatching lifecycle events, capturing
      * errors/warnings, and measuring execution duration.
      *
-     * @return Results ExampleResult containing match outcomes and metadata
+     * @return ExampleResult the match outcomes and metadata
      */
-    public function run(): Results
+    public function run(): ExampleResult
     {
         $subscriber = new ExampleSubscriber($this);
         DispatcherRegistry::dispatcher()->addSubscriber($subscriber);

--- a/src/PhpSpec/StoryBDD/Feature.php
+++ b/src/PhpSpec/StoryBDD/Feature.php
@@ -117,7 +117,7 @@ final readonly class Feature implements SpecBlock
                 }
                 $result = $this->runStep($step, $world, $collector);
                 $stepResults[] = $result;
-                if ($result->isFailure()) {
+                if ($result->isFailure() || $result->isSkipped()) {
                     $failed = true;
                 }
             }
@@ -130,7 +130,7 @@ final readonly class Feature implements SpecBlock
             }
             $result = $this->runStep($step, $world, $collector);
             $stepResults[] = $result;
-            if ($result->isFailure()) {
+            if ($result->isFailure() || $result->isSkipped()) {
                 $failed = true;
             }
         }


### PR DESCRIPTION
## What

Implements the coverage/CLI groundwork for mutation-testing (Infection) integration, as discussed in #1514. Targets the `9.0.0-beta.2` milestone.

### New: `--coverage-json=FILE` (experimental)

A machine-readable coverage report designed for tools that need to know **which example covers which source line**:

```json
{
    "version": 1,
    "tests": {
        "spec/App/Calculator.spec.php::Calculator > adds two numbers": {
            "time": 0.0021,
            "memory": 524288,
            "spec_file": "spec/App/Calculator.spec.php",
            "spec_checksum": "9b4f1af43ee97a2924b320db64067458"
        }
    },
    "sources": {
        "src/App/Calculator.php": {
            "checksum": "ac4a5f10068b3a275d47b87df2d78d59",
            "lines": {
                "9": ["spec/App/Calculator.spec.php::Calculator > adds two numbers"]
            }
        }
    }
}
```

- **Example-level granularity** — coverage is collected per example by cycling Xdebug around each one. The window includes `let`/`beforeEach`/`afterEach`, so code exercised only during setup still counts as covered by the example that ran it.
- **Per-test timing and peak memory** — for fastest-first ordering and timeout prediction.
- **MD5 checksums** of source and spec files — for stale-coverage detection.
- The schema is **experimental (`"version": 1`)** and will be iterated on with the Infection maintainers.

### New: parallel coverage

Coverage options now genuinely work with `--parallel` (previously the workers ran with `xdebug.mode=off`, silently producing near-empty reports). Workers run with coverage enabled and dump raw collector state via an internal `--coverage-partial` flag; the parent merges the partials, so **all** report formats (text, Clover, HTML, JSON) work in parallel runs.

### New CLI options

| Option | Purpose |
|---|---|
| `--coverage-json=FILE` | JSON coverage report (above) |
| `--coverage-src=DIR` | Scope coverage reports without a config file (overrides `src_path`) |
| `--paths-from=FILE` | Read spec/feature paths from a file, one per line — avoids ARG_MAX limits when tools pass large spec subsets |
| `-c, --config=FILE` | Explicit config file path (application-level, available on every command, forwarded to parallel workers). No working-directory magic — safe for concurrent processes in the same directory |

### Fixes along the way

- **Story runner**: a skipped step now skips the remaining steps of its scenario (Behat semantics). Previously subsequent steps kept executing and failed.
- `Example::run()` return type narrowed to `ExampleResult` (covariant).
- New `CoverageCollector::isCollecting()` guard prevents per-example cycling from clobbering a live whole-suite collection (Xdebug coverage state is process-global).

## Verification

Specs and stories run separately on every supported PHP version:

| PHP | Specs | Stories |
|---|---|---|
| 8.2.30 (no xdebug) | 1178 ✅ | 693 ✅ / 26 skipped |
| 8.3.16 | 1178 ✅ | 719 ✅ |
| 8.4.4 | 1178 ✅ | 719 ✅ |
| 8.5.3 (no xdebug) | 1178 ✅ | 693 ✅ / 26 skipped |

Coverage scenarios skip themselves cleanly where Xdebug is unavailable. PHPStan: no errors. php-cs-fixer: clean. Coverage gate: 90.1% (≥ 90 required). No runtime performance regression — the per-example hooks are null-check no-ops when coverage is off (specs 0.53s vs 0.64s baseline; stories 4.6s vs 4.2s baseline, +5 features).

## Docs

- `docs/cli.md`: new options, JSON schema reference, parallel coverage notes
- `docs/configuration.md`: `--config` behaviour

## Known limitations

- Coverage requires Xdebug with `xdebug.mode=coverage` (no PCOV yet — the new `CoverageDriver` interface leaves room for a `PcovDriver`).
- Code executed only in `beforeAll`/`afterAll` is not attributed to any example.
- The JSON schema may change before 9.0.0 stable, pending feedback on #1514.

Closes nothing yet — feedback on the report schema is welcome on #1514.
