### PR TITLE
Prepare for 8.3.1 release

### DIFF
--- a/CHANGES-v8.md
+++ b/CHANGES-v8.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [8.3.1]
+### Fixed
+- Bump `phpspec/prophecy` constraint to `^1.26.1` to fix compatibility issues that were breaking CI and had prevented the PHAR from being published with the 8.3.0 release
+
 ## [8.3.0]
 ### Added
 - Support `sebastian/exporter` 8.x to be compatible with PHPUnit 13 [@Jean85](https://github.com/Jean85)
@@ -20,4 +24,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - PHP 8.4 compatibility [@jrfnl](https://github.com/jrfnl) [@andypost](https://github.com/andypost)
 
+[8.3.1]: https://github.com/phpspec/phpspec/compare/8.3.0...8.3.1
 [8.3.0]: https://github.com/phpspec/phpspec/compare/8.2.0...8.3.0

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -24,4 +24,4 @@
 
     (new PhpSpec\Console\Application($version))->run();
 
-})('8.3.0');
+})('8.3.1');


### PR DESCRIPTION
  - 8.3.0's release was missing its PHAR because unrelated PHP 8.4/8.5 CI failures (phpspec/prophecy incompatible constraint) made the whole tests matrix job report failure, which skipped the publish-phar job even though the PHAR itself built fine.
  - That compatibility issue is already fixed on this branch (bumped phpspec/prophecy to ^1.26.1), so tests is green again and publish-phar will run.
  - This commit prepares the actual 8.3.1 release: bumps the version in bin/phpspec and adds the CHANGES-v8.md entry, so check-release.php passes and the release can be tagged with a working CI-published PHAR.

Fixes #1513