### PR TITLE
Add ability to run single example|scenario (#1517)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,9 +18,11 @@ bin/phpspec run [files] [options]
 ```bash
 bin/phpspec run                                    # Run all specs in spec/
 bin/phpspec run spec/App/Calculator.spec.php        # Run a single spec
+bin/phpspec run spec/App/Calculator.spec.php:14     # Run the example at line 14
 bin/phpspec run spec/App/Console                    # Run all specs in a directory
 bin/phpspec run features/                           # Run all feature files
 bin/phpspec run features/greeting.feature           # Run a single feature
+bin/phpspec run features/greeting.feature:12        # Run the scenario at line 12
 ```
 
 ### `pair`
@@ -141,17 +143,37 @@ bin/phpspec run --format=junit > results.xml
 
 | Option | Description |
 |---|---|
-| `--filter=PATTERN` | Only run spec files whose path contains PATTERN |
+| `--filter=PATTERN` | Only run specs/scenarios whose file path, example title, or scenario title contains PATTERN |
 | `--stop-on-failure` | Stop execution after the first spec file with a failure or error |
 | `--order=ORDER` | Run order: `default` or `random` |
 | `--seed=SEED` | Seed for random ordering (for reproducibility) |
 
 ```bash
-bin/phpspec run --filter Calculator              # Only specs with "Calculator" in path
+bin/phpspec run --filter Calculator              # Path or title contains "Calculator"
+bin/phpspec run --filter "should be good"        # Example/scenario titles matching a phrase
+bin/phpspec run --filter "it should be good"     # Leading "it" on the filter is ignored
 bin/phpspec run --stop-on-failure                 # Stop on first failing spec
 bin/phpspec run --order random                    # Randomize spec order
 bin/phpspec run --order random --seed 42          # Reproducible random order
 ```
+
+Matching is a case-insensitive substring test. When a spec file's path matches,
+every example in it runs; otherwise only the examples whose title matches run.
+Feature files behave the same with scenario titles.
+
+#### Running a single example or scenario by line
+
+Append `:LINE` to a spec or feature path to run just the block at that line:
+
+```bash
+bin/phpspec run spec/App/Calculator.spec.php:14   # The example at line 14
+bin/phpspec run features/checkout.feature:12      # The scenario at line 12
+```
+
+Any line inside an example (or scenario) body selects it; a line inside a
+`describe` but outside its examples runs that whole context. For Gherkin,
+targeting a `Scenario Outline:` line runs every row of its examples table,
+while targeting a single examples row runs just that expansion.
 
 ### Bootstrap
 

--- a/features/scenarios/cli/cli-options.feature
+++ b/features/scenarios/cli/cli-options.feature
@@ -52,6 +52,157 @@ Feature: CLI options
     Then all examples should pass
     And the output should not contain "Excluded"
 
+  Scenario: Filter examples by title
+    Given a spec file "spec/App/Alpha.spec.php":
+      """
+      <?php
+      describe('Alpha', function () {
+          it('does the wanted thing', function () {
+              expect(true)->toBeTrue();
+          });
+          it('does another thing', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    And a spec file "spec/App/Beta.spec.php":
+      """
+      <?php
+      describe('Beta', function () {
+          it('does something else', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    When I run phpspec run with option "--filter wanted"
+    Then all examples should pass
+    And the output should contain "does the wanted thing"
+    And the output should not contain "another thing"
+    And the output should not contain "Beta"
+    And the output should contain "1 example"
+
+  Scenario: Filter scenarios by title
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/paths.feature":
+      """
+      Feature: Paths
+        Scenario: Wanted path
+          Given a noted step
+
+        Scenario: Other path
+          Given another noted step
+      """
+    And a step file "features/steps/paths.steps.php":
+      """
+      <?php
+      given("a noted step", function () {
+          expect(true)->toBeTrue();
+      });
+
+      given("another noted step", function () {
+          expect(true)->toBeTrue();
+      });
+      """
+    When I run phpspec run with option "--story --filter Wanted"
+    Then all steps should pass
+    And the output should contain "Wanted path"
+    And the output should not contain "Other path"
+    And the output should contain "1 scenario"
+
+  Scenario: Run a single example by its line number
+    Given a spec file "spec/App/Picky.spec.php":
+      """
+      <?php
+      describe('Picky', function () {
+          it('first example', function () {
+              expect(true)->toBeTrue();
+          });
+          it('second example', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    When I run phpspec run "spec/App/Picky.spec.php:6"
+    Then all examples should pass
+    And the output should contain "second example"
+    And the output should not contain "first example"
+    And the output should contain "1 example"
+
+  Scenario: Run a single example by a line inside its body
+    Given a spec file "spec/App/Inner.spec.php":
+      """
+      <?php
+      describe('Inner', function () {
+          it('first example', function () {
+              expect(true)->toBeTrue();
+          });
+          it('second example', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    When I run phpspec run "spec/App/Inner.spec.php:4"
+    Then all examples should pass
+    And the output should contain "first example"
+    And the output should not contain "second example"
+    And the output should contain "1 example"
+
+  Scenario: Run a single scenario by its line number
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/numbers.feature":
+      """
+      Feature: Two scenarios
+        Scenario: First
+          Given a noted step
+
+        Scenario: Second
+          Given another noted step
+      """
+    And a step file "features/steps/numbers.steps.php":
+      """
+      <?php
+      given("a noted step", function () {
+          expect(true)->toBeTrue();
+      });
+
+      given("another noted step", function () {
+          expect(true)->toBeTrue();
+      });
+      """
+    When I run phpspec run "features/numbers.feature:5"
+    Then all steps should pass
+    And the output should contain "Second"
+    And the output should not contain "First"
+    And the output should contain "1 scenario"
+
+  Scenario: Run a single scenario by a line inside its body
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/inner.feature":
+      """
+      Feature: Two scenarios
+        Scenario: First
+          Given a noted step
+
+        Scenario: Second
+          Given another noted step
+      """
+    And a step file "features/steps/inner.steps.php":
+      """
+      <?php
+      given("a noted step", function () {
+          expect(true)->toBeTrue();
+      });
+
+      given("another noted step", function () {
+          expect(true)->toBeTrue();
+      });
+      """
+    When I run phpspec run "features/inner.feature:3"
+    Then all steps should pass
+    And the output should contain "First"
+    And the output should not contain "Second"
+    And the output should contain "1 scenario"
+
   Scenario: Dot formatter
     Given a spec file "spec/App/DotFormat.spec.php":
       """

--- a/spec/PhpSpec/Console/Command/Run.spec.php
+++ b/spec/PhpSpec/Console/Command/Run.spec.php
@@ -93,6 +93,70 @@ describe(Run::class, function () {
             expect($tester->getStatusCode())->toBe(0);
         });
 
+        it('filters examples by title and hides specs left with no examples', function (Filesystem $execFs) {
+            $dir = sys_get_temp_dir() . '/phpspec_run_filter_' . uniqid();
+            mkdir($dir, 0777, true);
+            file_put_contents($dir . '/Alpha.spec.php', <<<'PHP'
+            <?php
+            describe('Alpha', function () {
+                it('does the wanted thing', function () { expect(true)->toBeTrue(); });
+                it('does another thing', function () { expect(true)->toBeTrue(); });
+            });
+            PHP);
+            file_put_contents($dir . '/Beta.spec.php', <<<'PHP'
+            <?php
+            describe('Beta', function () {
+                it('does something else', function () { expect(true)->toBeTrue(); });
+            });
+            PHP);
+
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader(), new Runner(), $config);
+
+            try {
+                $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+                $exitCode = $tester->execute(['files' => [$dir], '--filter' => 'wanted']);
+                $output = $tester->getDisplay();
+
+                expect($exitCode)->toBe(0);
+                expect($output)->toContain('does the wanted thing');
+                expect($output)->not()->toContain('another thing');
+                expect($output)->not()->toContain('Beta');
+            } finally {
+                unlink($dir . '/Alpha.spec.php');
+                unlink($dir . '/Beta.spec.php');
+                rmdir($dir);
+            }
+        });
+
+        it('runs a single example addressed by spec path and line', function (Filesystem $execFs) {
+            $dir = sys_get_temp_dir() . '/phpspec_run_line_' . uniqid();
+            mkdir($dir, 0777, true);
+            file_put_contents($dir . '/Picky.spec.php', <<<'PHP'
+            <?php
+            describe('Picky', function () {
+                it('first example', function () { expect(true)->toBeTrue(); });
+                it('second example', function () { expect(true)->toBeTrue(); });
+            });
+            PHP);
+
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader(), new Runner(), $config);
+
+            try {
+                $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+                $exitCode = $tester->execute(['files' => [$dir . '/Picky.spec.php:4']]);
+                $output = $tester->getDisplay();
+
+                expect($exitCode)->toBe(0);
+                expect($output)->toContain('second example');
+                expect($output)->not()->toContain('first example');
+            } finally {
+                unlink($dir . '/Picky.spec.php');
+                rmdir($dir);
+            }
+        });
+
         it('loads bootstrap file when specified', function (Filesystem $execFs) {
             $tmpBootstrap = tempnam(sys_get_temp_dir(), 'phpspec_bs_') . '.php';
             file_put_contents($tmpBootstrap, '<?php // bootstrap loaded');

--- a/spec/PhpSpec/FilterRegistry.spec.php
+++ b/spec/PhpSpec/FilterRegistry.spec.php
@@ -1,0 +1,31 @@
+<?php
+
+use PhpSpec\FilterRegistry;
+use PhpSpec\TitleFilter;
+
+describe(FilterRegistry::class, function () {
+
+    afterEach(function () {
+        FilterRegistry::reset();
+    });
+
+    it('has no filter by default', function () {
+        expect(FilterRegistry::current())->toBeNull();
+    });
+
+    it('exposes the filter once activated', function () {
+        $filter = new TitleFilter('wanted');
+
+        FilterRegistry::activate($filter);
+
+        expect(FilterRegistry::current())->toBe($filter);
+    });
+
+    it('clears the filter on reset', function () {
+        FilterRegistry::activate(new TitleFilter('wanted'));
+
+        FilterRegistry::reset();
+
+        expect(FilterRegistry::current())->toBeNull();
+    });
+});

--- a/spec/PhpSpec/LineTargetRegistry.spec.php
+++ b/spec/PhpSpec/LineTargetRegistry.spec.php
@@ -1,0 +1,41 @@
+<?php
+
+use PhpSpec\LineTargetRegistry;
+
+describe(LineTargetRegistry::class, function () {
+
+    afterEach(function () {
+        LineTargetRegistry::reset();
+    });
+
+    it('has no target by default', function () {
+        expect(LineTargetRegistry::currentTarget())->toBeNull();
+    });
+
+    it('exposes the target of the spec that begins running', function () {
+        LineTargetRegistry::add('spec/App/Picky.spec.php', 6);
+
+        LineTargetRegistry::beginSpec('spec/App/Picky.spec.php');
+        expect(LineTargetRegistry::currentTarget())->toBe(6);
+
+        LineTargetRegistry::beginSpec('spec/App/Other.spec.php');
+        expect(LineTargetRegistry::currentTarget())->toBeNull();
+    });
+
+    it('ignores a leading ./ on either side', function () {
+        LineTargetRegistry::add('./spec/App/Picky.spec.php', 6);
+
+        LineTargetRegistry::beginSpec('spec/App/Picky.spec.php');
+
+        expect(LineTargetRegistry::currentTarget())->toBe(6);
+    });
+
+    it('clears targets on reset', function () {
+        LineTargetRegistry::add('spec/App/Picky.spec.php', 6);
+        LineTargetRegistry::beginSpec('spec/App/Picky.spec.php');
+
+        LineTargetRegistry::reset();
+
+        expect(LineTargetRegistry::currentTarget())->toBeNull();
+    });
+});

--- a/spec/PhpSpec/Loader.spec.php
+++ b/spec/PhpSpec/Loader.spec.php
@@ -214,4 +214,20 @@ describe(Loader::class, function () {
         expect($suite)->toBeAnInstanceOf(Suite::class);
     });
 
+    it("loads only the scenario at the targeted line for a feature.feature:LINE path", function (Filesystem $fs) {
+        allow($fs->isFile())->toReturnUsing(fn(string $p) => $p === './features/greeting.feature');
+        allow($fs->isDir())->toReturn(false);
+        allow($fs->read())->toReturn(
+            "Feature: Test\n  Scenario: First\n    Given a step\n\n  Scenario: Second\n    Given a step\n"
+        );
+
+        $suite = (new Loader($fs))->load('./features/greeting.feature:5');
+
+        $features = $suite->getSpecifications();
+        expect($features)->toHaveCount(1);
+        $scenarios = $features[0]->run()->getResults();
+        expect($scenarios)->toHaveCount(1);
+        expect($scenarios[0]->getTitle())->toBe('Second');
+    });
+
 });

--- a/spec/PhpSpec/Specification.spec.php
+++ b/spec/PhpSpec/Specification.spec.php
@@ -1,7 +1,9 @@
 <?php
 
+use PhpSpec\FilterRegistry;
 use PhpSpec\Specification;
 use PhpSpec\Specification\Example;
+use PhpSpec\TitleFilter;
 
 describe(Specification::class, function() {
 
@@ -27,6 +29,22 @@ describe(Specification::class, function() {
     it("returns the path", function() {
         $spec = new Specification('/some/path/MyClass.spec.php');
         expect($spec->getPath())->toBe('/some/path/MyClass.spec.php');
+    });
+
+    it("announces its path to the active title filter so path matches keep all examples", function() {
+        FilterRegistry::activate(new TitleFilter('Targeted'));
+
+        $file = sys_get_temp_dir() . '/phpspec_Targeted_' . uniqid() . '.spec.php';
+        file_put_contents($file, '<?php describe("Sample", function () { it("unrelated title", function () {}); });');
+
+        try {
+            $result = (new Specification($file))->run();
+        } finally {
+            FilterRegistry::reset();
+            unlink($file);
+        }
+
+        expect($result->getResults()[0]->getResults())->toHaveCount(1);
     });
 
 });

--- a/spec/PhpSpec/Specification/Context.spec.php
+++ b/spec/PhpSpec/Specification/Context.spec.php
@@ -1,8 +1,11 @@
 <?php
 
+use PhpSpec\FilterRegistry;
+use PhpSpec\LineTargetRegistry;
 use PhpSpec\Specification\Context;
 use PhpSpec\Specification\Subject;
 use PhpSpec\Result\ContextResult;
+use PhpSpec\TitleFilter;
 
 describe(Context::class, function() {
 
@@ -418,6 +421,74 @@ describe(Context::class, function() {
         $ctx->setWorld(new Subject(__FILE__));
         $ctx->run();
         expect($log)->toBe([]);
+    });
+
+    it("runs only the examples matching the active title filter", function () {
+        FilterRegistry::activate(new TitleFilter('wanted'));
+        $ran = [];
+
+        try {
+            $ctx = new Context("Filtered", function () use (&$ran) {
+                it("does the wanted thing", function () use (&$ran) {
+                    $ran[] = 'wanted';
+                });
+                it("does another thing", function () use (&$ran) {
+                    $ran[] = 'other';
+                });
+            });
+            $ctx->setWorld(new Subject(__FILE__));
+            $result = $ctx->run();
+        } finally {
+            FilterRegistry::reset();
+        }
+
+        expect($ran)->toBe(['wanted']);
+        expect($result->getResults())->toHaveCount(1);
+    });
+
+    it("runs only the example at the targeted line", function () {
+        $ran = [];
+        // The closures below must stay on single lines: the target is
+        // the line of the second it() call, three lines down from here.
+        $secondLine = __LINE__ + 3;
+        $block = function () use (&$ran) {
+            it("first", function () use (&$ran) { $ran[] = 'first'; });
+            it("second", function () use (&$ran) { $ran[] = 'second'; });
+        };
+        LineTargetRegistry::add('ctx.spec.php', $secondLine);
+        LineTargetRegistry::beginSpec('ctx.spec.php');
+
+        try {
+            $ctx = new Context("LineTargeted", $block);
+            $ctx->setWorld(new Subject(__FILE__));
+            $result = $ctx->run();
+        } finally {
+            LineTargetRegistry::reset();
+        }
+
+        expect($ran)->toBe(['second']);
+        expect($result->getResults())->toHaveCount(1);
+    });
+
+    it("runs the whole context when the targeted line is inside it but on no example", function () {
+        $ran = [];
+        $blockLine = __LINE__ + 1;
+        $block = function () use (&$ran) {
+            it("first", function () use (&$ran) { $ran[] = 'first'; });
+            it("second", function () use (&$ran) { $ran[] = 'second'; });
+        };
+        LineTargetRegistry::add('ctx.spec.php', $blockLine);
+        LineTargetRegistry::beginSpec('ctx.spec.php');
+
+        try {
+            $ctx = new Context("WholeContext", $block);
+            $ctx->setWorld(new Subject(__FILE__));
+            $ctx->run();
+        } finally {
+            LineTargetRegistry::reset();
+        }
+
+        expect($ran)->toBe(['first', 'second']);
     });
 
 });

--- a/spec/PhpSpec/Specification/Example.spec.php
+++ b/spec/PhpSpec/Specification/Example.spec.php
@@ -184,4 +184,18 @@ describe(Example::class, function() {
         expect($receivedService)->toBeAnInstanceOf(\JsonSerializable::class);
     });
 
+    it("knows whether a line falls within its closure", function() {
+        $start = __LINE__ + 1;
+        $example = new Example("span test", function() {
+            $noop = true;
+        });
+        $end = $start + 2;
+
+        expect($example->containsLine($start))->toBeTrue();
+        expect($example->containsLine($start + 1))->toBeTrue();
+        expect($example->containsLine($end))->toBeTrue();
+        expect($example->containsLine($start - 1))->toBeFalse();
+        expect($example->containsLine($end + 1))->toBeFalse();
+    });
+
 });

--- a/spec/PhpSpec/StoryBDD/Feature.spec.php
+++ b/spec/PhpSpec/StoryBDD/Feature.spec.php
@@ -2,6 +2,7 @@
 
 use PhpSpec\StoryBDD\Feature;
 use PhpSpec\StoryBDD\FeatureNode;
+use PhpSpec\TitleFilter;
 use PhpSpec\StoryBDD\ScenarioNode;
 use PhpSpec\StoryBDD\ScenarioOutlineNode;
 use PhpSpec\StoryBDD\StepNode;
@@ -108,6 +109,38 @@ describe(Feature::class, function () {
         expect($steps[0]->isFailure())->toBeTrue();
         expect($steps[0]->getError()->getMessage())->toBe("boom");
         expect($steps[1]->isSkipped())->toBeTrue();
+    });
+
+    it("reduces to the scenarios matching a title filter", function () {
+        $registry = new StepRegistry();
+        $registry->addStep("a step", function () {});
+
+        $feature = new Feature('test.feature', new FeatureNode(
+            'Paths',
+            '',
+            null,
+            [
+                new ScenarioNode('Wanted path', [new StepNode('Given', 'a step')]),
+                new ScenarioNode('Other path', [new StepNode('Given', 'a step')]),
+            ]
+        ), $registry, new HookRegistry());
+
+        $reduced = $feature->withScenariosMatching(new TitleFilter('Wanted'));
+
+        $scenarios = $reduced->run()->getResults();
+        expect($scenarios)->toHaveCount(1);
+        expect($scenarios[0]->getTitle())->toBe('Wanted path');
+    });
+
+    it("reduces to null when no scenario title matches the filter", function () {
+        $feature = new Feature('test.feature', new FeatureNode(
+            'Paths',
+            '',
+            null,
+            [new ScenarioNode('Only path', [new StepNode('Given', 'a step')])]
+        ), new StepRegistry(), new HookRegistry());
+
+        expect($feature->withScenariosMatching(new TitleFilter('nothing here')))->toBeNull();
     });
 
     it("shares world across steps in a scenario", function () {

--- a/spec/PhpSpec/StoryBDD/GherkinParser.spec.php
+++ b/spec/PhpSpec/StoryBDD/GherkinParser.spec.php
@@ -390,4 +390,36 @@ describe(GherkinParser::class, function () {
         expect($feature->scenarios[0]->tags)->toBe(["scenario-tag"]);
     });
 
+    it("records the line number of each scenario", function () {
+        $feature = $this->parser->parse(<<<GHERKIN
+        Feature: Lines
+          Scenario: First
+            Given a step
+
+          Scenario: Second
+            Given a step
+        GHERKIN);
+        expect($feature->scenarios[0]->line)->toBe(2);
+        expect($feature->scenarios[0]->exampleLine)->toBeNull();
+        expect($feature->scenarios[1]->line)->toBe(5);
+    });
+
+    it("gives outline-expanded scenarios the outline line and their example row line", function () {
+        $feature = $this->parser->parse(<<<GHERKIN
+        Feature: Outline lines
+          Scenario Outline: Adding
+            Given I add <a>
+
+            Examples:
+              | a |
+              | 1 |
+              | 2 |
+        GHERKIN);
+        expect($feature->scenarios)->toHaveCount(2);
+        expect($feature->scenarios[0]->line)->toBe(2);
+        expect($feature->scenarios[1]->line)->toBe(2);
+        expect($feature->scenarios[0]->exampleLine)->toBe(7);
+        expect($feature->scenarios[1]->exampleLine)->toBe(8);
+    });
+
 });

--- a/spec/PhpSpec/StoryBDD/ScenarioLineSelector.spec.php
+++ b/spec/PhpSpec/StoryBDD/ScenarioLineSelector.spec.php
@@ -1,0 +1,35 @@
+<?php
+
+use PhpSpec\StoryBDD\ScenarioLineSelector;
+use PhpSpec\StoryBDD\ScenarioNode;
+
+describe(ScenarioLineSelector::class, function () {
+
+    beforeEach(function () {
+        $this->first = new ScenarioNode('First', [], [], 2);
+        $this->second = new ScenarioNode('Second', [], [], 5);
+        $this->rowOne = new ScenarioNode('Adding', [], [], 8, 12);
+        $this->rowTwo = new ScenarioNode('Adding', [], [], 8, 13);
+        $this->scenarios = [$this->first, $this->second, $this->rowOne, $this->rowTwo];
+    });
+
+    it('selects the scenario whose keyword is on the given line', function () {
+        expect(ScenarioLineSelector::select($this->scenarios, 5))->toBe([$this->second]);
+    });
+
+    it('selects the nearest scenario above a line inside its body', function () {
+        expect(ScenarioLineSelector::select($this->scenarios, 3))->toBe([$this->first]);
+    });
+
+    it('selects every expansion of an outline when targeting its keyword line', function () {
+        expect(ScenarioLineSelector::select($this->scenarios, 8))->toBe([$this->rowOne, $this->rowTwo]);
+    });
+
+    it('selects a single outline expansion when targeting its examples row', function () {
+        expect(ScenarioLineSelector::select($this->scenarios, 13))->toBe([$this->rowTwo]);
+    });
+
+    it('selects nothing when the line is before the first scenario', function () {
+        expect(ScenarioLineSelector::select($this->scenarios, 1))->toBe([]);
+    });
+});

--- a/spec/PhpSpec/TitleFilter.spec.php
+++ b/spec/PhpSpec/TitleFilter.spec.php
@@ -1,0 +1,36 @@
+<?php
+
+use PhpSpec\TitleFilter;
+
+describe(TitleFilter::class, function () {
+
+    it('matches a title by case-insensitive substring', function () {
+        $filter = new TitleFilter('WANTED');
+
+        expect($filter->matches('does the wanted thing'))->toBeTrue();
+        expect($filter->matches('does another thing'))->toBeFalse();
+    });
+
+    it('ignores a leading "it" on the filter text', function () {
+        $filter = new TitleFilter('it should be good');
+
+        expect($filter->matches('should be good'))->toBeTrue();
+    });
+
+    it('matches every title once the current spec path matches', function () {
+        $filter = new TitleFilter('Targeted');
+
+        $filter->beginSpec('spec/App/Targeted.spec.php');
+        expect($filter->matches('anything at all'))->toBeTrue();
+
+        $filter->beginSpec('spec/App/Excluded.spec.php');
+        expect($filter->matches('anything at all'))->toBeFalse();
+    });
+
+    it('matches paths by case-insensitive substring', function () {
+        $filter = new TitleFilter('greeting');
+
+        expect($filter->matchesPath('features/Greeting.feature'))->toBeTrue();
+        expect($filter->matchesPath('features/other.feature'))->toBeFalse();
+    });
+});

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -20,6 +20,8 @@ use PhpSpec\Console\Command\Run\CodeGenerator;
 use PhpSpec\Console\Command\Run\CoverageReporter;
 use PhpSpec\Extensions\ExtensionLoader;
 use PhpSpec\Extensions\FormatterBridge;
+use PhpSpec\FilterRegistry;
+use PhpSpec\LineTargetRegistry;
 use PhpSpec\Loader;
 use PhpSpec\Parallel\ParallelRunner;
 use PhpSpec\Report\Formatter;
@@ -27,9 +29,13 @@ use PhpSpec\Report\Formatter\Dot;
 use PhpSpec\Report\Formatter\Junit;
 use PhpSpec\Report\Formatter\Pretty;
 use PhpSpec\Report\Formatter\Tap;
+use PhpSpec\Result\ExampleResult;
+use PhpSpec\Result\StepResult;
 use PhpSpec\Result\SuiteResult;
+use PhpSpec\Results;
 use PhpSpec\Runner;
 use PhpSpec\StopConditions;
+use PhpSpec\TitleFilter;
 use Random\RandomException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument as Argument;
@@ -250,7 +256,13 @@ final class Run extends Command
         } else {
             $files = $this->config->getAllLoadPaths();
         }
-        $suite = $this->loader->load($files, $input->getOption('filter'));
+        $filter = $input->getOption('filter');
+
+        if ($filter !== null) {
+            FilterRegistry::activate(new TitleFilter($filter));
+        }
+
+        $suite = $this->loader->load($files, $filter);
 
         $problems = (bool) $input->getOption('stop-on-problems');
         $configStop = $this->config->getStopConditions();
@@ -291,9 +303,20 @@ final class Run extends Command
             $stream = $this->runner->stream($suite, $stop, $seed);
         }
 
-        foreach ($stream as $result) {
-            $formatter->printResult($result);
-            $accumulated[] = $result;
+        $lineTargeted = str_contains($files, ':');
+
+        try {
+            foreach ($stream as $result) {
+                if (($filter !== null || $lineTargeted) && self::countLeaves($result) === 0) {
+                    continue;
+                }
+
+                $formatter->printResult($result);
+                $accumulated[] = $result;
+            }
+        } finally {
+            FilterRegistry::reset();
+            LineTargetRegistry::reset();
         }
 
         $results = new SuiteResult($accumulated);
@@ -301,6 +324,28 @@ final class Run extends Command
         $formatter->end($results);
 
         return $results;
+    }
+
+    /**
+     * Counts example and step results in a result tree, so spec files whose
+     * examples were all pruned by the title filter can be skipped entirely.
+     *
+     * @param Results $results the result tree to count
+     * @return int the number of example/step leaves
+     */
+    private static function countLeaves(Results $results): int
+    {
+        $count = 0;
+
+        foreach ($results->getResults() as $result) {
+            if ($result instanceof ExampleResult || $result instanceof StepResult) {
+                $count++;
+            } elseif ($result instanceof Results) {
+                $count += self::countLeaves($result);
+            }
+        }
+
+        return $count;
     }
 
     /**

--- a/src/PhpSpec/FilterRegistry.php
+++ b/src/PhpSpec/FilterRegistry.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec;
+
+/**
+ * @internal
+ * Holds the active title filter for the current run. The runner consults
+ * this registry when pruning examples; when no filter is active (the normal
+ * case) those consultations are no-ops.
+ */
+final class FilterRegistry
+{
+    private static ?TitleFilter $filter = null;
+
+    /**
+     * Activates a title filter for the current run.
+     *
+     * @param TitleFilter $filter the filter to consult when pruning examples
+     */
+    public static function activate(TitleFilter $filter): void
+    {
+        self::$filter = $filter;
+    }
+
+    /**
+     * Returns the active filter, or null when no filter is set.
+     */
+    public static function current(): ?TitleFilter
+    {
+        return self::$filter;
+    }
+
+    /**
+     * Deactivates the title filter.
+     */
+    public static function reset(): void
+    {
+        self::$filter = null;
+    }
+}

--- a/src/PhpSpec/LineTargetRegistry.php
+++ b/src/PhpSpec/LineTargetRegistry.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec;
+
+/**
+ * @internal
+ * Holds the line targets from "file.spec.php:LINE" run paths for the current
+ * run. The runner announces each spec file as it starts, and contexts consult
+ * the current target when pruning examples; with no targets set (the normal
+ * case) those consultations are no-ops.
+ */
+final class LineTargetRegistry
+{
+    /** @var array<string, int> targeted line numbers keyed by normalised spec path */
+    private static array $targets = [];
+
+    private static ?int $current = null;
+
+    /**
+     * Registers a line target for a spec file.
+     *
+     * @param string $path the spec file path as given on the command line
+     * @param int $line the targeted line number
+     */
+    public static function add(string $path, int $line): void
+    {
+        self::$targets[self::normalise($path)] = $line;
+    }
+
+    /**
+     * Records the spec file that is about to run, exposing its line target.
+     *
+     * @param string $path the spec file path
+     */
+    public static function beginSpec(string $path): void
+    {
+        self::$current = self::$targets[self::normalise($path)] ?? null;
+    }
+
+    /**
+     * Returns the line target of the currently running spec, or null.
+     */
+    public static function currentTarget(): ?int
+    {
+        return self::$current;
+    }
+
+    /**
+     * Removes all targets and the current target.
+     */
+    public static function reset(): void
+    {
+        self::$targets = [];
+        self::$current = null;
+    }
+
+    /**
+     * Normalises a path for comparison, stripping a leading "./".
+     *
+     * @param string $path the path to normalise
+     * @return string the normalised path
+     */
+    private static function normalise(string $path): string
+    {
+        return str_starts_with($path, './') ? substr($path, 2) : $path;
+    }
+}

--- a/src/PhpSpec/Loader.php
+++ b/src/PhpSpec/Loader.php
@@ -18,7 +18,9 @@ use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\EventDispatcher\Subscriber\SpecificationSubscriber;
 use PhpSpec\Specification\SpecBlock;
 use PhpSpec\StoryBDD\Feature;
+use PhpSpec\StoryBDD\FeatureNode;
 use PhpSpec\StoryBDD\GherkinParser;
+use PhpSpec\StoryBDD\ScenarioLineSelector;
 use PhpSpec\StoryBDD\StoryBDDRegistry;
 
 /**
@@ -57,9 +59,24 @@ final class Loader
             if ($path === '') {
                 continue;
             }
+
+            $lineTarget = null;
+
+            if (preg_match('/^(.+):(\d+)$/', $path, $matches) === 1
+                && (str_ends_with($matches[1], '.feature') || str_ends_with($matches[1], $this->specSuffix))
+            ) {
+                $path = $matches[1];
+                $lineTarget = (int) $matches[2];
+            }
+
             if ($this->isFeaturePath($path)) {
-                $blocks = array_merge($blocks, $this->loadFeatures($path));
+                $blocks = array_merge($blocks, $this->loadFeatures($path, $lineTarget));
             } else {
+                if ($lineTarget !== null) {
+                    // Example positions are only known at run time; the
+                    // registry hands the target to the spec as it runs
+                    LineTargetRegistry::add($path, $lineTarget);
+                }
                 $blocks = array_merge($blocks, $this->loadSuite($path));
             }
         }
@@ -77,21 +94,42 @@ final class Loader
      * @param string $path filesystem path to inspect
      */
     /**
-     * Filters spec blocks by path substring match.
+     * Filters spec blocks by path or title match.
+     *
+     * Blocks whose path matches are kept whole. Features are otherwise
+     * reduced to the scenarios whose title matches, and dropped when none
+     * does. Specifications are always kept: example titles are only known
+     * at run time, so they prune themselves as they run.
      *
      * @param array<SpecBlock> $blocks blocks to filter
-     * @param string $filter substring to match
+     * @param string $filter the --filter text
      * @return array<SpecBlock>
      */
     private function filterBlocks(array $blocks, string $filter): array
     {
+        $titleFilter = new TitleFilter($filter);
         $filtered = [];
+
         foreach ($blocks as $block) {
             $path = $this->getBlockPath($block);
-            if ($path === null || stripos($path, $filter) !== false) {
+
+            if ($path === null || $titleFilter->matchesPath($path)) {
                 $filtered[] = $block;
+                continue;
             }
+
+            if ($block instanceof Feature) {
+                $reduced = $block->withScenariosMatching($titleFilter);
+
+                if ($reduced !== null) {
+                    $filtered[] = $reduced;
+                }
+                continue;
+            }
+
+            $filtered[] = $block;
         }
+
         return $filtered;
     }
 
@@ -167,11 +205,14 @@ final class Loader
 
     /**
      * Parses Gherkin feature files and loads associated step definitions.
+     * When a line target is given, each feature is reduced to the scenarios
+     * addressed by that line.
      *
      * @param string $path directory or file containing .feature files
+     * @param int|null $lineTarget line number from a "file.feature:LINE" path, or null to load all scenarios
      * @return array<\PhpSpec\StoryBDD\Feature>
      */
-    private function loadFeatures(string $path): array
+    private function loadFeatures(string $path, ?int $lineTarget = null): array
     {
         $parser = new GherkinParser();
         $featureFiles = [];
@@ -191,6 +232,17 @@ final class Loader
         foreach ($featureFiles as $featureFile) {
             $content = $this->fs->read($featureFile);
             $featureNode = $parser->parse($content, $featureFile);
+
+            if ($lineTarget !== null) {
+                $featureNode = new FeatureNode(
+                    $featureNode->title,
+                    $featureNode->description,
+                    $featureNode->background,
+                    ScenarioLineSelector::select($featureNode->scenarios, $lineTarget),
+                    $featureNode->tags,
+                );
+            }
+
             $features[] = new Feature(
                 $featureFile,
                 $featureNode,

--- a/src/PhpSpec/Specification.php
+++ b/src/PhpSpec/Specification.php
@@ -49,6 +49,8 @@ class Specification implements ExampleRegistry, SpecBlock
     public function run(): Results
     {
         DispatcherRegistry::dispatcher()->dispatch(new SpecificationStarted($this->path), SpecificationStarted::NAME);
+        FilterRegistry::current()?->beginSpec($this->path);
+        LineTargetRegistry::beginSpec($this->path);
 
         // loads the specification file from the Subject constructor
         // so $this in the examples refers to Subject
@@ -58,7 +60,7 @@ class Specification implements ExampleRegistry, SpecBlock
 
         $blockResults = [];
 
-        foreach ($this->getSpecBlocks() as $specBlock) {
+        foreach ($this->targetedSpecBlocks() as $specBlock) {
             if ($specBlock instanceof Specification\Context) {
                 $specBlock->setWorld($subject);
             }
@@ -100,6 +102,27 @@ class Specification implements ExampleRegistry, SpecBlock
     public function getSpecBlocks(): array
     {
         return $this->specBlocks;
+    }
+
+    /**
+     * Returns the top-level blocks to run, honouring an active line target:
+     * only blocks whose closure spans the targeted line run, and none when
+     * the line falls outside every block.
+     *
+     * @return array<SpecBlock> the blocks addressed by the line target, or all blocks
+     */
+    private function targetedSpecBlocks(): array
+    {
+        $line = LineTargetRegistry::currentTarget();
+
+        if ($line === null) {
+            return $this->specBlocks;
+        }
+
+        return array_values(array_filter(
+            $this->specBlocks,
+            fn(SpecBlock $block) => $block instanceof Specification\Context && $block->containsLine($line),
+        ));
     }
 
     /**

--- a/src/PhpSpec/Specification/Context.php
+++ b/src/PhpSpec/Specification/Context.php
@@ -18,10 +18,13 @@ use Closure;
 use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\EventDispatcher\Event\ContextRan;
 use PhpSpec\EventDispatcher\Event\ContextStarted;
+use PhpSpec\FilterRegistry;
+use PhpSpec\LineTargetRegistry;
 use PhpSpec\Result\ContextResult;
 use PhpSpec\Result\ExampleResult;
 use PhpSpec\Results;
 use ReflectionException;
+use ReflectionFunction;
 use Throwable;
 
 /**
@@ -118,6 +121,8 @@ class Context implements ExampleRegistry, SpecBlock
             DispatcherRegistry::dispatcher()->popScope();
 
             $this->resolveFocus();
+            $this->applyTitleFilter();
+            $this->applyLineFilter();
 
             if (!$this->pending) {
                 foreach ($this->beforeAllHooks as $hook) {
@@ -295,6 +300,65 @@ class Context implements ExampleRegistry, SpecBlock
                 }
             }
         }
+    }
+
+    /**
+     * Removes examples whose title does not match the active title filter.
+     * Unlike focus, filtered examples are removed rather than marked pending,
+     * so they do not appear in the output at all. Nested contexts are kept;
+     * they prune their own examples when they run.
+     */
+    private function applyTitleFilter(): void
+    {
+        $filter = FilterRegistry::current();
+
+        if ($filter === null) {
+            return;
+        }
+
+        $this->specBlocks = array_values(array_filter(
+            $this->specBlocks,
+            fn(SpecBlock $block) => !($block instanceof Example) || $filter->matches($block->getTitle()),
+        ));
+    }
+
+    /**
+     * Reduces this context to the block at the targeted line, when one is set
+     * for the running spec file. If a child example or context spans the line,
+     * only the spanning children are kept; otherwise the line addresses this
+     * context as a whole and every child runs.
+     */
+    private function applyLineFilter(): void
+    {
+        $line = LineTargetRegistry::currentTarget();
+
+        if ($line === null) {
+            return;
+        }
+
+        $containing = array_values(array_filter(
+            $this->specBlocks,
+            fn(SpecBlock $block) => ($block instanceof Example || $block instanceof Context)
+                && $block->containsLine($line),
+        ));
+
+        if ($containing !== []) {
+            $this->specBlocks = $containing;
+        }
+    }
+
+    /**
+     * Checks whether a line number falls within this context's closure,
+     * used to resolve "file.spec.php:LINE" run targets.
+     *
+     * @param int $line the targeted line number
+     * @return bool true when the line is within the closure's span
+     */
+    public function containsLine(int $line): bool
+    {
+        $reflection = new ReflectionFunction($this->specBlock);
+
+        return $line >= $reflection->getStartLine() && $line <= $reflection->getEndLine();
     }
 
     /**

--- a/src/PhpSpec/Specification/Example.php
+++ b/src/PhpSpec/Specification/Example.php
@@ -60,6 +60,30 @@ class Example implements ExampleResultRegistry, SpecBlock
     public function __construct(private readonly string $title, private readonly Closure $example) {}
 
     /**
+     * Returns the descriptive label of the example.
+     *
+     * @return string the example title
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Checks whether a line number falls within this example's closure,
+     * used to resolve "file.spec.php:LINE" run targets.
+     *
+     * @param int $line the targeted line number
+     * @return bool true when the line is within the closure's span
+     */
+    public function containsLine(int $line): bool
+    {
+        $reflection = new ReflectionFunction($this->example);
+
+        return $line >= $reflection->getStartLine() && $line <= $reflection->getEndLine();
+    }
+
+    /**
      * Marks this example as pending (skipped).
      *
      * @param bool $pending whether to mark as pending

--- a/src/PhpSpec/StoryBDD/Feature.php
+++ b/src/PhpSpec/StoryBDD/Feature.php
@@ -22,6 +22,7 @@ use PhpSpec\Results;
 use PhpSpec\Specification\PendingException;
 use PhpSpec\Specification\SkippedException;
 use PhpSpec\Specification\SpecBlock;
+use PhpSpec\TitleFilter;
 
 /**
  * @internal
@@ -44,6 +45,35 @@ final readonly class Feature implements SpecBlock
         private StepRegistry $registry,
         private HookRegistry $hooks,
     ) {}
+
+    /**
+     * Returns a copy of this feature reduced to the scenarios whose title
+     * matches the filter, or null when no scenario matches.
+     *
+     * @param TitleFilter $filter the active title filter
+     * @return self|null the reduced feature, or null when nothing matches
+     */
+    public function withScenariosMatching(TitleFilter $filter): ?self
+    {
+        $scenarios = array_values(array_filter(
+            $this->featureNode->scenarios,
+            fn(ScenarioNode $scenario) => $filter->matches($scenario->title),
+        ));
+
+        if ($scenarios === []) {
+            return null;
+        }
+
+        $featureNode = new FeatureNode(
+            $this->featureNode->title,
+            $this->featureNode->description,
+            $this->featureNode->background,
+            $scenarios,
+            $this->featureNode->tags,
+        );
+
+        return new self($this->path, $featureNode, $this->registry, $this->hooks);
+    }
 
     /**
      * Yields each ScenarioResult as it completes.

--- a/src/PhpSpec/StoryBDD/GherkinParser.php
+++ b/src/PhpSpec/StoryBDD/GherkinParser.php
@@ -81,10 +81,11 @@ final class GherkinParser
         }
 
         $stepIndex = $this->buildStepIndex($document);
+        $scenarioLines = $this->buildScenarioLineIndex($document);
         $featureTags = $this->mapTags($document->feature->tags);
 
         $scenarios = array_map(
-            fn(Pickle $pickle) => $this->mapPickle($pickle, $stepIndex, $featureTags),
+            fn(Pickle $pickle) => $this->mapPickle($pickle, $stepIndex, $scenarioLines, $featureTags),
             $pickles,
         );
 
@@ -148,13 +149,48 @@ final class GherkinParser
     }
 
     /**
+     * Builds an index of AST scenario IDs to the line number of their
+     * "Scenario:"/"Scenario Outline:" keyword.
+     *
+     * @return array<string, int> map of scenario ID to keyword line number
+     */
+    private function buildScenarioLineIndex(GherkinDocument $document): array
+    {
+        $index = [];
+
+        if ($document->feature === null) {
+            return $index;
+        }
+
+        foreach ($document->feature->children as $child) {
+            if ($child->scenario !== null) {
+                $index[$child->scenario->id] = $child->scenario->location->line;
+            }
+            if ($child->rule !== null) {
+                foreach ($child->rule->children as $ruleChild) {
+                    if ($ruleChild->scenario !== null) {
+                        $index[$ruleChild->scenario->id] = $ruleChild->scenario->location->line;
+                    }
+                }
+            }
+        }
+
+        return $index;
+    }
+
+    /**
      * Maps a Cucumber Pickle to a ScenarioNode.
+     *
+     * The scenario line is the AST keyword line, shared by every scenario a
+     * Scenario Outline expands to; the pickle location (the examples table
+     * row for expanded outlines) is kept as the example line when it differs.
      *
      * @param Pickle $pickle the pickle to map
      * @param array<string, string> $stepIndex AST step ID to keyword map
+     * @param array<string, int> $scenarioLines AST scenario ID to keyword line map
      * @param string[] $featureTags feature-level tags to exclude from scenario tags
      */
-    private function mapPickle(Pickle $pickle, array $stepIndex, array $featureTags): ScenarioNode
+    private function mapPickle(Pickle $pickle, array $stepIndex, array $scenarioLines, array $featureTags): ScenarioNode
     {
         $steps = array_map(
             fn(PickleStep $step) => $this->mapPickleStep($step, $stepIndex),
@@ -169,7 +205,11 @@ final class GherkinParser
         // Pickles inherit feature tags; exclude them so scenario tags are scenario-only
         $scenarioTags = array_values(array_diff($pickleTags, $featureTags));
 
-        return new ScenarioNode($pickle->name, $steps, $scenarioTags);
+        $line = $scenarioLines[$pickle->astNodeIds[0] ?? ''] ?? 0;
+        $pickleLine = $pickle->location->line ?? 0;
+        $exampleLine = $pickleLine !== 0 && $pickleLine !== $line ? $pickleLine : null;
+
+        return new ScenarioNode($pickle->name, $steps, $scenarioTags, $line, $exampleLine);
     }
 
     /**

--- a/src/PhpSpec/StoryBDD/ScenarioLineSelector.php
+++ b/src/PhpSpec/StoryBDD/ScenarioLineSelector.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\StoryBDD;
+
+/**
+ * @internal
+ * Selects the scenarios addressed by a "file.feature:LINE" run target.
+ * A line matching a scenario keyword selects that scenario (every expansion,
+ * for outlines); a line matching an examples table row selects that single
+ * expansion; any other line selects the nearest scenario declared above it.
+ */
+final class ScenarioLineSelector
+{
+    /**
+     * Selects the scenarios matching the given line number.
+     *
+     * @param ScenarioNode[] $scenarios all scenarios of the feature, in declaration order
+     * @param int $line the targeted line number
+     * @return ScenarioNode[] the selected scenarios, empty when the line precedes every scenario
+     */
+    public static function select(array $scenarios, int $line): array
+    {
+        $exact = array_values(array_filter(
+            $scenarios,
+            fn(ScenarioNode $scenario) => $scenario->line === $line || $scenario->exampleLine === $line,
+        ));
+
+        if ($exact !== []) {
+            return $exact;
+        }
+
+        $nearest = 0;
+
+        foreach ($scenarios as $scenario) {
+            if ($scenario->line <= $line) {
+                $nearest = max($nearest, $scenario->line);
+            }
+        }
+
+        if ($nearest === 0) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $scenarios,
+            fn(ScenarioNode $scenario) => $scenario->line === $nearest,
+        ));
+    }
+}

--- a/src/PhpSpec/StoryBDD/ScenarioNode.php
+++ b/src/PhpSpec/StoryBDD/ScenarioNode.php
@@ -26,6 +26,8 @@ readonly class ScenarioNode
      * @param string $title the scenario title from the "Scenario:" line
      * @param StepNode[] $steps ordered list of StepNode instances
      * @param string[] $tags tags applied to the scenario
+     * @param int $line line number of the "Scenario:"/"Scenario Outline:" keyword in the feature file (0 = unknown)
+     * @param int|null $exampleLine line number of the examples table row for outline-expanded scenarios, or null
      */
     public function __construct(
         public string $title,
@@ -33,5 +35,7 @@ readonly class ScenarioNode
         public array $steps,
         /** @var string[] */
         public array $tags = [],
+        public int $line = 0,
+        public ?int $exampleLine = null,
     ) {}
 }

--- a/src/PhpSpec/TitleFilter.php
+++ b/src/PhpSpec/TitleFilter.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec;
+
+/**
+ * @internal
+ * Matches example and scenario titles (and file paths) against the --filter
+ * text using case-insensitive substring comparison. A leading "it" on the
+ * filter is ignored, so --filter="it should be good" matches the example
+ * title "should be good". While a spec whose path matches is running, every
+ * title in it matches, preserving the file-path filtering behaviour.
+ */
+final class TitleFilter
+{
+    private readonly string $needle;
+
+    private bool $currentSpecMatches = false;
+
+    /**
+     * @param string $filter the raw --filter option value
+     */
+    public function __construct(private readonly string $filter)
+    {
+        $needle = trim($filter);
+
+        if (preg_match('/^it[\s_]+(.+)$/i', $needle, $matches) === 1) {
+            $needle = $matches[1];
+        }
+
+        $this->needle = $needle;
+    }
+
+    /**
+     * Records the spec file that is about to run, so titles inside a
+     * path-matched file always match.
+     *
+     * @param string $path the spec file path
+     */
+    public function beginSpec(string $path): void
+    {
+        $this->currentSpecMatches = $this->matchesPath($path);
+    }
+
+    /**
+     * Checks whether an example or scenario title matches the filter,
+     * or whether the current spec file already matched by path.
+     *
+     * @param string $title the example or scenario title
+     * @return bool true when the title (or the current spec path) matches
+     */
+    public function matches(string $title): bool
+    {
+        if ($this->currentSpecMatches) {
+            return true;
+        }
+
+        return stripos($title, $this->needle) !== false;
+    }
+
+    /**
+     * Checks whether a file path matches the filter text.
+     *
+     * @param string $path the spec or feature file path
+     * @return bool true when the path contains the filter text
+     */
+    public function matchesPath(string $path): bool
+    {
+        return stripos($path, $this->filter) !== false;
+    }
+}


### PR DESCRIPTION
Add the ability to run single scenarios given a line (some_feature.feature:42).

We have the ability to run a single example by messing with the example name, but it may be needed to do this from the command line, so let's also add a --filter=EXAMPLE|SCENARIO option. This will filter by example name or scenario name. The option will require an argument with quotation marks.

Examples:

$ bin/phpspec features/some_feature:42
Runs scenario on line 42

$ bin/phpspec spec/Some.spec.php:42
Runs example on line 42

$ bin/phpspec --filter="should be good"
Runs example it("should be enough") ou scenario, substring is enough, "be good" would work