### PR TITLE
Improve capturing user input in pair mode

### DIFF
--- a/docs/pair.md
+++ b/docs/pair.md
@@ -106,10 +106,35 @@ The AI assistant has access to these tools during a pair session:
 | `write_file` | Create a new file (class, interface, etc.) |
 | `update_file` | Modify an existing file (shows a diff) |
 | `run_specs` | Run specs and return the output |
+| `ask_user` | Ask you a yes/no question through the numbered chooser |
 | `read_file` | Read a project file for context |
 | `list_files` | List directory contents |
 
 The assistant automatically scans your project tree and existing step definitions so it can reuse patterns already in your codebase.
+
+### Interactive Questions
+
+Every question in a pair session -- whether asked by PhpSpec itself (creating
+a class, running specs) or by the AI via `ask_user` -- uses the same numbered
+chooser:
+
+```
+  Do you want me to create class App\Checkout for you?
+   ▸ 1. Yes
+     2. Yes, and don't ask again -- always create classes
+     3. No
+```
+
+A single keypress decides: `1`/`2`/`3`, or the shortcuts `y` (yes), `a`
+(always) and `n` or `Esc` (no) -- no Enter needed. The arrow keys move the
+highlight and Enter confirms it. When input is piped rather than a terminal,
+the chooser reads one answer line instead (digits or y/a/n; empty defaults to
+yes), so scripted sessions keep working.
+
+Option 2 is remembered per question kind for the rest of the session --
+answer "always" to class creation and PhpSpec stops asking about classes,
+while other questions (running specs, applying AI file changes) still prompt.
+Nothing is persisted between sessions.
 
 ### Project Context
 

--- a/features/scenarios/cli/pair-ai.feature
+++ b/features/scenarios/cli/pair-ai.feature
@@ -75,3 +75,25 @@ Feature: AI-assisted pair programming
     Then the output should contain "Additional commands"
     And the output should contain "next"
     And the output should contain "refactor"
+
+  Scenario: Interactive questions offer numbered choices
+    When I run phpspec pair with input "describe App/Wanted" answering "1,3"
+    Then the output should contain "1. Yes"
+    And the output should contain "2. Yes, and don't ask again"
+    And the output should contain "3. No"
+    And a class file "src/App/Wanted.php" should be generated
+
+  Scenario: Answering No declines the offer
+    When I run phpspec pair with input "describe App/Declined" answering "3,3"
+    Then no file "src/App/Declined.php" should be generated
+
+  Scenario: Answering always suppresses repeat questions of the same kind
+    When I run phpspec pair with input "describe App/First; describe App/Second" answering "2,3,3"
+    Then a class file "src/App/First.php" should be generated
+    And a class file "src/App/Second.php" should be generated
+    And the output should not contain "create class App\Second"
+
+  Scenario: Describe with a slash path generates a namespaced class
+    When I run phpspec pair with input "describe App/Basket" answering "1,3"
+    Then the file "src/App/Basket.php" should contain "namespace App;"
+    And the file "src/App/Basket.php" should contain "class Basket"

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -163,3 +163,7 @@ then('a step file should be generated with step definitions', function () {
     }
     expect($found)->toBeTrue();
 });
+
+then('no file {string} should be generated', function (string $path) {
+    expect(file_exists($this->projectDir . '/' . $path))->toBeFalse();
+});

--- a/features/steps/pair.steps.php
+++ b/features/steps/pair.steps.php
@@ -5,9 +5,52 @@
  * instantiates CommandDispatcher directly, bypassing the TTY check.
  */
 
