### PR TITLE
Add format --agent to interact with AI agents

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,0 +1,282 @@
+# Coding Agents (`--format=agent`)
+
+PhpSpec speaks a machine-readable dialect designed for coding agents (Claude
+Code, Cursor, or any script that shells out and parses output). Instead of the
+ANSI-decorated prose the human formatters produce, `--format=agent` emits a
+single JSON document where **the failure itself is the payload** — everything an
+agent needs to decide its next move, without re-reading the project.
+
+The same idea runs through the scaffolding commands: `describe --agent` and
+`exemplify --agent` return JSON receipts instead of prose, and `--accept-offers`
+applies PhpSpec's code-generation offers non-interactively. Together they let an
+agent drive the whole spec → red → green loop through the CLI, never guessing at
+output and never hand-editing what PhpSpec can generate.
+
+> **Just want the CLAUDE.md snippet?** Jump to
+> [Teaching an agent to use PhpSpec](#teaching-an-agent-to-use-phpspec).
+
+## Running
+
+```bash
+bin/phpspec run --format=agent
+```
+
+One JSON object is written to stdout, with no ANSI and no prose. It is
+`--parallel`-safe: the whole document is emitted once, at the end of the run,
+when the parent process holds the complete result.
+
+## The document
+
+A run of three examples — one passing, one failing, one erroring on a missing
+class — produces:
+
+```json
+{
+  "suite": {
+    "v": 1, "event": "run_started", "suite": "default",
+    "examples": 3, "steps": 0, "seed": null
+  },
+  "examples": [
+    {
+      "v": 1,
+      "id": "6fd046add251",
+      "example": "Basket totals the prices of its products",
+      "state": "failing",
+      "expected": { "matcher": "toBe", "value": 4000, "negated": false },
+      "actual": 3500,
+      "message": "Expected 3500 to be 4000",
+      "spec": "spec/App/Basket.spec.php:6",
+      "rerun": "run spec/App/Basket.spec.php:6"
+    },
+    {
+      "v": 1,
+      "id": "66b1647a77b6",
+      "example": "Basket applies a coupon",
+      "state": "error",
+      "exception": {
+        "class": "Error",
+        "message": "Class \"App\\Coupon\" not found",
+        "at": "spec/App/Basket.spec.php:8"
+      },
+      "spec": "spec/App/Basket.spec.php:8",
+      "rerun": "run spec/App/Basket.spec.php:8",
+      "offer": { "action": "create_class", "target": "App\\Coupon" }
+    }
+  ],
+  "result": {
+    "v": 1, "event": "summary",
+    "examples": 3, "steps": 0,
+    "passing": 1, "failing": 1, "errors": 1, "pending": 0, "skipped": 0,
+    "actionable": 2,
+    "duration_ms": 4,
+    "offers": [
+      { "action": "create_class", "target": "App\\Coupon" },
+      { "action": "fake_method", "target": "App\\Basket::total", "value": "4000" }
+    ]
+  }
+}
+```
+
+Every object carries `"v"` — the agent-protocol version (currently `1`).
+
+### `suite` — the header
+
+`examples` and `steps` are the totals for the run (`steps` is non-zero only for
+Story BDD feature runs). `suite` is the suite name; `seed` is the random-order
+seed when one was used, else `null`.
+
+### `examples` — only what needs attention
+
+**Passing examples are omitted.** A green suite of thousands need not spend
+tokens on entries an agent will never act on — the summary still counts them.
+Each listed entry is one that failed, errored, or is pending/skipped.
+
+| Field | Meaning |
+|---|---|
+| `id` | A stable identifier for this example — a hash of its full name (described subject + title). It survives edits that move lines or change where a failure fires, so you can ask *"is THIS exact failure still here?"* across runs. Recomputable from `example`. |
+| `example` | The full name: the described subject followed by the example title. |
+| `state` | `failing`, `error`, `pending`, or `skipped` (`passing` entries are omitted). |
+| `spec` | The `file:line` of the failing assertion or the error, project-relative. |
+| `rerun` | The exact arguments to re-run **just this one example** — prepend your PhpSpec binary. No full-suite re-run needed to verify one fix. |
+
+**`failing`** entries also carry the expectation:
+
+- `expected` — what the matcher wanted: `matcher` is its name (`toBe`,
+  `toThrow`, …), `value` is the target value, and `negated` is `true` when the
+  expectation used `not()`.
+- `actual` — the value your code actually produced.
+- `message` — PhpSpec's rendered failure message.
+
+> **Note on `expected` vs `actual`.** These follow the universal convention:
+> `expected.value` is what should have happened, `actual` is what did. (PhpSpec's
+> internal naming is the reverse — the formatter un-inverts it for you.)
+
+**`error`** entries carry `exception` (`class`, `message`, `at`) instead. When
+the error names something PhpSpec can generate — a missing class, interface, or
+method — the entry also carries a per-example `offer` (see below). A failing
+expectation carries **no** offer: the code exists and its behaviour is simply
+wrong, so `state: failing` already says everything.
+
+**Warnings, deprecations and notices.** When an example emits PHP
+warnings/deprecations/notices, the entry gains `warnings`, `deprecations` and/or
+`notices` arrays of `{ "message", "at" }` — present only when non-empty.
+Sometimes the deprecation is the actual clue behind a failure.
+
+Large or object values in `expected`/`actual` are exported compactly (long
+strings and arrays are truncated with a `{ "truncated": true, "length": N }`
+marker; objects render as `ClassName#id`) so the document never blows up.
+
+### `result` — the summary
+
+The counts (`passing`, `failing`, `errors`, `pending`, `skipped`) are for the
+whole run. The one number to branch on is **`actionable`** = failing + errors +
+pending. **Zero means there is nothing to do.** `duration_ms` is the run's wall
+time; `offers` is the run-wide, de-duplicated list of code PhpSpec can generate.
+
+## Offers — code PhpSpec can generate for you
+
+An **offer** is a `{ action, target }` pair (with an optional `value`). They are
+the same "shall I create this?" prompts the interactive runner shows a human,
+turned into flat data:
+
+| `action` | `target` | Meaning |
+|---|---|---|
+| `create_class` | `App\Coupon` | A referenced class doesn't exist yet. |
+| `create_interface` | `App\Repository` | A mocked type doesn't exist yet. |
+| `create_method` | `App\Basket::checkout` | A called method doesn't exist on its class/interface. |
+| `create_steps` | `features/checkout.feature` | A feature has undefined steps. |
+| `fake_method` | `App\Basket::total` | An existing **empty** method that a spec pins to a value; `value` is the return expression `--fake` would insert (e.g. `"4000"`, `"'hello'"`, `"true"`). |
+
+Offers appear in two places: run-wide in `result.offers`, and per-example on the
+`offer` field of an `error` entry that maps to a concrete generation.
+
+### Acting on offers
+
+Rather than write the boilerplate itself, an agent can have PhpSpec apply every
+pending offer in one non-interactive pass:
+
+```bash
+bin/phpspec run --accept-offers            # create missing classes/interfaces/methods/steps
+bin/phpspec run --accept-offers --fake     # ...and fill empty methods with their spec'd return values
+```
+
+`--accept-offers` runs the suite, applies all offers (no prompts), and exits `0`.
+Add `--fake` to also fill empty method bodies with the hardcoded returns their
+specs expect (the `fake_method` offers) — a fast way to a first green before you
+replace the fakes with real logic.
+
+## Scaffolding with JSON receipts
+
+`describe` and `exemplify` take an `--agent` flag that swaps their prose for a
+one-line JSON receipt — so an agent can scaffold without parsing English. No file
+content is returned; the agent reads the file itself.
+
+```bash
+bin/phpspec describe App/Basket --agent
+```
+```json
+{"v":1,"action":"describe","class":"App\\Basket","spec":"spec/App/Basket.spec.php","created":true}
+```
+
+`created` is `false` when the spec already existed (both commands are
+idempotent). Combine `describe --agent` with `-e` to also add a method example:
+
+```bash
+bin/phpspec describe App/Basket --agent -e checkout
+```
+```json
+{"v":1,"action":"describe","class":"App\\Basket","spec":"spec/App/Basket.spec.php","created":false,"example":{"method":"checkout","added":true}}
+```
+
+`exemplify --agent` adds a single method example to a spec (creating the spec
+first if needed):
+
+```bash
+bin/phpspec exemplify App/Basket checkout --agent
+```
+```json
+{"v":1,"action":"exemplify","class":"App\\Basket","method":"checkout","spec":"spec/App/Basket.spec.php","added":true}
+```
+
+`added` is `false` when an example for that method is already present.
+
+## The loop
+
+Putting it together, an agent drives the full cycle through the CLI:
+
+1. **Scaffold** — `describe App/Basket --agent` (and `exemplify … --agent` per
+   method) to lay down specs.
+2. **Read** — `run --format=agent`; branch on `result.actionable`.
+3. **Generate** — for `create_*` offers, either write the code or run
+   `run --accept-offers`; for `fake_method` offers, `run --accept-offers --fake`
+   to get a first green.
+4. **Fix & verify** — implement real behaviour for `failing` entries, then
+   `run <entry.rerun>` to check just that one example. Track it by `id` across
+   runs.
+5. **Repeat** until `actionable` is `0` (exit code `0`).
+
+## Teaching an agent to use PhpSpec
+
+Drop something like this into your `CLAUDE.md` (or `.cursorrules`, or any
+agent-instruction file) so the agent uses PhpSpec effectively:
+
+```markdown
+## Running specs with PhpSpec
+
+Always run PhpSpec with the machine-readable formatter and parse the JSON:
+
+    bin/phpspec run --format=agent
+
+Read the single JSON object it prints:
+
+- `result.actionable` is the number to act on. **0 means the suite is green —
+  stop.** Otherwise it's `failing + errors + pending`.
+- `examples[]` lists only what needs attention (passing examples are omitted).
+  Each has a `state`:
+  - `failing` — the code ran but behaviour is wrong. Look at `expected.value`
+    (what the spec wants), `actual` (what the code produced), and `message`.
+    Fix the implementation; do not change the spec to match the code unless the
+    spec is genuinely wrong.
+  - `error` — an exception was thrown (`exception.class`, `exception.message`).
+    If the entry has an `offer`, PhpSpec can generate the missing piece.
+  - `pending` — an unimplemented example; implement it.
+- To verify a single fix, re-run just that example: take its `rerun` value and
+  prepend the binary — e.g. `bin/phpspec run spec/App/Basket.spec.php:6`. Don't
+  re-run the whole suite to check one change.
+- Track a specific failure across runs by its `id` (stable across edits that
+  move lines). A failure is fixed when its `id` no longer appears.
+
+## Generating code
+
+Prefer letting PhpSpec generate boilerplate over writing it by hand:
+
+- Scaffold a spec: `bin/phpspec describe App/Basket --agent`
+- Add a method example: `bin/phpspec exemplify App/Basket checkout --agent`
+- Apply all pending offers (missing classes/interfaces/methods/steps):
+  `bin/phpspec run --accept-offers`
+- Also fill empty methods with their spec'd return values (fast first green):
+  `bin/phpspec run --accept-offers --fake`
+
+`--fake` produces hardcoded returns to reach green quickly — always replace them
+with real logic before considering the work done. Offers are suggestions, not
+commands: skip any that don't fit the design.
+
+## Workflow
+
+1. `describe`/`exemplify` to lay down specs (red).
+2. `run --format=agent`; if `actionable > 0`, act on the entries.
+3. Use `--accept-offers` for missing code; implement real behaviour for
+   `failing` entries.
+4. Re-run each fixed example via its `rerun`; repeat until `actionable` is 0.
+```
+
+## Exit codes
+
+Unchanged from every other formatter: `0` when all examples pass, `1` when any
+fail or error. `--accept-offers` exits `0` after applying offers.
+
+## See also
+
+- [CLI Reference](cli.md) — every `run` option, and the human formatters.
+- [Code Generation](code-generation.md) — how the offers are produced.
+- [Story BDD](story-bdd.md) — feature runs (`steps`) and step generation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,9 +30,13 @@ Bootstraps autoloading, registers the custom class autoloader, and runs the Symf
 
 ### 2. Application -- `Console\Application`
 
-Extends Symfony's `Application`. Registers two commands:
+Extends Symfony's `Application`. Registers six commands:
 - `run` -- load and execute specs
-- `describe` -- generate spec files
+- `describe` -- generate a spec file for a class
+- `exemplify` -- add a method example to a spec
+- `pair` -- interactive pair-programming REPL with an AI assistant
+- `next` -- AI suggests what to describe or specify next
+- `refactor` -- AI-powered, behaviour-preserving refactoring
 
 ### 3. Run Command -- `Console\Command\Run`
 
@@ -88,28 +92,31 @@ The `Dispatcher` uses a **scope stack** for structure building. DSL functions (`
 
 | Event | When |
 |---|---|
+| `SuiteStarted` | The suite begins running |
 | `SpecificationStarted` | A spec file begins running |
+| `SpecificationFinished` | A spec file finishes running |
 | `ContextCreated` | `describe()`/`context()` is called |
 | `ContextStarted` | A context block begins execution |
 | `ContextModified` | `let()` is called |
-| `ContextRunned` | A context block finishes |
+| `ContextRan` | A context block finishes |
 | `ExampleCreated` | `it()`/`its()` is called |
 | `ExampleStarted` | An example begins execution |
 | `ExampleRunned` | An example finishes |
+| `ExampleCompleted` | An example's result has been recorded |
 | `ExampleErrored` | An exception is thrown during an example |
 | `ExpectationStarted` | `expect()` begins a match |
 | `MatchCreated` | A matcher registers a match closure |
 | `ExpectationPassed` | A match passes |
 | `ExpectationFailed` | A match fails |
 | `MethodMocked` | A mock expectation is set |
+| `SuiteFinished` | The suite finishes running |
 
 ### Subscribers
 
-Subscribers react to events and wire the spec tree together:
+Subscribers (in `EventDispatcher/Subscriber/`) react to events:
 
-- **`SpecificationSubscriber`** -- Listens for `ExampleCreated` and `ContextCreated` to add blocks to the current `Specification`. Resets on `SpecificationStarted`.
-- **`ContextSubscriber`** -- Listens for `ExampleCreated`, `ContextCreated`, and `ContextModified` to add blocks and apply `let()` modifications to the current `Context`.
-- **`ExampleSubscriber`** -- Collects `MatchCreated` closures, executes them on `ExampleRunned`, and builds `ExampleResult`. Handles `ExampleErrored`.
+- **`SpecificationSubscriber`** -- Resets the subscribed `Specification` on `SpecificationStarted`, so each spec file builds its tree from a clean slate.
+- **`ExampleSubscriber`** -- Collects `MatchCreated` closures, executes them on `ExampleRunned`, and builds the `ExampleResult`. Handles `ExampleErrored`.
 
 ### Listeners
 
@@ -178,23 +185,24 @@ The `Report` interface delegates to a `Formatter`. Available formatters:
 | `Dot` | Compact one-character-per-example output |
 | `Tap` | TAP (Test Anything Protocol) format |
 | `Junit` | JUnit XML for CI integration |
+| `Html` | Self-contained HTML report |
+| `Agent` | Single machine-readable JSON document for coding agents (see [Coding Agents](agent.md)) |
 
 ### Pretty Formatter
 
-Uses PHP template files in `Report/Formatter/Pretty/views/`:
+Rendering lives in `Report/Formatter/Pretty/PrettyViews.php` -- a class of static
+methods, one per node type, each writing colorized output through the Symfony
+Console `OutputInterface`:
 
-| Template | Renders |
+| Method | Renders |
 |---|---|
-| `suite.view.php` | Top-level: tagline, specs, errors, counts |
-| `specification.view.php` | Spec file title + children |
-| `context.view.php` | Context title + indented children |
-| `example.view.php` | Pass or fail with title |
-| `example.errors.view.php` | Error details with message + code |
-| `matchResult.view.php` | Failure message + surrounding code |
-| `surroundingCode.view.php` | Source code snippet with error line highlighted |
-| `counts.view.php` | Summary line (X specs, Y examples, Z passes...) |
-
-Templates use a `TemplateRenderer` that supports nested rendering via `$this->render()` and colorized output via Symfony Console styles.
+| `specification()` / `specificationErrors()` | Spec file title + children; its error details |
+| `context()` / `contextErrors()` | Context title + indented children; its errors |
+| `example()` / `exampleErrors()` | Pass/fail line; error message + code |
+| `feature()` / `scenario()` / `step()` | Story BDD feature, scenario, and step lines |
+| `matchResult()` | Failure message with expected/actual |
+| `surroundingCode()` | Source snippet with the error line highlighted |
+| `counts()` | Summary line (X specs, Y examples, Z passes...) |
 
 ## Code Coverage
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,7 +69,9 @@ bin/phpspec describe <class> [options]
 - `class` -- The class path using `/` as namespace separator.
 
 **Options:**
-- `-e`, `--example` -- Include an example for the specified method.
+- `-e`, `--exemplify=METHOD` -- Include an example for the specified method.
+- `-r`, `--run` -- Run the specs after generating.
+- `--agent` -- Emit a machine-readable JSON receipt instead of prose (for coding agents).
 
 **Examples:**
 
@@ -77,7 +79,31 @@ bin/phpspec describe <class> [options]
 bin/phpspec describe App/Calculator
 bin/phpspec describe App/Console/Command/Run
 bin/phpspec describe App/Calculator -e add          # with "add" method example
+bin/phpspec describe App/Calculator --agent          # JSON receipt (see Coding Agents)
 ```
+
+### `exemplify`
+
+Adds an example for a method to a spec file, generating the spec first if needed.
+
+```bash
+bin/phpspec exemplify <class> <method> [options]
+```
+
+**Arguments:**
+- `class` -- The class path using `/` as namespace separator.
+- `method` -- The method to add an example for.
+
+**Options:**
+- `--agent` -- Emit a machine-readable JSON receipt instead of prose.
+
+```bash
+bin/phpspec exemplify App/Calculator add
+bin/phpspec exemplify App/Calculator add --agent
+```
+
+See [Coding Agents](agent.md) for the `--agent` receipts and
+[Code Generation](code-generation.md) for the generated templates.
 
 ## Run Options
 
@@ -85,7 +111,7 @@ bin/phpspec describe App/Calculator -e add          # with "add" method example
 
 | Option | Description |
 |---|---|
-| `-f`, `--format=FORMAT` | Output formatter: `pretty` (default), `dot`, `tap`, `junit`, `html`. Repeatable; pair each with `-o` |
+| `-f`, `--format=FORMAT` | Output formatter: `pretty` (default), `dot`, `tap`, `junit`, `html`, `agent`. Repeatable; pair each with `-o` |
 | `-o`, `--out=FILE` | Report destination for the corresponding `--format`; `std` means the console |
 | `-v` | Verbose mode -- shows per-example duration |
 | `-q` | Quiet mode -- suppresses all output, exit code still reflects pass/fail |
@@ -149,6 +175,20 @@ summary, ready to open in a browser:
 bin/phpspec run --format=html > report.html
 ```
 
+#### Agent Formatter
+
+Emits the whole run as a single machine-readable JSON document for coding agents
+— no ANSI, no prose. Each failing/erroring example carries the expectation, a
+stable `id`, a line-targeted `rerun` command, and any code-generation `offer`;
+the summary carries the counts and a run-wide `offers` list:
+
+```bash
+bin/phpspec run --format=agent
+```
+
+See [Coding Agents](agent.md) for the full contract, the `--accept-offers` /
+`--fake` apply flow, and a ready-made `CLAUDE.md` snippet.
+
 #### Report Files
 
 Every formatter writes to standard output, so a single format is best saved
@@ -172,9 +212,23 @@ rejected with an error rather than silently falling back.
 |---|---|
 | `--filter=PATTERN` | Only run specs/scenarios whose file path, example title, or scenario title contains PATTERN |
 | `--paths-from=FILE` | Read spec/feature paths to run from a file, one per line |
-| `--stop-on-failure` | Stop execution after the first spec file with a failure or error |
+| `--all` | Run all suites -- both specs and features |
+| `--story` | Run only features (Story BDD) |
 | `--order=ORDER` | Run order: `default` or `random` |
 | `--seed=SEED` | Seed for random ordering (for reproducibility) |
+
+**Stopping early.** By default a run continues to the end. These flags halt it at
+the first result of a given kind (useful for tight feedback loops and CI):
+
+| Option | Stops on the first... |
+|---|---|
+| `--stop-on-failure` | failure or error |
+| `--stop-on-error` | error |
+| `--stop-on-warning` | warning |
+| `--stop-on-deprecation` | deprecation |
+| `--stop-on-notice` | notice |
+| `--stop-on-skipped` | skipped example |
+| `--stop-on-problems` | any non-passing result |
 
 ```bash
 bin/phpspec run --filter Calculator              # Path or title contains "Calculator"
@@ -234,17 +288,47 @@ is loaded instead (its format is resolved from the extension), and the command
 fails if the file does not exist. The option is available on every command and
 is forwarded to worker processes in `--parallel` runs.
 
+### Parallel Execution
+
+| Option | Description |
+|---|---|
+| `--parallel[=N]` | Run specs across N worker processes (defaults to the number of CPU cores) |
+
+```bash
+bin/phpspec run --parallel        # one worker per CPU core
+bin/phpspec run --parallel=4      # four workers
+```
+
+Each worker runs a slice of the spec files in its own process and reports back
+via JUnit; the parent merges the results before rendering. Coverage
+(`--coverage*`) composes with `--parallel` -- workers collect per-example
+coverage and the parent merges it. `--format=agent` is parallel-safe too, since
+its single document is emitted once the parent holds the complete result.
+
 ### Code Generation
 
 | Option | Description |
 |---|---|
 | `--fake` | Auto-generate method bodies with hardcoded return values from spec expectations |
+| `--accept-offers` | Apply all pending code-generation offers non-interactively, then exit (for `--format=agent` consumers) |
 
 When specs reference methods that don't exist, PhpSpec can generate method stubs. With `--fake`, it goes further and fills in the method body based on what your specs expect:
 
 ```bash
 bin/phpspec run --fake
 ```
+
+`--accept-offers` applies every pending offer (missing classes, interfaces,
+methods, feature steps) in one non-interactive pass and exits `0` -- the
+scripted counterpart to the interactive "shall I create this?" prompts. Combine
+it with `--fake` to also fill empty method bodies:
+
+```bash
+bin/phpspec run --accept-offers            # generate all missing code, no prompts
+bin/phpspec run --accept-offers --fake     # ...and fill empty methods with spec'd returns
+```
+
+See [Coding Agents](agent.md) for the offer format and the full agent workflow.
 
 ### Code Coverage
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -35,6 +35,34 @@ Generates a spec that includes an example for the `add` method.
 
 The argument uses `/` as separator: `App/Calculator` becomes `spec/App/Calculator.spec.php`. This maps to the namespace `App\Calculator`.
 
+## The `exemplify` Command
+
+Add an example for a single method to a spec (creating the spec first if it
+doesn't exist):
+
+```bash
+bin/phpspec exemplify App/Calculator add
+```
+
+Both `describe -e` and `exemplify` are idempotent -- an example for a method that
+is already present is not duplicated.
+
+## Machine-Readable Receipts (`--agent`)
+
+`describe` and `exemplify` accept an `--agent` flag that replaces their prose
+with a one-line JSON receipt, so a coding agent can scaffold without parsing
+English:
+
+```bash
+bin/phpspec describe App/Calculator --agent
+```
+```json
+{"v":1,"action":"describe","class":"App\\Calculator","spec":"spec/App/Calculator.spec.php","created":true}
+```
+
+`created` (and `exemplify`'s `added`) report whether anything changed. See
+[Coding Agents](agent.md) for the full contract.
+
 ## Auto-Class Generation
 
 When specs reference a class that doesn't exist, PhpSpec's custom autoloader prompts:
@@ -131,6 +159,23 @@ public function add()
 ```
 
 The `--fake` flag works by extracting the expected values from matcher results (via `fakeExpression` metadata) and using them as return values. This creates a quick feedback loop: write spec, run with `--fake`, get passing tests immediately, then replace the faked implementation with real logic.
+
+## Applying Offers Non-Interactively (`--accept-offers`)
+
+Everything above is offered interactively -- PhpSpec asks `[y/n]` before it
+writes. `--accept-offers` applies **every** pending offer (missing classes,
+interfaces, methods, and feature steps) in one non-interactive pass, then exits
+`0`:
+
+```bash
+bin/phpspec run --accept-offers            # generate all missing code, no prompts
+bin/phpspec run --accept-offers --fake     # ...and fill empty methods with spec'd returns
+```
+
+This is the scripted counterpart to the prompts -- built for
+`--format=agent` consumers and CI, where an agent reads the run's `offers` and
+then has PhpSpec generate them. See [Coding Agents](agent.md) for the offer
+format and the full loop.
 
 ## Step Definition Generation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,6 +125,8 @@ Default output formatter. Overridden by `--format` CLI flag.
 | `dot` | One character per example |
 | `tap` | TAP (Test Anything Protocol) |
 | `junit` | JUnit XML for CI integration |
+| `html` | Self-contained HTML report |
+| `agent` | Machine-readable JSON for coding agents (see [Coding Agents](agent.md)) |
 
 ### `bootstrap`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 A specification-oriented BDD framework for PHP 8.2+, inspired by RSpec and Jasmine.
 
-PhpSpec lets you write expressive, readable specs using `describe`, `context`, `it`, and `expect` -- bringing the best of Ruby and JavaScript testing to PHP. Version 9.0 is a ground-up rewrite that unifies Story BDD and Spec BDD in a single tool and adds AI-native features for the modern development workflow.
+PhpSpec lets you write expressive, readable specs using `describe`, `context`, `it`, and `expect` -- bringing the best of Ruby and JavaScript testing to PHP. Version 9.0 is a ground-up rewrite that unifies Story BDD and Spec BDD in a single tool and adds AI-native features for the modern development workflow -- including a machine-readable [`--format=agent`](agent.md) for coding agents.
 
 ## Table of Contents
 
@@ -15,11 +15,12 @@ PhpSpec lets you write expressive, readable specs using `describe`, `context`, `
 6. [Story BDD](story-bdd.md) -- Gherkin `.feature` files and step definitions
 7. [Code Generation](code-generation.md) -- Specs, classes, interfaces, method stubs, step definitions
 8. [Pair Programming & AI](pair.md) -- Interactive pair mode, AI assistant, refactoring
-9. [Extensions](extensions.md) -- Custom formatters, matchers, commands, listeners
-10. [CLI Reference](cli.md) -- Commands, options, formatters, coverage
-11. [Configuration](configuration.md) -- `phpspec.json` reference, autoloading
-12. [Architecture](architecture.md) -- Internal design: loader, runner, events, results, reporting
-13. [Roadmap](roadmap.md) -- Status and planned features
+9. [Coding Agents](agent.md) -- `--format=agent`, offers, `--accept-offers`, and a CLAUDE.md snippet
+10. [Extensions](extensions.md) -- Custom formatters, matchers, commands, listeners
+11. [CLI Reference](cli.md) -- Commands, options, formatters, coverage
+12. [Configuration](configuration.md) -- `phpspec.json` reference, autoloading
+13. [Architecture](architecture.md) -- Internal design: loader, runner, events, results, reporting
+14. [Roadmap](roadmap.md) -- Status and planned features
 
 ## Quick Example
 

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -60,6 +60,24 @@ expect([])->toBeEmpty();     // passes
 expect('')->toBeEmpty();     // passes
 ```
 
+### `toBeTruthy()`
+
+Asserts the subject is loosely truthy (`(bool) $subject === true`).
+
+```php
+expect(1)->toBeTruthy();     // passes
+expect('0')->toBeTruthy();   // fails
+```
+
+### `toBeFalsy()`
+
+Asserts the subject is loosely falsy (`(bool) $subject === false`).
+
+```php
+expect(0)->toBeFalsy();      // passes
+expect('')->toBeFalsy();     // passes
+```
+
 ## Type Matchers
 
 ### `toBeAnInstanceOf(string $class)`
@@ -146,6 +164,23 @@ expect(['name' => 'Alice'])->toHaveKey('name');
 expect([10, 20])->toHaveKey(0);
 ```
 
+### `toHaveLength(int $length)`
+
+Asserts the subject string or array has the given length.
+
+```php
+expect('hello')->toHaveLength(5);
+expect([1, 2, 3])->toHaveLength(3);
+```
+
+### `toContainEqual(mixed $value)`
+
+Asserts the array contains an element loosely equal (`==`) to the value.
+
+```php
+expect([1, 2, 3])->toContainEqual('2');   // passes (loose comparison)
+```
+
 ## Comparison Matchers
 
 ### `toBeGreaterThan(int|float $value)`
@@ -164,6 +199,40 @@ Asserts the subject is less than the given value.
 expect(3)->toBeLessThan(10);
 ```
 
+### `toBeGreaterThanOrEqualTo(mixed $value)`
+
+Asserts the subject is greater than or equal to the given value.
+
+```php
+expect(5)->toBeGreaterThanOrEqualTo(5);
+```
+
+### `toBeLessThanOrEqualTo(mixed $value)`
+
+Asserts the subject is less than or equal to the given value.
+
+```php
+expect(5)->toBeLessThanOrEqualTo(5);
+```
+
+### `toBeBetween(mixed $min, mixed $max)`
+
+Asserts the subject is between `$min` and `$max`, inclusive.
+
+```php
+expect(5)->toBeBetween(1, 10);
+```
+
+### `toBeCloseTo(float $value, float $delta = 0.00001)`
+
+Asserts the subject is within `$delta` of the given float — for comparing
+floating-point numbers without exact-equality surprises.
+
+```php
+expect(0.1 + 0.2)->toBeCloseTo(0.3);
+expect(3.14159)->toBeCloseTo(3.14, 0.01);
+```
+
 ## Object Matchers
 
 ### `toHaveProperty(string $property)`
@@ -174,6 +243,24 @@ Asserts the object has a public property with the given name.
 $obj = new stdClass();
 $obj->name = 'Alice';
 expect($obj)->toHaveProperty('name');
+```
+
+### `toRespondTo(string $method)`
+
+Asserts the object has (responds to) the given method.
+
+```php
+expect(new Calculator())->toRespondTo('add');
+```
+
+### `toSatisfy(callable $predicate)`
+
+Asserts the subject satisfies a custom predicate — a callback that receives the
+subject and returns `true` (pass) or `false` (fail). Handy for one-off checks
+that don't warrant a named custom matcher.
+
+```php
+expect(42)->toSatisfy(fn ($n) => $n % 2 === 0);
 ```
 
 ## Exception Matcher
@@ -189,6 +276,60 @@ expect(fn () => throw new \RuntimeException('boom'))
 // With message check:
 expect(fn () => throw new \RuntimeException('boom'))
     ->toThrow(\RuntimeException::class, 'boom');
+```
+
+## HTTP Response Matchers
+
+For asserting on HTTP responses. All work with the built-in `Browser\Response`
+(see [Browser Testing](browser.md)) and any PSR-7 `ResponseInterface`.
+
+### `toBeOk()`
+
+Asserts the response status is `200`.
+
+```php
+expect($response)->toBeOk();
+```
+
+### `toBeBad()`
+
+Asserts the response status is `400`.
+
+```php
+expect($response)->toBeBad();
+```
+
+### `toHaveStatus(int $code)`
+
+Asserts the response has the given HTTP status code.
+
+```php
+expect($response)->toHaveStatus(201);
+```
+
+### `toHavePath(string $path, mixed $expected)`
+
+Asserts a dot-notation path in the response's JSON body equals the expected value.
+
+```php
+expect($response)->toHavePath('data.user.name', 'Alice');
+```
+
+### `toHaveHeader(string $name, ?string $value = null)`
+
+Asserts the response has the given header — optionally matching a value.
+
+```php
+expect($response)->toHaveHeader('Content-Type');
+expect($response)->toHaveHeader('Content-Type', 'application/json');
+```
+
+### `toRedirectTo(string $url)`
+
+Asserts the response is a redirect (`3xx`) whose `Location` header matches the URL.
+
+```php
+expect($response)->toRedirectTo('/login');
 ```
 
 ## Negation

--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -137,6 +137,56 @@ Matches using a custom callback:
 expect($repo->save($user))->toBeCalledWith(callback(fn ($arg) => $arg->name === 'Alice'));
 ```
 
+### `satisfy(Closure $fn)`
+
+Matches a single argument against a predicate — like `callback()`, reads well
+alongside the others:
+
+```php
+expect($repo->save($user))->toBeCalledWith(satisfy(fn ($u) => $u->isActive()));
+```
+
+### `anInstanceOf(string $class)`
+
+Matches an argument that is an instance of the given class or interface:
+
+```php
+expect($bus->dispatch($cmd))->toBeCalledWith(anInstanceOf(Command::class));
+```
+
+### `arrayIncluding(array $subset)`
+
+Matches an array argument that contains (at least) the given key/value subset:
+
+```php
+expect($api->send($payload))->toBeCalledWith(arrayIncluding(['type' => 'order']));
+```
+
+### `startWith(string $prefix)`
+
+Matches a string argument that starts with the given prefix:
+
+```php
+expect($logger->log($line))->toBeCalledWith(startWith('ERROR:'));
+```
+
+### `noArgs()`
+
+Matches a call made with no arguments at all:
+
+```php
+expect($service->flush())->toBeCalledWith(noArgs());
+```
+
+### `cetera()`
+
+Matches all remaining arguments (zero or more) — the "and so on" wildcard. Must
+be the last matcher in the expected list:
+
+```php
+expect($logger->log('hello', 'x', 'y'))->toBeCalledWith('hello', cetera());
+```
+
 ## Negation
 
 All mock matchers support negation via `not()`:

--- a/docs/pair.md
+++ b/docs/pair.md
@@ -120,15 +120,21 @@ The AI assistant has access to these tools during a pair session:
 
 | Tool | Description |
 |---|---|
-| `generate_spec` | Write a `.spec.php` file with full content |
+| `describe` | Start a spec: writes an empty `describe()` skeleton for a class (idempotent) |
+| `add_example` | Add one `it()` example to a spec, one at a time (idempotent; never overwrites existing examples) |
 | `generate_feature` | Write a Gherkin `.feature` file |
 | `generate_steps` | Write a `.steps.php` step definitions file |
 | `write_file` | Create a new file (class, interface, etc.) |
 | `update_file` | Modify an existing file (shows a diff) |
+| `inspect_symbol` | Inspect a class or method's signature for context |
 | `run_specs` | Run specs and return the output |
 | `ask_user` | Ask you a yes/no question through the numbered chooser |
 | `read_file` | Read a project file for context |
 | `list_files` | List directory contents |
+
+Specs are never written whole-file: the assistant starts one with `describe`
+and grows it one example at a time with `add_example`, so your existing examples
+are never overwritten.
 
 The assistant automatically scans your project tree and existing step definitions so it can reuse patterns already in your codebase.
 
@@ -185,7 +191,7 @@ The AI maintains conversation history within a session. You can build on previou
 
 ### Logging
 
-All AI interactions are logged to `.phpspec/pair.log` with timestamps, tool calls, and results. This is useful for debugging or reviewing what the assistant did.
+All AI interactions are logged to `.phpspec/pair/session.log` with timestamps, tool calls, and results. This is useful for debugging or reviewing what the assistant did.
 
 ## The `next` Command
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,19 +32,24 @@ PhpSpec is a fully-featured Spec BDD and Story BDD framework for PHP 8.2+. It su
 
 #### Code Generation
 - Spec generation (`describe` command)
+- Method example generation (`exemplify` command, `describe -e`)
 - Auto-class generation (from spec errors)
 - Interface generation (from mock errors)
 - Method stub generation (from method-not-found errors)
 - `--fake` mode for auto-generating method bodies
+- Non-interactive apply for agents/CI (`--accept-offers`, `--accept-offers --fake`)
 
 #### CLI & Reporting
-- Pretty, Dot, TAP, JUnit XML formatters
+- Pretty, Dot, TAP, JUnit XML, HTML, and Agent (JSON) formatters
+- Machine-readable agent workflow (`--format=agent`, `describe/exemplify --agent`)
+- Parallel execution (`--parallel[=N]`)
 - Verbose mode (`-v`) with per-example timing
 - Quiet mode (`-q`)
 - Profile mode (`--profile`)
 - Random ordering (`--order=random`, `--seed`)
-- Filter (`--filter`)
-- Stop on failure (`--stop-on-failure`)
+- Filter (`--filter`), path list (`--paths-from`), line-targeted runs (`spec.php:LINE`)
+- Suite selection (`--all`, `--story`)
+- Stop-on family (`--stop-on-failure`, `-error`, `-warning`, `-deprecation`, `-notice`, `-skipped`, `-problems`)
 - Bootstrap file support
 
 #### Code Coverage

--- a/features/scenarios/cli/agent-commands.feature
+++ b/features/scenarios/cli/agent-commands.feature
@@ -1,0 +1,29 @@
+Feature: Agent scaffolding commands
+  As a coding agent
+  I want describe and exemplify to emit machine-readable JSON receipts
+  So that I can scaffold specs without parsing prose
+
+  Background:
+    Given a PSR-4 project with "spec" and "src" directories
+
+  Scenario: describe --agent scaffolds a spec and emits a JSON receipt
+    When I run phpspec command "describe App/Basket --agent"
+    Then the output should be valid JSON
+    And the output should contain "action"
+    And the output should contain "created"
+    And a spec file "spec/App/Basket.spec.php" should be generated
+
+  Scenario: describe --agent is idempotent and reports it in the receipt
+    When I run phpspec command "describe App/Basket --agent"
+    And I run phpspec command "describe App/Basket --agent"
+    Then the output should be valid JSON
+    And the output should contain "false"
+
+  Scenario: exemplify --agent adds an example and emits a JSON receipt
+    When I run phpspec command "exemplify App/Basket checkout --agent"
+    Then the output should be valid JSON
+    And the output should contain "exemplify"
+    And the output should contain "added"
+    And the output should contain "checkout"
+    And a spec file "spec/App/Basket.spec.php" should be generated
+    And the spec file should contain an example for "checkout"

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -1,0 +1,94 @@
+Feature: Agent output format
+  As a coding agent
+  I want phpspec results as a single machine-readable JSON document
+  So that I can decide my next action without parsing prose
+
+  Scenario: A passing run emits a valid JSON document with run_started and summary
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () { expect(2)->toBe(2); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "run_started"
+    And the output should contain "summary"
+    And the output should contain "passing"
+
+  Scenario: A failing example carries its expected, actual and state
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () { expect(3500)->toBe(4000); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "failing"
+    And the output should contain "expected"
+    And the output should contain "4000"
+    And the output should contain "3500"
+
+  Scenario: A failing example carries a line-targeted rerun command
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () { expect(3500)->toBe(4000); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "rerun"
+    And the output should contain "run spec/App/Calc.spec.php:"
+
+  Scenario: A missing class surfaces as an offer, and --accept-offers generates it
+    Given a spec file "spec/App/Basket.spec.php":
+      """
+      <?php
+      describe('App\Basket', function () {
+          it('applies a coupon', function () {
+              expect(new App\Coupon())->toBeAnInstanceOf(App\Coupon::class);
+          });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "create_class"
+    And the output should contain "Coupon"
+    When I run phpspec run with option "--accept-offers"
+    Then the exit code should be 0
+    And a class file "src/App/Coupon.php" should be generated
+
+  Scenario: An empty method surfaces as a fake_method offer, filled by --accept-offers --fake
+    Given a spec file "spec/App/Calculator.spec.php":
+      """
+      <?php
+      use App\Calculator;
+
+      describe(Calculator::class, function () {
+          let("calc", fn() => new Calculator());
+          it("adds", function () {
+              expect($this->calc->add(1, 2))->toBe(3);
+          });
+      });
+      """
+    And a class "src/App/Calculator.php":
+      """
+      <?php
+      namespace App;
+
+      class Calculator {
+          public function add($a, $b) {}
+      }
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "fake_method"
+    When I run phpspec run with option "--accept-offers --fake"
+    Then the exit code should be 0
+    And a class file "src/App/Calculator.php" should be generated
+    And it should contain "return 3"

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -10,7 +10,7 @@
 then('all examples should pass', function () {
     if ($this->exitCode !== 0) {
         throw new \RuntimeException(
-            "Expected exit code 0, got {$this->exitCode}.\nOutput:\n{$this->output}"
+            "Expected exit code 0, got {$this->exitCode}.\nOutput:\n{$this->output}",
         );
     }
 });
@@ -18,7 +18,7 @@ then('all examples should pass', function () {
 then('all steps should pass', function () {
     if ($this->exitCode !== 0) {
         throw new \RuntimeException(
-            "Expected exit code 0, got {$this->exitCode}.\nOutput:\n{$this->output}"
+            "Expected exit code 0, got {$this->exitCode}.\nOutput:\n{$this->output}",
         );
     }
 });
@@ -32,7 +32,7 @@ then('{int} example should fail', function (int $count) {
 then('the exit code should be {int}', function (int $code) {
     if ($this->exitCode !== $code) {
         throw new \RuntimeException(
-            "Expected exit code {$code}, got {$this->exitCode}.\nOutput:\n{$this->output}"
+            "Expected exit code {$code}, got {$this->exitCode}.\nOutput:\n{$this->output}",
         );
     }
 });
@@ -40,7 +40,7 @@ then('the exit code should be {int}', function (int $code) {
 then('the exit code should not be {int}', function (int $code) {
     if ($this->exitCode === $code) {
         throw new \RuntimeException(
-            "Expected exit code NOT to be {$code}, got {$this->exitCode}.\nOutput:\n{$this->output}"
+            "Expected exit code NOT to be {$code}, got {$this->exitCode}.\nOutput:\n{$this->output}",
         );
     }
 });
@@ -50,7 +50,7 @@ then('the exit code should not be {int}', function (int $code) {
 then('the output should contain {string}', function (string $text) {
     if (!str_contains($this->output, $text)) {
         throw new \RuntimeException(
-            "Expected output to contain \"{$text}\".\nOutput:\n{$this->output}"
+            "Expected output to contain \"{$text}\".\nOutput:\n{$this->output}",
         );
     }
 });
@@ -58,7 +58,7 @@ then('the output should contain {string}', function (string $text) {
 then('the output should not contain {string}', function (string $text) {
     if (str_contains($this->output, $text)) {
         throw new \RuntimeException(
-            "Expected output NOT to contain \"{$text}\".\nOutput:\n{$this->output}"
+            "Expected output NOT to contain \"{$text}\".\nOutput:\n{$this->output}",
         );
     }
 });
@@ -67,7 +67,17 @@ then('the output should contain {string} exactly {int} times', function (string 
     $found = substr_count($this->output, $text);
     if ($found !== $times) {
         throw new \RuntimeException(
-            "Expected output to contain \"{$text}\" exactly {$times} time(s), found {$found}.\nOutput:\n{$this->output}"
+            "Expected output to contain \"{$text}\" exactly {$times} time(s), found {$found}.\nOutput:\n{$this->output}",
+        );
+    }
+});
+
+then('the output should be valid JSON', function () {
+    try {
+        json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
+    } catch (\JsonException $e) {
+        throw new \RuntimeException(
+            "Expected valid JSON output ({$e->getMessage()}).\nOutput:\n{$this->output}",
         );
     }
 });

--- a/spec/PhpSpec/CodeGeneration/SpecGenerator.spec.php
+++ b/spec/PhpSpec/CodeGeneration/SpecGenerator.spec.php
@@ -36,6 +36,18 @@ describe(SpecGenerator::class, function () {
         expect($fs->write('', ''))->toBeCalled();
     });
 
+    it("returns true when it creates the spec file", function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+
+        expect($this->generator->generate('Calculator'))->toBe(true);
+    });
+
+    it("returns false when the spec file already exists", function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+
+        expect($this->generator->generate('Existing'))->toBe(false);
+    });
+
     it("adds example for a method to existing spec", function (Filesystem $fs) {
         $specPath = getcwd() . DIRECTORY_SEPARATOR . 'spec' . DIRECTORY_SEPARATOR . 'Calculator.spec.php';
 

--- a/spec/PhpSpec/Console/Command/Describe.spec.php
+++ b/spec/PhpSpec/Console/Command/Describe.spec.php
@@ -4,6 +4,7 @@ use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Console\Command\Describe;
 use PhpSpec\Filesystem;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
 describe(Describe::class, function() {
@@ -46,6 +47,55 @@ describe(Describe::class, function() {
         $output = new \Symfony\Component\Console\Output\BufferedOutput();
         $this->describe->run(new ArrayInput(['class' => 'Some/Spec']), $output);
         expect($output->fetch())->not()->toContain("Example for method");
+    });
+
+    it("emits a JSON receipt with --agent instead of prose", function(Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        allow($fs->mkdir())->toReturn(null);
+        allow($fs->write())->toReturn(null);
+
+        $output = new BufferedOutput();
+        $this->describe->run(new ArrayInput(['class' => 'App/Basket', '--agent' => true]), $output);
+
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        expect($doc)->toBe([
+            'v' => 1,
+            'action' => 'describe',
+            'class' => 'App\\Basket',
+            'spec' => 'spec/App/Basket.spec.php',
+            'created' => true,
+        ]);
+    });
+
+    it("reports created false in the receipt when the spec already exists", function(Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+
+        $output = new BufferedOutput();
+        $this->describe->run(new ArrayInput(['class' => 'App/Basket', '--agent' => true]), $output);
+
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        expect($doc['created'])->toBe(false);
+    });
+
+    it("includes the example receipt when --agent is combined with -e", function(Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn(<<<'PHP'
+        <?php
+
+        describe(Spec::class, function() {
+            it("instantiates", fn() => null);
+        });
+        PHP);
+        allow($fs->write())->toReturn(null);
+
+        $output = new BufferedOutput();
+        $this->describe->run(
+            new ArrayInput(['class' => 'App/Basket', '--agent' => true, '--exemplify' => 'checkout']),
+            $output
+        );
+
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        expect($doc['example'])->toBe(['method' => 'checkout', 'added' => true]);
     });
 
     it("outputs confirmation when -e option is used", function(Filesystem $fs) {

--- a/spec/PhpSpec/Console/Command/Exemplify.spec.php
+++ b/spec/PhpSpec/Console/Command/Exemplify.spec.php
@@ -38,6 +38,56 @@ describe(Exemplify::class, function () {
         expect($output->fetch())->toContain('Example for Acme\Calculator::add added.');
     });
 
+    it('emits a JSON receipt with --agent instead of prose', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn(<<<'PHP'
+        <?php
+
+        describe(Calculator::class, function() {
+            it("instantiates", fn() => null);
+        });
+        PHP);
+        allow($fs->write())->toReturn(null);
+
+        $output = new BufferedOutput();
+        $this->exemplify->run(
+            new ArrayInput(['class' => 'Acme\Calculator', 'method' => 'add', '--agent' => true]),
+            $output
+        );
+
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        expect($doc)->toBe([
+            'v' => 1,
+            'action' => 'exemplify',
+            'class' => 'Acme\\Calculator',
+            'method' => 'add',
+            'spec' => 'spec/Acme/Calculator.spec.php',
+            'added' => true,
+        ]);
+    });
+
+    it('reports added false in the receipt when the example already exists', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn(<<<'PHP'
+        <?php
+
+        describe(Calculator::class, function() {
+            it("instantiates", fn() => null);
+            it("should add", fn() => null);
+        });
+        PHP);
+        allow($fs->write())->toReturn(null);
+
+        $output = new BufferedOutput();
+        $this->exemplify->run(
+            new ArrayInput(['class' => 'Acme\Calculator', 'method' => 'add', '--agent' => true]),
+            $output
+        );
+
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        expect($doc['added'])->toBe(false);
+    });
+
     it('does not duplicate spec when it already exists', function (Filesystem $fs) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturn(<<<'PHP'

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -1,0 +1,188 @@
+<?php
+
+use PhpSpec\Report\Formatter\Agent;
+use PhpSpec\Result\ExampleResult;
+use PhpSpec\Result\FeatureResult;
+use PhpSpec\Result\MatchResult;
+use PhpSpec\Result\ScenarioResult;
+use PhpSpec\Result\SpecificationResult;
+use PhpSpec\Result\StepResult;
+use PhpSpec\Result\SuiteResult;
+use PhpSpec\Specification\ExampleError;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+describe(Agent::class, function () {
+
+    $render = function (SuiteResult $suite): array {
+        $output = new BufferedOutput();
+        (new Agent($output))->format($suite);
+
+        return json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+    };
+
+    it('emits one JSON object with suite, examples and result sections', function () use ($render) {
+        $doc = $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
+        ]));
+
+        expect($doc)->toHaveKey('suite');
+        expect($doc)->toHaveKey('examples');
+        expect($doc)->toHaveKey('result');
+        expect($doc['suite'])->toBe(['v' => 1, 'event' => 'run_started', 'suite' => 'default', 'examples' => 1, 'steps' => 0, 'seed' => null]);
+    });
+
+    it('omits passing examples from the entries but still counts them', function () use ($render) {
+        $doc = $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
+        ]));
+
+        expect($doc['examples'])->toBe([]);
+        expect($doc['result']['passing'])->toBe(1);
+        expect($doc['result']['examples'])->toBe(1);
+        expect($doc['result']['actionable'])->toBe(0);
+    });
+
+    it('reports a failing example, mapping the subject to actual and the target to expected', function () use ($render) {
+        // As phpspec records it for expect(3500)->toBe(4000): getExpected() is the
+        // subject (3500), getActual() is the matcher target (4000).
+        $match = MatchResult::failed(3500, 4000, 'Expected 3500 to be 4000', getcwd() . '/spec/App/Basket.spec.php', 12, null, 'toBe');
+        $doc = $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('totals the prices', [$match])]),
+        ]));
+
+        $example = $doc['examples'][0];
+        expect($example['state'])->toBe('failing');
+        expect($example['expected'])->toBe(['matcher' => 'toBe', 'value' => 4000, 'negated' => false]);
+        expect($example['actual'])->toBe(3500);
+        expect($example['message'])->toBe('Expected 3500 to be 4000');
+        expect($example['spec'])->toBe('spec/App/Basket.spec.php:12');
+        expect($example['rerun'])->toBe('run spec/App/Basket.spec.php:12');
+        expect($example)->not()->toHaveKey('offer');
+    });
+
+    it('flags a negated matcher on the expected block', function () use ($render) {
+        $match = MatchResult::failed(5, 5, 'Expected 5 not to be 5', getcwd() . '/spec/App/X.spec.php', 1, null, 'toBe', true);
+        $example = $render(new SuiteResult([
+            new SpecificationResult('App\\X', [new ExampleResult('rejects equality', [$match])]),
+        ]))['examples'][0];
+
+        expect($example['expected']['negated'])->toBe(true);
+    });
+
+    it('derives a stable id from the full example name so an agent can recompute it', function () use ($render) {
+        $example = $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [
+                new ExampleResult('totals the prices', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/App/Basket.spec.php', 3)]),
+            ]),
+        ]))['examples'][0];
+
+        expect($example['id'])->toBe(substr(sha1('App\\Basket totals the prices'), 0, 12));
+    });
+
+    it('keeps an example id stable when only its line moves', function () use ($render) {
+        $atLine = fn (int $line) => $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [
+                new ExampleResult('totals the prices', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/App/Basket.spec.php', $line)]),
+            ]),
+        ]))['examples'][0];
+
+        expect($atLine(12)['id'])->toBe($atLine(40)['id']);
+    });
+
+    it('surfaces deprecations on an entry, as lean message-and-location items', function () use ($render) {
+        $example = new ExampleResult('totals', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/App/X.spec.php', 3)]);
+        $example->setDeprecations([
+            ['severity' => E_USER_DEPRECATED, 'message' => 'since 9.0: use bar()', 'file' => getcwd() . '/src/App/X.php', 'line' => 7],
+        ]);
+
+        $entry = $render(new SuiteResult([new SpecificationResult('App\\X', [$example])]))['examples'][0];
+
+        expect($entry['deprecations'])->toBe([['message' => 'since 9.0: use bar()', 'at' => 'src/App/X.php:7']]);
+    });
+
+    it('surfaces warnings likewise and omits the note keys when empty', function () use ($render) {
+        $example = new ExampleResult('totals', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/App/X.spec.php', 3)]);
+        $example->setWarnings([
+            ['severity' => E_WARNING, 'message' => 'array offset on null', 'file' => getcwd() . '/src/App/X.php', 'line' => 2],
+        ]);
+
+        $entry = $render(new SuiteResult([new SpecificationResult('App\\X', [$example])]))['examples'][0];
+
+        expect($entry['warnings'])->toBe([['message' => 'array offset on null', 'at' => 'src/App/X.php:2']]);
+        expect($entry)->not()->toHaveKey('deprecations');
+        expect($entry)->not()->toHaveKey('notices');
+    });
+
+    it('reports an error example with the exception class, message and location', function () use ($render) {
+        $errored = new ExampleResult('blows up', [], true);
+        $errored->setError(new ExampleError('boom', new \RuntimeException('boom')));
+
+        $example = $render(new SuiteResult([new SpecificationResult('App\\Thing', [$errored])]))['examples'][0];
+
+        expect($example['state'])->toBe('error');
+        expect($example['exception']['class'])->toBe('RuntimeException');
+        expect($example['exception']['message'])->toBe('boom');
+        expect($example['exception']['at'])->toContain(':');
+        expect($example['rerun'])->toBe('run ' . $example['spec']);
+        expect($example)->not()->toHaveKey('offer');
+    });
+
+    it('carries a per-example create_class offer when the error is a missing class', function () use ($render) {
+        $errored = new ExampleResult('needs a coupon', [], true);
+        $errored->setError(new ExampleError('Class "App\\Coupon" not found', new \Error('Class "App\\Coupon" not found')));
+
+        $example = $render(new SuiteResult([new SpecificationResult('App\\Basket', [$errored])]))['examples'][0];
+
+        expect($example['offer'])->toBe(['action' => 'create_class', 'target' => 'App\\Coupon']);
+    });
+
+    it('summarises totals and duration, offers empty for now', function () use ($render) {
+        $suite = new SuiteResult([
+            new SpecificationResult('App\\Basket', [
+                new ExampleResult('holds products', [MatchResult::passed()]),
+                new ExampleResult('totals', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/X.spec.php', 3)]),
+            ]),
+        ]);
+        $suite->setDuration(0.074);
+
+        $result = $render($suite)['result'];
+
+        expect($result['event'])->toBe('summary');
+        expect($result['examples'])->toBe(2);
+        expect($result['passing'])->toBe(1);
+        expect($result['failing'])->toBe(1);
+        expect($result['errors'])->toBe(0);
+        expect($result['actionable'])->toBe(1);
+        expect($result['duration_ms'])->toBe(74);
+        expect($result['offers'])->toBe([]);
+    });
+
+    it('lists code-generation offers in the summary from the candidate resolver', function () {
+        $output = new BufferedOutput();
+        $suite = new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('needs a coupon', [], true)]),
+        ]);
+
+        $agent = new Agent($output, fn() => ['missingSpecClasses' => ['App\\Coupon']]);
+        $agent->format($suite);
+
+        $result = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR)['result'];
+        expect($result['offers'])->toBe([['action' => 'create_class', 'target' => 'App\\Coupon']]);
+    });
+
+    it('counts feature steps as steps, not examples, and emits the failing one', function () use ($render) {
+        $step = new StepResult('Given a basket', 'failure');
+        $step->setError(new \PhpSpec\StoryBDD\StepError('step went wrong', new \RuntimeException('step went wrong')));
+        $scenario = new ScenarioResult('Checkout', [$step]);
+        $feature = new FeatureResult('Shopping', [$scenario], '/features/shopping.feature');
+
+        $doc = $render(new SuiteResult([$feature]));
+
+        expect($doc['result']['steps'])->toBe(1);
+        expect($doc['result']['examples'])->toBe(0);
+        expect($doc['examples'][0]['state'])->toBe('failing');
+        expect($doc['examples'][0]['example'])->toContain('Given a basket');
+        expect($doc['examples'][0]['id'])->toBe(substr(sha1($doc['examples'][0]['example']), 0, 12));
+    });
+
+});

--- a/spec/PhpSpec/Report/Formatter/Agent/Offers.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent/Offers.spec.php
@@ -1,0 +1,74 @@
+<?php
+
+use PhpSpec\Report\Formatter\Agent\Offers;
+
+describe(Offers::class, function () {
+
+    it('maps a missing spec class to create_class', function () {
+        expect(Offers::fromCandidates(['missingSpecClasses' => ['App\\Coupon']]))
+            ->toBe([['action' => 'create_class', 'target' => 'App\\Coupon']]);
+    });
+
+    it('maps a missing mock type to create_interface', function () {
+        expect(Offers::fromCandidates(['missingMockTypes' => ['App\\Repository']]))
+            ->toBe([['action' => 'create_interface', 'target' => 'App\\Repository']]);
+    });
+
+    it('maps an undefined class method to create_method with a Class::method target', function () {
+        $candidates = ['undefinedClassMethods' => [
+            ['className' => 'App\\Basket', 'methodName' => 'checkout', 'file' => 'x', 'line' => 1],
+        ]];
+
+        expect(Offers::fromCandidates($candidates))
+            ->toBe([['action' => 'create_method', 'target' => 'App\\Basket::checkout']]);
+    });
+
+    it('maps a fakeable method to fake_method carrying its return expression as value', function () {
+        $candidates = ['fakeableMethods' => [
+            ['className' => 'App\\Calc', 'methodName' => 'add', 'fakeExpression' => 'return 3', 'file' => 'x', 'line' => 1],
+        ]];
+
+        expect(Offers::fromCandidates($candidates))
+            ->toBe([['action' => 'fake_method', 'target' => 'App\\Calc::add', 'value' => 'return 3']]);
+    });
+
+    it('maps undefined steps to create_steps keyed by feature path', function () {
+        $candidates = ['undefinedSteps' => [
+            'features/checkout.feature' => [['keyword' => 'Given', 'text' => 'a basket']],
+        ]];
+
+        expect(Offers::fromCandidates($candidates))
+            ->toBe([['action' => 'create_steps', 'target' => 'features/checkout.feature']]);
+    });
+
+    it('deduplicates the same action and target', function () {
+        $candidates = ['missingSpecClasses' => ['App\\Coupon'], 'missingStepClasses' => ['App\\Coupon']];
+
+        expect(Offers::fromCandidates($candidates))
+            ->toBe([['action' => 'create_class', 'target' => 'App\\Coupon']]);
+    });
+
+    it('returns an empty list when there is nothing to generate', function () {
+        expect(Offers::fromCandidates([]))->toBe([]);
+    });
+
+    it('derives a create_class offer from a "Class not found" error', function () {
+        expect(Offers::forError('Class "App\\Coupon" not found'))
+            ->toBe(['action' => 'create_class', 'target' => 'App\\Coupon']);
+    });
+
+    it('derives a create_interface offer from a mock-creation error', function () {
+        expect(Offers::forError("Cannot create mock: class or interface 'App\\Repo' does not exist"))
+            ->toBe(['action' => 'create_interface', 'target' => 'App\\Repo']);
+    });
+
+    it('derives a create_method offer from an undefined-method error', function () {
+        expect(Offers::forError('Call to undefined method App\\Basket::checkout()'))
+            ->toBe(['action' => 'create_method', 'target' => 'App\\Basket::checkout']);
+    });
+
+    it('returns null for an error a generator cannot resolve', function () {
+        expect(Offers::forError('Division by zero'))->toBeNull();
+    });
+
+});

--- a/spec/PhpSpec/Report/Formatter/Agent/ValueExporter.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent/ValueExporter.spec.php
@@ -1,0 +1,65 @@
+<?php
+
+use PhpSpec\Report\Formatter\Agent\ValueExporter;
+
+describe(ValueExporter::class, function () {
+
+    it('passes scalars and null through unchanged', function () {
+        expect(ValueExporter::export(42))->toBe(42);
+        expect(ValueExporter::export(3.5))->toBe(3.5);
+        expect(ValueExporter::export(true))->toBe(true);
+        expect(ValueExporter::export(null))->toBe(null);
+    });
+
+    it('passes a short string through unchanged', function () {
+        expect(ValueExporter::export('hello'))->toBe('hello');
+    });
+
+    it('truncates a string longer than 200 characters and says so', function () {
+        $out = ValueExporter::export(str_repeat('x', 250));
+
+        expect($out['truncated'])->toBe(true);
+        expect($out['length'])->toBe(250);
+        expect(strlen($out['value']))->toBe(200);
+    });
+
+    it('renders an object as ClassName#id without dumping its graph', function () {
+        expect(ValueExporter::export(new \RuntimeException('boom')))->toStartWith('RuntimeException#');
+    });
+
+    it('exports a small array recursively, hashing nested objects', function () {
+        $out = ValueExporter::export([1, 'two', new \stdClass()]);
+
+        expect($out[0])->toBe(1);
+        expect($out[1])->toBe('two');
+        expect($out[2])->toStartWith('stdClass#');
+    });
+
+    it('truncates an array with more than 10 elements and says so', function () {
+        $out = ValueExporter::export(range(1, 25));
+
+        expect($out['truncated'])->toBe(true);
+        expect($out['length'])->toBe(25);
+        expect(count($out['value']))->toBe(10);
+        expect($out['value'][0])->toBe(1);
+    });
+
+    it('preserves associative array keys', function () {
+        expect(ValueExporter::export(['a' => 1, 'b' => 2]))->toBe(['a' => 1, 'b' => 2]);
+    });
+
+    it('bounds recursion on a deeply nested array', function () {
+        $deep = 'too deep';
+        for ($i = 0; $i < 6; $i++) {
+            $deep = [$deep];
+        }
+
+        $node = ValueExporter::export($deep);
+        for ($i = 0; $i < 5; $i++) {
+            $node = $node[0];
+        }
+
+        expect($node['truncated'])->toBe(true);
+    });
+
+});

--- a/spec/PhpSpec/Result/MatchResult.spec.php
+++ b/spec/PhpSpec/Result/MatchResult.spec.php
@@ -3,9 +3,9 @@
 use PhpSpec\Result\MatchResult;
 use PhpSpec\Result\Result;
 
-describe(MatchResult::class, function() {
+describe(MatchResult::class, function () {
 
-    it("creates a passed result", function() {
+    it('creates a passed result', function () {
         $result = MatchResult::passed();
         expect($result)->toBeAnInstanceOf(MatchResult::class);
         expect($result->getResult())->toBe(Result::Passed);
@@ -19,45 +19,69 @@ describe(MatchResult::class, function() {
         expect($result->getFakeExpression())->toBeNull();
     });
 
-    it("creates a failed result", function() {
-        $result = MatchResult::failed("expected", "actual", "Expected expected to be actual", __FILE__, __LINE__);
+    it('creates a failed result', function () {
+        $result = MatchResult::failed('expected', 'actual', 'Expected expected to be actual', __FILE__, __LINE__);
         expect($result)->toBeAnInstanceOf(MatchResult::class);
         expect($result->getResult())->toBe(Result::Failed);
         expect($result->isFailure())->toBe(true);
-        expect($result->getMessage())->toBe("Expected expected to be actual");
+        expect($result->getMessage())->toBe('Expected expected to be actual');
         expect($result->getLine())->toBeOfType('int');
         expect($result->getFile())->toBe(__FILE__);
-        expect($result->getExpected())->toBe("expected");
-        expect($result->getActual())->toBe("actual");
+        expect($result->getExpected())->toBe('expected');
+        expect($result->getActual())->toBe('actual');
         expect($result->getCode())->toBeOfType('array');
     });
 
-    it("returns null fake expression when not provided", function() {
-        $result = MatchResult::failed("a", "b", "msg", __FILE__, __LINE__);
+    it('returns null fake expression when not provided', function () {
+        $result = MatchResult::failed('a', 'b', 'msg', __FILE__, __LINE__);
         expect($result->getFakeExpression())->toBeNull();
     });
 
-    it("carries fake expression when provided", function() {
-        $result = MatchResult::failed("a", "b", "msg", __FILE__, __LINE__, "'hello'");
+    it('carries fake expression when provided', function () {
+        $result = MatchResult::failed('a', 'b', 'msg', __FILE__, __LINE__, "'hello'");
         expect($result->getFakeExpression())->toBe("'hello'");
     });
 
-    it("returns empty results array", function() {
+    it('returns empty results array', function () {
         $result = MatchResult::passed();
         expect($result->getResults())->toBe([]);
     });
 
-    it("returns expected value from failed result", function() {
-        $result = MatchResult::failed("expected_val", "actual_val", "msg", __FILE__, __LINE__);
-        expect($result->getExpected())->toBe("expected_val");
-        expect($result->getActual())->toBe("actual_val");
+    it('returns expected value from failed result', function () {
+        $result = MatchResult::failed('expected_val', 'actual_val', 'msg', __FILE__, __LINE__);
+        expect($result->getExpected())->toBe('expected_val');
+        expect($result->getActual())->toBe('actual_val');
     });
 
-    it("returns null expected/actual for passed result", function() {
+    it('returns null expected/actual for passed result', function () {
         $result = MatchResult::passed();
         expect($result->getExpected())->toBeNull();
         expect($result->getActual())->toBeNull();
         expect($result->getFakeExpression())->toBeNull();
+    });
+
+    it('carries the matcher name when provided', function () {
+        $result = MatchResult::failed('a', 'b', 'msg', __FILE__, __LINE__, null, 'toBe');
+        expect($result->getMatcher())->toBe('toBe');
+    });
+
+    it('returns null matcher when not provided', function () {
+        $result = MatchResult::failed('a', 'b', 'msg', __FILE__, __LINE__);
+        expect($result->getMatcher())->toBeNull();
+    });
+
+    it('returns null matcher for a passed result', function () {
+        expect(MatchResult::passed()->getMatcher())->toBeNull();
+    });
+
+    it('carries the negated flag when the matcher was negated', function () {
+        $result = MatchResult::failed('a', 'b', 'msg', __FILE__, __LINE__, null, 'toBe', true);
+        expect($result->isNegated())->toBe(true);
+    });
+
+    it('is not negated by default', function () {
+        $result = MatchResult::failed('a', 'b', 'msg', __FILE__, __LINE__);
+        expect($result->isNegated())->toBe(false);
     });
 
 });

--- a/src/PhpSpec/CodeGeneration/SpecGenerator.php
+++ b/src/PhpSpec/CodeGeneration/SpecGenerator.php
@@ -59,15 +59,18 @@ final class SpecGenerator
     /**
      * Generates a spec file for the given class path with a describe block and basic example.
      *
+     * Idempotent: an existing spec file is left untouched.
+     *
      * @param string $spec the class path using forward slashes (e.g. "App/Model/User")
-     * @return void
+     * @return bool true when the spec file was created, false when it already existed
      */
-    public function generate(string $spec): void
+    public function generate(string $spec): bool
     {
-        $filePath = getcwd() . DIRECTORY_SEPARATOR .
-                    $this->specPath . DIRECTORY_SEPARATOR .
-                    str_replace('/', DIRECTORY_SEPARATOR, $spec) .
-                    $this->specSuffix;
+        $filePath = $this->filePath($spec);
+
+        if ($this->filesystem->exists($filePath)) {
+            return false;
+        }
 
         $pieces = explode('/', $spec);
         $use = '';
@@ -86,12 +89,25 @@ final class SpecGenerator
         });
         EOD;
 
-        if (!$this->filesystem->exists($filePath)) {
-            if (!$this->filesystem->exists(dirname($filePath))) {
-                $this->filesystem->mkdir(dirname($filePath));
-            }
-            $this->filesystem->write($filePath, $specContent);
+        if (!$this->filesystem->exists(dirname($filePath))) {
+            $this->filesystem->mkdir(dirname($filePath));
         }
+        $this->filesystem->write($filePath, $specContent);
+
+        return true;
+    }
+
+    /**
+     * The absolute path of the spec file for a class path.
+     *
+     * @param string $spec the class path using forward slashes
+     */
+    private function filePath(string $spec): string
+    {
+        return getcwd() . DIRECTORY_SEPARATOR .
+               $this->specPath . DIRECTORY_SEPARATOR .
+               str_replace('/', DIRECTORY_SEPARATOR, $spec) .
+               $this->specSuffix;
     }
 
     /**
@@ -106,10 +122,7 @@ final class SpecGenerator
      */
     public function addExample(string $spec, string $method): bool
     {
-        $filePath = getcwd() . DIRECTORY_SEPARATOR .
-                    $this->specPath . DIRECTORY_SEPARATOR .
-                    str_replace('/', DIRECTORY_SEPARATOR, $spec) .
-                    $this->specSuffix;
+        $filePath = $this->filePath($spec);
 
         if (!$this->filesystem->exists($filePath)) {
             return false;

--- a/src/PhpSpec/Console/Command/Describe.php
+++ b/src/PhpSpec/Console/Command/Describe.php
@@ -15,6 +15,7 @@
 namespace PhpSpec\Console\Command;
 
 use PhpSpec\CodeGeneration\SpecGenerator;
+use PhpSpec\Report\Formatter\Agent\Schema;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -55,6 +56,7 @@ final class Describe extends Command
             ])
             ->addOption('exemplify', 'e', Option::VALUE_REQUIRED, 'Add an example for a method')
             ->addOption('run', 'r', Option::VALUE_NONE, 'Run specs after generating')
+            ->addOption('agent', null, Option::VALUE_NONE, 'Emit a machine-readable JSON receipt instead of prose (for coding agents)')
             ->setDescription('Generate spec for a class');
     }
 
@@ -70,6 +72,11 @@ final class Describe extends Command
     {
         $class = $input->getArgument('class');
         $spec = str_replace('\\', '/', $class);
+
+        if ($input->getOption('agent')) {
+            return $this->describeForAgent($spec, $input, $output);
+        }
+
         $this->generator->generate($spec);
         $specPath = $this->generator->getSpecPath();
         $output->writeln(
@@ -93,6 +100,43 @@ final class Describe extends Command
             }
             return $application->find('run')->run(new ArrayInput([]), $output);
         }
+
+        return 0;
+    }
+
+    /**
+     * Scaffolds the spec and emits a single JSON receipt — the class, the spec
+     * path, whether it was created, and (with -e) whether the example was added
+     * — so a coding agent can scaffold without parsing prose. No file content:
+     * the agent reads the file itself.
+     *
+     * @param string $spec the class path using forward slashes
+     * @param Input $input the console input
+     * @param Output $output the console output
+     * @return int the exit code (0 for success)
+     */
+    private function describeForAgent(string $spec, Input $input, Output $output): int
+    {
+        $created = $this->generator->generate($spec);
+
+        $receipt = [
+            'v' => Schema::V,
+            'action' => 'describe',
+            'class' => str_replace('/', '\\', $spec),
+            'spec' => $this->generator->getSpecPath() . '/' . $spec . $this->generator->getSpecSuffix(),
+            'created' => $created,
+        ];
+
+        $method = $input->getOption('exemplify');
+        if ($method) {
+            $receipt['example'] = [
+                'method' => $method,
+                'added' => $this->generator->addExample($spec, $method),
+            ];
+        }
+
+        $json = json_encode($receipt, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+        $output->write($json . "\n", false, Output::OUTPUT_RAW);
 
         return 0;
     }

--- a/src/PhpSpec/Console/Command/Exemplify.php
+++ b/src/PhpSpec/Console/Command/Exemplify.php
@@ -15,9 +15,11 @@
 namespace PhpSpec\Console\Command;
 
 use PhpSpec\CodeGeneration\SpecGenerator;
+use PhpSpec\Report\Formatter\Agent\Schema;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument as Argument;
 use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Input\InputOption as Option;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 
 /**
@@ -44,6 +46,7 @@ final class Exemplify extends Command
                 new Argument('class', Argument::REQUIRED, 'Class to add the example to'),
                 new Argument('method', Argument::REQUIRED, 'Method to exemplify'),
             ])
+            ->addOption('agent', null, Option::VALUE_NONE, 'Emit a machine-readable JSON receipt instead of prose (for coding agents)')
             ->setDescription('Add an example for a method to a spec file');
     }
 
@@ -54,7 +57,23 @@ final class Exemplify extends Command
         $spec = str_replace('\\', '/', $class);
 
         $this->generator->generate($spec);
-        $this->generator->addExample($spec, $method);
+        $added = $this->generator->addExample($spec, $method);
+
+        if ($input->getOption('agent')) {
+            $receipt = [
+                'v' => Schema::V,
+                'action' => 'exemplify',
+                'class' => str_replace('/', '\\', $spec),
+                'method' => $method,
+                'spec' => $this->generator->getSpecPath() . '/' . $spec . $this->generator->getSpecSuffix(),
+                'added' => $added,
+            ];
+
+            $json = json_encode($receipt, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+            $output->write($json . "\n", false, Output::OUTPUT_RAW);
+
+            return 0;
+        }
 
         $output->writeln(sprintf(
             'Example for <info>%s::%s</info> added.',

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -29,6 +29,7 @@ use PhpSpec\LineTargetRegistry;
 use PhpSpec\Loader;
 use PhpSpec\Parallel\ParallelRunner;
 use PhpSpec\Report\Formatter;
+use PhpSpec\Report\Formatter\Agent;
 use PhpSpec\Report\Formatter\Dot;
 use PhpSpec\Report\Formatter\Html;
 use PhpSpec\Report\Formatter\Junit;
@@ -46,6 +47,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument as Argument;
 use Symfony\Component\Console\Input\InputInterface as Input;
 use Symfony\Component\Console\Input\InputOption as Option;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -102,6 +104,7 @@ final class Run extends Command
             ->addOption('all', null, Option::VALUE_NONE, 'Run all suites (specs and features)')
             ->addOption('story', null, Option::VALUE_NONE, 'Run only features (story BDD)')
             ->addOption('fake', null, Option::VALUE_NONE, 'Generate method bodies with hardcoded return values from specs')
+            ->addOption('accept-offers', null, Option::VALUE_NONE, 'Apply all pending code-generation offers non-interactively, then exit (for --format=agent consumers)')
             ->addOption('coverage', null, Option::VALUE_NONE, 'Generate code coverage report')
             ->addOption('coverage-clover', null, Option::VALUE_REQUIRED, 'Generate Clover XML coverage report to file')
             ->addOption('coverage-html', null, Option::VALUE_REQUIRED, 'Generate HTML coverage report to directory')
@@ -172,7 +175,7 @@ final class Run extends Command
         $unknownFormats = $this->unknownFormats($input);
 
         if ($unknownFormats !== []) {
-            $output->writeln('<fg=red>Unknown format: ' . implode(', ', $unknownFormats) . ' (available: pretty, dot, tap, junit, html)</>');
+            $output->writeln('<fg=red>Unknown format: ' . implode(', ', $unknownFormats) . ' (available: pretty, dot, tap, junit, html, agent)</>');
 
             return 1;
         }
@@ -196,6 +199,15 @@ final class Run extends Command
             }
         }
 
+        if ($input->getOption('accept-offers')) {
+            // Apply every pending generation offer without prompting, then exit.
+            // The run's own output already went out; generation notes are discarded
+            // so an upstream --format=agent document stays a single clean object.
+            $this->generateCode(new BufferedOutput(), $results, (bool) $input->getOption('fake'), false);
+
+            return 0;
+        }
+
         // When pair mode spawned this run (it sets an env var naming a report
         // file), record the generation candidates there and let pair mode drive
         // the interactive generation in the REPL. Otherwise generate here as usual.
@@ -205,7 +217,7 @@ final class Run extends Command
                 $this->codeGenerator(false)->scan($results),
                 SuiteSummary::fromSuiteResult($results),
             ));
-        } elseif (!in_array($this->resolveFormat($input), ['junit', 'html'], true)) {
+        } elseif (!in_array($this->resolveFormat($input), ['junit', 'html', 'agent'], true)) {
             $this->generateCode($output, $results, (bool) $input->getOption('fake'), $input->isInteractive());
         }
 
@@ -530,7 +542,7 @@ final class Run extends Command
      */
     private function unknownFormats(Input $input): array
     {
-        $known = ['pretty', 'dot', 'tap', 'junit', 'html'];
+        $known = ['pretty', 'dot', 'tap', 'junit', 'html', 'agent'];
 
         return array_values(array_filter(
             (array) $input->getOption('format'),
@@ -555,6 +567,7 @@ final class Run extends Command
             'tap' => new Tap($output),
             'junit' => new Junit($output),
             'html' => new Html($output),
+            'agent' => new Agent($output, fn(SuiteResult $results) => $this->codeGenerator(false)->scan($results)->toArray()),
             default => new Pretty($output),
         };
     }

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -1,0 +1,387 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter;
+
+use PhpSpec\Report\AbstractFormatter;
+use PhpSpec\Report\Formatter\Agent\Offers;
+use PhpSpec\Report\Formatter\Agent\Schema;
+use PhpSpec\Report\Formatter\Agent\ValueExporter;
+use PhpSpec\Result\ExampleResult;
+use PhpSpec\Result\FeatureResult;
+use PhpSpec\Result\MatchResult;
+use PhpSpec\Result\SpecificationResult;
+use PhpSpec\Result\StepResult;
+use PhpSpec\Result\SuiteResult;
+use PhpSpec\Results;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ * Emits the whole run as a single machine-readable JSON document for a coding
+ * agent: a run_started header, one entry per example (and feature step), and a
+ * summary with totals. No ANSI, no prose — the failure itself is the payload.
+ */
+final class Agent extends AbstractFormatter
+{
+    /** @var list<array<string, mixed>> the actionable entries (passing ones are omitted) */
+    private array $examples = [];
+
+    /** @var array<string, int> tally of every unit by state, including passing */
+    private array $counts = [];
+
+    /** How many spec examples ran (as opposed to story steps). */
+    private int $exampleCount = 0;
+
+    /** How many story (feature) steps ran. */
+    private int $stepCount = 0;
+
+    /** @var (\Closure(SuiteResult): mixed)|null resolves the run's generation candidates as a plain array */
+    private readonly ?\Closure $resolveCandidates;
+
+    public function __construct(OutputInterface $output, ?\Closure $resolveCandidates = null)
+    {
+        parent::__construct($output);
+        $this->resolveCandidates = $resolveCandidates;
+    }
+
+    public function begin(): void {}
+
+    public function printResult(Results $result): void
+    {
+        $this->collect($result, $this->subjectOf($result));
+    }
+
+    public function end(SuiteResult $results): void
+    {
+        $failing = $this->counts['failing'] ?? 0;
+        $errors = $this->counts['error'] ?? 0;
+        $pending = $this->counts['pending'] ?? 0;
+
+        $document = [
+            'suite' => [
+                'v' => Schema::V,
+                'event' => Schema::EVENT_RUN_STARTED,
+                'suite' => 'default',
+                'examples' => $this->exampleCount,
+                'steps' => $this->stepCount,
+                'seed' => null,
+            ],
+            'examples' => $this->examples,
+            'result' => [
+                'v' => Schema::V,
+                'event' => Schema::EVENT_SUMMARY,
+                'examples' => $this->exampleCount,
+                'steps' => $this->stepCount,
+                'passing' => $this->counts['passing'] ?? 0,
+                'failing' => $failing,
+                'errors' => $errors,
+                'pending' => $pending,
+                'skipped' => $this->counts['skipped'] ?? 0,
+                // The one number an agent checks: everything red or unfinished
+                // (failures + errors + pending). Zero means nothing to do.
+                'actionable' => $failing + $errors + $pending,
+                'duration_ms' => (int) round($results->getDuration() * 1000),
+                'offers' => $this->offers($results),
+            ],
+        ];
+
+        $json = json_encode($document, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+
+        $this->output->write($json . "\n", false, OutputInterface::OUTPUT_RAW);
+    }
+
+    /**
+     * The run's code-generation offers as flat data, or an empty list when no
+     * candidate resolver was supplied.
+     *
+     * @return list<array{action: string, target: string, value?: string}>
+     */
+    private function offers(SuiteResult $results): array
+    {
+        if ($this->resolveCandidates === null) {
+            return [];
+        }
+
+        $candidates = ($this->resolveCandidates)($results);
+
+        return is_array($candidates) ? Offers::fromCandidates($candidates) : [];
+    }
+
+    /**
+     * The subject a result names its children after — the described class for a
+     * spec, the title for a feature — or null when it carries none.
+     */
+    private function subjectOf(Results $result): ?string
+    {
+        if ($result instanceof SpecificationResult || $result instanceof FeatureResult) {
+            return $result->getTitle();
+        }
+
+        return null;
+    }
+
+    /**
+     * Walks the result tree, emitting one entry per example/step and threading
+     * the enclosing subject down so each entry is named in full.
+     */
+    private function collect(Results $results, ?string $subject): void
+    {
+        foreach ($results->getResults() as $child) {
+            if ($child instanceof ExampleResult) {
+                $this->record($this->fromExample($child, $subject), 'example');
+            } elseif ($child instanceof StepResult) {
+                $this->record($this->fromStep($child, $subject), 'step');
+            } elseif ($child instanceof Results) {
+                $this->collect($child, $this->subjectOf($child) ?? $subject);
+            }
+        }
+    }
+
+    /**
+     * Counts an entry by state, and keeps it in the emitted list unless it
+     * passed — a green suite of thousands need not spend tokens on entries an
+     * agent will never act on; the summary still counts them.
+     *
+     * @param array<string, mixed> $entry
+     * @param 'example'|'step' $kind
+     */
+    private function record(array $entry, string $kind): void
+    {
+        $state = is_string($entry['state'] ?? null) ? $entry['state'] : 'passing';
+        $this->counts[$state] = ($this->counts[$state] ?? 0) + 1;
+
+        if ($kind === 'step') {
+            $this->stepCount++;
+        } else {
+            $this->exampleCount++;
+        }
+
+        if ($state !== 'passing') {
+            $this->examples[] = $entry;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fromExample(ExampleResult $example, ?string $subject): array
+    {
+        $state = $this->exampleState($example);
+        $name = $this->name($subject, $example->getTitle());
+        $entry = [
+            'v' => Schema::V,
+            'id' => $this->identify($name),
+            'example' => $name,
+            'state' => $state,
+        ];
+
+        if ($state === 'failing') {
+            $match = $this->failingMatch($example);
+            // phpspec names these from the matcher's point of view — getExpected()
+            // is the expect() subject (the value the code produced) and getActual()
+            // is the matcher's argument (the target). The agent contract uses the
+            // universal convention, so they are swapped here: actual = the subject,
+            // expected = the target.
+            $entry['expected'] = [
+                'matcher' => $match?->getMatcher(),
+                'value' => ValueExporter::export($match?->getActual()),
+                'negated' => $match?->isNegated() ?? false,
+            ];
+            $entry['actual'] = ValueExporter::export($match?->getExpected());
+            $entry['message'] = $example->getMessage();
+            $location = $this->location($match?->getFile(), $match?->getLine());
+            $entry['spec'] = $location;
+            $this->addRerun($entry, $location);
+            // No offer on a failure: the code exists and the behaviour is wrong,
+            // there is nothing to generate — `state: failing` already says so.
+        } elseif ($state === 'error') {
+            $error = $example->getError();
+            $entry['exception'] = [
+                'class' => $error?->getType(),
+                'message' => $error?->getMessage(),
+                'at' => $this->location($error?->getFile(), $error?->getLine()),
+            ];
+            $location = $this->location($error?->getFile(), $error?->getLine());
+            $entry['spec'] = $location;
+            $this->addRerun($entry, $location);
+            // A missing class/method/interface the error names becomes a concrete
+            // offer to generate it, right on the example that hit it. Only present
+            // when the error actually maps to something a generator can create.
+            $offer = Offers::forError($error?->getMessage() ?? '');
+            if ($offer !== null) {
+                $entry['offer'] = $offer;
+            }
+        }
+
+        $this->attachNotes($entry, $example);
+
+        return $entry;
+    }
+
+    /**
+     * Attaches any PHP warnings, deprecations or notices the example collected,
+     * as lean {message, at} lists and only when non-empty — a clean entry stays
+     * clean. A deprecation is sometimes the very clue that explains a failure.
+     *
+     * @param array<string, mixed> $entry
+     */
+    private function attachNotes(array &$entry, ExampleResult $example): void
+    {
+        $warnings = $this->notes($example->getWarnings());
+        if ($warnings !== []) {
+            $entry['warnings'] = $warnings;
+        }
+
+        $deprecations = $this->notes($example->getDeprecations());
+        if ($deprecations !== []) {
+            $entry['deprecations'] = $deprecations;
+        }
+
+        $notices = $this->notes($example->getNotices());
+        if ($notices !== []) {
+            $entry['notices'] = $notices;
+        }
+    }
+
+    /**
+     * Reduces raw {severity, message, file, line} items to the agent-facing
+     * {message, at} shape — the severity flag is noise once the note's kind is
+     * named by its key.
+     *
+     * @param array<array{severity: int, message: string, file: string, line: int}> $items
+     * @return list<array{message: string, at: string|null}>
+     */
+    private function notes(array $items): array
+    {
+        $notes = [];
+        foreach ($items as $item) {
+            $notes[] = [
+                'message' => $item['message'],
+                'at' => $this->location($item['file'], $item['line']),
+            ];
+        }
+
+        return $notes;
+    }
+
+    /**
+     * Maps an example to its agent state, in the precedence the counter uses.
+     */
+    private function exampleState(ExampleResult $example): string
+    {
+        return match (true) {
+            $example->isPending() => 'pending',
+            $example->isSkipped() => 'skipped',
+            $example->isError() => 'error',
+            $example->isFailure() => 'failing',
+            default => 'passing',
+        };
+    }
+
+    /**
+     * The first failing expectation of an example, or null when none failed.
+     */
+    private function failingMatch(ExampleResult $example): ?MatchResult
+    {
+        foreach ($example->getResults() as $match) {
+            if ($match->isFailure()) {
+                return $match;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fromStep(StepResult $step, ?string $subject): array
+    {
+        $state = match (true) {
+            $step->isPending() || $step->isUndefined() => 'pending',
+            $step->isFailure() => 'failing',
+            $step->isSkipped() => 'skipped',
+            default => 'passing',
+        };
+
+        $name = $this->name($subject, $step->getTitle());
+        $entry = [
+            'v' => Schema::V,
+            'id' => $this->identify($name),
+            'example' => $name,
+            'state' => $state,
+        ];
+
+        if ($state === 'failing' && $step->getError() !== null) {
+            $entry['message'] = $step->getError()->getMessage();
+        }
+
+        return $entry;
+    }
+
+    /**
+     * Joins the subject and the title into the example's full name.
+     */
+    private function name(?string $subject, string $title): string
+    {
+        return $subject !== null && $subject !== '' ? $subject . ' ' . $title : $title;
+    }
+
+    /**
+     * A stable, compact identifier for an example, derived from its full name
+     * (described subject + title) — the one part of an entry that survives edits
+     * moving lines or shifting where a failure fires (an error location often
+     * points into src/, not the spec). Lets an agent ask "is THIS exact failure
+     * still here?" across runs; recomputable from the emitted `example` field.
+     */
+    private function identify(string $name): string
+    {
+        return substr(sha1($name), 0, 12);
+    }
+
+    /**
+     * Attaches the exact line-targeted command that re-runs just this one
+     * example, so an agent can verify a single fix without a full-suite run.
+     * phpspec resolves a "spec.php:LINE" path to the example whose closure spans
+     * that line, and the expectation/error site always falls inside it — so the
+     * entry's own location is a valid target. Omitted when there is none.
+     *
+     * @param array<string, mixed> $entry
+     */
+    private function addRerun(array &$entry, ?string $location): void
+    {
+        if ($location !== null) {
+            $entry['rerun'] = 'run ' . $location;
+        }
+    }
+
+    /**
+     * Renders a file:line as a project-relative, forward-slashed location, or
+     * null when either part is missing.
+     */
+    private function location(?string $file, ?int $line): ?string
+    {
+        if ($file === null || $line === null) {
+            return null;
+        }
+
+        $cwd = getcwd();
+        if ($cwd !== false && str_starts_with($file, $cwd . DIRECTORY_SEPARATOR)) {
+            $file = substr($file, strlen($cwd) + 1);
+        }
+
+        return str_replace('\\', '/', $file) . ':' . $line;
+    }
+}

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -377,11 +377,19 @@ final class Agent extends AbstractFormatter
             return null;
         }
 
+        // Normalise both sides to forward slashes before comparing: on Windows
+        // getcwd() yields backslashes while a file path may already carry
+        // forward slashes, so a raw DIRECTORY_SEPARATOR prefix check would miss
+        // and leak the absolute path.
+        $file = str_replace('\\', '/', $file);
         $cwd = getcwd();
-        if ($cwd !== false && str_starts_with($file, $cwd . DIRECTORY_SEPARATOR)) {
-            $file = substr($file, strlen($cwd) + 1);
+        if ($cwd !== false) {
+            $cwd = str_replace('\\', '/', $cwd);
+            if (str_starts_with($file, $cwd . '/')) {
+                $file = substr($file, strlen($cwd) + 1);
+            }
         }
 
-        return str_replace('\\', '/', $file) . ':' . $line;
+        return $file . ':' . $line;
     }
 }

--- a/src/PhpSpec/Report/Formatter/Agent/Offers.php
+++ b/src/PhpSpec/Report/Formatter/Agent/Offers.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter\Agent;
+
+/**
+ * @internal
+ * Turns a run's code-generation candidates (the interactive runner's "shall I
+ * create this?" offers) into flat, deduplicated JSON data — {action, target} —
+ * so an agent can act on them (write the code, or run --accept-offers) instead
+ * of being prompted. Operates on the plain GenerationCandidates::toArray() shape
+ * so the formatter stays free of the console-command layer.
+ */
+final class Offers
+{
+    /**
+     * @param array<string, mixed> $candidates the GenerationCandidates::toArray() output
+     * @return list<array{action: string, target: string, value?: string}>
+     */
+    public static function fromCandidates(array $candidates): array
+    {
+        $offers = [];
+        $seen = [];
+
+        $add = static function (string $action, string $target, ?string $value = null) use (&$offers, &$seen): void {
+            $key = $action . ' ' . $target;
+            if (isset($seen[$key])) {
+                return;
+            }
+
+            $seen[$key] = true;
+            $offer = ['action' => $action, 'target' => $target];
+            if ($value !== null) {
+                $offer['value'] = $value;
+            }
+
+            $offers[] = $offer;
+        };
+
+        foreach (self::fqcns($candidates, 'missingSpecClasses') as $fqcn) {
+            $add('create_class', $fqcn);
+        }
+
+        foreach (self::fqcns($candidates, 'missingStepClasses') as $fqcn) {
+            $add('create_class', $fqcn);
+        }
+
+        foreach (self::fqcns($candidates, 'missingMockTypes') as $fqcn) {
+            $add('create_interface', $fqcn);
+        }
+
+        foreach (self::methodTargets($candidates, 'undefinedClassMethods') as $target) {
+            $add('create_method', $target);
+        }
+
+        foreach (self::methodTargets($candidates, 'undefinedMockInterfaceMethods') as $target) {
+            $add('create_method', $target);
+        }
+
+        foreach (self::fakeableMethods($candidates) as [$target, $value]) {
+            $add('fake_method', $target, $value);
+        }
+
+        foreach (self::featurePaths($candidates) as $path) {
+            $add('create_steps', $path);
+        }
+
+        return $offers;
+    }
+
+    /**
+     * Derives the single generation offer implied by an error message — a
+     * missing class, mock interface, or method — or null when the error is not
+     * something a generator can resolve. This lets each errored example carry
+     * its own offer, not just the run-wide summary.
+     *
+     * @return array{action: string, target: string}|null
+     */
+    public static function forError(string $message): ?array
+    {
+        if (preg_match('/^Class "([^"]+)" not found$/', $message, $matches)) {
+            return ['action' => 'create_class', 'target' => $matches[1]];
+        }
+
+        if (preg_match('/Cannot create mock: class or interface \'([^\']+)\' does not exist/', $message, $matches)) {
+            return ['action' => 'create_interface', 'target' => $matches[1]];
+        }
+
+        if (preg_match('/Call to undefined method ([^:]+)::([A-Za-z0-9_]+)\(\)/', $message, $matches)) {
+            return ['action' => 'create_method', 'target' => $matches[1] . '::' . $matches[2]];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $candidates
+     * @return list<string>
+     */
+    private static function fqcns(array $candidates, string $key): array
+    {
+        $values = $candidates[$key] ?? [];
+
+        return is_array($values) ? array_values(array_filter($values, 'is_string')) : [];
+    }
+
+    /**
+     * @param array<string, mixed> $candidates
+     * @return list<string>
+     */
+    private static function methodTargets(array $candidates, string $key): array
+    {
+        $values = $candidates[$key] ?? [];
+        if (!is_array($values)) {
+            return [];
+        }
+
+        $targets = [];
+        foreach ($values as $method) {
+            if (is_array($method) && is_string($method['className'] ?? null) && is_string($method['methodName'] ?? null)) {
+                $targets[] = $method['className'] . '::' . $method['methodName'];
+            }
+        }
+
+        return $targets;
+    }
+
+    /**
+     * Existing empty methods that --fake could fill, paired with the return
+     * expression it would insert (derived from the spec's expectation).
+     *
+     * @param array<string, mixed> $candidates
+     * @return list<array{0: string, 1: string}> [Class::method, returnExpression] pairs
+     */
+    private static function fakeableMethods(array $candidates): array
+    {
+        $values = $candidates['fakeableMethods'] ?? [];
+        if (!is_array($values)) {
+            return [];
+        }
+
+        $targets = [];
+        foreach ($values as $method) {
+            if (is_array($method)
+                && is_string($method['className'] ?? null)
+                && is_string($method['methodName'] ?? null)
+                && is_string($method['fakeExpression'] ?? null)
+            ) {
+                $targets[] = [$method['className'] . '::' . $method['methodName'], $method['fakeExpression']];
+            }
+        }
+
+        return $targets;
+    }
+
+    /**
+     * @param array<string, mixed> $candidates
+     * @return list<string>
+     */
+    private static function featurePaths(array $candidates): array
+    {
+        $values = $candidates['undefinedSteps'] ?? [];
+
+        return is_array($values) ? array_values(array_filter(array_keys($values), 'is_string')) : [];
+    }
+}

--- a/src/PhpSpec/Report/Formatter/Agent/Schema.php
+++ b/src/PhpSpec/Report/Formatter/Agent/Schema.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter\Agent;
+
+/**
+ * @internal
+ * The agent formatter's output contract in one place: the schema version stamped
+ * on every event as "v", and the event-type names. Bump V on any breaking change
+ * to the emitted shape so a consuming agent can detect it.
+ */
+final class Schema
+{
+    public const V = 1;
+
+    public const EVENT_RUN_STARTED = 'run_started';
+    public const EVENT_SUMMARY = 'summary';
+}

--- a/src/PhpSpec/Report/Formatter/Agent/ValueExporter.php
+++ b/src/PhpSpec/Report/Formatter/Agent/ValueExporter.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter\Agent;
+
+/**
+ * @internal
+ * Exports an arbitrary value into a compact, JSON-encodable shape for the agent
+ * formatter: scalars pass through, long strings and large arrays are truncated
+ * with a marker of their real length, and objects become "ClassName#id" — never
+ * a full object graph — so a single expectation cannot flood the model's context.
+ */
+final class ValueExporter
+{
+    private const STRING_MAX = 200;
+    private const ARRAY_MAX = 10;
+    private const MAX_DEPTH = 5;
+
+    /**
+     * Exports a value to a JSON-encodable representation.
+     *
+     * @return mixed a scalar, a compact array, or a truncation marker array
+     */
+    public static function export(mixed $value, int $depth = 0): mixed
+    {
+        if (is_object($value)) {
+            return $value::class . '#' . spl_object_id($value);
+        }
+
+        if (is_string($value)) {
+            return self::exportString($value);
+        }
+
+        if (is_array($value)) {
+            return self::exportArray($value, $depth);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Returns the string as-is, or a truncation marker when it exceeds the cap.
+     *
+     * @return string|array{truncated: true, length: int, value: string}
+     */
+    private static function exportString(string $value): string|array
+    {
+        if (mb_strlen($value) <= self::STRING_MAX) {
+            return $value;
+        }
+
+        return [
+            'truncated' => true,
+            'length' => mb_strlen($value),
+            'value' => mb_substr($value, 0, self::STRING_MAX),
+        ];
+    }
+
+    /**
+     * Exports each element (preserving keys), truncating to the first ARRAY_MAX
+     * elements when the array is larger and marking the real length. Depth is
+     * bounded so a deeply nested structure cannot recurse without limit.
+     *
+     * @param array<array-key, mixed> $value
+     * @return mixed
+     */
+    private static function exportArray(array $value, int $depth): mixed
+    {
+        if ($depth >= self::MAX_DEPTH) {
+            return ['truncated' => true, 'length' => count($value)];
+        }
+
+        $count = count($value);
+        $slice = $count > self::ARRAY_MAX ? array_slice($value, 0, self::ARRAY_MAX, true) : $value;
+
+        $exported = [];
+        foreach ($slice as $key => $item) {
+            $exported[$key] = self::export($item, $depth + 1);
+        }
+
+        if ($count > self::ARRAY_MAX) {
+            return ['truncated' => true, 'length' => $count, 'value' => $exported];
+        }
+
+        return $exported;
+    }
+}

--- a/src/PhpSpec/Result/Detail/Failed.php
+++ b/src/PhpSpec/Result/Detail/Failed.php
@@ -42,6 +42,12 @@ final class Failed extends Detail
     /** @var string|null Expression used for --fake code generation */
     private ?string $fakeExpression = null;
 
+    /** @var string|null The matcher method that produced the failure (e.g. "toBe") */
+    private ?string $matcher = null;
+
+    /** @var bool Whether the matcher was negated (expect(...)->not()->...) */
+    private bool $negated = false;
+
     /**
      * Creates a Failed detail from a matcher comparison.
      *
@@ -52,8 +58,10 @@ final class Failed extends Detail
      * @param int $line line number of the failing expectation
      * @param string $file file path of the failing expectation
      * @param ?string $fakeExpression optional expression for --fake code generation
+     * @param ?string $matcher the matcher method that produced the failure (e.g. "toBe")
+     * @param bool $negated whether the matcher was negated
      */
-    public static function matcher(mixed $expected, mixed $actual, string $message, SurroundingCode $code, int $line, string $file, ?string $fakeExpression = null): Detail
+    public static function matcher(mixed $expected, mixed $actual, string $message, SurroundingCode $code, int $line, string $file, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false): Detail
     {
         $failed = new self($message);
         $failed->expected = $expected;
@@ -62,7 +70,25 @@ final class Failed extends Detail
         $failed->line = $line;
         $failed->file = $file;
         $failed->fakeExpression = $fakeExpression;
+        $failed->matcher = $matcher;
+        $failed->negated = $negated;
         return $failed;
+    }
+
+    /**
+     * Returns the matcher method that produced the failure, or null when unknown.
+     */
+    public function getMatcher(): ?string
+    {
+        return $this->matcher;
+    }
+
+    /**
+     * Returns whether the matcher was negated (expect(...)->not()->...).
+     */
+    public function isNegated(): bool
+    {
+        return $this->negated;
     }
 
     /**

--- a/src/PhpSpec/Result/MatchResult.php
+++ b/src/PhpSpec/Result/MatchResult.php
@@ -59,6 +59,8 @@ final readonly class MatchResult implements Results
      * @param string $file file path of the failing expectation
      * @param int $line line number of the failing expectation
      * @param ?string $fakeExpression optional expression for --fake code generation
+     * @param ?string $matcher the matcher method that produced the failure (e.g. "toBe")
+     * @param bool $negated whether the matcher was negated
      */
     public static function failed(
         mixed $expected,
@@ -67,6 +69,8 @@ final readonly class MatchResult implements Results
         string $file,
         int $line,
         ?string $fakeExpression = null,
+        ?string $matcher = null,
+        bool $negated = false,
     ): MatchResult {
         return new self(
             Result::Failed,
@@ -78,6 +82,8 @@ final readonly class MatchResult implements Results
                 $line,
                 $file,
                 $fakeExpression,
+                $matcher,
+                $negated,
             ),
         );
     }
@@ -154,5 +160,23 @@ final readonly class MatchResult implements Results
     public function getFakeExpression(): ?string
     {
         return $this->detail instanceof Detail\Failed ? $this->detail->getFakeExpression() : null;
+    }
+
+    /**
+     * Returns the matcher method that produced the failure (e.g. "toBe"), or null
+     * for a passed result or when the matcher could not be determined.
+     */
+    public function getMatcher(): ?string
+    {
+        return $this->detail instanceof Detail\Failed ? $this->detail->getMatcher() : null;
+    }
+
+    /**
+     * Returns whether the failing matcher was negated (expect(...)->not()->...);
+     * false for a passed result.
+     */
+    public function isNegated(): bool
+    {
+        return $this->detail instanceof Detail\Failed && $this->detail->isNegated();
     }
 }

--- a/src/PhpSpec/Specification/EventfulExpectation.php
+++ b/src/PhpSpec/Specification/EventfulExpectation.php
@@ -43,10 +43,12 @@ final readonly class EventfulExpectation
      * @param \Closure $match matcher callback receiving the subject
      * @param string $message failure message template
      * @param string|null $fakeExpression PHP expression for --fake code generation
+     * @param string|null $matcher the matcher method that produced the expectation (e.g. "toBe")
+     * @param bool $negated whether the matcher was negated
      * @param mixed ...$values format values for the failure message
      * @return void
      */
-    public function createMatchEvent(\Closure $match, string $message, ?string $fakeExpression = null, ...$values): void
+    public function createMatchEvent(\Closure $match, string $message, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false, ...$values): void
     {
         DispatcherRegistry::dispatcher()->dispatch(new ExpectationStarted(), ExpectationStarted::NAME);
         DispatcherRegistry::dispatcher()->dispatch(new MatchCreated(fn() => match (true) {
@@ -58,6 +60,8 @@ final readonly class EventfulExpectation
                 $this->file,
                 $this->line,
                 $fakeExpression,
+                $matcher,
+                $negated,
             )
         }), MatchCreated::NAME);
     }

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -774,6 +774,12 @@ class Expectation
      */
     private function match($match, ...$message): static
     {
+        // The matcher name is the public method that called this chokepoint
+        // (e.g. toBe); __call-based custom/predicate matchers stay anonymous.
+        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'] ?? null;
+        $matcher = $caller !== null && !in_array($caller, ['__call', 'match'], true) ? $caller : null;
+        $negated = $this->negated;
+
         $fakeExpression = null;
         // Extract fakeExpression if last argument is an array with '__fake' key
         if (!empty($message) && is_array(end($message)) && array_key_exists('__fake', end($message))) {
@@ -789,7 +795,7 @@ class Expectation
             }
             $fakeExpression = null; // negated matchers don't produce fakes
         }
-        $this->eventCreator?->createMatchEvent($match, $message[0], $fakeExpression, ...array_slice($message, 1));
+        $this->eventCreator?->createMatchEvent($match, $message[0], $fakeExpression, $matcher, $negated, ...array_slice($message, 1));
         return $this;
     }
 


### PR DESCRIPTION
## What

A new --format=agent formatter that emits an entire run as a single machine-readable JSON document (no ANSI, no prose) for coding agents. The goal: the failure is the prompt, each actionable example carries, in as few tokens as possible, everything an agent needs to act without re-reading the project.

It also adds the write side, so an agent can drive the whole loop from the CLI: describe --agent / exemplify --agent (JSON receipts) and run --accept-offers (apply code-generation offers non-interactively).

## Output

One JSON object on stdout, three sections, all versioned ("v":1):

 - suite (run_started) — suite name, example/step counts, seed.
 - examples — the actionable entries only; passing examples are omitted (the summary still counts them). A failing entry carries expected (matcher, value, negated), actual, message, spec (file:line), a stable id, and a line-targeted rerun command. An error entry carries exception (class/message/at) and, when the error names something generatable, an offer. PHP warnings/deprecations/notices attach when present.
 - result (summary) — totals, an actionable count, duration, and the run-wide list of offers.

Offers turn the interactive "create class / interface / method / step" (and fake_method) prompts into {action, target} data; an agent applies them with --accept-offers (add --fake to fill empty method bodies) or writes the code itself. --format=agent never blocks on a prompt. Values are exported compactly with explicit truncation.

## Notes

 - Exit codes unchanged. Parallel-safe: the one document is emitted once, at the end, when the parent holds the complete result.
 - expected/actual follow the universal convention (un-inverted from phpspec's internal matcher-centric naming).
 - Documented in docs/agent.md, including a copy-paste CLAUDE.md snippet.
 - No new dependencies.
 - Deterministic hints, and a per-failure subject/source slice, were considered and dropped; may revisit.

## Testing

Feature scenarios assert valid JSON, the failing-example fields, per-example and summary offers, the --accept-offers[ --fake] round-trip, and the describe/exemplify --agent receipts. Unit specs cover the formatter, value truncation, and offer mapping. Full matrix green on PHP 8.2–8.5.