### PR TITLE
Fix html formatter (#1521)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,7 +83,8 @@ bin/phpspec describe App/Calculator -e add          # with "add" method example
 
 | Option | Description |
 |---|---|
-| `-f`, `--format=FORMAT` | Output formatter: `pretty` (default), `dot`, `tap`, `junit` |
+| `-f`, `--format=FORMAT` | Output formatter: `pretty` (default), `dot`, `tap`, `junit`, `html`. Repeatable; pair each with `-o` |
+| `-o`, `--out=FILE` | Report destination for the corresponding `--format`; `std` means the console |
 | `-v` | Verbose mode -- shows per-example duration |
 | `-q` | Quiet mode -- suppresses all output, exit code still reflects pass/fail |
 | `--profile[=N]` | Show the N slowest examples (default: 10) |
@@ -136,6 +137,32 @@ Outputs JUnit XML for CI integration:
 ```bash
 bin/phpspec run --format=junit > results.xml
 ```
+
+#### HTML Formatter
+
+Outputs a self-contained HTML document with passed/failed examples and a
+summary, ready to open in a browser:
+
+```bash
+bin/phpspec run --format=html > report.html
+```
+
+#### Report Files
+
+Every formatter writes to standard output, so a single format is best saved
+with shell redirection as above. To produce report files *in addition to* the
+console output — or several formats in one run — repeat `--format`/`-f` and
+pair each occurrence with an `--out`/`-o` destination. Outs pair with formats
+by position (Behat style), and `std` names the console:
+
+```bash
+bin/phpspec run -f html -o report.html                             # pretty on console + HTML file
+bin/phpspec run -f pretty -o std -f html -o report.html -f junit -o report.xml
+```
+
+A format without a matching `-o` writes to the console; when every format
+targets a file, the console falls back to `pretty`. Unknown format names are
+rejected with an error rather than silently falling back.
 
 ### Filtering and Selection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,25 @@ Directory containing source files. Used for code generation and coverage filteri
 src_path: lib
 ```
 
+### `features_path`
+
+Directory containing Gherkin `.feature` files, used by `--story` and step
+discovery. Default: `features/`.
+
+```yaml
+features_path: acceptance
+```
+
+### `steps_path`
+
+An additional directory to search for `*.steps.php` step definitions. Step
+definitions are always discoverable anywhere inside the features folder;
+when `steps_path` is set, that directory is searched as well. Default: unset.
+
+```yaml
+steps_path: acceptance_steps
+```
+
 ### `format`
 
 Default output formatter. Overridden by `--format` CLI flag.

--- a/docs/story-bdd.md
+++ b/docs/story-bdd.md
@@ -20,7 +20,11 @@ Feature: Greeting
 
 ## Step Definitions
 
-Define steps in `features/steps/*.steps.php`:
+Define steps in `*.steps.php` files. They are discoverable anywhere inside
+the features folder (conventionally `features/steps/`, but a file beside its
+feature works too), regardless of which feature path you run. An additional
+directory can be searched by setting `steps_path` in the
+[configuration](configuration.md#steps_path).
 
 ```php
 <?php

--- a/features/scenarios/cli/cli-options.feature
+++ b/features/scenarios/cli/cli-options.feature
@@ -94,6 +94,114 @@ Feature: CLI options
     Then the output should contain "<testsuites>"
     And the output should contain "<testcase"
 
+  Scenario: Run features from a nested directory with steps defined at the features root
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/scenarios/checkout/checkout.feature":
+      """
+      Feature: Checkout
+        Scenario: Buys an item
+          Given a checkout step
+      """
+    And a step file "features/steps/checkout.steps.php":
+      """
+      <?php
+      given("a checkout step", function () {
+          expect(true)->toBeTrue();
+      });
+      """
+    When I run phpspec run "features/scenarios/checkout"
+    Then all steps should pass
+    And the output should not contain "undefined"
+
+  Scenario: Steps are discoverable anywhere inside the features folder
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/checkout/checkout.feature":
+      """
+      Feature: Checkout
+        Scenario: Buys an item
+          Given a sibling step
+      """
+    And a file "features/checkout/checkout.steps.php":
+      """
+      <?php
+      given("a sibling step", function () {
+          expect(true)->toBeTrue();
+      });
+      """
+    When I run phpspec run "features/checkout/checkout.feature"
+    Then all steps should pass
+    And the output should not contain "undefined"
+
+  Scenario: HTML formatter
+    Given a spec file "spec/App/HtmlFormat.spec.php":
+      """
+      <?php
+      describe('HtmlFormat', function () {
+          it('renders a passing example', function () {
+              expect(true)->toBeTrue();
+          });
+          it('renders a failing example', function () {
+              expect(1)->toBe(2);
+          });
+      });
+      """
+    When I run phpspec run with option "--format html"
+    Then the output should contain "<!DOCTYPE html>"
+    And the output should contain "renders a passing example"
+    And the output should contain "renders a failing example"
+    And the output should contain "2 examples"
+    And the exit code should not be 0
+
+  Scenario: Write report files alongside the console format
+    Given a spec file "spec/App/Reports.spec.php":
+      """
+      <?php
+      describe('Reports', function () {
+          it('passes', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    When I run phpspec run with option "-f pretty -o std -f html -o reports/report.html -f junit -o reports/report.xml"
+    Then all examples should pass
+    And the output should contain "Reports"
+    And a file "reports/report.html" should be generated
+    And the file "reports/report.html" should contain "<!DOCTYPE html>"
+    And a file "reports/report.xml" should be generated
+    And the file "reports/report.xml" should contain "<testsuites>"
+    And the output should contain "Report written to reports/report.html"
+    And the output should contain "Report written to reports/report.xml"
+
+  Scenario: File formats default the console to pretty
+    Given a spec file "spec/App/FileOnly.spec.php":
+      """
+      <?php
+      describe('FileOnly', function () {
+          it('passes', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    When I run phpspec run with option "-f html -o report.html"
+    Then all examples should pass
+    And the output should contain "FileOnly"
+    And a file "report.html" should be generated
+    And the file "report.html" should contain "<!DOCTYPE html>"
+
+  Scenario: Unknown formats are rejected instead of silently falling back
+    Given a spec file "spec/App/BadFormat.spec.php":
+      """
+      <?php
+      describe('BadFormat', function () {
+          it('passes', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    When I run phpspec run with option "--format nope"
+    Then the exit code should not be 0
+    And the output should contain "Unknown format: nope"
+
   Scenario: Random execution order with seed
     Given a spec file "spec/App/Random.spec.php":
       """

--- a/features/scenarios/cli/configuration.feature
+++ b/features/scenarios/cli/configuration.feature
@@ -276,3 +276,28 @@ Feature: Configuration
       """
     When I run phpspec run
     Then all examples should pass
+
+  Scenario: Configure a steps directory outside the features folder
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a phpspec.json config:
+      """
+      {
+          "steps_path": "acceptance_steps"
+      }
+      """
+    And a feature file "features/checkout.feature":
+      """
+      Feature: Checkout
+        Scenario: Buys an item
+          Given a configured step
+      """
+    And a file "acceptance_steps/checkout.steps.php":
+      """
+      <?php
+      given("a configured step", function () {
+          expect(true)->toBeTrue();
+      });
+      """
+    When I run phpspec run "features/"
+    Then all steps should pass
+    And the output should not contain "undefined"

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -118,6 +118,11 @@ then('the class {string} should contain {string}', function (string $path, strin
     expect($content)->toContain($text);
 });
 
+then('the file {string} should contain {string}', function (string $path, string $text) {
+    $content = file_get_contents($this->projectDir . '/' . $path);
+    expect($content)->toContain($text);
+});
+
 then('the class should have a {string} method stub', function (string $method) {
     $content = file_get_contents($this->lastFile);
     expect($content)->toContain("function {$method}");

--- a/spec/PhpSpec/Configuration.spec.php
+++ b/spec/PhpSpec/Configuration.spec.php
@@ -326,4 +326,18 @@ describe(Configuration::class, function () {
         expect($config->getPsr4Prefix())->toBe('App');
     });
 
+    it("has no steps path by default", function (Filesystem $fs) {
+        $config = new Configuration('/app', $fs);
+        expect($config->getStepsPath())->toBeNull();
+    });
+
+    it("returns the configured steps path", function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => $path === '/app/phpspec.json');
+        allow($fs->read())->toReturn(json_encode(['steps_path' => 'acceptance_steps']));
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->getStepsPath())->toBe('acceptance_steps');
+    });
+
 });

--- a/spec/PhpSpec/Console/Command/Run.spec.php
+++ b/spec/PhpSpec/Console/Command/Run.spec.php
@@ -56,6 +56,71 @@ describe(Run::class, function () {
             expect($output)->toContain('<?xml');
         });
 
+        it('runs with html format', function (Filesystem $execFs) {
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader($execFs), new Runner(), $config);
+
+            $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+            $tester->execute(['--format' => 'html']);
+            expect($tester->getDisplay())->toContain('<!DOCTYPE html>');
+        });
+
+        it('rejects unknown formats', function (Filesystem $execFs) {
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader($execFs), new Runner(), $config);
+
+            $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+            $exitCode = $tester->execute(['--format' => 'nope']);
+            expect($exitCode)->toBe(1);
+            expect($tester->getDisplay())->toContain('Unknown format: nope');
+        });
+
+        it('pairs each -o file with its format by position', function (Filesystem $execFs) {
+            $dir = sys_get_temp_dir() . '/phpspec_reports_' . uniqid();
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader($execFs), new Runner(), $config);
+
+            try {
+                $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+                $tester->execute([
+                    '--format' => ['pretty', 'html', 'junit'],
+                    '--out' => ['std', $dir . '/report.html', $dir . '/report.xml'],
+                ]);
+                $output = $tester->getDisplay();
+
+                expect($output)->toContain('No specs found');
+                expect((string) file_get_contents($dir . '/report.html'))->toContain('<!DOCTYPE html>');
+                expect((string) file_get_contents($dir . '/report.xml'))->toContain('<testsuites');
+                expect($output)->toContain('Report written to ' . $dir . '/report.html');
+            } finally {
+                @unlink($dir . '/report.html');
+                @unlink($dir . '/report.xml');
+                @rmdir($dir);
+            }
+        });
+
+        it('defaults the console to pretty when every format writes to a file', function (Filesystem $execFs) {
+            $dir = sys_get_temp_dir() . '/phpspec_fileonly_' . uniqid();
+            $config = new Configuration('.', $execFs);
+            $cmd = new Run(new Loader($execFs), new Runner(), $config);
+
+            try {
+                $tester = new \Symfony\Component\Console\Tester\CommandTester($cmd);
+                $tester->execute([
+                    '--format' => ['html'],
+                    '--out' => [$dir . '/report.html'],
+                ]);
+                $output = $tester->getDisplay();
+
+                expect($output)->toContain('No specs found');
+                expect($output)->not()->toContain('<!DOCTYPE html>');
+                expect((string) file_get_contents($dir . '/report.html'))->toContain('<!DOCTYPE html>');
+            } finally {
+                @unlink($dir . '/report.html');
+                @rmdir($dir);
+            }
+        });
+
         it('runs with profile option', function (Filesystem $execFs) {
             $config = new Configuration('.', $execFs);
             $cmd = new Run(new Loader($execFs), new Runner(), $config);

--- a/spec/PhpSpec/Coverage/HtmlReport.spec.php
+++ b/spec/PhpSpec/Coverage/HtmlReport.spec.php
@@ -1,0 +1,57 @@
+<?php
+
+use PhpSpec\Coverage\HtmlReport;
+
+describe(HtmlReport::class, function () {
+
+    beforeEach(function () {
+        $this->dir = sys_get_temp_dir() . '/phpspec_html_cov_' . uniqid();
+    });
+
+    afterEach(function () {
+        if (is_dir($this->dir)) {
+            array_map('unlink', glob($this->dir . '/*.html') ?: []);
+            rmdir($this->dir);
+        }
+    });
+
+    it('renders a branded index with the coverage table and meter', function () {
+        $report = new HtmlReport();
+
+        $report->render(['PhpSpec/Loader.php' => [1 => 1, 2 => -1]], $this->dir);
+
+        $index = (string) file_get_contents($this->dir . '/index.html');
+        expect($index)->toContain('<!DOCTYPE html>');
+        expect($index)->toContain('class="wordmark"');
+        expect($index)->toContain('class="meter"');
+        expect($index)->toContain('class="coverage"');
+        expect($index)->toContain('PhpSpec/Loader.php');
+        expect($index)->toContain('1/2');
+    });
+
+    it('grades coverage bars by percentage', function () {
+        $report = new HtmlReport();
+
+        $report->render([
+            'PhpSpec/Loader.php' => [1 => 1, 2 => 1],
+            'PhpSpec/Runner.php' => [1 => 1, 2 => -1, 3 => -1, 4 => -1],
+        ], $this->dir);
+
+        $index = (string) file_get_contents($this->dir . '/index.html');
+        expect($index)->toContain('class="hi"');
+        expect($index)->toContain('class="lo"');
+    });
+
+    it('renders per-file source pages with hit and miss line classes', function () {
+        $report = new HtmlReport();
+
+        $report->render(['PhpSpec/Loader.php' => [17 => 1, 18 => -1]], $this->dir);
+
+        $page = (string) file_get_contents($this->dir . '/PhpSpec_Loader.php.html');
+        expect($page)->toContain('class="wordmark"');
+        expect($page)->toContain('class="source"');
+        expect($page)->toContain('<tr class="hit">');
+        expect($page)->toContain('<tr class="miss">');
+        expect($page)->toContain('Back to index');
+    });
+});

--- a/spec/PhpSpec/InProcessRunner.spec.php
+++ b/spec/PhpSpec/InProcessRunner.spec.php
@@ -53,6 +53,15 @@ describe(InProcessRunner::class, function () {
             ]);
         });
 
+        it('aggregates repeated options into arrays, preserving order', function () {
+            $result = ($this->parseArgs)('run -f pretty -o std -f html -o report.html');
+            expect($result)->toBe([
+                'command' => 'run',
+                '-f' => ['pretty', 'html'],
+                '-o' => ['std', 'report.html'],
+            ]);
+        });
+
         it('parses run with a short option and value', function () {
             $result = ($this->parseArgs)('run -f pretty');
             expect($result)->toBe([

--- a/spec/PhpSpec/Loader.spec.php
+++ b/spec/PhpSpec/Loader.spec.php
@@ -203,6 +203,91 @@ describe(Loader::class, function () {
         expect($suite)->toBeAnInstanceOf(Suite::class);
     });
 
+    it("finds step definitions in ancestor steps directories when loading a feature directory", function () {
+        $root = sys_get_temp_dir() . '/phpspec_loader_steps_' . uniqid();
+        mkdir($root . '/features/scenarios/checkout', 0777, true);
+        mkdir($root . '/features/steps', 0777, true);
+        file_put_contents(
+            $root . '/features/scenarios/checkout/checkout.feature',
+            "Feature: Checkout\n  Scenario: Buys\n    Given a checkout step\n"
+        );
+        file_put_contents(
+            $root . '/features/steps/checkout.steps.php',
+            '<?php given("a checkout step", function () { expect(true)->toBeTrue(); });'
+        );
+
+        try {
+            $suite = (new Loader())->load($root . '/features/scenarios/checkout');
+
+            $steps = $suite->getSpecifications()[0]->run()->getResults()[0]->getResults();
+            expect($steps[0]->isUndefined())->toBeFalse();
+            expect($steps[0]->isPassed())->toBeTrue();
+        } finally {
+            unlink($root . '/features/scenarios/checkout/checkout.feature');
+            unlink($root . '/features/steps/checkout.steps.php');
+            rmdir($root . '/features/scenarios/checkout');
+            rmdir($root . '/features/scenarios');
+            rmdir($root . '/features/steps');
+            rmdir($root . '/features');
+            rmdir($root);
+        }
+    });
+
+    it("finds step definitions anywhere under the features root", function () {
+        $root = sys_get_temp_dir() . '/phpspec_loader_root_' . uniqid();
+        mkdir($root . '/features/checkout', 0777, true);
+        file_put_contents(
+            $root . '/features/checkout/checkout.feature',
+            "Feature: Checkout\n  Scenario: Buys\n    Given a sibling step\n"
+        );
+        file_put_contents(
+            $root . '/features/checkout/checkout.steps.php',
+            '<?php given("a sibling step", function () { expect(true)->toBeTrue(); });'
+        );
+
+        try {
+            $loader = new Loader(featuresPath: $root . '/features');
+            $suite = $loader->load($root . '/features/checkout/checkout.feature');
+
+            $steps = $suite->getSpecifications()[0]->run()->getResults()[0]->getResults();
+            expect($steps[0]->isPassed())->toBeTrue();
+        } finally {
+            unlink($root . '/features/checkout/checkout.feature');
+            unlink($root . '/features/checkout/checkout.steps.php');
+            rmdir($root . '/features/checkout');
+            rmdir($root . '/features');
+            rmdir($root);
+        }
+    });
+
+    it("finds step definitions in the configured steps path", function () {
+        $root = sys_get_temp_dir() . '/phpspec_loader_stepspath_' . uniqid();
+        mkdir($root . '/features', 0777, true);
+        mkdir($root . '/acceptance_steps', 0777, true);
+        file_put_contents(
+            $root . '/features/checkout.feature',
+            "Feature: Checkout\n  Scenario: Buys\n    Given a configured step\n"
+        );
+        file_put_contents(
+            $root . '/acceptance_steps/checkout.steps.php',
+            '<?php given("a configured step", function () { expect(true)->toBeTrue(); });'
+        );
+
+        try {
+            $loader = new Loader(featuresPath: $root . '/features', stepsPath: $root . '/acceptance_steps');
+            $suite = $loader->load($root . '/features');
+
+            $steps = $suite->getSpecifications()[0]->run()->getResults()[0]->getResults();
+            expect($steps[0]->isPassed())->toBeTrue();
+        } finally {
+            unlink($root . '/features/checkout.feature');
+            unlink($root . '/acceptance_steps/checkout.steps.php');
+            rmdir($root . '/features');
+            rmdir($root . '/acceptance_steps');
+            rmdir($root);
+        }
+    });
+
     it("filters features by path", function (Filesystem $fs) {
         allow($fs->isFile())->toReturnUsing(fn(string $p) => str_ends_with($p, '.feature'));
         allow($fs->isDir())->toReturnUsing(fn(string $p) => $p === './features');

--- a/spec/PhpSpec/Report/Formatter/Html.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Html.spec.php
@@ -1,0 +1,187 @@
+<?php
+
+use PhpSpec\Report\Formatter\Html;
+use PhpSpec\Result\ContextResult;
+use PhpSpec\Result\ExampleResult;
+use PhpSpec\Result\FeatureResult;
+use PhpSpec\Result\MatchResult;
+use PhpSpec\Result\ScenarioResult;
+use PhpSpec\Result\SpecificationResult;
+use PhpSpec\Result\StepResult;
+use PhpSpec\Result\SuiteResult;
+use PhpSpec\Specification\ExampleError;
+use PhpSpec\StoryBDD\StepError;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+describe(Html::class, function() {
+
+    it("formats passing results as an HTML document", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $match = MatchResult::passed();
+        $example = new ExampleResult("renders a passing example", [$match]);
+        $spec = new SpecificationResult("MySpec", [$example]);
+        $suite = new SuiteResult([$spec]);
+
+        $formatter->format($suite);
+        $text = $output->fetch();
+        expect($text)->toContain('<!DOCTYPE html>');
+        expect($text)->toContain('MySpec');
+        expect($text)->toContain('renders a passing example');
+        expect($text)->toContain('class="example passed"');
+        expect($text)->toContain('1 example');
+    });
+
+    it("formats failing results with their failure message", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $match = MatchResult::failed("a", "b", "Expected a to be b", __FILE__, __LINE__);
+        $example = new ExampleResult("fails", [$match]);
+        $spec = new SpecificationResult("MySpec", [$example]);
+        $suite = new SuiteResult([$spec]);
+
+        $formatter->format($suite);
+        $text = $output->fetch();
+        expect($text)->toContain('class="example failed"');
+        expect($text)->toContain('Expected a to be b');
+        expect($text)->toContain('1 failure');
+    });
+
+    it("collapses the failure details under the failed example", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $line = __LINE__ + 1;
+        $match = MatchResult::failed("a", "b", "Expected a to be b", __FILE__, $line);
+        $example = new ExampleResult("fails", [$match]);
+        $spec = new SpecificationResult("MySpec", [$example]);
+
+        $formatter->format(new SuiteResult([$spec]));
+        $text = $output->fetch();
+        expect($text)->toContain('<details class="example failed">');
+        expect($text)->toContain('<summary>fails</summary>');
+        expect($text)->toContain('expected:');
+        expect($text)->toContain('got:');
+        expect($text)->toContain('at ' . __FILE__ . ':' . $line);
+        expect($text)->toContain('class="snippet"');
+        expect($text)->toContain('MatchResult::failed');
+    });
+
+    it("collapses the error message under a failed step", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $step = new StepResult("Then it fails", "failure");
+        $step->setError(new StepError("Assertion failed badly", new \RuntimeException("boom")));
+        $story = new FeatureResult("My feature", [
+            new ScenarioResult("My scenario", [$step]),
+        ], "features/my.feature");
+
+        $formatter->format(new SuiteResult([$story]));
+        $text = $output->fetch();
+        expect($text)->toContain('<details class="example failure">');
+        expect($text)->toContain('<summary>Then it fails</summary>');
+        expect($text)->toContain('Assertion failed badly');
+    });
+
+    it("formats error results with the error message", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $example = new ExampleResult("errors", [], true);
+        $example->setError(new ExampleError("boom", new \RuntimeException("boom")));
+        $spec = new SpecificationResult("MySpec", [$example]);
+        $suite = new SuiteResult([$spec]);
+
+        $formatter->format($suite);
+        $text = $output->fetch();
+        expect($text)->toContain('class="example error"');
+        expect($text)->toContain('boom');
+    });
+
+    it("marks pending and skipped examples", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $pending = new ExampleResult("not yet written", [], false, true);
+        $skipped = new ExampleResult("not on this platform", [], false, false, true);
+        $spec = new SpecificationResult("MySpec", [$pending, $skipped]);
+        $suite = new SuiteResult([$spec]);
+
+        $formatter->format($suite);
+        $text = $output->fetch();
+        expect($text)->toContain('class="example pending"');
+        expect($text)->toContain('class="example skipped"');
+    });
+
+    it("opens groups containing failures and collapses passing ones", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $passing = new SpecificationResult("AllGood", [new ExampleResult("passes", [MatchResult::passed()])]);
+        $failing = new SpecificationResult("Broken", [
+            new ExampleResult("fails", [MatchResult::failed("a", "b", "nope", __FILE__, __LINE__)]),
+        ]);
+        $suite = new SuiteResult([$passing, $failing]);
+
+        $formatter->format($suite);
+        $text = $output->fetch();
+        expect($text)->toMatch('/<details class="group passed">\s*<summary>/');
+        expect($text)->toMatch('/<details class="group failed" open>\s*<summary>/');
+        expect($text)->toContain('1 example · 1 failed');
+    });
+
+    it("shows tabs only when specs and stories are mixed", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $spec = new SpecificationResult("MySpec", [new ExampleResult("passes", [MatchResult::passed()])]);
+        $story = new FeatureResult("My feature", [
+            new ScenarioResult("My scenario", [new StepResult("Given a step", "passed")]),
+        ], "features/my.feature");
+
+        $formatter->format(new SuiteResult([$spec, $story]));
+        $mixed = $output->fetch();
+        expect($mixed)->toContain('role="tablist"');
+        expect($mixed)->toContain('Specs');
+        expect($mixed)->toContain('Stories');
+        expect($mixed)->toContain('My scenario');
+
+        $formatter->format(new SuiteResult([$spec]));
+        $specsOnly = $output->fetch();
+        expect($specsOnly)->not()->toContain('role="tablist"');
+    });
+
+    it("fills the pass-ratio meter proportionally", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $spec = new SpecificationResult("Halves", [
+            new ExampleResult("passes", [MatchResult::passed()]),
+            new ExampleResult("fails", [MatchResult::failed("a", "b", "nope", __FILE__, __LINE__)]),
+        ]);
+
+        $formatter->format(new SuiteResult([$spec]));
+        expect($output->fetch())->toContain('width:50.0%');
+    });
+
+    it("renders nested contexts and escapes HTML in titles and messages", function() {
+        $output = new BufferedOutput();
+        $formatter = new Html($output);
+
+        $match = MatchResult::failed("a", "b", 'Expected <b> to be "safe"', __FILE__, __LINE__);
+        $example = new ExampleResult('handles <input> titles', [$match]);
+        $context = new ContextResult('when <nested>', [$example]);
+        $spec = new SpecificationResult("MySpec", [$context]);
+        $suite = new SuiteResult([$spec]);
+
+        $formatter->format($suite);
+        $text = $output->fetch();
+        expect($text)->toContain('when &lt;nested&gt;');
+        expect($text)->toContain('handles &lt;input&gt; titles');
+        expect($text)->toContain('Expected &lt;b&gt; to be &quot;safe&quot;');
+        expect($text)->not()->toContain('<input>');
+    });
+});

--- a/spec/PhpSpec/Report/HtmlTheme.spec.php
+++ b/spec/PhpSpec/Report/HtmlTheme.spec.php
@@ -1,0 +1,33 @@
+<?php
+
+use PhpSpec\Report\HtmlTheme;
+
+describe(HtmlTheme::class, function () {
+
+    it('wraps content in a full HTML document with the brand stylesheet', function () {
+        $page = HtmlTheme::page('PhpSpec Results', '<p>content</p>');
+
+        expect($page)->toContain('<!DOCTYPE html>');
+        expect($page)->toContain('<title>PhpSpec Results</title>');
+        expect($page)->toContain('<p>content</p>');
+        expect($page)->toContain('--ps-red');
+        expect($page)->toContain('--ps-green');
+    });
+
+    it('renders the header band with the logo, wordmark, a subtitle and meta text', function () {
+        $header = HtmlTheme::header('Results', '4 examples · 2 failures');
+
+        expect($header)->toContain('phpspec');
+        expect($header)->toContain('Results');
+        expect($header)->toContain('4 examples · 2 failures');
+        expect($header)->toContain('class="band"');
+        expect($header)->toContain('data:image/png;base64,');
+        expect($header)->toContain('alt="phpspec"');
+    });
+
+    it('renders the pass-ratio meter with a clamped width', function () {
+        expect(HtmlTheme::meter(50.0))->toContain('width:50.0%');
+        expect(HtmlTheme::meter(150.0))->toContain('width:100.0%');
+        expect(HtmlTheme::meter(-10.0))->toContain('width:0.0%');
+    });
+});

--- a/src/PhpSpec/Configuration.php
+++ b/src/PhpSpec/Configuration.php
@@ -250,6 +250,15 @@ final class Configuration
     }
 
     /**
+     * Returns the configured step definitions directory, searched in addition
+     * to the features folder, or null when not configured.
+     */
+    public function getStepsPath(): ?string
+    {
+        return $this->get('steps_path');
+    }
+
+    /**
      * Returns the extensions configuration block.
      *
      * @return array<string, mixed>

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -55,7 +55,7 @@ final class Application extends BaseApplication
         ));
         $specSuffix = $config->getSpecSuffix();
         $defaultCommands[] = new Run(
-            new Loader(specSuffix: $specSuffix),
+            new Loader(specSuffix: $specSuffix, featuresPath: $config->getFeaturesPath(), stepsPath: $config->getStepsPath()),
             new Runner(),
             $config,
             $extensionLoader,
@@ -67,7 +67,7 @@ final class Application extends BaseApplication
             new SpecGenerator(ltrim($config->getSpecPath(), './'), specSuffix: $specSuffix),
         );
         $defaultCommands[] = new Pair(
-            new Loader(specSuffix: $specSuffix),
+            new Loader(specSuffix: $specSuffix, featuresPath: $config->getFeaturesPath(), stepsPath: $config->getStepsPath()),
             new Runner(),
             new SpecGenerator(ltrim($config->getSpecPath(), './'), specSuffix: $specSuffix),
             new ClassGenerator(ltrim($config->getSrcPath(), './'), psr4Prefix: $config->getPsr4Prefix()),

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -24,6 +24,7 @@ use PhpSpec\Loader;
 use PhpSpec\Parallel\ParallelRunner;
 use PhpSpec\Report\Formatter;
 use PhpSpec\Report\Formatter\Dot;
+use PhpSpec\Report\Formatter\Html;
 use PhpSpec\Report\Formatter\Junit;
 use PhpSpec\Report\Formatter\Pretty;
 use PhpSpec\Report\Formatter\Tap;
@@ -36,6 +37,7 @@ use Symfony\Component\Console\Input\InputArgument as Argument;
 use Symfony\Component\Console\Input\InputInterface as Input;
 use Symfony\Component\Console\Input\InputOption as Option;
 use Symfony\Component\Console\Output\OutputInterface as Output;
+use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * @internal
@@ -77,7 +79,8 @@ final class Run extends Command
             ->addOption('stop-on-skipped', null, Option::VALUE_NONE, 'Stop on first skipped example')
             ->addOption('stop-on-problems', null, Option::VALUE_NONE, 'Stop on any non-pass result')
             ->addOption('filter', null, Option::VALUE_REQUIRED, 'Run only specs matching pattern')
-            ->addOption('format', 'f', Option::VALUE_REQUIRED, 'Output format (pretty, dot, tap, junit)', 'pretty')
+            ->addOption('format', 'f', Option::VALUE_REQUIRED | Option::VALUE_IS_ARRAY, 'Output format(s): pretty, dot, tap, junit, html; repeatable, pair each with -o', [])
+            ->addOption('out', 'o', Option::VALUE_REQUIRED | Option::VALUE_IS_ARRAY, 'Report destination for the corresponding --format; "std" is the console', [])
             ->addOption('order', null, Option::VALUE_REQUIRED, 'Run order (default, random)', 'default')
             ->addOption('seed', null, Option::VALUE_REQUIRED, 'Seed for random order')
             ->addOption('profile', null, Option::VALUE_OPTIONAL, 'Show N slowest examples', false)
@@ -109,7 +112,8 @@ final class Run extends Command
      *    applies --filter, --stop-on-failure, --order=random/--seed, then delegates
      *    execution to the Runner. Measures wall-clock duration.
      *
-     * 5. Renders results through the selected formatter (pretty, dot, tap, junit),
+     * 5. Renders results through the selected formatter (pretty, dot, tap,
+     *    junit, html), then writes any report files requested with --output-*,
      *    resolved from --format or the config file.
      *
      * 6. If --profile was given, prints the N slowest examples with their durations.
@@ -139,6 +143,14 @@ final class Run extends Command
         }
         $this->registerAutoloader();
 
+        $unknownFormats = $this->unknownFormats($input);
+
+        if ($unknownFormats !== []) {
+            $output->writeln('<fg=red>Unknown format: ' . implode(', ', $unknownFormats) . ' (available: pretty, dot, tap, junit, html)</>');
+
+            return 1;
+        }
+
         $coverageReporter = $this->startCoverage($input, $output);
 
         if ($coverageReporter === false) {
@@ -147,6 +159,7 @@ final class Run extends Command
 
         $results = $this->runSuiteStreaming($input, $output);
 
+        $this->writeReportFiles($input, $output, $results);
         $this->printProfile($input, $output, $results);
 
         if ($coverageReporter) {
@@ -157,11 +170,49 @@ final class Run extends Command
             }
         }
 
-        if ($this->resolveFormat($input) !== 'junit') {
+        if (!in_array($this->resolveFormat($input), ['junit', 'html'], true)) {
             $this->generateCode($output, $results, (bool) $input->getOption('fake'), $input->isInteractive());
         }
 
         return $results->status();
+    }
+
+    /**
+     * Writes the report files requested with --format/-o pairs, each rendered
+     * from the full suite results in addition to the console format, and
+     * renders any additional console-bound formats.
+     *
+     * @param Input $input the console input for the --format and -o options
+     * @param Output $output the console output for the confirmation notes
+     * @param SuiteResult $results the aggregated suite results
+     */
+    private function writeReportFiles(Input $input, Output $output, SuiteResult $results): void
+    {
+        $outputs = $this->resolveOutputs($input);
+
+        foreach ($outputs['files'] as [$format, $file]) {
+            $dir = dirname($file);
+
+            if (!is_dir($dir)) {
+                mkdir($dir, 0777, true);
+            }
+
+            $handle = fopen($file, 'w');
+
+            if ($handle === false) {
+                $output->writeln("<fg=red>Could not write report to $file</>");
+                continue;
+            }
+
+            $this->createFormatter($format, new StreamOutput($handle, StreamOutput::VERBOSITY_NORMAL, false))->format($results);
+            fclose($handle);
+
+            $output->writeln("  Report written to $file");
+        }
+
+        foreach ($outputs['extraConsole'] as $format) {
+            $this->createFormatter($format, $output)->format($results);
+        }
     }
 
     /**
@@ -270,7 +321,7 @@ final class Run extends Command
             $output->writeln("<fg=yellow>Randomised with seed $seed</>");
         }
 
-        $formatter = $this->createFormatter($input, $output);
+        $formatter = $this->createFormatter($this->resolveFormat($input), $output);
         $formatter->begin();
 
         $start = hrtime(true);
@@ -309,19 +360,72 @@ final class Run extends Command
      * @param Input $input the console input for the --format option
      * @return string
      */
-    private function resolveFormat(Input $input): string
+    /**
+     * Resolves the --format/-o pairs into the console format and the report
+     * files to write. Outs pair with formats by position, Behat style; "std"
+     * (the default when a format has no -o) means the console. The first
+     * console-bound format streams live; additional ones render at the end.
+     *
+     * @param Input $input the console input for the --format and -o options
+     * @return array{console: string, files: array<int, array{string, string}>, extraConsole: array<int, string>}
+     */
+    private function resolveOutputs(Input $input): array
     {
-        $format = $input->getOption('format') !== 'pretty'
-            ? $input->getOption('format')
-            : $this->config->getFormat();
+        $formats = (array) $input->getOption('format');
+        $outs = (array) $input->getOption('out');
 
-        return $format ?? 'pretty';
+        if ($formats === []) {
+            $formats = [$this->config->getFormat()];
+        }
+
+        $console = null;
+        $files = [];
+        $extraConsole = [];
+
+        foreach (array_values($formats) as $i => $format) {
+            $file = $outs[$i] ?? 'std';
+
+            if ($file !== 'std') {
+                $files[] = [$format, $file];
+            } elseif ($console === null) {
+                $console = $format;
+            } else {
+                $extraConsole[] = $format;
+            }
+        }
+
+        return [
+            'console' => $console ?? 'pretty',
+            'files' => $files,
+            'extraConsole' => $extraConsole,
+        ];
     }
 
-    private function createFormatter(Input $input, Output $output): Formatter
+    /**
+     * Returns the requested formats that neither the built-in set nor a
+     * loaded extension can provide.
+     *
+     * @param Input $input the console input for the --format option
+     * @return array<int, string> the unknown format names
+     */
+    private function unknownFormats(Input $input): array
     {
-        $format = $this->resolveFormat($input);
+        $known = ['pretty', 'dot', 'tap', 'junit', 'html'];
 
+        return array_values(array_filter(
+            (array) $input->getOption('format'),
+            fn(string $format) => !in_array($format, $known, true)
+                && !($this->extensionLoader?->hasFormatter($format) ?? false),
+        ));
+    }
+
+    private function resolveFormat(Input $input): string
+    {
+        return $this->resolveOutputs($input)['console'];
+    }
+
+    private function createFormatter(string $format, Output $output): Formatter
+    {
         if ($this->extensionLoader !== null && $this->extensionLoader->hasFormatter($format)) {
             return new FormatterBridge($this->extensionLoader->getFormatter($format), $output);
         }
@@ -330,6 +434,7 @@ final class Run extends Command
             'dot' => new Dot($output),
             'tap' => new Tap($output),
             'junit' => new Junit($output),
+            'html' => new Html($output),
             default => new Pretty($output),
         };
     }