-when('I run phpspec pair with input {string}', function (string $input) {
-    // Write a shim script that exercises CommandDispatcher directly
-    $shim = <<<'PHP'
+if (!function_exists('_pair_exec')) {
+    /**
+     * Runs the pair shim: dispatches each ";"-separated input in one session,
+     * optionally interactive with the given answers piped to stdin.
+     */
+    function _pair_exec(object $world, string $input, ?string $answers = null): void
+    {
+        $interactive = $answers !== null ? 'true' : 'false';
+
+        $shim = _pair_shim_source($interactive);
+        file_put_contents($world->projectDir . '/_pair_shim.php', $shim);
+
+        $cmd = [
+            $world->phpBin, '-d', 'xdebug.mode=off',
+            $world->projectDir . '/_pair_shim.php',
+            $input,
+        ];
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($cmd, $descriptors, $pipes, $world->projectDir);
+
+        if ($answers !== null) {
+            fwrite($pipes[0], implode("\n", array_map('trim', explode(',', $answers))) . "\n");
+        }
+        fclose($pipes[0]);
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $world->exitCode = proc_close($process);
+        $world->output = $stdout . $stderr;
+    }
+
+    /**
+     * Builds the shim source with the given interactivity flag.
+     */
+    function _pair_shim_source(string $interactive): string
+    {
+        $shim = <<<'PHP'
     <?php
     require __DIR__ . '/vendor/autoload.php';
 
@@ -36,36 +79,23 @@ when('I run phpspec pair with input {string}', function (string $input) {
         new ClassGenerator(ltrim($config->getSrcPath(), './')),
         $config,
         $pairOutput,
-        interactive: false,
+        interactive: %INTERACTIVE%,
         application: $app,
     );
 
-    $input = $argv[1] ?? '';
-    $dispatcher->dispatch($input);
+    foreach (array_filter(array_map('trim', explode(';', $argv[1] ?? ''))) as $command) {
+        $dispatcher->dispatch($command);
+    }
     PHP;
 
-    file_put_contents($this->projectDir . '/_pair_shim.php', $shim);
+        return str_replace('%INTERACTIVE%', $interactive, $shim);
+    }
+}
 
-    $cmd = [
-        $this->phpBin, '-d', 'xdebug.mode=off',
-        $this->projectDir . '/_pair_shim.php',
-        $input,
-    ];
+when('I run phpspec pair with input {string}', function (string $input) {
+    _pair_exec($this, $input);
+});
 
-    $descriptors = [
-        0 => ['pipe', 'r'],
-        1 => ['pipe', 'w'],
-        2 => ['pipe', 'w'],
-    ];
-
-    $process = proc_open($cmd, $descriptors, $pipes, $this->projectDir);
-    fclose($pipes[0]);
-
-    $stdout = stream_get_contents($pipes[1]);
-    $stderr = stream_get_contents($pipes[2]);
-    fclose($pipes[1]);
-    fclose($pipes[2]);
-
-    $this->exitCode = proc_close($process);
-    $this->output = $stdout . $stderr;
+when('I run phpspec pair with input {string} answering {string}', function (string $input, string $answers) {
+    _pair_exec($this, $input, $answers);
 });

--- a/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
@@ -1,0 +1,180 @@
+<?php
+
+use PhpSpec\Ai\Contracts\ProviderInterface;
+use PhpSpec\Ai\Response;
+use PhpSpec\Ai\ToolCall;
+use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Pair\AiAssistant;
+use PhpSpec\Console\Command\Pair\Chooser;
+use PhpSpec\Console\Command\Pair\PairOutput;
+use PhpSpec\Filesystem;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+describe(AiAssistant::class, function () {
+
+    beforeEach(function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        allow($fs->read())->toReturn('');
+        allow($fs->isDir())->toReturn(false);
+        allow($fs->isFile())->toReturn(false);
+        allow($fs->scandir())->toReturn([]);
+
+        $this->buffer = new BufferedOutput();
+        $this->pairOutput = new PairOutput($this->buffer);
+        $this->answers = [];
+        $this->reads = 0;
+        $this->chooser = new Chooser($this->pairOutput, true, function () {
+            $this->reads++;
+            return array_shift($this->answers) ?? '';
+        });
+        $this->config = new Configuration('.', $fs);
+
+        // Hand-rolled fake: the built-in Double cannot fabricate the concrete
+        // Response return type, so we script responses with a closure instead
+        $this->provider = new class implements ProviderInterface {
+            public ?Closure $responder = null;
+
+            public function chat(array $messages, array $options = []): Response
+            {
+                return ($this->responder)($messages, $options);
+            }
+        };
+    });
+
+    it('routes ask_user tool calls from the model through the chooser', function (Filesystem $fs) {
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'ask_user', [
+                    'question' => 'Do you want me to generate the method fooBar()?',
+                    'action' => 'generate methods',
+                ])]);
+            }
+            $captured = $messages;
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser);
+        $this->answers = ['2'];
+        $assistant->handle('add a fooBar method');
+
+        $text = $this->buffer->fetch();
+        expect($text)->toContain('Do you want me to generate the method fooBar()?');
+        expect($text)->toContain('1. Yes');
+        expect((string) json_encode($captured))->toContain('always');
+    });
+
+    it('blocks write tools when the chooser declines', function (Filesystem $fs) {
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'generate_spec', [
+                    'class_name' => 'App/Wanted',
+                    'spec_content' => '<?php // spec',
+                ])]);
+            }
+            $captured = $messages;
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser);
+        $this->answers = ['3'];
+        $assistant->handle('spec App/Wanted');
+
+        expect($fs->write())->not()->toHaveBeenCalled();
+        expect((string) json_encode($captured))->toContain('User declined');
+    });
+
+    it('executes feature, steps and file tools once approved', function (Filesystem $fs) {
+        $turn = 0;
+        $this->provider->responder = function () use (&$turn) {
+            if (++$turn === 1) {
+                return new Response('', [
+                    new ToolCall('t1', 'generate_feature', ['feature_name' => 'checkout', 'content' => 'Feature: Checkout']),
+                    new ToolCall('t2', 'generate_steps', ['feature_name' => 'checkout', 'content' => '<?php // steps']),
+                    new ToolCall('t3', 'write_file', ['path' => 'src/App/Checkout.php', 'content' => '<?php // class']),
+                ]);
+            }
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser);
+        $this->answers = ['2'];
+        $assistant->handle('build the checkout feature');
+
+        expect($this->reads)->toBe(1);
+        expect($fs->write())->toBeCalled()->exactly(3)->times();
+    });
+
+    it('updates an existing file showing what changed', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("<?php\n// old body\n");
+
+        $turn = 0;
+        $this->provider->responder = function () use (&$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'update_file', [
+                    'path' => 'src/App/Checkout.php',
+                    'content' => "<?php\n// new body\n",
+                ])]);
+            }
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser);
+        $this->answers = ['1'];
+        $assistant->handle('update the checkout class');
+
+        expect($fs->write())->toHaveBeenCalled();
+    });
+
+    it('reports unknown tools back to the model instead of crashing', function (Filesystem $fs) {
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'no_such_tool', [])]);
+            }
+            $captured = $messages;
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser);
+        $assistant->handle('do something odd');
+
+        expect((string) json_encode($captured))->toContain('Unknown tool');
+    });
+
+    it('reports provider failures as an AI error', function (Filesystem $fs) {
+        $this->provider->responder = function () {
+            throw new RuntimeException('rate limited');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser);
+        $assistant->handle('anything');
+
+        expect($this->buffer->fetch())->toContain('AI error: rate limited');
+    });
+
+    it('stops asking about write tools after answering always', function (Filesystem $fs) {
+        $turn = 0;
+        $this->provider->responder = function () use (&$turn) {
+            if (++$turn === 1) {
+                return new Response('', [
+                    new ToolCall('t1', 'generate_spec', ['class_name' => 'App/First', 'spec_content' => '<?php // a']),
+                    new ToolCall('t2', 'generate_spec', ['class_name' => 'App/Second', 'spec_content' => '<?php // b']),
+                ]);
+            }
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser);
+        $this->answers = ['2'];
+        $assistant->handle('spec both classes');
+
+        expect($this->reads)->toBe(1);
+        expect($fs->write())->toBeCalled()->twice();
+    });
+});

