### PR TITLE
Fix repeated run losing sessions

### DIFF
--- a/features/scenarios/cli/pair-ai.feature
+++ b/features/scenarios/cli/pair-ai.feature
@@ -152,3 +152,22 @@ Feature: AI-assisted pair programming
       """
     When I run phpspec pair with input "run; run"
     Then the output should contain "1 example (1 passes)" exactly 2 times
+
+  Scenario: Running a spec that declares a top-level type twice does not crash
+    Given a spec file "spec/App/Widget.spec.php":
+      """
+      <?php
+      interface WidgetCollaborator
+      {
+          public function help(): string;
+      }
+
+      describe('Widget', function () {
+          it('uses a collaborator', function (WidgetCollaborator $collaborator) {
+              expect($collaborator)->toBeAnInstanceOf(WidgetCollaborator::class);
+          });
+      });
+      """
+    When I run phpspec pair with input "run; run"
+    Then the output should contain "1 example (1 passes)" exactly 2 times
+    And the output should not contain "Cannot declare interface"

--- a/features/scenarios/cli/pair-ai.feature
+++ b/features/scenarios/cli/pair-ai.feature
@@ -123,3 +123,32 @@ Feature: AI-assisted pair programming
     And the output should contain "2. Yes, and don't ask again"
     And the output should contain "3. No"
     And the class "src/App/Calculator.php" should contain "function add"
+
+  Scenario: Running specs twice in the same pair session shows results both times
+    Given a class "src/App/Calculator.php":
+      """
+      <?php
+      namespace App;
+
+      class Calculator
+      {
+          public function add(int $a, int $b): int
+          {
+              return $a + $b;
+          }
+      }
+      """
+    And a spec file "spec/App/Calculator.spec.php":
+      """
+      <?php
+      use App\Calculator;
+
+      describe(Calculator::class, function () {
+          it('adds numbers', function () {
+              $calc = new Calculator();
+              expect($calc->add(2, 3))->toBe(5);
+          });
+      });
+      """
+    When I run phpspec pair with input "run; run"
+    Then the output should contain "1 example (1 passes)" exactly 2 times

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -63,6 +63,15 @@ then('the output should not contain {string}', function (string $text) {
     }
 });
 
+then('the output should contain {string} exactly {int} times', function (string $text, int $times) {
+    $found = substr_count($this->output, $text);
+    if ($found !== $times) {
+        throw new \RuntimeException(
+            "Expected output to contain \"{$text}\" exactly {$times} time(s), found {$found}.\nOutput:\n{$this->output}"
+        );
+    }
+});
+
 // -- File existence (sets $this->lastFile for chained assertions) ------
 
 then('a spec file {string} should be generated', function (string $path) {

--- a/spec/PhpSpec/Specification/Context.spec.php
+++ b/spec/PhpSpec/Specification/Context.spec.php
@@ -19,7 +19,7 @@ describe(Context::class, function() {
 
     it("runs its closure and returns a ContextResult", function() {
         $ctx = new Context("test context", function() {});
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($result)->toBeAnInstanceOf(ContextResult::class);
         expect($result->getTitle())->toBe("test context");
@@ -32,7 +32,7 @@ describe(Context::class, function() {
                 $ran = true;
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($ran)->toBe(true);
         expect($result->getResults())->toHaveCount(1);
@@ -42,7 +42,7 @@ describe(Context::class, function() {
         $ctx = new Context("broken", function() {
             throw new \RuntimeException("boom");
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($result->isError())->toBe(true);
     });
@@ -60,7 +60,7 @@ describe(Context::class, function() {
                 $log[] = 'ex2';
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($log)->toBe(['before', 'ex1', 'before', 'ex2']);
     });
@@ -75,7 +75,7 @@ describe(Context::class, function() {
                 $log[] = 'ex1';
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($log)->toBe(['ex1', 'after']);
     });
@@ -88,7 +88,7 @@ describe(Context::class, function() {
             });
         });
         $ctx->setPending(true);
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($ran)->toBe(false);
         expect($result->getResults())->toHaveCount(1);
@@ -109,7 +109,7 @@ describe(Context::class, function() {
             });
         });
         $ctx->setPending(true);
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($log)->toBe([]);
     });
@@ -121,7 +121,7 @@ describe(Context::class, function() {
                 $ran = true;
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($ran)->toBe(false);
         expect($result->getResults())->toHaveCount(1);
@@ -137,7 +137,7 @@ describe(Context::class, function() {
                 });
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($ran)->toBe(false);
     });
@@ -152,7 +152,7 @@ describe(Context::class, function() {
                 $log[] = 'focused';
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($log)->toBe(['focused']);
         expect($result->getResults())->toHaveCount(2);
@@ -172,7 +172,7 @@ describe(Context::class, function() {
                 $log[] = 'ex2';
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($log)->toBe(['beforeAll', 'ex1', 'ex2']);
     });
@@ -190,7 +190,7 @@ describe(Context::class, function() {
                 $log[] = 'ex2';
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($log)->toBe(['ex1', 'ex2', 'afterAll']);
     });
@@ -210,7 +210,7 @@ describe(Context::class, function() {
                 });
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($log)->toContain('child1');
         expect($log)->toContain('child2');
@@ -231,7 +231,7 @@ describe(Context::class, function() {
                 });
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($log)->toContain('parent-before');
         expect($log)->toContain('nested');
@@ -245,7 +245,7 @@ describe(Context::class, function() {
                 expect($this->calculator)->toBeAnInstanceOf(\stdClass::class);
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($result->isError())->toBe(false);
     });
@@ -257,7 +257,7 @@ describe(Context::class, function() {
                 $ran = true;
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($ran)->toBe(true);
     });
@@ -271,7 +271,7 @@ describe(Context::class, function() {
                 });
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($ran)->toBe(false);
     });
@@ -288,7 +288,7 @@ describe(Context::class, function() {
                 });
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($log)->toContain('focused');
     });
@@ -313,7 +313,7 @@ describe(Context::class, function() {
                 pending("Not yet implemented");
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($result->getResults())->toHaveCount(1);
         expect($result->getResults()[0]->isPending())->toBe(true);
@@ -325,7 +325,7 @@ describe(Context::class, function() {
                 skip("Skipped");
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($result->getResults())->toHaveCount(1);
         expect($result->getResults()[0]->isSkipped())->toBe(true);
@@ -340,7 +340,7 @@ describe(Context::class, function() {
                 });
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         // The nested context should have 1 child result
         $nestedCtx = $result->getResults()[0];
@@ -361,7 +361,7 @@ describe(Context::class, function() {
                 expect($this->val)->toBeOfType('int');
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         // let should be called once during describe loading + once per example re-apply = 3 total
         expect($counter)->toBeGreaterThanOrEqualTo(2);
@@ -374,7 +374,7 @@ describe(Context::class, function() {
                 expect(4)->toBeEven();
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($result->isError())->toBe(false);
     });
@@ -386,7 +386,7 @@ describe(Context::class, function() {
                 expect(10)->toBeMultipleOf(5);
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $result = $ctx->run();
         expect($result->isError())->toBe(false);
     });
@@ -402,7 +402,7 @@ describe(Context::class, function() {
                 expect(true)->toBeTrue();
             });
         });
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($resolved)->toBeAnInstanceOf(\JsonSerializable::class);
     });
@@ -421,7 +421,7 @@ describe(Context::class, function() {
             });
         });
         $ctx->setPending(true);
-        $ctx->setWorld(new Subject(__FILE__));
+        $ctx->setWorld(new Subject());
         $ctx->run();
         expect($log)->toBe([]);
     });
@@ -451,7 +451,7 @@ describe(Context::class, function() {
                     $log[] = 'example';
                 });
             });
-            $ctx->setWorld(new Subject(__FILE__));
+            $ctx->setWorld(new Subject());
             $ctx->run();
         } finally {
             CoverageRegistry::reset();
@@ -476,7 +476,7 @@ describe(Context::class, function() {
                     $ran[] = 'other';
                 });
             });
-            $ctx->setWorld(new Subject(__FILE__));
+            $ctx->setWorld(new Subject());
             $result = $ctx->run();
         } finally {
             FilterRegistry::reset();
@@ -500,7 +500,7 @@ describe(Context::class, function() {
 
         try {
             $ctx = new Context("LineTargeted", $block);
-            $ctx->setWorld(new Subject(__FILE__));
+            $ctx->setWorld(new Subject());
             $result = $ctx->run();
         } finally {
             LineTargetRegistry::reset();
@@ -522,7 +522,7 @@ describe(Context::class, function() {
 
         try {
             $ctx = new Context("WholeContext", $block);
-            $ctx->setWorld(new Subject(__FILE__));
+            $ctx->setWorld(new Subject());
             $ctx->run();
         } finally {
             LineTargetRegistry::reset();

--- a/spec/PhpSpec/Specification/SpecFileCache.spec.php
+++ b/spec/PhpSpec/Specification/SpecFileCache.spec.php
@@ -1,0 +1,74 @@
+<?php
+
+use PhpSpec\Specification\Context;
+use PhpSpec\Specification\Rebindable;
+use PhpSpec\Specification\SpecFileCache;
+use PhpSpec\Specification\Subject;
+
+describe(SpecFileCache::class, function () {
+
+    // Each example uses a fresh, unique path, so entries never collide and no
+    // global cache reset is needed (or offered — see SpecFileCache).
+    beforeEach(function () {
+        $this->file = sys_get_temp_dir() . '/phpspec_cache_' . uniqid() . '.spec.php';
+        register_shutdown_function(fn() => @unlink($this->file));
+    });
+
+    it('parses a spec file into its top-level blocks', function () {
+        file_put_contents($this->file, "<?php\ndescribe('Cached', function () { it('a', function () {}); });\n");
+
+        $templates = SpecFileCache::templates($this->file);
+
+        expect($templates)->toHaveCount(1);
+        expect($templates[0])->toBeAnInstanceOf(Context::class);
+        expect($templates[0])->toBeAnInstanceOf(Rebindable::class);
+    });
+
+    it('loads the file only once while its content is unchanged', function () {
+        file_put_contents($this->file, "<?php\n\$GLOBALS['phpspec_cache_loads'] = (\$GLOBALS['phpspec_cache_loads'] ?? 0) + 1;\ndescribe('Cached', function () { it('a', function () {}); });\n");
+        $GLOBALS['phpspec_cache_loads'] = 0;
+
+        SpecFileCache::templates($this->file);
+        SpecFileCache::templates($this->file);
+        SpecFileCache::templates($this->file);
+
+        expect($GLOBALS['phpspec_cache_loads'])->toBe(1);
+    });
+
+    it('reloads the file when its content changes', function () {
+        file_put_contents($this->file, "<?php\n\$GLOBALS['phpspec_cache_loads'] = (\$GLOBALS['phpspec_cache_loads'] ?? 0) + 1;\ndescribe('One', function () { it('a', function () {}); });\n");
+        $GLOBALS['phpspec_cache_loads'] = 0;
+
+        SpecFileCache::templates($this->file);
+
+        // A longer body changes the size component of the signature.
+        file_put_contents($this->file, "<?php\n\$GLOBALS['phpspec_cache_loads'] = (\$GLOBALS['phpspec_cache_loads'] ?? 0) + 1;\ndescribe('Two', function () { it('a', function () {}); it('b', function () {}); });\n");
+
+        SpecFileCache::templates($this->file);
+
+        expect($GLOBALS['phpspec_cache_loads'])->toBe(2);
+    });
+
+    it('resolves different path strings for one file to a single entry', function () {
+        file_put_contents($this->file, "<?php\n\$GLOBALS['phpspec_cache_loads'] = (\$GLOBALS['phpspec_cache_loads'] ?? 0) + 1;\ndescribe('Cached', function () { it('a', function () {}); });\n");
+        $GLOBALS['phpspec_cache_loads'] = 0;
+
+        SpecFileCache::templates($this->file);
+        // The same file reached through a redundant "/./" segment must not reparse.
+        SpecFileCache::templates(str_replace('/phpspec_cache_', '/./phpspec_cache_', $this->file));
+
+        expect($GLOBALS['phpspec_cache_loads'])->toBe(1);
+    });
+
+    it('keeps templates pristine so each withWorld copy is a fresh, independent block', function () {
+        file_put_contents($this->file, "<?php\ndescribe('Cached', function () { it('a', function () {}); });\n");
+
+        $template = SpecFileCache::templates($this->file)[0];
+
+        $first = $template->withWorld(new Subject());
+        $second = $template->withWorld(new Subject());
+
+        expect($first)->not()->toBe($template);
+        expect($second)->not()->toBe($first);
+    });
+});

--- a/spec/PhpSpec/Specification/Subject.spec.php
+++ b/spec/PhpSpec/Specification/Subject.spec.php
@@ -1,0 +1,38 @@
+<?php
+
+use PhpSpec\Specification\Subject;
+
+describe(Subject::class, function () {
+
+    it('re-executes the spec file on every construction, not just the first', function () {
+        $counterFile = sys_get_temp_dir() . '/phpspec_subject_counter_' . uniqid() . '.txt';
+        $file = sys_get_temp_dir() . '/phpspec_subject_test_' . uniqid() . '.php';
+        file_put_contents($counterFile, '0');
+        file_put_contents($file, sprintf(
+            '<?php file_put_contents(%s, (int) file_get_contents(%s) + 1);',
+            var_export($counterFile, true),
+            var_export($counterFile, true),
+        ));
+
+        try {
+            new Subject($file);
+            new Subject($file);
+
+            expect((int) file_get_contents($counterFile))->toBe(2);
+        } finally {
+            unlink($file);
+            unlink($counterFile);
+        }
+    });
+
+    it('propagates errors thrown while loading the spec file', function () {
+        $file = sys_get_temp_dir() . '/phpspec_subject_error_test_' . uniqid() . '.php';
+        file_put_contents($file, "<?php\nthrow new \\RuntimeException('boom');\n");
+        // `->toThrow()` evaluates the closure after this callback returns, so
+        // cleanup can't sit in a try/finally around it without deleting the
+        // file before the deferred assertion runs it.
+        register_shutdown_function(fn() => @unlink($file));
+
+        expect(fn() => new Subject($file))->toThrow(\RuntimeException::class);
+    });
+});

--- a/spec/PhpSpec/Specification/Subject.spec.php
+++ b/spec/PhpSpec/Specification/Subject.spec.php
@@ -4,35 +4,30 @@ use PhpSpec\Specification\Subject;
 
 describe(Subject::class, function () {
 
-    it('re-executes the spec file on every construction, not just the first', function () {
-        $counterFile = sys_get_temp_dir() . '/phpspec_subject_counter_' . uniqid() . '.txt';
-        $file = sys_get_temp_dir() . '/phpspec_subject_test_' . uniqid() . '.php';
-        file_put_contents($counterFile, '0');
-        file_put_contents($file, sprintf(
-            '<?php file_put_contents(%s, (int) file_get_contents(%s) + 1);',
-            var_export($counterFile, true),
-            var_export($counterFile, true),
-        ));
+    it('is a bare world when constructed without a file', function () {
+        $subject = new Subject();
+        $subject->foo = 'bar';
 
-        try {
-            new Subject($file);
-            new Subject($file);
-
-            expect((int) file_get_contents($counterFile))->toBe(2);
-        } finally {
-            unlink($file);
-            unlink($counterFile);
-        }
+        expect($subject->foo)->toBe('bar');
     });
 
-    it('propagates errors thrown while loading the spec file', function () {
-        $file = sys_get_temp_dir() . '/phpspec_subject_error_test_' . uniqid() . '.php';
-        file_put_contents($file, "<?php\nthrow new \\RuntimeException('boom');\n");
-        // `->toThrow()` evaluates the closure after this callback returns, so
-        // cleanup can't sit in a try/finally around it without deleting the
-        // file before the deferred assertion runs it.
+    it('runs a spec file with $this bound to itself, so top-level closures capture it as their world', function () {
+        $file = sys_get_temp_dir() . '/phpspec_subject_bind_' . uniqid() . '.php';
+        file_put_contents($file, "<?php\n\$GLOBALS['phpspec_subject_probe'] = function () { return \$this; };\n");
         register_shutdown_function(fn() => @unlink($file));
 
-        expect(fn() => new Subject($file))->toThrow(\RuntimeException::class);
+        $subject = new Subject();
+        $subject->load($file);
+
+        $captured = (new ReflectionFunction($GLOBALS['phpspec_subject_probe']))->getClosureThis();
+        expect($captured)->toBe($subject);
+    });
+
+    it('propagates errors thrown while loading a spec file', function () {
+        $file = sys_get_temp_dir() . '/phpspec_subject_error_' . uniqid() . '.php';
+        file_put_contents($file, "<?php\nthrow new \\RuntimeException('boom');\n");
+        register_shutdown_function(fn() => @unlink($file));
+
+        expect(fn() => (new Subject())->load($file))->toThrow(\RuntimeException::class);
     });
 });

--- a/src/PhpSpec/Specification.php
+++ b/src/PhpSpec/Specification.php
@@ -20,7 +20,9 @@ use PhpSpec\EventDispatcher\Event\SpecificationFinished;
 use PhpSpec\EventDispatcher\Event\SpecificationStarted;
 use PhpSpec\Result\SpecificationResult;
 use PhpSpec\Specification\ExampleRegistry;
+use PhpSpec\Specification\Rebindable;
 use PhpSpec\Specification\SpecBlock;
+use PhpSpec\Specification\SpecFileCache;
 use PhpSpec\Specification\Subject;
 
 /**
@@ -54,11 +56,7 @@ class Specification implements ExampleRegistry, SpecBlock
         FilterRegistry::current()?->beginSpec($this->path);
         LineTargetRegistry::beginSpec($this->path);
 
-        // loads the specification file from the Subject constructor
-        // so $this in the examples refers to Subject
-        DispatcherRegistry::dispatcher()->pushScope($this);
         $subject = $this->loadSubject();
-        DispatcherRegistry::dispatcher()->popScope();
 
         $blockResults = [];
 
@@ -146,10 +144,21 @@ class Specification implements ExampleRegistry, SpecBlock
     }
 
     /**
-     * Creates a Subject that loads the spec file, making $this available inside closures.
+     * Builds a fresh world for this run and registers the spec file's top-level
+     * blocks against it, rebound to that world. The file is parsed (require'd)
+     * at most once per process by SpecFileCache; every run works from fresh
+     * copies of the cached templates so repeated runs never re-execute the file.
+     *
+     * @return Subject the world shared by this run's examples
      */
     private function loadSubject(): Subject
     {
-        return new Subject($this->path);
+        $world = new Subject();
+
+        foreach (SpecFileCache::templates($this->path) as $template) {
+            $this->addSpecBlock($template instanceof Rebindable ? $template->withWorld($world) : $template);
+        }
+
+        return $world;
     }
 }

--- a/src/PhpSpec/Specification/BlockCollector.php
+++ b/src/PhpSpec/Specification/BlockCollector.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Specification;
+
+/**
+ * @internal
+ * Minimal scope used while parsing a spec file: it captures the top-level
+ * blocks that describe()/it() register, without running them.
+ */
+final class BlockCollector implements ExampleRegistry
+{
+    /** @var list<SpecBlock> top-level blocks registered during the parse */
+    private array $blocks = [];
+
+    /**
+     * Records a top-level spec block registered during the parse.
+     *
+     * @param SpecBlock $example the block to collect
+     * @return void
+     */
+    public function addSpecBlock(SpecBlock $example): void
+    {
+        $this->blocks[] = $example;
+    }
+
+    /**
+     * Returns the collected top-level blocks in registration order.
+     *
+     * @return list<SpecBlock>
+     */
+    public function blocks(): array
+    {
+        return $this->blocks;
+    }
+}

--- a/src/PhpSpec/Specification/Context.php
+++ b/src/PhpSpec/Specification/Context.php
@@ -33,7 +33,7 @@ use Throwable;
  * Represents a describe()/context() block containing examples, nested contexts,
  * lifecycle hooks, and shared world state.
  */
-class Context implements ExampleRegistry, SpecBlock
+class Context implements ExampleRegistry, Rebindable
 {
     /** @var array<SpecBlock> child examples and nested contexts */
     private array $specBlocks = [];
@@ -73,6 +73,24 @@ class Context implements ExampleRegistry, SpecBlock
      * @param Closure $specBlock closure containing nested DSL calls
      */
     public function __construct(private readonly mixed $context, private readonly Closure $specBlock) {}
+
+    /**
+     * Returns a fresh, unrun copy of this context with its block closure bound
+     * to the given world. The nested it()/let()/hook closures the block defines
+     * inherit that binding when the copy runs, so every run gets its own world
+     * without re-parsing the spec file.
+     *
+     * @param Subject $world the world to bind the copy's closure to
+     * @return SpecBlock the fresh context copy
+     */
+    public function withWorld(Subject $world): SpecBlock
+    {
+        $copy = new self($this->context, Closure::bind($this->specBlock, $world, $world));
+        $copy->pending = $this->pending;
+        $copy->focused = $this->focused;
+
+        return $copy;
+    }
 
     /**
      * Marks this context and all its children as pending (skipped).

--- a/src/PhpSpec/Specification/Example.php
+++ b/src/PhpSpec/Specification/Example.php
@@ -33,7 +33,7 @@ use ReflectionFunction;
  * Represents a single it() example. Executes the test closure, captures
  * match results and errors, and reports timing information.
  */
-class Example implements ExampleResultRegistry, SpecBlock
+class Example implements ExampleResultRegistry, Rebindable
 {
     /** @var array<Closure> collected match closures from expectations */
     private array $matches = [];
@@ -58,6 +58,23 @@ class Example implements ExampleResultRegistry, SpecBlock
      * @param Closure $example executable test body
      */
     public function __construct(private readonly string $title, private readonly Closure $example) {}
+
+    /**
+     * Returns a fresh, unrun copy of this example with its closure bound to the
+     * given world, so a top-level it() gets a fresh world per run without
+     * re-parsing the spec file.
+     *
+     * @param Subject $world the world to bind the copy's closure to
+     * @return SpecBlock the fresh example copy
+     */
+    public function withWorld(Subject $world): SpecBlock
+    {
+        $copy = new self($this->title, Closure::bind($this->example, $world, $world));
+        $copy->pending = $this->pending;
+        $copy->focused = $this->focused;
+
+        return $copy;
+    }
 
     /**
      * Returns the descriptive label of the example.

--- a/src/PhpSpec/Specification/Rebindable.php
+++ b/src/PhpSpec/Specification/Rebindable.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Specification;
+
+/**
+ * @internal
+ * A top-level spec block (Context or Example) parsed once and kept as a
+ * pristine template. Because run() mutates a block, each run must start from a
+ * fresh copy; withWorld() produces that copy with its closure rebound to the
+ * run's world, so the parsed file never has to be require'd again.
+ */
+interface Rebindable extends SpecBlock
+{
+    /**
+     * Returns a fresh, unrun copy of this block with its closure bound to the
+     * given world (and, transitively, any closures it defines when it runs).
+     *
+     * @param Subject $world the world to bind the copy's closure to
+     * @return SpecBlock a fresh block ready to run against $world
+     */
+    public function withWorld(Subject $world): SpecBlock;
+}

--- a/src/PhpSpec/Specification/SpecFileCache.php
+++ b/src/PhpSpec/Specification/SpecFileCache.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Specification;
+
+use PhpSpec\EventDispatcher\DispatcherRegistry;
+
+/**
+ * @internal
+ * Parses each spec file at most once per process and keeps its top-level blocks
+ * as pristine templates. Every run then rebuilds fresh, world-bound blocks from
+ * the templates (see Specification::loadSubject) instead of requiring the file
+ * again.
+ *
+ * Re-requiring matters because a spec file may declare a class/interface/trait
+ * at its top level: running the file a second time redeclares it and PHP raises
+ * an uncatchable "cannot declare ... already in use" fatal. A long-lived process
+ * such as `phpspec pair` runs the same suite repeatedly, so requiring once and
+ * rebinding is what keeps repeated runs both correct and crash-free.
+ *
+ * The cache is keyed by the file's path and content signature (mtime + size),
+ * so editing a spec — e.g. `exemplify` appending an example — re-parses it while
+ * unchanged files stay cached.
+ */
+final class SpecFileCache
+{
+    /** @var array<string, array{signature: string, templates: list<SpecBlock>}> */
+    private static array $entries = [];
+
+    /**
+     * Returns the top-level template blocks for a spec file, parsing it once
+     * per content signature and reusing the result on later calls.
+     *
+     * The key is the file's real path so the same file requested by different
+     * path strings (a scanned "./spec/X" and an explicit "spec/X") resolves to
+     * a single entry — otherwise the file would be require'd twice and a
+     * top-level type declaration would fatal on the second require.
+     *
+     * There is deliberately no way to clear the cache: a spec file is require'd
+     * at most once per process, so eviction could only reintroduce that
+     * redeclaration fatal on a later run.
+     *
+     * @param string $path filesystem path to the .spec.php file
+     * @return list<SpecBlock> pristine top-level blocks
+     */
+    public static function templates(string $path): array
+    {
+        $realPath = realpath($path) ?: $path;
+        $signature = self::signature($realPath);
+        $entry = self::$entries[$realPath] ?? null;
+
+        if ($entry === null || $entry['signature'] !== $signature) {
+            $entry = ['signature' => $signature, 'templates' => self::parse($realPath)];
+            self::$entries[$realPath] = $entry;
+        }
+
+        return $entry['templates'];
+    }
+
+    /**
+     * Computes a content signature that changes when the file is edited.
+     *
+     * @param string $path filesystem path to the .spec.php file
+     * @return string the signature
+     */
+    private static function signature(string $path): string
+    {
+        // PHP caches stat results per path for the whole process, so an edit
+        // made during a long-lived `phpspec pair` session would otherwise read
+        // a stale mtime/size and never invalidate the cache.
+        clearstatcache(true, $path);
+
+        return @filemtime($path) . ':' . @filesize($path);
+    }
+
+    /**
+     * Loads a spec file once, collecting the top-level blocks its describe()/
+     * it() calls register. The blocks stay pristine (never run); each run copies
+     * them via withWorld().
+     *
+     * @param string $path filesystem path to the .spec.php file
+     * @return list<SpecBlock> the collected top-level blocks
+     */
+    private static function parse(string $path): array
+    {
+        $collector = new BlockCollector();
+        $dispatcher = DispatcherRegistry::dispatcher();
+        $dispatcher->pushScope($collector);
+
+        try {
+            (new Subject())->load($path);
+        } finally {
+            $dispatcher->popScope();
+        }
+
+        return $collector->blocks();
+    }
+}

--- a/src/PhpSpec/Specification/Subject.php
+++ b/src/PhpSpec/Specification/Subject.php
@@ -27,10 +27,22 @@ final class Subject implements World
     /**
      * Loads the spec file, making describe()/context()/it() calls register their blocks.
      *
+     * A plain `require` is used, not `require_once`: describe()/context()/it()
+     * attach their blocks to whichever scope is currently pushed on the
+     * dispatcher (see Specification::run()), so the file must re-execute on
+     * every run — long-lived processes like `phpspec pair` run the same spec
+     * file's path more than once per session, and `require_once` would only
+     * ever fire the registration on the first run, silently dropping every
+     * later one. A spec file that also declares a class/function/interface at
+     * the top level (unusual for a spec file, but not disallowed) will fatal
+     * with a "Cannot redeclare" error on a second run in the same process —
+     * PHP does not allow catching that error, so it can't be worked around
+     * here; avoid top-level declarations in spec files.
+     *
      * @param string $path filesystem path to the .spec.php file
      */
     public function __construct(string $path)
     {
-        require_once($path);
+        require($path);
     }
 }

--- a/src/PhpSpec/Specification/Subject.php
+++ b/src/PhpSpec/Specification/Subject.php
@@ -15,34 +15,29 @@
 namespace PhpSpec\Specification;
 
 /**
- * Dynamic-property object serving as $this inside spec closures. Loads the spec file
- * on construction and holds shared state set by let() bindings.
+ * @internal
+ * Dynamic-property object serving as $this inside spec closures. Holds shared
+ * state set by let() bindings; a fresh Subject is the world for each run.
  */
 #[\AllowDynamicProperties]
-/** @internal */
 final class Subject implements World
 {
     /** @var array<string, object> mocks created by let() parameter injection */
     public array $__phpspec_let_mocks = [];
+
     /**
-     * Loads the spec file, making describe()/context()/it() calls register their blocks.
-     *
-     * A plain `require` is used, not `require_once`: describe()/context()/it()
-     * attach their blocks to whichever scope is currently pushed on the
-     * dispatcher (see Specification::run()), so the file must re-execute on
-     * every run — long-lived processes like `phpspec pair` run the same spec
-     * file's path more than once per session, and `require_once` would only
-     * ever fire the registration on the first run, silently dropping every
-     * later one. A spec file that also declares a class/function/interface at
-     * the top level (unusual for a spec file, but not disallowed) will fatal
-     * with a "Cannot redeclare" error on a second run in the same process —
-     * PHP does not allow catching that error, so it can't be worked around
-     * here; avoid top-level declarations in spec files.
+     * Loads a spec file, executing its top-level describe()/it() calls so they
+     * register their blocks. The require runs in this method's scope, so every
+     * closure defined at the file's top level is bound to $this — that binding
+     * is what makes $this->foo work inside examples. Loading is done at most
+     * once per file per process (see SpecFileCache); each run then rebinds the
+     * parsed closures to its own fresh Subject rather than requiring again.
      *
      * @param string $path filesystem path to the .spec.php file
+     * @return void
      */
-    public function __construct(string $path)
+    public function load(string $path): void
     {
-        require($path);
+        require $path;
     }
 }


### PR DESCRIPTION
Subject::__construct() loaded spec files with require_once. Since describe()/it() attach blocks to whatever scope is currently active (pushed/popped per Specification::run()), the file must re-execute every run to re-register — but in a long-lived process (pair mode), require_once only ever fires that top-level code once, ever.

This was impacting pair mode second runs.