--- a/src/PhpSpec/Coverage/HtmlReport.php
+++ b/src/PhpSpec/Coverage/HtmlReport.php
@@ -14,10 +14,14 @@
 
 namespace PhpSpec\Coverage;
 
+use PhpSpec\Report\HtmlTheme;
+
 /**
  * @internal
- * Renders an HTML code coverage report with an index page and per-file source views.
- * Lines are color-coded green (covered), red (uncovered), or grey (non-executable).
+ * Renders an HTML code coverage report with an index page and per-file source
+ * views, in the PhpSpec brand shared with the results formatter (HtmlTheme).
+ * Lines are color-coded green (covered), red (uncovered), or plain
+ * (non-executable).
  */
 final class HtmlReport
 {
@@ -74,50 +78,39 @@ final class HtmlReport
 
         $rows = '';
         foreach ($files as $file => $info) {
-            $safeFile = htmlspecialchars($file);
+            $safeFile = htmlspecialchars($file, ENT_QUOTES);
             $linkFile = str_replace('/', '_', $file) . '.html';
-            $barColor = $this->barColor($info['pct']);
+            $grade = $this->barGrade($info['pct']);
+            $width = sprintf('%.1f', $info['pct']);
 
             $rows .= <<<ROW
             <tr>
                 <td><a href="$linkFile">$safeFile</a></td>
-                <td>
-                    <div class="bar"><div class="fill" style="width:{$info['pct']}%;background:$barColor"></div></div>
-                </td>
+                <td><div class="bar"><span class="$grade" style="width:$width%"></span></div></td>
                 <td class="num">{$info['covered']}/{$info['executable']}</td>
                 <td class="num">{$this->fmt($info['pct'])}</td>
             </tr>
             ROW;
         }
 
-        $barColor = $this->barColor($totalPct);
+        $meta = sprintf('%d/%d lines · %s', $totalCovered, $totalExecutable, $this->fmt($totalPct));
 
-        $html = <<<HTML
-        <!DOCTYPE html>
-        <html lang="en"><head><meta charset="utf-8"><title>Code Coverage</title>
-        <style>
-        body { font-family: sans-serif; margin: 2em; }
-        table { border-collapse: collapse; width: 100%; }
-        th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid #ddd; }
-        .num { text-align: right; }
-        .bar { background: #eee; height: 14px; border-radius: 3px; width: 200px; }
-        .fill { height: 100%; border-radius: 3px; }
-        .total { font-weight: bold; font-size: 1.1em; margin-top: 1em; }
-        a { color: #0366d6; text-decoration: none; }
-        a:hover { text-decoration: underline; }
-        </style></head><body>
-        <h1>Code Coverage Report</h1>
-        <table>
-        <tr><th>File</th><th>Coverage</th><th>Lines</th><th>%</th></tr>
-        {$rows}
-        </table>
-        <p class="total">Total: $totalCovered/$totalExecutable ({$this->fmt($totalPct)})
-        <div class="bar" style="width:300px"><div class="fill" style="width:$totalPct%;background:$barColor"></div></div>
-        </p>
-        </body></html>
-        HTML;
+        $body = HtmlTheme::header('Coverage', $meta)
+            . HtmlTheme::meter($totalPct)
+            . "<main>\n"
+            . "<table class=\"coverage\">\n"
+            . "<tr><th>File</th><th>Coverage</th><th>Lines</th><th>%</th></tr>\n"
+            . $rows
+            . "\n</table>\n"
+            . sprintf(
+                "<footer class=\"summary\">\n<p>Total: %d/%d lines covered (%s)</p>\n</footer>\n",
+                $totalCovered,
+                $totalExecutable,
+                $this->fmt($totalPct),
+            )
+            . "</main>\n";
 
-        file_put_contents($dirPath . '/index.html', $html);
+        file_put_contents($dirPath . '/index.html', HtmlTheme::page('PhpSpec Coverage', $body));
     }
 
     /**
@@ -142,49 +135,38 @@ final class HtmlReport
 
         foreach ($source as $i => $line) {
             $lineNo = $i + 1;
-            $safeLine = htmlspecialchars($line);
+            $safeLine = htmlspecialchars($line, ENT_QUOTES);
+            $hit = $lineData[$lineNo] ?? -2;
 
-            if (isset($lineData[$lineNo])) {
-                $hit = $lineData[$lineNo];
-                if ($hit === -2) {
-                    $bg = '#f5f5f5';
-                } elseif ($hit >= 1) {
-                    $bg = '#dfd';
-                } else {
-                    $bg = '#fdd';
-                }
-            } else {
-                $bg = '#f5f5f5';
-            }
+            $class = match (true) {
+                $hit >= 1 => ' class="hit"',
+                $hit === -2 => '',
+                default => ' class="miss"',
+            };
 
             $lines .= sprintf(
-                '<tr style="background:%s"><td class="ln">%d</td><td class="code"><pre>%s</pre></td></tr>',
-                $bg,
+                '<tr%s><td class="ln">%d</td><td><pre>%s</pre></td></tr>',
+                $class,
                 $lineNo,
                 rtrim($safeLine),
             );
         }
 
-        $safeFile = htmlspecialchars($file);
-        $html = <<<HTML
-        <!DOCTYPE html>
-        <html lang="en"><head><meta charset="utf-8"><title>$safeFile - Coverage</title>
-        <style>
-        body { font-family: sans-serif; margin: 2em; }
-        table { border-collapse: collapse; width: 100%; }
-        td { padding: 0 8px; vertical-align: top; }
-        .ln { text-align: right; color: #999; width: 50px; user-select: none; }
-        .code pre { margin: 0; font-size: 13px; }
-        a { color: #0366d6; }
-        </style></head><body>
-        <p><a href="index.html">Back to index</a></p>
-        <h1>$safeFile</h1>
-        <table>$lines</table>
-        </body></html>
-        HTML;
+        $safeFile = htmlspecialchars($file, ENT_QUOTES);
+        $counts = CoverageCollector::countLines($lineData);
+        $pct = $counts['executable'] > 0 ? ($counts['covered'] / $counts['executable']) * 100 : 0;
+        $meta = sprintf('%d/%d lines · %s', $counts['covered'], $counts['executable'], $this->fmt($pct));
+
+        $body = HtmlTheme::header('Coverage', $meta)
+            . HtmlTheme::meter($pct)
+            . "<main>\n"
+            . "<p><a class=\"back\" href=\"index.html\">‹ Back to index</a></p>\n"
+            . "<h2>$safeFile</h2>\n"
+            . "<table class=\"source\">$lines</table>\n"
+            . "</main>\n";
 
         $linkFile = str_replace('/', '_', $file) . '.html';
-        file_put_contents($dirPath . '/' . $linkFile, $html);
+        file_put_contents($dirPath . '/' . $linkFile, HtmlTheme::page("$safeFile — PhpSpec Coverage", $body));
     }
 
     /**
@@ -206,20 +188,20 @@ final class HtmlReport
     }
 
     /**
-     * Returns the CSS color for a coverage percentage bar.
+     * Returns the bar grade class for a coverage percentage.
      *
      * @param float $pct the coverage percentage
-     * @return string the hex color code (green >= 80%, orange >= 50%, red otherwise)
+     * @return string "hi" (green, >= 80%), "mid" (amber, >= 50%) or "lo" (red)
      */
-    private function barColor(float $pct): string
+    private function barGrade(float $pct): string
     {
         if ($pct >= 80) {
-            return '#4caf50';
+            return 'hi';
         }
         if ($pct >= 50) {
-            return '#ff9800';
+            return 'mid';
         }
-        return '#f44336';
+        return 'lo';
     }
 
     /**

--- a/src/PhpSpec/InProcessRunner.php
+++ b/src/PhpSpec/InProcessRunner.php
@@ -167,12 +167,12 @@ final class InProcessRunner
             if (str_starts_with($part, '--')) {
                 if (str_contains($part, '=')) {
                     [$key, $value] = explode('=', $part, 2);
-                    $result[$key] = $value;
+                    self::addOptionValue($result, $key, $value);
                 } else {
                     // Check if next part is a value (not another option)
                     $next = $parts[$i + 1] ?? null;
                     if ($next !== null && !str_starts_with($next, '-')) {
-                        $result[$part] = $next;
+                        self::addOptionValue($result, $part, $next);
                         $skipNext = true;
                     } else {
                         $result[$part] = true;
@@ -182,7 +182,7 @@ final class InProcessRunner
                 // Short option: check if next part is a value
                 $next = $parts[$i + 1] ?? null;
                 if ($next !== null && !str_starts_with($next, '-')) {
-                    $result[$part] = $next;
+                    self::addOptionValue($result, $part, $next);
                     $skipNext = true;
                 } else {
                     $result[$part] = true;
@@ -209,5 +209,28 @@ final class InProcessRunner
         }
 
         return $result;
+    }
+
+    /**
+     * Records an option value, aggregating repeated occurrences into an
+     * ordered array so Behat-style --format/-o pairs survive parsing.
+     *
+     * @param array<string, mixed> $result the parsed arguments (by reference)
+     * @param string $key the option name including dashes
+     * @param string $value the option value
+     */
+    private static function addOptionValue(array &$result, string $key, string $value): void
+    {
+        if (!isset($result[$key])) {
+            $result[$key] = $value;
+
+            return;
+        }
+
+        if (!is_array($result[$key])) {
+            $result[$key] = [$result[$key]];
+        }
+
+        $result[$key][] = $value;
     }
 }

--- a/src/PhpSpec/Loader.php
+++ b/src/PhpSpec/Loader.php
@@ -30,11 +30,17 @@ final class Loader
     /**
      * @param Filesystem|null $filesystem injectable filesystem for testability
      * @param string $specSuffix file suffix used to identify spec files
+     * @param string $featuresPath the features root; step definitions anywhere under it are discoverable
+     * @param string|null $stepsPath additional step definitions directory, or null when not configured
      */
     private Filesystem $fs;
 
-    public function __construct(?Filesystem $filesystem = null, private string $specSuffix = '.spec.php')
-    {
+    public function __construct(
+        ?Filesystem $filesystem = null,
+        private string $specSuffix = '.spec.php',
+        private string $featuresPath = './features',
+        private ?string $stepsPath = null,
+    ) {
         $this->fs = $filesystem ?? new RealFilesystem();
     }
 
@@ -179,11 +185,24 @@ final class Loader
 
         $this->scanFeatures($path, $featureFiles, $stepFiles);
 
+        // Step definitions are discoverable anywhere under the features root
+        // and in the configured steps directory, wherever the run points
+        $featuresRoot = rtrim($this->featuresPath, '/');
+
+        if ($this->fs->isDir($featuresRoot)) {
+            $this->collectStepFiles($featuresRoot, $stepFiles);
+        }
+
+        if ($this->stepsPath !== null && $this->fs->isDir($this->stepsPath)) {
+            $this->collectStepFiles($this->stepsPath, $stepFiles);
+        }
+
         // Fresh registry so prior spec execution can't pollute step definitions
         StoryBDDRegistry::init();
 
-        // Load step definitions into the fresh registry
-        foreach ($stepFiles as $stepFile) {
+        // Load step definitions into the fresh registry; ancestor and in-tree
+        // discovery can both find the same steps directory, so deduplicate
+        foreach (array_unique($stepFiles) as $stepFile) {
             require $stepFile;
         }
 
@@ -213,21 +232,18 @@ final class Loader
     {
         if ($this->fs->isFile($path) && str_ends_with($path, '.feature')) {
             $featureFiles[] = $path;
-            // Walk up from the feature file's directory to find steps/ dirs
-            $dir = dirname($path);
-            while ($dir !== dirname($dir)) {
-                $stepsDir = $dir . '/steps';
-                if ($this->fs->isDir($stepsDir)) {
-                    $this->collectStepFiles($stepsDir, $stepFiles);
-                }
-                $dir = dirname($dir);
-            }
+            $this->collectAncestorSteps(dirname($path), $stepFiles);
+
             return;
         }
 
         if (!$this->fs->isDir($path)) {
             return;
         }
+
+        // Steps may live beside an ancestor (e.g. features/steps/ when
+        // running features/scenarios/checkout), not only inside the tree
+        $this->collectAncestorSteps($path, $stepFiles);
 
         $files = $this->fs->scandir($path);
 
@@ -247,6 +263,26 @@ final class Loader
             } elseif (str_ends_with($file, '.feature')) {
                 $featureFiles[] = $filePath;
             }
+        }
+    }
+
+    /**
+     * Walks up from a directory collecting step files from every steps/
+     * directory found beside it or its ancestors.
+     *
+     * @param string $dir the directory to walk up from
+     * @param array<string> $stepFiles collected step file paths (by reference)
+     */
+    private function collectAncestorSteps(string $dir, array &$stepFiles): void
+    {
+        while ($dir !== dirname($dir)) {
+            $stepsDir = $dir . '/steps';
+
+            if ($this->fs->isDir($stepsDir)) {
+                $this->collectStepFiles($stepsDir, $stepFiles);
+            }
+
+            $dir = dirname($dir);
         }
     }
 

--- a/src/PhpSpec/Report/Formatter/Html.php
+++ b/src/PhpSpec/Report/Formatter/Html.php
@@ -1,0 +1,526 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter;
+
+use PhpSpec\Report\AbstractFormatter;
+use PhpSpec\Report\HtmlTheme;
+use PhpSpec\Result\Counts;
+use PhpSpec\Result\ExampleResult;
+use PhpSpec\Result\FeatureResult;
+use PhpSpec\Result\MatchResult;
+use PhpSpec\Result\Result;
+use PhpSpec\Result\StepResult;
+use PhpSpec\Result\SuiteResult;
+use PhpSpec\Results;
+
+/**
+ * @internal
+ * Renders spec results as a self-contained HTML document in the PhpSpec brand
+ * (see HtmlTheme): collapsible group bars per spec/feature, tabs separating
+ * spec and story results when a run mixes them, and a pass-ratio meter.
+ * Suitable for saving with `phpspec run --format=html > report.html`.
+ */
+final class Html extends AbstractFormatter
+{
+    /**
+     * No-op; the HTML document is non-streamable, all output happens in end().
+     */
+    public function begin(): void
+    {
+        // HTML is non-streamable; all output happens in end()
+    }
+
+    /**
+     * No-op; the HTML document is non-streamable, all output happens in end().
+     */
+    public function printResult(Results $result): void
+    {
+        // HTML is non-streamable; all output happens in end()
+    }
+
+    /**
+     * Builds and outputs the complete HTML document from all collected results.
+     */
+    public function end(SuiteResult $results): void
+    {
+        $specs = [];
+        $stories = [];
+
+        foreach ($results->getResults() as $result) {
+            if ($result instanceof FeatureResult) {
+                $stories[] = $result;
+            } else {
+                $specs[] = $result;
+            }
+        }
+
+        $counts = (new Counts($results))->toArray();
+        $total = $counts['examples'] + $counts['steps'];
+        $passed = $counts['passes'] + $counts['stepPasses'];
+
+        $body = HtmlTheme::header('Results', $this->summaryLine($counts))
+            . HtmlTheme::meter($total > 0 ? ($passed / $total) * 100 : 100.0)
+            . "<main>\n"
+            . $this->renderPanels($specs, $stories)
+            . $this->renderFooter($counts, $results->getDuration())
+            . "</main>\n"
+            . $this->script();
+
+        $this->output->writeln(HtmlTheme::page('PhpSpec Results', $body));
+    }
+
+    /**
+     * Renders the spec and story panels, with a tab bar when both are present.
+     *
+     * @param array<int, Results> $specs top-level spec results
+     * @param array<int, Results> $stories top-level feature results
+     * @return string the panels HTML
+     */
+    private function renderPanels(array $specs, array $stories): string
+    {
+        $html = '';
+        $mixed = $specs !== [] && $stories !== [];
+
+        if ($mixed) {
+            $html .= "<div class=\"tabs\" role=\"tablist\">\n"
+                . "<button role=\"tab\" aria-selected=\"true\" data-panel=\"specs\">Specs</button>\n"
+                . "<button role=\"tab\" aria-selected=\"false\" data-panel=\"stories\">Stories</button>\n"
+                . "</div>\n";
+        }
+
+        $html .= "<div class=\"toolbar\">\n"
+            . "<button type=\"button\" data-act=\"expand\">Expand all</button>\n"
+            . "<button type=\"button\" data-act=\"collapse\">Collapse all</button>\n"
+            . "</div>\n";
+
+        if ($specs !== []) {
+            $html .= "<section class=\"panel\" data-panel=\"specs\">\n"
+                . $this->renderGroups($specs, 'example')
+                . "</section>\n";
+        }
+
+        if ($stories !== []) {
+            $hidden = $mixed ? ' hidden' : '';
+            $html .= "<section class=\"panel\" data-panel=\"stories\"$hidden>\n"
+                . $this->renderGroups($stories, 'step')
+                . "</section>\n";
+        }
+
+        return $html;
+    }
+
+    /**
+     * Renders top-level results as collapsible group bars: groups containing
+     * failures open, all-passing groups collapsed.
+     *
+     * @param array<int, Results> $groups the top-level results
+     * @param string $leafNoun the leaf label for the count, "example" or "step"
+     * @return string the groups HTML
+     */
+    private function renderGroups(array $groups, string $leafNoun): string
+    {
+        $html = '';
+
+        foreach ($groups as $group) {
+            $failed = $this->hasFailure($group);
+            $leaves = $this->countLeaves($group);
+            $title = method_exists($group, 'getTitle') ? (string) $group->getTitle() : '';
+            $count = $leaves . ' ' . $leafNoun . ($leaves !== 1 ? 's' : '');
+
+            if ($failed) {
+                $count .= ' · ' . $this->countFailures($group) . ' failed';
+            }
+
+            $html .= sprintf(
+                "<details class=\"group %s\"%s>\n<summary>%s <span class=\"count\">%s</span></summary>\n<ul>\n%s</ul>\n</details>\n",
+                $failed ? 'failed' : 'passed',
+                $failed ? ' open' : '',
+                $this->escape($title),
+                $this->escape($count),
+                $this->renderChildren($group, 3),
+            );
+        }
+
+        return $html;
+    }
+
+    /**
+     * Renders a result subtree: leaves become list items, nested groups
+     * become subsections with a heading and a nested list.
+     *
+     * @param Results $result the result node to render
+     * @param int $level heading level for nested group titles (capped at h6)
+     * @return string the rendered HTML fragment
+     */
+    private function renderChildren(Results $result, int $level): string
+    {
+        $html = '';
+
+        foreach ($result->getResults() as $child) {
+            if ($child instanceof ExampleResult) {
+                $html .= $this->renderExample($child);
+                continue;
+            }
+
+            if ($child instanceof StepResult) {
+                $html .= $this->renderStep($child);
+                continue;
+            }
+
+            $title = method_exists($child, 'getTitle') ? (string) $child->getTitle() : '';
+            $html .= sprintf(
+                "<section class=\"subgroup\">\n<h%d>%s</h%d>\n<ul>\n%s</ul>\n</section>\n",
+                $level,
+                $this->escape($title),
+                $level,
+                $this->renderChildren($child, min($level + 1, 6)),
+            );
+        }
+
+        return $html;
+    }
+
+    /**
+     * Renders a single example: passing, pending and skipped examples are
+     * plain list items; failures and errors collapse their full detail
+     * (message, expected/got, code snippet, location) under the title.
+     *
+     * @param ExampleResult $example the example result to render
+     * @return string the rendered HTML fragment
+     */
+    private function renderExample(ExampleResult $example): string
+    {
+        $state = match (true) {
+            $example->isError() => 'error',
+            $example->isFailure() => 'failed',
+            $example->isPending() => 'pending',
+            $example->isSkipped() => 'skipped',
+            default => 'passed',
+        };
+
+        if ($state === 'failed') {
+            $detail = '';
+
+            foreach ($example->getResults() as $match) {
+                if ($match->getResult() === Result::Failed) {
+                    $detail .= $this->renderFailureDetail($match);
+                }
+            }
+
+            return $this->collapsedLeaf($state, $example->getTitle(), $detail);
+        }
+
+        if ($state === 'error') {
+            $detail = sprintf(
+                "<p class=\"message\">%s</p>\n",
+                $this->escape($example->getError()?->getMessage() ?? ''),
+            );
+
+            return $this->collapsedLeaf($state, $example->getTitle(), $detail);
+        }
+
+        return sprintf(
+            "<li class=\"example %s\">%s</li>\n",
+            $state,
+            $this->escape($example->getTitle()),
+        );
+    }
+
+    /**
+     * Renders a single step: failed steps collapse their error message
+     * under the title; every other state is a plain list item.
+     *
+     * @param StepResult $step the step result to render
+     * @return string the rendered HTML fragment
+     */
+    private function renderStep(StepResult $step): string
+    {
+        if ($step->isFailure() && $step->getError() !== null) {
+            $detail = sprintf(
+                "<p class=\"message\">%s</p>\n",
+                $this->escape($step->getError()->getMessage()),
+            );
+
+            return $this->collapsedLeaf($step->getState(), $step->getTitle(), $detail);
+        }
+
+        return sprintf(
+            "<li class=\"example %s\">%s</li>\n",
+            $this->escape($step->getState()),
+            $this->escape($step->getTitle()),
+        );
+    }
+
+    /**
+     * Wraps a failing leaf in a collapsed disclosure: the title stays a
+     * one-line row, the detail reveals on click.
+     *
+     * @param string $state the outcome class, e.g. "failed" or "error"
+     * @param string $title the example or step title
+     * @param string $detail the pre-rendered detail HTML
+     * @return string the rendered HTML fragment
+     */
+    private function collapsedLeaf(string $state, string $title, string $detail): string
+    {
+        return sprintf(
+            "<li><details class=\"example %s\">\n<summary>%s</summary>\n<div class=\"detail\">\n%s</div>\n</details></li>\n",
+            $this->escape($state),
+            $this->escape($title),
+            $detail,
+        );
+    }
+
+    /**
+     * Renders one failed expectation: message, expected/got values, the
+     * surrounding code snippet with the failing line marked, and location.
+     *
+     * @param MatchResult $match the failed match
+     * @return string the rendered HTML fragment
+     */
+    private function renderFailureDetail(MatchResult $match): string
+    {
+        $html = sprintf("<p class=\"message\">%s</p>\n", $this->escape((string) $match->getMessage()));
+
+        $html .= sprintf(
+            "<dl class=\"kv\"><dt>expected:</dt><dd>%s</dd><dt>got:</dt><dd>%s</dd></dl>\n",
+            $this->escape($this->formatValue($match->getExpected())),
+            $this->escape($this->formatValue($match->getActual())),
+        );
+
+        $code = $match->getCode();
+        $failingLine = $match->getLine();
+
+        if ($code !== []) {
+            $rows = '';
+
+            foreach ($code as $lineNo => $source) {
+                $rows .= sprintf(
+                    "<tr%s><td class=\"ln\">%d</td><td><pre>%s</pre></td></tr>\n",
+                    $lineNo === $failingLine ? ' class="mark"' : '',
+                    $lineNo,
+                    $this->escape(rtrim($source)),
+                );
+            }
+
+            $html .= "<table class=\"snippet\">$rows</table>\n";
+        }
+
+        if ($match->getFile() !== null) {
+            $html .= sprintf(
+                "<p class=\"where\">at %s:%d</p>\n",
+                $this->escape($match->getFile()),
+                $failingLine ?? 0,
+            );
+        }
+
+        return $html;
+    }
+
+    /**
+     * Formats a matcher value for the expected/got display.
+     *
+     * @param mixed $value the value to format
+     * @return string a short human-readable representation
+     */
+    private function formatValue(mixed $value): string
+    {
+        return match (true) {
+            $value === null => 'null',
+            is_bool($value) => $value ? 'true' : 'false',
+            is_string($value) => '"' . $value . '"',
+            is_scalar($value) => (string) $value,
+            is_array($value) => 'Array(' . count($value) . ')',
+            is_object($value) => $value::class . '#' . spl_object_id($value),
+            default => get_debug_type($value),
+        };
+    }
+
+    /**
+     * Builds the header meta line from the suite counts.
+     *
+     * @param array<string, int> $counts the tallied suite counts
+     * @return string e.g. "4 examples · 2 failures"
+     */
+    private function summaryLine(array $counts): string
+    {
+        $parts = [];
+
+        if ($counts['examples'] > 0 || $counts['steps'] === 0) {
+            $parts[] = $counts['examples'] . ' example' . ($counts['examples'] !== 1 ? 's' : '');
+        }
+
+        if ($counts['steps'] > 0) {
+            $parts[] = $counts['steps'] . ' step' . ($counts['steps'] !== 1 ? 's' : '');
+        }
+
+        $failures = $counts['failures'] + $counts['errors'] + $counts['stepFailures'];
+
+        if ($failures > 0) {
+            $parts[] = $failures . ' failure' . ($failures !== 1 ? 's' : '');
+        }
+
+        return implode(' · ', $parts);
+    }
+
+    /**
+     * Renders the summary footer with example counts and duration.
+     *
+     * @param array<string, int> $counts the tallied suite counts
+     * @param float $duration the suite duration in seconds
+     * @return string the rendered HTML fragment
+     */
+    private function renderFooter(array $counts, float $duration): string
+    {
+        $parts = [];
+        $labels = [
+            'passes' => ['pass', 'passes'],
+            'failures' => ['failure', 'failures'],
+            'errors' => ['error', 'errors'],
+        ];
+
+        foreach ($labels as $key => [$singular, $plural]) {
+            if ($counts[$key] > 0) {
+                $parts[] = $counts[$key] . ' ' . ($counts[$key] === 1 ? $singular : $plural);
+            }
+        }
+
+        if ($counts['pending'] > 0) {
+            $parts[] = $counts['pending'] . ' pending';
+        }
+
+        if ($counts['exampleSkipped'] > 0) {
+            $parts[] = $counts['exampleSkipped'] . ' skipped';
+        }
+
+        return sprintf(
+            "<footer class=\"summary\">\n<p>%d example%s%s</p>\n<p>Finished in %.4f seconds</p>\n</footer>\n",
+            $counts['examples'],
+            $counts['examples'] !== 1 ? 's' : '',
+            $parts !== [] ? ' (' . implode(', ', $parts) . ')' : '',
+            $duration,
+        );
+    }
+
+    /**
+     * Checks whether the result subtree contains any failed or errored leaf.
+     *
+     * @param Results $result the result node to inspect
+     * @return bool true when a failure or error exists in the subtree
+     */
+    private function hasFailure(Results $result): bool
+    {
+        foreach ($result->getResults() as $child) {
+            if ($child instanceof ExampleResult) {
+                if ($child->isFailure() || $child->isError()) {
+                    return true;
+                }
+            } elseif ($child instanceof StepResult) {
+                if ($child->isFailure()) {
+                    return true;
+                }
+            } elseif ($this->hasFailure($child)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Counts example and step leaves in a result subtree.
+     *
+     * @param Results $result the result node to count
+     * @return int the number of leaves
+     */
+    private function countLeaves(Results $result): int
+    {
+        $count = 0;
+
+        foreach ($result->getResults() as $child) {
+            if ($child instanceof ExampleResult || $child instanceof StepResult) {
+                $count++;
+            } elseif ($child instanceof Results) {
+                $count += $this->countLeaves($child);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Counts failed and errored leaves in a result subtree.
+     *
+     * @param Results $result the result node to count
+     * @return int the number of failing leaves
+     */
+    private function countFailures(Results $result): int
+    {
+        $count = 0;
+
+        foreach ($result->getResults() as $child) {
+            if ($child instanceof ExampleResult) {
+                $count += $child->isFailure() || $child->isError() ? 1 : 0;
+            } elseif ($child instanceof StepResult) {
+                $count += $child->isFailure() ? 1 : 0;
+            } else {
+                $count += $this->countFailures($child);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Returns the inline script powering the tabs and the expand/collapse
+     * toolbar; both no-op when their elements are absent.
+     *
+     * @return string the script tag
+     */
+    private function script(): string
+    {
+        return <<<'HTML'
+        <script>
+        document.querySelectorAll('.tabs [role="tab"]').forEach(function (tab) {
+            tab.addEventListener('click', function () {
+                document.querySelectorAll('.tabs [role="tab"]').forEach(function (other) {
+                    other.setAttribute('aria-selected', String(other === tab));
+                });
+                document.querySelectorAll('.panel').forEach(function (panel) {
+                    panel.hidden = panel.dataset.panel !== tab.dataset.panel;
+                });
+            });
+        });
+        document.querySelectorAll('.toolbar [data-act]').forEach(function (button) {
+            button.addEventListener('click', function () {
+                document.querySelectorAll('details.group').forEach(function (group) {
+                    group.open = button.dataset.act === 'expand';
+                });
+            });
+        });
+        </script>
+        HTML;
+    }
+
+    /**
+     * Escapes text for safe embedding in the HTML document.
+     *
+     * @param string $text the raw text
+     * @return string the escaped text
+     */
+    private function escape(string $text): string
+    {
+        return htmlspecialchars($text, ENT_QUOTES);
+    }
+}

--- a/src/PhpSpec/Report/HtmlTheme.php
+++ b/src/PhpSpec/Report/HtmlTheme.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report;
+
+/**
+ * @internal
+ * Shared visual identity for PhpSpec's HTML artifacts (the results report and
+ * the coverage report). The header band follows the phpspec site identity
+ * (dark bar, logo, monospace wordmark, green accent) with a pass-ratio meter
+ * fused to its bottom edge; the body is a modernised take on the classic
+ * RSpec TextMate look with its saturated green/red group bars. Everything is
+ * inlined so reports stay self-contained.
+ */
+final class HtmlTheme
+{
+    /**
+     * Wraps body content in a complete standalone HTML document carrying
+     * the brand stylesheet.
+     *
+     * @param string $title the document title
+     * @param string $body the body HTML
+     * @return string the full HTML document
+     */
+    public static function page(string $title, string $body): string
+    {
+        $safeTitle = htmlspecialchars($title, ENT_QUOTES);
+        $css = self::css();
+
+        return "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n"
+            . "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+            . "<title>$safeTitle</title>\n<style>$css</style>\n</head>\n<body>\n$body</body>\n</html>";
+    }
+
+    /**
+     * The phpspec logo from phpspec-site, inlined so reports stay self-contained.
+     */
+    private const LOGO = 'iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAIZklEQVRo3u2Ze3DU1RXHP+e3y5Ism83DJeRJmyUJgUSjIQVHKCPUR4FKgXaU4nRqrSiFSakPhBAdo4VCRx1ora2iM6BQlGplBnRKkVac+gRGSEqN2oysSYS4hhhC3ISw+Z3+kQTCstnfbh62f3hn7tx93Pv7ne+559xzzvfC1+1/22SoH1heVOBAJAtIA1w9PwfUNA/s/dn8zi7OUHXXhv8fAKsKCxwiXI3ILGA6MBGIE0B7XiCGwcp9+8tnbN3QAKwE3gD9q8K+9+5aFxjM++2D0HSGQBlwC5CGar/aGZWUTILHk6CoFyjq6UuAlpJHy7cDG967e13tVwKgvHB8kiAVwFLAGc2apIwMgGMoU0P/6nnO7SWPlD+raMXhe9Y3DguA1RPzQWQ2yJNAFhr9S5LTMwDqVPXmCHLcCsy74uFVy7u0a1v1vQ9H9WwjKq1PyDcQWQfsBs3qtu7oe1JGBgo+lLEWU1OArTaxbb7y0fvihgRA+YQ8h4jsQFklihGj7KCQlJ4e3FtT5VfVDFUlin7LWbPr1e89uT5lUAAqJuTbDTF2CPxQ+jhmrD3BM7pp5a7tLpS4aEF3mea0pra2V+/euTVlQABW5ucDPI7qPFQZTHePGVOH8s0otX+ut5/tLDnS4Nv99w+POmN2YruNW4HbYz2l3KmpfGNSKaO9Xka6EtrM4Nm20V7vUVXlEqcr0Bz40nk+QliPTW2nr9ryzv6nVPVmEYkukFUU5HlBqpBzkTSyHRoGhdddT+mNN/m9k6f8WQxjN3BIVZsN4/wmm6Y5ede/Dt2w78OjC98+9lHu2a6uqJRiMwwWTZq6eMW1c5+2BLA6Lw+x8QowO9zk0NMzY2Ihcx+obM66rPhB4GkRsYysqmpsO/DPBc8denNdQ8vJ3GhAZCd7Wp9YeFthdoqnIaIPiMFMgdnhnDHUiUvm/4Dbtm3fm3VZcaGI/C4a4QFExPzxlOkvVnx3QXGaO2lTNK5U19zkfuad19dpSMS/AMCq/BwEKqI5JSb/aBHz16zd4oiPnyMijQygTR03PrB85nV3jLTZHyAKp37r448WtrQHJvYLwI6tCPRqK+lzp05jzur7XhLDWCwiwcEkY3MKJ/PlmY6HVNlipbS65ib7S4ffvTOSCd2MRbCKS3Azb83aWsNu/+lghe9tNZUbUTXLVNVntQvVDZ8sVFXXRQBW5+UAzI3k4QJMv/0OEtPTy0SkdSjriH8/sKENpdxqFw4cq3W1drTPvgiAgWSIaoGo0tvp81lUcTidlN5401vAnuGorkzTfNFqF061B3iz9oNZFwEQpNQqtZhwzbXEJyb+MVxAGRJTemhjENXnrXbhWJP/qt7T6LzASoHVwnFTpwaBXcNZ46ryNys/ONl2Ore3XO2jcc22On08Od7qobb9iwCYesRKkZ+dOmUAY0N3ICVSkSzdldVHw80yqGprT4/oBz2kwflkTsDemyf0B2JEfHzzcAMwTdO0GUYH4O5vTrA7h3KGZKPaaUVgBFpa7MMNQBBDNXKtPcKwhUmnFQvtKk21tZ6vgKtKoU+gCtcS450AbaH1wCdWT26sqSlg+J2gRC3oqvSkZIDGECfW9yUkcPUNZqjyaVVVgaqmDpWsuSuWOXJXLHOHHKOzrFJTrye1E/CFmtAhBDM0mPVNo2tf3298Wl29AHgiZmHvWWoXkVLgcpDi7pGi2cUltRtVp4hIZ+49Sx0oC1XCWvC5gmR8euYHQMcFAIKYTSPUOAKU9Ov9HWd4d/Pmn6vqJhExY3TPVODt89J0N6fDcTngAY6D3Aqa1i/npOBxuSnKGvtGbzZwTtu/9tUButMqmNXs2XPZwa1bFw3gfPerEgi1iOa2NgBP7t1LU4FfWRU2MycWMcJmeyV8Oq1sRwlGwnC2vZ23Nm16tGrnzrRYAHR1BYKoNoRK9MWXbbR3dqYqbEbVY2X/N1xR2gT8IywAMc2PgZfD2X/fsaW+PnXf+vUv7F692hktAN/GLajiC5Xp5OnTlD3z9AaU2VbaL8ocy7e8ec+KSEdYAJX19aC6VlBTtHtLRLVnvPD76RMnph154YXda/LzU2KwI1+oVL7P/eyvOVoUDb+05DvXdxgiv41c1JvmIZTtoOd9rUf4C79D15kzM4MdHYcrx46de383A23lB8cGyo9NGZfHtZcWbxKROkteqDI7Ow2RKiD6M195B3gM9OWzwWDr2hMnLpqSs3zJjQI7Yj0A4kY4eOmuexvHp2cWikizJbVYWV/fiOpiFDNqEheuBP4E8nli6phXVTUrnAkNRPvl319gZiSnLMv5xZK4nLI7vFFxo5X19btAHxSUGLsjbeKEa4BpYXJ9X6zSC/CHvXsovvfO5wQ+neQd96aqFkR3waG6BsOWjmkuiWXLkzKz6A31IT7QDLRGSpXDrOHEF80G4ABIco5K67nZsabXKxsaTMeoUcvsI0f+PhYAiVmZAHWhv3/y+FNBlIaB3DGEmGsMFxw175vfLltelpA2ZoVhswWjotPT0gOAvx+N+mKl2S/oaOxXTNN/WcadBw8+4p02bZZr9OjjVvNdqaOPA8F+inbfUO5A1BVWT/K07z+vvXbpwc1bfnP88OFbAiebw65PzMz09Uu9qB5TC1bGEANXXBwpLheeBDcetxtPQgKXJLjNwuzsNqBzwNeseTNmNKvq4roDBx478vyOihPV1fP8NR84elVjczhIysryRaBNqifleAOZKZc4PW43Ka4EM9EZ3+J2Ov3Jo1z+VHeiPy05uTEhPv6zETabv8cUG3tGP9DRl9IcFEOlqnR1dmZ9uHfvovoDB+efqm8obW89Zf/JX168X0TWRFh3ZY8W/UAT0Bl7ej70dAiqmqSq1/Q9p79uFu2/SlTTwm+/AwIAAAAASUVORK5CYII=';
+
+    /**
+     * Renders the dark header band in the phpspec site identity: logo and
+     * monospace wordmark with the subtitle on the left, monospace meta
+     * (counts, duration) on the right.
+     *
+     * @param string $subtitle the artifact name, e.g. "Results" or "Coverage"
+     * @param string $meta plain-text meta shown right-aligned, e.g. counts
+     * @return string the header HTML
+     */
+    public static function header(string $subtitle, string $meta): string
+    {
+        $safeSubtitle = htmlspecialchars($subtitle, ENT_QUOTES);
+        $safeMeta = htmlspecialchars($meta, ENT_QUOTES);
+        $logo = self::LOGO;
+
+        return "<header class=\"band\">\n"
+            . "<p class=\"wordmark\"><img src=\"data:image/png;base64,$logo\" alt=\"phpspec\" width=\"28\" height=\"28\">phpspec<span>$safeSubtitle</span></p>\n"
+            . "<p class=\"meta\">$safeMeta</p>\n"
+            . "</header>\n";
+    }
+
+    /**
+     * Renders the pass-ratio meter strip that sits under the header band:
+     * a green fill over a red track, so the verdict is visible before any
+     * number is read.
+     *
+     * @param float $pct percentage of the bar to fill green (clamped to 0-100)
+     * @return string the meter HTML
+     */
+    public static function meter(float $pct): string
+    {
+        $clamped = max(0.0, min(100.0, $pct));
+
+        return sprintf(
+            "<div class=\"meter\" role=\"img\" aria-label=\"%.1f%%\"><span style=\"width:%.1f%%\"></span></div>\n",
+            $clamped,
+            $clamped,
+        );
+    }
+
+    /**
+     * Returns the shared stylesheet: brand tokens and components for both
+     * the results report and the coverage report.
+     *
+     * @return string the CSS rules
+     */
+    private static function css(): string
+    {
+        return <<<'CSS'
+        :root{
+        --ps-red:#C22015;--ps-red-tint:#FCEBE8;
+        --ps-green:#58A302;--ps-green-ink:#38680A;--ps-green-tint:#EDF7E0;
+        --ps-amber:#B57C00;--ps-amber-tint:#FBF3DC;
+        --ps-slate:#667085;--ps-slate-tint:#F0F1F3;
+        --ps-ink:#23282E;--ps-paper:#F7F7F5;--ps-card:#FFFFFF;--ps-line:#E3E5E8;
+        --brand-bg:#0a0c10;--brand-border:#1e2535;--brand-heading:#f0f4f8;
+        --brand-dim:#8b95a7;--brand-green:#3dd68c;
+        --code-bg:#080a0e;--code-border:#161c28;--code-red:#ef4444;
+        --mono:"IBM Plex Mono","Menlo","Consolas","Liberation Mono",monospace;
+        --body-font:"DM Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
+        }
+        *{box-sizing:border-box}
+        body{margin:0;background:var(--ps-paper);color:var(--ps-ink);
+        font:15px/1.5 var(--body-font)}
+        .band{display:flex;align-items:center;justify-content:space-between;gap:1rem;
+        flex-wrap:wrap;background:var(--brand-bg);color:var(--brand-heading);
+        border-bottom:1px solid var(--brand-border);padding:.8rem 1.5rem}
+        .wordmark{display:inline-flex;align-items:center;gap:.45rem;margin:0;
+        font-family:var(--mono);font-size:1.15rem;font-weight:700;letter-spacing:-.02em}
+        .wordmark img{width:28px;height:28px;border-radius:4px}
+        .wordmark span{font-weight:400;color:var(--brand-dim);font-size:.8rem;
+        letter-spacing:.14em;text-transform:uppercase;margin-left:.4rem}
+        .meta{margin:0;font-family:var(--mono);font-size:.85rem;color:var(--brand-green);
+        text-align:right;white-space:pre-line}
+        .meter{height:4px;background:var(--brand-border)}
+        .meter span{display:block;height:100%;background:var(--brand-green)}
+        main{max-width:60rem;margin:0 auto;padding:1.25rem 1.5rem 3rem}
+        .tabs{display:flex;gap:.25rem;margin:0 0 1rem;padding:0;list-style:none;
+        border-bottom:2px solid var(--ps-line)}
+        .tabs button{font-family:var(--mono);font-size:.8rem;letter-spacing:.1em;
+        text-transform:uppercase;border:0;background:none;color:var(--ps-slate);
+        padding:.6rem 1rem;cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-2px}
+        .tabs button[aria-selected="true"]{color:var(--ps-ink);border-bottom-color:var(--ps-green)}
+        .tabs button:focus-visible{outline:2px solid var(--ps-green-ink);outline-offset:2px}
+        .panel[hidden]{display:none}
+        .toolbar{display:flex;justify-content:flex-end;gap:1rem;margin:0 0 .75rem}
+        .toolbar button{font:inherit;font-size:.8rem;border:0;background:none;
+        color:var(--ps-slate);cursor:pointer;text-decoration:underline}
+        details.group{margin:0 0 .5rem;background:var(--ps-card);border:1px solid var(--ps-line);
+        border-radius:6px;overflow:hidden}
+        details.group>summary{list-style:none;cursor:pointer;display:flex;align-items:center;
+        justify-content:space-between;gap:1rem;padding:.55rem .9rem;background:var(--ps-green);
+        color:#fff;font-weight:600}
+        details.group>summary::-webkit-details-marker{display:none}
+        details.group>summary::after{content:"›";font-family:var(--mono);opacity:.8;
+        transition:transform .15s ease}
+        details.group[open]>summary::after{transform:rotate(90deg)}
+        @media (prefers-reduced-motion:reduce){details.group>summary::after{transition:none}}
+        details.group.failed>summary{background:var(--ps-red)}
+        details.group>summary .count{font-family:var(--mono);font-weight:400;font-size:.8rem}
+        details.group ul{margin:0;padding:.4rem 0;list-style:none}
+        .example{padding:.35rem .9rem .35rem 1.4rem;border-left:4px solid transparent}
+        .example.passed{border-left-color:var(--ps-green);background:var(--ps-green-tint);
+        color:var(--ps-green-ink)}
+        .example.failed,.example.failure,.example.error{border-left-color:var(--ps-red);
+        background:var(--ps-red-tint);color:var(--ps-red)}
+        .example.pending{border-left-color:var(--ps-amber);background:var(--ps-amber-tint);
+        color:var(--ps-amber)}
+        .example.skipped,.example.undefined{border-left-color:var(--ps-slate);
+        background:var(--ps-slate-tint);color:var(--ps-slate)}
+        .example+.example{margin-top:2px}
+        li>details.example{padding:0}
+        details.example>summary{list-style:none;cursor:pointer;padding:.35rem .9rem .35rem 1.4rem}
+        details.example>summary::-webkit-details-marker{display:none}
+        details.example>summary::after{content:" ›";font-family:var(--mono);opacity:.7}
+        details.example[open]>summary::after{content:" ˅"}
+        details.example .detail{padding:.2rem 1.4rem .8rem;border-top:1px dashed var(--ps-line)}
+        .message{margin:.35rem 0 .1rem;font-family:var(--mono);font-size:.8rem;
+        white-space:pre-wrap;color:var(--ps-red)}
+        .kv{display:grid;grid-template-columns:max-content 1fr;gap:.1rem .6rem;
+        margin:.4rem 0;font-family:var(--mono);font-size:.8rem}
+        .kv dt{color:var(--ps-slate)}
+        .kv dd{margin:0;color:var(--ps-ink)}
+        table.snippet{border-collapse:collapse;margin:.4rem 0;width:100%;
+        background:var(--code-bg);border:1px solid var(--code-border);border-radius:4px}
+        table.snippet td{padding:0 .6rem;font-family:var(--mono);font-size:.78rem;line-height:1.6;
+        color:#fff;font-weight:700}
+        table.snippet td.ln{text-align:right;color:var(--brand-dim);font-weight:400;
+        width:3rem;user-select:none;border-right:1px solid var(--code-border)}
+        table.snippet tr.mark{background:rgba(239,68,68,.15)}
+        table.snippet tr.mark td.ln{color:var(--code-red);font-weight:700}
+        table.snippet pre{margin:0}
+        .where{margin:.2rem 0 0;font-family:var(--mono);font-size:.75rem;color:var(--ps-slate)}
+        section.subgroup{padding:.2rem .6rem .4rem}
+        section.subgroup h3,section.subgroup h4,section.subgroup h5,section.subgroup h6{
+        margin:.5rem 0 .25rem;font-size:.9rem;color:var(--ps-ink)}
+        footer.summary{margin-top:1.5rem;border-top:1px solid var(--ps-line);padding-top:.9rem;
+        font-family:var(--mono);font-size:.85rem;color:var(--ps-slate)}
+        table.coverage{border-collapse:collapse;width:100%;background:var(--ps-card);
+        border:1px solid var(--ps-line);border-radius:6px}
+        table.coverage th{font-family:var(--mono);font-size:.72rem;letter-spacing:.14em;
+        text-transform:uppercase;color:var(--ps-slate);text-align:left;padding:.6rem .9rem;
+        border-bottom:2px solid var(--ps-line)}
+        table.coverage td{padding:.45rem .9rem;border-bottom:1px solid var(--ps-line);
+        font-size:.85rem}
+        table.coverage td.num{font-family:var(--mono);text-align:right;white-space:nowrap}
+        table.coverage a{color:var(--ps-ink);text-decoration:none}
+        table.coverage a:hover{color:var(--ps-red);text-decoration:underline}
+        .bar{background:var(--ps-slate-tint);height:8px;border-radius:4px;min-width:10rem}
+        .bar span{display:block;height:100%;border-radius:4px}
+        .bar .hi{background:var(--ps-green)}
+        .bar .mid{background:var(--ps-amber)}
+        .bar .lo{background:var(--ps-red)}
+        table.source{border-collapse:collapse;width:100%;background:var(--ps-card);
+        border:1px solid var(--ps-line)}
+        table.source td{padding:0 .6rem;vertical-align:top;font-family:var(--mono);
+        font-size:.8rem;line-height:1.5}
+        table.source td.ln{text-align:right;color:var(--ps-slate);width:3.5rem;user-select:none}
+        table.source tr.hit{background:var(--ps-green-tint)}
+        table.source tr.miss{background:var(--ps-red-tint)}
+        table.source pre{margin:0}
+        a.back{font-family:var(--mono);font-size:.8rem;color:var(--ps-slate)}
+        CSS;
+    }
+}


### PR DESCRIPTION
Fix html formatter

1. HTML formatter (-f html) + Behat-style -f/-o pairs for multiple report files, unknown formats rejected
2. Branded reports — shared HtmlTheme (site's dark header, inlined logo, IBM Plex Mono, green accent + meter), tabs for Specs/Stories, collapsible group bars, coverage report consolidated on the same identity, coverage report's first-ever spec
3. Collapsed failure forensics — click a failed example for message, expected/got, dark code excerpt (site's --code-bg, white bold text, red-marked failing line), at file:line; failed steps collapse their error output
4. Step discovery fix + steps_path config — steps found anywhere under the features root regardless of run path, plus the configured extra directory; docs for features_path/steps_path
5. InProcessRunner::parseArgs repeated-option aggregation