--- a/spec/PhpSpec/Console/Command/Pair/Chooser.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/Chooser.spec.php
@@ -1,0 +1,147 @@
+<?php
+
+use PhpSpec\Console\Command\Pair\Chooser;
+use PhpSpec\Console\Command\Pair\PairOutput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+describe(Chooser::class, function () {
+
+    beforeEach(function () {
+        $this->buffer = new BufferedOutput();
+        $this->output = new PairOutput($this->buffer);
+        $this->answers = [];
+        $this->reads = 0;
+        $this->reader = function () {
+            $this->reads++;
+            return array_shift($this->answers) ?? '';
+        };
+    });
+
+    it('renders the question with three numbered options', function () {
+        $this->answers = ['1'];
+        $chooser = new Chooser($this->output, true, $this->reader);
+
+        $chooser->choose('Do you want me to create class App\Wanted for you?', 'create-class', 'create classes');
+
+        $text = $this->buffer->fetch();
+        expect($text)->toContain('Do you want me to create class');
+        expect($text)->toContain('1. Yes');
+        expect($text)->toContain("2. Yes, and don't ask again — always create classes");
+        expect($text)->toContain('3. No');
+    });
+
+    it('accepts on 1, empty input and y', function () {
+        $chooser = new Chooser($this->output, true, $this->reader);
+
+        $this->answers = ['1'];
+        expect($chooser->choose('Generate?', 'k', 'do it'))->toBeTrue();
+        $this->answers = [''];
+        expect($chooser->choose('Generate?', 'k2', 'do it'))->toBeTrue();
+        $this->answers = ['y'];
+        expect($chooser->choose('Generate?', 'k3', 'do it'))->toBeTrue();
+    });
+
+    it('declines on 3 and n', function () {
+        $chooser = new Chooser($this->output, true, $this->reader);
+
+        $this->answers = ['3'];
+        expect($chooser->choose('Generate?', 'k', 'do it'))->toBeFalse();
+        $this->answers = ['n'];
+        expect($chooser->choose('Generate?', 'k2', 'do it'))->toBeFalse();
+    });
+
+    it('remembers always per question kind and stops asking', function () {
+        $chooser = new Chooser($this->output, true, $this->reader);
+
+        $this->answers = ['2'];
+        expect($chooser->choose('Create class App\First?', 'create-class', 'create classes'))->toBeTrue();
+        expect($this->reads)->toBe(1);
+
+        expect($chooser->choose('Create class App\Second?', 'create-class', 'create classes'))->toBeTrue();
+        expect($this->reads)->toBe(1);
+        expect($this->buffer->fetch())->not()->toContain('App\Second');
+    });
+
+    it('still asks for a different question kind after always', function () {
+        $chooser = new Chooser($this->output, true, $this->reader);
+
+        $this->answers = ['2', '3'];
+        $chooser->choose('Create class?', 'create-class', 'create classes');
+
+        expect($chooser->choose('Run specs now?', 'run-specs', 'run specs'))->toBeFalse();
+        expect($this->reads)->toBe(2);
+    });
+
+    it('selects instantly on a single key without enter', function () {
+        $keys = ['3'];
+        $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+            return array_shift($keys) ?? "\n";
+        });
+
+        expect($chooser->choose('Generate?', 'k', 'do it'))->toBeFalse();
+        expect($keys)->toBe([]);
+        expect($this->buffer->fetch())->toContain('▸ 1. Yes');
+    });
+
+    it('selects yes with y and always with a instantly', function () {
+        $keys = ['y', 'a'];
+        $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+            return array_shift($keys) ?? "\n";
+        });
+
+        expect($chooser->choose('Generate?', 'k', 'do it'))->toBeTrue();
+        expect($chooser->choose('Generate?', 'k2', 'do it'))->toBeTrue();
+        expect($chooser->hasAlways('k2'))->toBeTrue();
+    });
+
+    it('moves the selection with arrow keys and confirms with enter', function () {
+        $keys = ["\033[B", "\033[B", "\n"];
+        $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+            return array_shift($keys) ?? "\n";
+        });
+
+        expect($chooser->choose('Generate?', 'k', 'do it'))->toBeFalse();
+        expect($this->buffer->fetch())->toContain('▸ 3. No');
+    });
+
+    it('clamps arrow movement at the first and last option', function () {
+        $keys = ["\033[A", "\n"];
+        $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+            return array_shift($keys) ?? "\n";
+        });
+
+        expect($chooser->choose('Generate?', 'k', 'do it'))->toBeTrue();
+
+        $keys = ["\033[B", "\033[B", "\033[B", "\033[B", "\n"];
+        expect($chooser->choose('Generate?', 'k2', 'do it'))->toBeFalse();
+    });
+
+    it('treats escape as no', function () {
+        $keys = ["\033"];
+        $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+            return array_shift($keys) ?? "\n";
+        });
+
+        expect($chooser->choose('Generate?', 'k', 'do it'))->toBeFalse();
+    });
+
+    it('exposes whether a kind was answered always', function () {
+        $chooser = new Chooser($this->output, true, $this->reader);
+
+        expect($chooser->hasAlways('create-class'))->toBeFalse();
+
+        $this->answers = ['2'];
+        $chooser->choose('Create class?', 'create-class', 'create classes');
+
+        expect($chooser->hasAlways('create-class'))->toBeTrue();
+        expect($chooser->hasAlways('run-specs'))->toBeFalse();
+    });
+
+    it('prints the question and auto-accepts when not interactive', function () {
+        $chooser = new Chooser($this->output, false, $this->reader);
+
+        expect($chooser->choose('Create class App\Auto?', 'create-class', 'create classes'))->toBeTrue();
+        expect($this->reads)->toBe(0);
+        expect($this->buffer->fetch())->toContain('Create class App\Auto?');
+    });
+});

--- a/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
@@ -45,7 +45,7 @@ describe(CommandDispatcher::class, function () {
 
         $classContents = implode("\n", array_filter(
             $written,
-            fn(string $path) => str_ends_with($path, 'src/App/Basket.php'),
+            fn(string $path) => str_ends_with(str_replace('\\', '/', $path), 'src/App/Basket.php'),
             ARRAY_FILTER_USE_KEY,
         ));
         expect($classContents)->toContain('namespace App;');

--- a/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
@@ -35,6 +35,24 @@ describe(CommandDispatcher::class, function () {
 
     it('instantiates', fn() => expect($this->dispatcher)->toBeAnInstanceOf(CommandDispatcher::class));
 
+    it('normalises slash paths to namespaced classes in describe', function (Filesystem $fs) {
+        $written = [];
+        allow($fs->write())->toReturnUsing(function (string $path, string $content) use (&$written) {
+            $written[$path] = $content;
+        });
+
+        $this->dispatcher->dispatch('describe App/Basket');
+
+        $classContents = implode("\n", array_filter(
+            $written,
+            fn(string $path) => str_ends_with($path, 'src/App/Basket.php'),
+            ARRAY_FILTER_USE_KEY,
+        ));
+        expect($classContents)->toContain('namespace App;');
+        expect($classContents)->toContain('class Basket');
+        expect($classContents)->not()->toContain('class App/Basket');
+    });
+
     it('returns CONTINUE for /help', function () {
         expect($this->dispatcher->dispatch('/help'))->toBe(CommandDispatcher::CONTINUE);
     });

--- a/src/PhpSpec/Console/Command/Pair/AiAssistant.php
+++ b/src/PhpSpec/Console/Command/Pair/AiAssistant.php
@@ -50,7 +50,7 @@ final class AiAssistant
 
     private const WRITE_TOOLS = ['generate_spec', 'generate_feature', 'generate_steps', 'write_file', 'update_file'];
 
-    private bool $autoApproveWrites = false;
+    private readonly Chooser $chooser;
 
     /**
      * @param ProviderInterface $provider the AI provider for LLM interactions
@@ -60,6 +60,8 @@ final class AiAssistant
      * @param Filesystem|null $filesystem filesystem abstraction for testability
      * @param bool $interactive whether to prompt for user confirmation on write actions
      * @param ExtensionLoader|null $extensionLoader optional extension loader for custom tools
+     * @param Chooser|null $chooser the interactive chooser; shared with the dispatcher
+     *                              so "always" answers span the whole pair session
      */
     public function __construct(
         private readonly ProviderInterface $provider,
@@ -69,8 +71,10 @@ final class AiAssistant
         ?Filesystem $filesystem = null,
         private readonly bool $interactive = true,
         private readonly ?ExtensionLoader $extensionLoader = null,
+        ?Chooser $chooser = null,
     ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
+        $this->chooser = $chooser ?? new Chooser($output, $interactive);
     }
 
     /**
@@ -155,7 +159,7 @@ final class AiAssistant
         PairLogger::log('TOOL', "$toolCall->name(" . json_encode($toolCall->arguments) . ')');
 
         if (in_array($toolCall->name, self::WRITE_TOOLS, true)) {
-            if (!$this->confirmTool($toolCall)) {
+            if (!$this->chooser->choose('Allow this action?', 'write-files', 'apply file changes')) {
                 PairLogger::log('RESULT', 'User declined');
                 return ['error' => 'User declined this action.'];
             }
@@ -169,38 +173,6 @@ final class AiAssistant
             PairLogger::log('RESULT', "ERROR: {$e->getMessage()}");
             return ['error' => $e->getMessage()];
         }
-    }
-
-    private function confirmTool(ToolCall $toolCall): bool
-    {
-        if (!$this->interactive || $this->autoApproveWrites) {
-            return true;
-        }
-
-        $out = $this->output->getOutput();
-        $out->writeln('');
-        $out->writeln('  <fg=yellow>Allow this action?</>');
-        $out->writeln('    <fg=white>1</> - Yes');
-        $out->writeln('    <fg=white>2</> - Always yes');
-        $out->writeln('    <fg=white>3</> - No');
-
-        $this->output->prepareForInput();
-
-        if (function_exists('readline') && stream_isatty(STDIN)) {
-            $answer = (string) readline('  > ');
-        } else {
-            $line = fgets(STDIN);
-            $answer = $line === false ? '' : rtrim($line, "\r\n");
-        }
-
-        $this->output->returnToContent();
-        $this->output->echoInput($answer ?: '1');
-
-        return match (trim($answer)) {
-            '', '1' => true,
-            '2' => $this->autoApproveWrites = true,
-            default => false,
-        };
     }
 
     private function ensureInitialised(): void
@@ -232,6 +204,7 @@ final class AiAssistant
             $this->writeFileTool(),
             $this->updateFileTool(),
             $this->runSpecsTool(),
+            $this->askUserTool(),
             AiTools::readFile($this->filesystem),
             AiTools::listFiles($this->filesystem),
         ];
@@ -245,6 +218,37 @@ final class AiAssistant
         }
 
         return $tools;
+    }
+
+    private function askUserTool(): Tool
+    {
+        $chooser = $this->chooser;
+
+        return Tool::make(
+            name: 'ask_user',
+            description: 'Ask the user a yes/no question before proceeding. Use this whenever you need '
+                . 'a confirmation or decision from the user instead of asking in plain text. '
+                . 'Returns "yes", "always" (yes now and for all similar future questions) or "no".',
+            parameters: [
+                'question' => [
+                    'type' => 'string',
+                    'description' => 'The question to show the user, e.g. "Do you want me to generate the method fooBar()?"',
+                ],
+                'action' => [
+                    'type' => 'string',
+                    'description' => 'Short verb phrase naming the action, completing the sentence "always ..." (e.g. "generate methods")',
+                ],
+            ],
+            handler: function (array $args) use ($chooser) {
+                $kind = 'ai-' . preg_replace('/[^a-z0-9]+/', '-', strtolower($args['action']));
+
+                if (!$chooser->choose($args['question'], $kind, $args['action'])) {
+                    return 'no';
+                }
+
+                return $chooser->hasAlways($kind) ? 'always' : 'yes';
+            },
+        );
     }
 
     private function generateSpecTool(): Tool

--- a/src/PhpSpec/Console/Command/Pair/Chooser.php
+++ b/src/PhpSpec/Console/Command/Pair/Chooser.php
@@ -1,0 +1,290 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Command\Pair;
+
+use Closure;
+
+/**
+ * @internal
+ * Presents interactive questions as a numbered chooser, in the style of
+ * AI CLI assistants:
+ *
+ *   ▸ 1. Yes
+ *     2. Yes, and don't ask again — always <action>
+ *     3. No
+ *
+ * On a TTY a single keypress decides — 1/2/3, y (yes), a (always), n or
+ * Esc (no), no Enter needed — and the arrow keys move the highlight with
+ * Enter confirming it. Piped input falls back to reading one answer line
+ * (digits or y/a/n; empty defaults to yes) so scripted sessions keep
+ * working. Option 2 is remembered per question kind for the session, so
+ * later questions of the same kind auto-accept without prompting.
+ * Non-interactive sessions print the question and auto-accept.
+ */
+final class Chooser
+{
+    /** @var array<string, true> question kinds answered with "always" this session */
+    private array $always = [];
+
+    private readonly Closure $reader;
+
+    private readonly ?Closure $keys;
+
+    /**
+     * @param PairOutput $output the pair screen to render into
+     * @param bool $interactive whether a user is attached; false auto-accepts
+     * @param Closure|null $reader reads one answer line (piped input); injectable
+     *                             for specs, defaults to the stdin flow
+     * @param Closure|null $keys reads one raw key token (TTY input); injectable
+     *                           for specs — when given, key mode is used without
+     *                           touching the real terminal
+     */
+    private readonly bool $detectTty;
+
+    public function __construct(
+        private readonly PairOutput $output,
+        private readonly bool $interactive = true,
+        ?Closure $reader = null,
+        ?Closure $keys = null,
+    ) {
+        $this->reader = $reader ?? fn(): string => $this->readAnswer();
+        $this->keys = $keys;
+        // Only probe the real terminal when no input source was injected,
+        // so specs behave the same whether run from a TTY or a pipe
+        $this->detectTty = $reader === null && $keys === null;
+    }
+
+    /**
+     * Asks a yes/always/no question and returns whether the action was accepted.
+     *
+     * @param string $question the question to display
+     * @param string $kind stable identifier grouping questions for "always" memory
+     * @param string $action verb phrase completing "always ..." in option 2
+     * @return bool true when the user accepted (or accepted always, now or earlier)
+     */
+    public function choose(string $question, string $kind, string $action): bool
+    {
+        if (isset($this->always[$kind])) {
+            return true;
+        }
+
+        $console = $this->output->getOutput();
+        $console->writeln('');
+        $console->writeln(sprintf('  <fg=yellow>%s</>', $question));
+
+        if (!$this->interactive) {
+            return true;
+        }
+
+        if ($this->keys !== null || ($this->detectTty && stream_isatty(STDIN))) {
+            return $this->resolve($this->chooseByKey($action), $kind);
+        }
+
+        return $this->resolve($this->chooseByLine($action), $kind);
+    }
+
+    /**
+     * Returns whether a question kind was answered with "always" this session.
+     *
+     * @param string $kind the question kind identifier
+     * @return bool true when future questions of this kind auto-accept
+     */
+    public function hasAlways(string $kind): bool
+    {
+        return isset($this->always[$kind]);
+    }
+
+    /**
+     * Applies the chosen option: records "always", reports acceptance.
+     *
+     * @param int $choice the selected option (1 yes, 2 always, 3 no)
+     * @param string $kind the question kind for "always" memory
+     * @return bool true when option 1 or 2 was chosen
+     */
+    private function resolve(int $choice, string $kind): bool
+    {
+        if ($choice === 2) {
+            $this->always[$kind] = true;
+        }
+
+        return $choice !== 3;
+    }
+
+    /**
+     * Key mode (TTY): a single keypress decides, the arrow keys move the
+     * highlight and Enter confirms it.
+     *
+     * @param string $action verb phrase for option 2
+     * @return int the selected option (1, 2 or 3)
+     */
+    private function chooseByKey(string $action): int
+    {
+        $selected = 1;
+        $rendered = false;
+        $rawMode = $this->keys === null;
+
+        if ($rawMode) {
+            system('stty -icanon -echo');
+        }
+
+        try {
+            $this->renderOptions($selected, $action, $rendered);
+
+            while (true) {
+                $key = $this->keys !== null ? ($this->keys)() : $this->readKeyToken();
+
+                switch ($key) {
+                    case "\033[A":
+                        $selected = max(1, $selected - 1);
+                        break;
+                    case "\033[B":
+                        $selected = min(3, $selected + 1);
+                        break;
+                    case "\n":
+                    case "\r":
+                        return $selected;
+                    case '1':
+                    case 'y':
+                    case 'Y':
+                        $this->renderOptions(1, $action, $rendered);
+
+                        return 1;
+                    case '2':
+                    case 'a':
+                    case 'A':
+                        $this->renderOptions(2, $action, $rendered);
+
+                        return 2;
+                    case '3':
+                    case 'n':
+                    case 'N':
+                    case "\033":
+                        $this->renderOptions(3, $action, $rendered);
+
+                        return 3;
+                    default:
+                        continue 2;
+                }
+
+                $this->renderOptions($selected, $action, $rendered);
+            }
+        } finally {
+            if ($rawMode) {
+                system('stty icanon echo');
+            }
+        }
+    }
+
+    /**
+     * Line mode (piped input): prints the options and reads one answer line.
+     *
+     * @param string $action verb phrase for option 2
+     * @return int the selected option (1, 2 or 3)
+     */
+    private function chooseByLine(string $action): int
+    {
+        $rendered = false;
+        $this->renderOptions(1, $action, $rendered);
+
+        return match (strtolower(trim(($this->reader)()))) {
+            '2', 'a' => 2,
+            '3', 'n' => 3,
+            default => 1,
+        };
+    }
+
+    /**
+     * Renders the three options with the current highlight, redrawing in
+     * place after the first paint.
+     *
+     * @param int $selected the highlighted option
+     * @param string $action verb phrase for option 2
+     * @param bool $rendered whether a previous paint must be overwritten (by reference)
+     */
+    private function renderOptions(int $selected, string $action, bool &$rendered): void
+    {
+        $console = $this->output->getOutput();
+
+        if ($rendered) {
+            $console->write("\033[3A");
+        }
+
+        $rendered = true;
+
+        $labels = [
+            1 => 'Yes',
+            2 => "Yes, and don't ask again — always $action",
+            3 => 'No',
+        ];
+
+        foreach ($labels as $number => $label) {
+            if ($number === $selected) {
+                $console->writeln(sprintf("  <options=reverse> ▸ %d. %s </>\033[K", $number, $label));
+            } else {
+                $console->writeln(sprintf("     <fg=white>%d.</> %s\033[K", $number, $label));
+            }
+        }
+    }
+
+    /**
+     * Reads one raw key token from the terminal: a single character, or a
+     * complete escape sequence for the arrow keys (bare Esc stays a lone \033).
+     *
+     * @return string the key token
+     */
+    private function readKeyToken(): string
+    {
+        $char = fgetc(STDIN);
+
+        if ($char === false) {
+            return "\n";
+        }
+
+        if ($char !== "\033") {
+            return $char;
+        }
+
+        $read = [STDIN];
+        $write = $except = [];
+
+        if ((int) stream_select($read, $write, $except, 0, 20000) < 1) {
+            return "\033";
+        }
+
+        $bracket = fgetc(STDIN);
+
+        if ($bracket !== '[') {
+            return "\033";
+        }
+
+        return "\033[" . fgetc(STDIN);
+    }
+
+    /**
+     * Reads one answer line from piped stdin, cooperating with the pair
+     * screen's reserved input row.
+     *
+     * @return string the raw answer
+     */
+    private function readAnswer(): string
+    {
+        $this->output->prepareForInput();
+        $result = trim((string) fgets(STDIN));
+        $this->output->returnToContent();
+        $this->output->echoInput($result !== '' ? $result : '1');
+
+        return $result;
+    }
+}

--- a/src/PhpSpec/Console/Command/Pair/Chooser.php
+++ b/src/PhpSpec/Console/Command/Pair/Chooser.php
@@ -88,7 +88,10 @@ final class Chooser
             return true;
         }
 
-        if ($this->keys !== null || ($this->detectTty && stream_isatty(STDIN))) {
+        // Raw key mode needs stty, so Windows terminals use line mode
+        $keyCapable = DIRECTORY_SEPARATOR === '/' && $this->detectTty && stream_isatty(STDIN);
+
+        if ($this->keys !== null || $keyCapable) {
             return $this->resolve($this->chooseByKey($action), $kind);
         }
 

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -44,6 +44,7 @@ final class CommandDispatcher
 
     private InputParser $parser;
     private Filesystem $filesystem;
+    private readonly Chooser $chooser;
     private ?AiAssistant $ai = null;
 
     /**
@@ -68,9 +69,11 @@ final class CommandDispatcher
         ?Filesystem $filesystem = null,
         private readonly ?Application $application = null,
         private readonly ?ExtensionLoader $extensionLoader = null,
+        ?Chooser $chooser = null,
     ) {
         $this->parser = new InputParser();
         $this->filesystem = $filesystem ?? new RealFilesystem();
+        $this->chooser = $chooser ?? new Chooser($output, $interactive);
         $this->registerAutoloader();
 
         $aiConfig = $this->config->getAiConfig();
@@ -78,7 +81,7 @@ final class CommandDispatcher
             try {
                 $provider = ProviderFactory::create($aiConfig);
                 $model = $aiConfig['model'] ?? ProviderFactory::defaultModel($aiConfig['provider']);
-                $this->ai = new AiAssistant($provider, $this->config, $this->output, $model, $this->filesystem, $this->interactive, $this->extensionLoader);
+                $this->ai = new AiAssistant($provider, $this->config, $this->output, $model, $this->filesystem, $this->interactive, $this->extensionLoader, $this->chooser);
             } catch (RuntimeException $e) {
                 $this->output->error($e->getMessage());
             }
@@ -152,7 +155,7 @@ final class CommandDispatcher
             return self::CONTINUE;
         }
 
-        $fqcn = $argument;
+        $fqcn = str_replace('/', '\\', $argument);
         $spec = str_replace('\\', '/', $fqcn);
 
         $specPath = $this->specGenerator->getSpecPath();
@@ -184,12 +187,8 @@ final class CommandDispatcher
 
         // Offer class generation
         if (!class_exists($fqcn)) {
-            $this->output->getOutput()->writeln('');
-            $this->output->getOutput()->writeln(sprintf(
-                '  <fg=yellow>Do you want me to create class <fg=white>%s</> for you?</> [Y/n] ',
-                $fqcn,
-            ));
-            if ($this->confirm()) {
+            $question = sprintf('Do you want me to create class <fg=white>%s</> for you?', $fqcn);
+            if ($this->chooser->choose($question, 'create-class', 'create classes')) {
                 try {
                     $message = $this->classGenerator->generate($fqcn);
                     $this->output->success($message);
@@ -205,9 +204,7 @@ final class CommandDispatcher
         }
 
         // Offer to run specs
-        $this->output->getOutput()->writeln('');
-        $this->output->getOutput()->writeln('  <fg=yellow>Do you want to run specs now?</> [Y/n] ');
-        if ($this->confirm()) {
+        if ($this->chooser->choose('Do you want to run specs now?', 'run-specs', 'run specs')) {
             $this->handleRun('');
         }
 
@@ -268,9 +265,7 @@ final class CommandDispatcher
         }
 
         // Offer to run specs
-        $this->output->getOutput()->writeln('');
-        $this->output->getOutput()->writeln('  <fg=yellow>Do you want to run specs now?</> [Y/n] ');
-        if ($this->confirm()) {
+        if ($this->chooser->choose('Do you want to run specs now?', 'run-specs', 'run specs')) {
             $this->handleRun('');
         }
 
@@ -481,41 +476,6 @@ final class CommandDispatcher
             . '  To use natural language, configure an AI provider in phpspec.yaml.',
         );
         return self::CONTINUE;
-    }
-
-    /**
-     * Prompts for Y/n confirmation. Returns true if accepted.
-     * In non-interactive mode, auto-accepts (returns true).
-     */
-    private function confirm(): bool
-    {
-        $answer = $this->ask('  > ');
-        return $answer === '' || strtolower($answer) === 'y';
-    }
-
-    /**
-     * Reads user input via readline (TTY) or fgets (pipe).
-     * In non-interactive mode, returns empty string (auto-accept).
-     */
-    private function ask(string $prompt): string
-    {
-        if (!$this->interactive) {
-            return '';
-        }
-
-        $this->output->prepareForInput();
-
-        if (function_exists('readline') && stream_isatty(STDIN)) {
-            $result = (string) readline($prompt);
-        } else {
-            $line = fgets(STDIN);
-            $result = $line === false ? '' : rtrim($line, "\r\n");
-        }
-
-        $this->output->returnToContent();
-        $this->output->echoInput($result ?: 'Y');
-
-        return $result;
     }
 
     /**


### PR DESCRIPTION
Present pair-mode questions as a numbered chooser shared with the AI ask_user tool

Three call sites unified: the dispatcher's create-class and both run-specs prompts (old confirm()/ask() deleted); the AI write-gate (old hand-rolled confirmTool() menu and its autoApproveWrites flag deleted — the chooser's write-files kind replaces it); and a new ask_user tool the LLM can call with {question, action} — it blocks on the chooser and returns "yes", "always" or "no" as the tool result, so the model asks structured questions instead of prose. The dispatcher and assistant share one chooser instance, so "always" spans the whole session. Documented in docs/pair.md.