### PR TITLE
Add slash commands, /generate, and next-command hints to pair mode

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,7 +57,21 @@ bin/phpspec refactor "App\Calculator::sum"
 
 See [Pair Programming & AI](pair.md#the-refactor-command) for full documentation.
 
-### `describe`
+### `generate`
+
+Turns a natural-language instruction into a single file edit — a spec example or a
+piece of implementation code — authored by the AI, shown as a diff, and written after a
+`[Y/n]` confirmation. Requires an AI provider (see [Configuration](configuration.md#ai)).
+
+```bash
+bin/phpspec generate an example for App/Calculator add where it sums two numbers
+bin/phpspec generate implement Calculator::add to return the sum of its arguments
+```
+
+The instruction is free-form text after `generate`. Use it when a spec is red for a
+*missing implementation* (not a missing class or method — those are offered automatically
+on `run`). Also available in pair mode as `/generate <instruction>`.
+
 
 Generates a spec file for a class.
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -177,6 +177,24 @@ This is the scripted counterpart to the prompts -- built for
 then has PhpSpec generate them. See [Coding Agents](agent.md) for the offer
 format and the full loop.
 
+## Generating From an Instruction (`generate`)
+
+The generators above are deterministic — they emit fixed stubs (`toBe(null)`, empty
+method bodies). When a spec is red because an existing method needs *real behaviour*
+(not because a class or method is missing), the `generate` command turns a
+natural-language instruction into one file edit — a spec example or a piece of
+implementation code — authored by the AI, shown as a diff, and written after you confirm:
+
+```bash
+bin/phpspec generate an example for App/Calculator add where it sums two numbers
+bin/phpspec generate implement Calculator::add to return the sum of its arguments
+```
+
+It requires an AI provider. A spec edit is checked so it never drops an existing example
+(specs are grown, not shrunk). In pair mode the same thing is `/generate <instruction>`,
+with the diff confirmed through the numbered chooser. See
+[Pair Programming & AI](pair.md) and the [CLI Reference](cli.md#generate).
+
 ## Step Definition Generation
 
 When running feature files with undefined steps, PhpSpec generates step definition stubs:

--- a/docs/pair.md
+++ b/docs/pair.md
@@ -27,13 +27,13 @@ Pair mode opens by looking at your project once and greeting you with what matte
 - **Green and clean** — a short observation, then it's your call.
 - **Empty project** — an invitation to write the first spec.
 
-The greeting adapts to your configuration: with an AI provider configured it invites plain English; without one it points you at the deterministic commands (`describe`, `exemplify`, `run`). The full command list is always available behind `/help`.
+The greeting adapts to your configuration: with an AI provider configured it invites plain English; without one it points you at the deterministic commands (`/describe`, `/exemplify`, `/run`). The full command list is always available behind `/help`.
 
 ### Driving and navigating
 
 Pair mode is a pair, not a code agent: you share one keyboard and work in turns. Nobody hand-types code any more — the generators are the keyboard, and *driving* means deciding what gets generated and pulling the trigger. `/swap` changes who holds it (this needs an AI provider):
 
-- **You drive, the AI navigates** (the default). The AI reviews and suggests one step ahead — intent, then location, then the exact line only when you ask — but it never writes files on its own. You generate code by triggering it: `describe`, `exemplify`, `run`, and the numbered choosers.
+- **You drive, the AI navigates** (the default). The AI reviews and suggests one step ahead — intent, then location, then the exact line only when you ask — but it never writes files on its own. You generate code by triggering it: `/describe`, `/exemplify`, `/run`, and the numbered choosers.
 - **The AI drives, you navigate** (after `/swap`). You give the intent; the AI makes it real one artifact at a time, shows the diff, runs the spec, and hands back.
 
 `/help` shows the current contract. Swap back at any time with another `/swap`.
@@ -42,27 +42,46 @@ Pair mode is a pair, not a code agent: you share one keyboard and work in turns.
 
 These commands work without AI configuration:
 
+Every command starts with a slash. These work without AI configuration:
+
 | Command | Description |
 |---|---|
-| `describe <Class>` | Generate a spec file and optionally create the class |
-| `exemplify <Class> <method>` | Add a method example to an existing spec |
-| `run [path]` | Run specs and offer code generation for failures |
-| `clear` | Clear the terminal |
+| `/describe <Class>` | Generate a spec file and optionally create the class |
+| `/exemplify <Class> <method>` | Add a method example to an existing spec |
+| `/run [path]` | Run specs and offer code generation for failures |
+| `/next` | Suggest the next step from the real suite state |
+| `/generate <instruction>` | Turn plain English into a spec example or code — diff, then confirm (requires AI) |
+| `/clear` | Clear the terminal |
 | `/help` | Show available commands and AI status |
 | `/quit`, `/exit` | Exit pair mode |
 
-Commands mirror the CLI but add interactive prompts. For example, `describe` shows the generated spec, then asks whether to create the source class. `run` displays results and offers to generate missing classes or methods.
+Commands mirror the CLI but add interactive prompts. For example, `/describe` shows the generated spec, then asks whether to create the source class. `/run` displays results and offers to generate missing classes or methods.
 
-### Smart Routing
+### Command or prompt: the slash rule
 
-When AI is configured, input that doesn't match a built-in command is sent to the AI assistant. PhpSpec also detects when you're addressing the AI even if the input starts with a command name:
+The leading slash is the one signal that a line is a command. Anything **without** a slash is sent to the AI assistant (or, with no AI configured, shows the unknown-command hint). No keyword guessing — `/describe App/Calculator` runs the command; `describe what the Loader class does` is a prompt.
 
 ```
-> describe App/Calculator                       # runs describe command
-> describe what the Loader class does            # routes to AI (too many words)
-> run spec/App                                   # runs specs
-> run my specs and explain the failures          # routes to AI
+> /describe App/Calculator                      # runs the describe command
+> describe what the Loader class does           # no slash → routes to the AI
+> /run spec/App                                 # runs specs at a path
+> run my specs and explain the failures         # no slash → routes to the AI
 ```
+
+### Suggested next command (ghost text)
+
+After each command the prompt is pre-filled with a dim **ghost** of the natural next
+step — describe a spec and it suggests running it, run and it suggests `/next`, and so on:
+
+```
+> /describe App/Todo
+  ...
+> /run spec/App/Todo.spec.php          ← the greyed-out suggestion, cursor before the /
+```
+
+Press **Right-arrow** or **Tab** to accept it (it turns full colour, cursor to the end),
+or just start typing to dismiss it. **Up/Down** walk your history. On a terminal that
+can't enter raw mode (or piped input) the prompt falls back to a plain line reader.
 
 ## AI Configuration
 

--- a/features/scenarios/cli/generate.feature
+++ b/features/scenarios/cli/generate.feature
@@ -1,0 +1,23 @@
+Feature: Generate code from a natural-language instruction
+  As a developer
+  I want to describe a change in plain English and have phpspec generate it
+  So that I can drive out examples and implementation without hand-writing them
+
+  Scenario: generate requires AI configuration
+    Given no phpspec.json config
+    And a phpspec.yaml config:
+      """
+      spec_path: spec
+      """
+    When I run phpspec command "generate an example for App/Calculator that adds"
+    Then the output should contain "AI configuration required"
+
+  Scenario: generate analyses the instruction when AI is configured
+    Given a phpspec.yaml config:
+      """
+      ai:
+        provider: google
+        api_key: test-key
+      """
+    When I run phpspec command "generate a Calculator that adds two numbers"
+    Then the output should contain "Generating"

--- a/features/scenarios/cli/pair-ai.feature
+++ b/features/scenarios/cli/pair-ai.feature
@@ -62,7 +62,7 @@ Feature: AI-assisted pair programming
       """
       spec_path: spec
       """
-    When I run phpspec pair with input "next"
+    When I run phpspec pair with input "/next"
     Then the output should not contain "Unknown command"
 
   Scenario: Help lists additional delegated commands
@@ -77,24 +77,24 @@ Feature: AI-assisted pair programming
     And the output should contain "refactor"
 
   Scenario: Interactive questions offer numbered choices
-    When I run phpspec pair with input "describe App/Wanted" answering "1,3"
+    When I run phpspec pair with input "/describe App/Wanted" answering "1,3"
     Then the output should contain "1. Yes"
     And the output should contain "2. Yes, and don't ask again"
     And the output should contain "3. No"
     And a class file "src/App/Wanted.php" should be generated
 
   Scenario: Answering No declines the offer
-    When I run phpspec pair with input "describe App/Declined" answering "3,3"
+    When I run phpspec pair with input "/describe App/Declined" answering "3,3"
     Then no file "src/App/Declined.php" should be generated
 
   Scenario: Answering always suppresses repeat questions of the same kind
-    When I run phpspec pair with input "describe App/First; describe App/Second" answering "2,3,3"
+    When I run phpspec pair with input "/describe App/First; /describe App/Second" answering "2,3,3"
     Then a class file "src/App/First.php" should be generated
     And a class file "src/App/Second.php" should be generated
     And the output should not contain "create class App\Second"
 
   Scenario: Describe with a slash path generates a namespaced class
-    When I run phpspec pair with input "describe App/Basket" answering "1,3"
+    When I run phpspec pair with input "/describe App/Basket" answering "1,3"
     Then the file "src/App/Basket.php" should contain "namespace App;"
     And the file "src/App/Basket.php" should contain "class Basket"
 
@@ -118,7 +118,7 @@ Feature: AI-assisted pair programming
           });
       });
       """
-    When I run phpspec pair with input "run" answering "1"
+    When I run phpspec pair with input "/run" answering "1"
     Then the output should contain "1. Yes"
     And the output should contain "2. Yes, and don't ask again"
     And the output should contain "3. No"
@@ -150,7 +150,7 @@ Feature: AI-assisted pair programming
           });
       });
       """
-    When I run phpspec pair with input "run; run"
+    When I run phpspec pair with input "/run; /run"
     Then the output should contain "1 example (1 passes)" exactly 2 times
 
   Scenario: Running a spec that declares a top-level type twice does not crash
@@ -168,7 +168,7 @@ Feature: AI-assisted pair programming
           });
       });
       """
-    When I run phpspec pair with input "run; run"
+    When I run phpspec pair with input "/run; /run"
     Then the output should contain "1 example (1 passes)" exactly 2 times
     And the output should not contain "Cannot declare interface"
 
@@ -189,7 +189,7 @@ Feature: AI-assisted pair programming
           it('adds numbers', fn() => expect((new Calculator())->add())->toBe(null));
       });
       """
-    When I run phpspec pair with input "run; run" answering "1"
+    When I run phpspec pair with input "/run; /run" answering "1"
     Then the file "src/App/Calculator.php" should contain "function add"
     And the output should contain "1 example (1 passes)"
 
@@ -203,7 +203,7 @@ Feature: AI-assisted pair programming
           it('adds numbers', fn() => expect((new Calculator())->add())->toBe(null));
       });
       """
-    When I run phpspec pair with input "exemplify App/Calculator subtract" answering "3"
+    When I run phpspec pair with input "/exemplify App/Calculator subtract" answering "3"
     Then the output should contain "[MODIFIED]"
     And the output should contain "subtract"
     And the output should not contain "+ <?php"
@@ -219,7 +219,7 @@ Feature: AI-assisted pair programming
           it('adds numbers', fn() => expect((new Calculator())->add())->toBe(null));
       });
       """
-    When I run phpspec pair with input "exemplify App/Calculator subtract; exemplify App/Calculator subtract" answering "3,3"
+    When I run phpspec pair with input "/exemplify App/Calculator subtract; /exemplify App/Calculator subtract" answering "3,3"
     Then the output should contain "already exists"
     And the output should contain "should subtract" exactly 1 times
 
@@ -245,6 +245,6 @@ Feature: AI-assisted pair programming
           it('subtracts numbers', fn() => expect((new Calculator())->subtract())->toBe(null));
       });
       """
-    When I run phpspec pair with input "run" answering "1"
+    When I run phpspec pair with input "/run" answering "1"
     Then the output should contain "function subtract"
     And the output should not contain "+ }"

--- a/features/scenarios/cli/pair-generate.feature
+++ b/features/scenarios/cli/pair-generate.feature
@@ -1,0 +1,22 @@
+Feature: Pair mode /generate turns words into a diff to confirm
+  As a developer pairing with phpspec
+  I want to describe a change in plain English and get a diff to approve
+  So that I can grow specs and code without hand-typing them
+
+  Scenario: /generate needs an AI provider
+    Given no phpspec.json config
+    And a phpspec.yaml config:
+      """
+      spec_path: spec
+      """
+    When I run phpspec pair with input "/generate a Calculator that adds"
+    Then the output should contain "AI configuration required"
+
+  Scenario: /generate without an instruction shows usage
+    Given no phpspec.json config
+    And a phpspec.yaml config:
+      """
+      spec_path: spec
+      """
+    When I run phpspec pair with input "/generate"
+    Then the output should contain "Usage: /generate"

--- a/features/scenarios/cli/pair-next.feature
+++ b/features/scenarios/cli/pair-next.feature
@@ -14,7 +14,7 @@ Feature: Pair mode next coaches the next step from real suite state
           it('adds numbers', fn() => expect((new Calculator())->add(2, 3))->toBe(5));
       });
       """
-    When I run phpspec pair with input "next"
+    When I run phpspec pair with input "/next"
     Then the output should contain "run"
     And the output should contain "Calculator"
     And the output should not contain "Specification for"
@@ -30,6 +30,6 @@ Feature: Pair mode next coaches the next step from real suite state
           });
       });
       """
-    When I run phpspec pair with input "next"
+    When I run phpspec pair with input "/next"
     Then the output should contain "reconciles entries"
     And the output should not contain "Specification for"

--- a/spec/PhpSpec/Console/Command/Generate.spec.php
+++ b/spec/PhpSpec/Console/Command/Generate.spec.php
@@ -1,0 +1,66 @@
+<?php
+
+use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Generate;
+use PhpSpec\Filesystem;
+use Symfony\Component\Console\Tester\CommandTester;
+
+describe(Generate::class, function () {
+
+    beforeEach(function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        allow($fs->isFile())->toReturn(false);
+        allow($fs->isDir())->toReturn(false);
+        allow($fs->scandir())->toReturn([]);
+    });
+
+    $withAi = function (Filesystem $fs): void {
+        $yamlPath = './phpspec.yaml';
+        allow($fs->exists())->toReturnUsing(fn(string $p) => $p === $yamlPath);
+        allow($fs->read())->toReturnUsing(fn(string $p) => $p === $yamlPath
+            ? "ai:\n  provider: openai\n  api_key: test-key\n"
+            : '');
+    };
+
+    it('errors without AI configuration', function (Filesystem $fs) {
+        $cmd = new Generate(new Configuration('.', $fs));
+        $tester = new CommandTester($cmd);
+
+        $tester->execute(['instruction' => ['a', 'Calc']], ['interactive' => false]);
+
+        expect($tester->getDisplay())->toContain('AI configuration required');
+    });
+
+    it('shows a NEW FILE diff and writes the proposal non-interactively', function (Filesystem $fs) use ($withAi) {
+        $withAi($fs);
+        $written = [];
+        allow($fs->write())->toReturnUsing(function (string $p, string $c) use (&$written) {
+            $written[$p] = $c;
+        });
+        allow($fs->mkdir())->toReturn(null);
+
+        $fn = fn(array $ai, string $context) => json_encode(['path' => 'src/App/Calc.php', 'content' => "<?php\nclass Calc {}"]);
+        $cmd = new Generate(new Configuration('.', $fs), $fs, $fn);
+        $tester = new CommandTester($cmd);
+
+        $tester->execute(['instruction' => ['a', 'Calc', 'class']], ['interactive' => false]);
+
+        $out = $tester->getDisplay();
+        expect($out)->toContain('[NEW FILE]');
+        expect($out)->toContain('src/App/Calc.php');
+        expect($out)->toContain('Created');
+        expect($written)->toHaveLength(1);
+        expect(array_values($written)[0])->toContain('class Calc');
+    });
+
+    it('reports when nothing could be generated', function (Filesystem $fs) use ($withAi) {
+        $withAi($fs);
+        $cmd = new Generate(new Configuration('.', $fs), $fs, fn() => null);
+        $tester = new CommandTester($cmd);
+
+        $tester->execute(['instruction' => ['x']], ['interactive' => false]);
+
+        expect($tester->getDisplay())->toContain('Could not generate');
+    });
+
+});

--- a/spec/PhpSpec/Console/Command/Generate/GenerateAgent.spec.php
+++ b/spec/PhpSpec/Console/Command/Generate/GenerateAgent.spec.php
@@ -54,25 +54,18 @@ describe(GenerateAgent::class, function () {
         expect($agent->propose($this->aiConfig, 'x'))->toBeNull();
     });
 
-    it('rejects a spec edit that would drop an example', function (Filesystem $fs) {
+    it('proposes a spec rewrite, leaving any example change for the diff to reveal', function (Filesystem $fs) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturn('<?php describe("X", function () { it("a", fn() => null); it("b", fn() => null); });');
+        // Even a rewrite that removes an example is proposed — the diff + confirm is the safety net.
         $fn = fn() => json_encode(['path' => 'spec/App/X.spec.php', 'content' => '<?php describe("X", function () { it("a", fn() => null); });']);
         $agent = new GenerateAgent($this->config, $fs, $fn);
 
-        expect($agent->propose($this->aiConfig, 'rewrite'))->toBeNull();
-    });
-
-    it('allows a spec edit that keeps the example count', function (Filesystem $fs) {
-        allow($fs->exists())->toReturn(true);
-        allow($fs->read())->toReturn('<?php describe("X", function () { it("a", fn() => null); });');
-        $fn = fn() => json_encode(['path' => 'spec/App/X.spec.php', 'content' => '<?php describe("X", function () { it("returns zero", fn() => expect(1)->toBe(0)); });']);
-        $agent = new GenerateAgent($this->config, $fs, $fn);
-
-        $proposal = $agent->propose($this->aiConfig, 'rewrite');
+        $proposal = $agent->propose($this->aiConfig, 'remove the b example');
 
         expect($proposal)->not()->toBeNull();
-        expect($proposal['new'])->toContain('returns zero');
+        expect($proposal['old'])->toContain('it("b"');
+        expect($proposal['new'])->not()->toContain('it("b"');
     });
 
     it('feeds the AI the project tree and the files the instruction names', function (Filesystem $fs) {

--- a/spec/PhpSpec/Console/Command/Generate/GenerateAgent.spec.php
+++ b/spec/PhpSpec/Console/Command/Generate/GenerateAgent.spec.php
@@ -1,0 +1,112 @@
+<?php
+
+use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Generate\GenerateAgent;
+use PhpSpec\Filesystem;
+
+describe(GenerateAgent::class, function () {
+
+    beforeEach(function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        allow($fs->isFile())->toReturn(false);
+        allow($fs->isDir())->toReturn(false);
+        allow($fs->scandir())->toReturn([]);
+    });
+
+    let('config', fn(Filesystem $fs) => new Configuration('.', $fs));
+    let('aiConfig', fn() => ['provider' => 'openai', 'api_key' => 'test-key']);
+
+    it('proposes a new file from an instruction', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        $fn = fn(array $ai, string $context) => json_encode(['path' => 'src/App/Calc.php', 'content' => "<?php\nclass Calc {}"]);
+        $agent = new GenerateAgent($this->config, $fs, $fn);
+
+        $proposal = $agent->propose($this->aiConfig, 'a Calc class');
+
+        expect($proposal['path'])->toBe('src/App/Calc.php');
+        expect($proposal['new'])->toContain('class Calc');
+        expect($proposal['isNew'])->toBe(true);
+        expect($proposal['old'])->toBe('');
+    });
+
+    it('carries the existing content for a modified file', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("<?php\n// old");
+        $fn = fn() => json_encode(['path' => 'src/App/Calc.php', 'content' => "<?php\n// new"]);
+        $agent = new GenerateAgent($this->config, $fs, $fn);
+
+        $proposal = $agent->propose($this->aiConfig, 'change Calc');
+
+        expect($proposal['isNew'])->toBe(false);
+        expect($proposal['old'])->toBe("<?php\n// old");
+        expect($proposal['new'])->toBe("<?php\n// new");
+    });
+
+    it('returns null when the AI produces nothing usable', function (Filesystem $fs) {
+        $agent = new GenerateAgent($this->config, $fs, fn() => null);
+
+        expect($agent->propose($this->aiConfig, 'x'))->toBeNull();
+    });
+
+    it('returns null when the AI reply is not valid JSON', function (Filesystem $fs) {
+        $agent = new GenerateAgent($this->config, $fs, fn() => 'sorry, I could not do that');
+
+        expect($agent->propose($this->aiConfig, 'x'))->toBeNull();
+    });
+
+    it('rejects a spec edit that would drop an example', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn('<?php describe("X", function () { it("a", fn() => null); it("b", fn() => null); });');
+        $fn = fn() => json_encode(['path' => 'spec/App/X.spec.php', 'content' => '<?php describe("X", function () { it("a", fn() => null); });']);
+        $agent = new GenerateAgent($this->config, $fs, $fn);
+
+        expect($agent->propose($this->aiConfig, 'rewrite'))->toBeNull();
+    });
+
+    it('allows a spec edit that keeps the example count', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn('<?php describe("X", function () { it("a", fn() => null); });');
+        $fn = fn() => json_encode(['path' => 'spec/App/X.spec.php', 'content' => '<?php describe("X", function () { it("returns zero", fn() => expect(1)->toBe(0)); });']);
+        $agent = new GenerateAgent($this->config, $fs, $fn);
+
+        $proposal = $agent->propose($this->aiConfig, 'rewrite');
+
+        expect($proposal)->not()->toBeNull();
+        expect($proposal['new'])->toContain('returns zero');
+    });
+
+    it('feeds the AI the project tree and the files the instruction names', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $p) => str_ends_with($p, 'src') || str_ends_with($p, 'spec') || str_ends_with($p, 'Calc.php') || str_ends_with($p, 'Calc.spec.php'));
+        allow($fs->isDir())->toReturnUsing(fn(string $p) => str_ends_with($p, 'src') || str_ends_with($p, 'spec'));
+        allow($fs->scandir())->toReturn(['Calc.php']);
+        allow($fs->read())->toReturn('<?php class Calc {}');
+
+        $captured = '';
+        $chatFn = function (array $ai, string $context) use (&$captured) {
+            $captured = $context;
+
+            return json_encode(['path' => 'src/Calc.php', 'content' => '<?php // updated']);
+        };
+        $agent = new GenerateAgent($this->config, $fs, $chatFn);
+
+        $agent->propose($this->aiConfig, 'change Calc to do something');
+
+        expect($captured)->toContain('change Calc to do something');
+        expect($captured)->toContain('Calc.php');
+    });
+
+    it('writes the proposal content to the filesystem', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        $written = [];
+        allow($fs->write())->toReturnUsing(function (string $p, string $c) use (&$written) {
+            $written[$p] = $c;
+        });
+        $agent = new GenerateAgent($this->config, $fs);
+
+        $agent->write(['path' => 'src/App/Calc.php', 'old' => '', 'new' => "<?php\nclass Calc {}", 'isNew' => false]);
+
+        expect($written)->toHaveLength(1);
+        expect(array_values($written)[0])->toContain('class Calc');
+    });
+
+});

--- a/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
@@ -3,6 +3,7 @@
 use PhpSpec\CodeGeneration\ClassGenerator;
 use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Generate\GenerateAgent;
 use PhpSpec\Console\Command\Pair\CommandDispatcher;
 use PhpSpec\Console\Command\Pair\PairOutput;
 use PhpSpec\Console\Command\Pair\SpecRunner;
@@ -33,6 +34,7 @@ describe(CommandDispatcher::class, function () {
         allow($fs->exists())->toReturn(false);
         allow($fs->isFile())->toReturn(false);
         allow($fs->isDir())->toReturn(false);
+        allow($fs->scandir())->toReturn([]);
     });
 
     let('buffer', fn() => new BufferedOutput());
@@ -51,13 +53,13 @@ describe(CommandDispatcher::class, function () {
 
     it('instantiates', fn() => expect($this->dispatcher)->toBeAnInstanceOf(CommandDispatcher::class));
 
-    it('normalises slash paths to namespaced classes in describe', function (Filesystem $fs) {
+    it('normalises slash paths to namespaced classes in /describe', function (Filesystem $fs) {
         $written = [];
         allow($fs->write())->toReturnUsing(function (string $path, string $content) use (&$written) {
             $written[$path] = $content;
         });
 
-        $this->dispatcher->dispatch('describe App/Basket');
+        $this->dispatcher->dispatch('/describe App/Basket');
 
         $classContents = implode("\n", array_filter(
             $written,
@@ -91,24 +93,24 @@ describe(CommandDispatcher::class, function () {
         expect($this->dispatcher->dispatch(''))->toBe(CommandDispatcher::CONTINUE);
     });
 
-    it('returns CONTINUE for unknown command', function () {
-        expect($this->dispatcher->dispatch('foobar'))->toBe(CommandDispatcher::CONTINUE);
+    it('returns CONTINUE for an unknown slash command', function () {
+        expect($this->dispatcher->dispatch('/foobar'))->toBe(CommandDispatcher::CONTINUE);
     });
 
-    it('shows error for unknown command', function () {
-        $this->dispatcher->dispatch('foobar');
+    it('shows an error for an unknown slash command', function () {
+        $this->dispatcher->dispatch('/foobar');
         $output = $this->buffer->fetch();
-        expect($output)->toContain('Unknown command: foobar');
+        expect($output)->toContain('Unknown command: /foobar');
     });
 
-    it('returns CONTINUE for clear command', function () {
-        expect($this->dispatcher->dispatch('clear'))->toBe(CommandDispatcher::CONTINUE);
+    it('returns CONTINUE for /clear', function () {
+        expect($this->dispatcher->dispatch('/clear'))->toBe(CommandDispatcher::CONTINUE);
     });
 
-    it('shows error when describe is missing argument', function () {
-        $this->dispatcher->dispatch('describe');
+    it('shows error when /describe is missing argument', function () {
+        $this->dispatcher->dispatch('/describe');
         $output = $this->buffer->fetch();
-        expect($output)->toContain('Usage: describe');
+        expect($output)->toContain('Usage: /describe');
     });
 
     it('describe auto-generates spec and shows confirmation', function (Filesystem $fs) {
@@ -119,7 +121,7 @@ describe(CommandDispatcher::class, function () {
         allow($fs->mkdir())->toReturn(null);
         allow($fs->write())->toReturn(null);
 
-        $result = $this->dispatcher->dispatch('describe Acme\Greeter');
+        $result = $this->dispatcher->dispatch('/describe Acme\Greeter');
         expect($result)->toBe(CommandDispatcher::CONTINUE);
         $output = $this->buffer->fetch();
         expect($output)->toContain('Specification for');
@@ -132,7 +134,7 @@ describe(CommandDispatcher::class, function () {
         allow($fs->mkdir())->toReturn(null);
         allow($fs->write())->toReturn(null);
 
-        $this->dispatcher->dispatch('describe Acme\Greeter');
+        $this->dispatcher->dispatch('/describe Acme\Greeter');
         $output = $this->buffer->fetch();
         expect($output)->toContain('Do you want me to create class');
     });
@@ -145,7 +147,7 @@ describe(CommandDispatcher::class, function () {
         allow($fs->mkdir())->toReturn(null);
         allow($fs->write())->toReturn(null);
 
-        $this->dispatcher->dispatch('describe Acme\Greeter');
+        $this->dispatcher->dispatch('/describe Acme\Greeter');
         $output = $this->buffer->fetch();
         expect($output)->toContain('Do you want me to create class');
     });
@@ -155,7 +157,7 @@ describe(CommandDispatcher::class, function () {
         allow($fs->mkdir())->toReturn(null);
         allow($fs->write())->toReturn(null);
 
-        $this->dispatcher->dispatch('describe Acme\Greeter');
+        $this->dispatcher->dispatch('/describe Acme\Greeter');
         $output = $this->buffer->fetch();
         expect($output)->toContain('Do you want to run specs now');
     });
@@ -163,7 +165,7 @@ describe(CommandDispatcher::class, function () {
     it('describe shows existing spec message when spec exists', function (Filesystem $fs) {
         allow($fs->exists())->toReturnUsing(fn(string $p) => str_ends_with($p, '.spec.php'));
 
-        $this->dispatcher->dispatch('describe Acme\Greeter');
+        $this->dispatcher->dispatch('/describe Acme\Greeter');
         $output = $this->buffer->fetch();
         expect($output)->toContain('Spec already exists');
     });
@@ -181,7 +183,7 @@ describe(CommandDispatcher::class, function () {
         allow($fs->write())->toReturn(null);
         allow($fs->read())->toReturn("<?php\n// spec content");
 
-        $this->dispatcher->dispatch('describe Acme\Greeter');
+        $this->dispatcher->dispatch('/describe Acme\Greeter');
         $output = $this->buffer->fetch();
         expect($output)->toContain('[NEW FILE]');
         expect($output)->toContain('spec content');
@@ -204,21 +206,21 @@ describe(CommandDispatcher::class, function () {
         allow($fs->write())->toReturn(null);
         allow($fs->read())->toReturn("<?php\nclass Greeter {}");
 
-        $this->dispatcher->dispatch('describe Acme\Greeter');
+        $this->dispatcher->dispatch('/describe Acme\Greeter');
         $output = $this->buffer->fetch();
         expect($output)->toContain('class Greeter');
     });
 
-    it('shows error when exemplify is missing arguments', function () {
-        $this->dispatcher->dispatch('exemplify');
+    it('shows error when /exemplify is missing arguments', function () {
+        $this->dispatcher->dispatch('/exemplify');
         $output = $this->buffer->fetch();
-        expect($output)->toContain('Usage: exemplify');
+        expect($output)->toContain('Usage: /exemplify');
     });
 
-    it('shows error when exemplify is missing method argument', function () {
-        $this->dispatcher->dispatch('exemplify Acme\Calculator');
+    it('shows error when /exemplify is missing method argument', function () {
+        $this->dispatcher->dispatch('/exemplify Acme\Calculator');
         $output = $this->buffer->fetch();
-        expect($output)->toContain('Usage: exemplify');
+        expect($output)->toContain('Usage: /exemplify');
     });
 
     it('exemplify adds example and shows confirmation', function (Filesystem $fs) {
@@ -230,7 +232,7 @@ describe(CommandDispatcher::class, function () {
         allow($fs->write())->toReturn(null);
         allow($fs->read())->toReturn("<?php\ndescribe(Calculator::class, function() {\n});");
 
-        $result = $this->dispatcher->dispatch('exemplify Acme\Calculator add');
+        $result = $this->dispatcher->dispatch('/exemplify Acme\Calculator add');
         expect($result)->toBe(CommandDispatcher::CONTINUE);
         $output = $this->buffer->fetch();
         expect($output)->toContain('Example for');
@@ -243,7 +245,7 @@ describe(CommandDispatcher::class, function () {
         allow($fs->write())->toReturn(null);
         allow($fs->read())->toReturn("<?php\ndescribe(Calculator::class, function() {\n});");
 
-        $this->dispatcher->dispatch('exemplify Acme\Calculator add');
+        $this->dispatcher->dispatch('/exemplify Acme\Calculator add');
         $output = $this->buffer->fetch();
         expect($output)->toContain('Specification for');
     });
@@ -252,84 +254,129 @@ describe(CommandDispatcher::class, function () {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturn("<?php\ndescribe(Calculator::class, function() {\n    it(\"should add\", fn() => expect(\$this->calculator->add())->toBe(null));\n});");
 
-        $this->dispatcher->dispatch('exemplify Acme\Calculator add');
+        $this->dispatcher->dispatch('/exemplify Acme\Calculator add');
         $output = $this->buffer->fetch();
         expect($output)->toContain('already exists');
         expect($fs->write('', ''))->not()->toBeCalled();
     });
 
-    it('runs specs with run command', function () {
-        $result = $this->dispatcher->dispatch('run');
+    it('runs specs with /run', function () {
+        $result = $this->dispatcher->dispatch('/run');
         expect($result)->toBe(CommandDispatcher::CONTINUE);
         expect($this->specRunner->arguments)->toBe(['']);
     });
 
-    it('runs specs at specific path with run command', function () {
-        $result = $this->dispatcher->dispatch('run spec/NonExistent');
+    it('runs specs at a specific path with /run', function () {
+        $result = $this->dispatcher->dispatch('/run spec/NonExistent');
         expect($result)->toBe(CommandDispatcher::CONTINUE);
         expect($this->specRunner->arguments)->toBe(['spec/NonExistent']);
     });
 
-    context('smart command routing without AI', function () {
-        it('falls through to run command for multi-word argument without AI', function () {
-            $result = $this->dispatcher->dispatch('run the scenarios and fix them');
+    context('slash marks a command; anything else is an AI prompt', function () {
+        it('runs a slash command with a path argument', function () {
+            $result = $this->dispatcher->dispatch('/run spec/App');
             expect($result)->toBe(CommandDispatcher::CONTINUE);
-            $output = $this->buffer->fetch();
-            // Without AI, shouldRouteToAi returns false, so it goes to handleRun
-            expect($output)->not()->toContain('Unknown command');
+            expect($this->specRunner->arguments)->toBe(['spec/App']);
         });
 
-        it('routes single-word run argument as run command', function () {
-            $result = $this->dispatcher->dispatch('run spec/App');
-            expect($result)->toBe(CommandDispatcher::CONTINUE);
-        });
-
-        it('routes unrecognized input to AI fallback', function () {
-            $this->dispatcher->dispatch('hello world');
+        it('routes non-slash prose to the AI (unknown fallback without AI)', function () {
+            $this->dispatcher->dispatch('run the scenarios and fix them');
             $output = $this->buffer->fetch();
-            // Without AI, handleAi falls back to handleUnknown with config hint
+            // No leading slash → an AI prompt; with no AI it degrades to the hint.
             expect($output)->toContain('Unknown command');
             expect($output)->toContain('configure an AI provider');
         });
 
-        it('routes single-word describe argument as describe command', function (Filesystem $fs) {
+        it('routes a bare command word (no slash) to the AI, not the command', function () {
+            $this->dispatcher->dispatch('describe Acme\\Foo');
+            $output = $this->buffer->fetch();
+            // `describe` without a slash is prose now, so no spec is generated.
+            expect($output)->not()->toContain('Specification for');
+            expect($this->specRunner->arguments)->toBe([]);
+        });
+
+        it('routes unrecognized prose to the AI fallback', function () {
+            $this->dispatcher->dispatch('hello world');
+            $output = $this->buffer->fetch();
+            expect($output)->toContain('Unknown command');
+            expect($output)->toContain('configure an AI provider');
+        });
+    });
+
+    context('/generate (AI-required)', function () {
+        it('shows usage when /generate has no instruction', function () {
+            $this->dispatcher->dispatch('/generate');
+            expect($this->buffer->fetch())->toContain('Usage: /generate');
+        });
+
+        it('requires AI configuration', function () {
+            $this->dispatcher->dispatch('/generate build a Calculator');
+            expect($this->buffer->fetch())->toContain('AI configuration required');
+        });
+
+        it('shows a diff and writes the proposal once confirmed', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p) => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p) => $p === $yamlPath ? "ai:\n  provider: openai\n  api_key: k\n" : '');
+            allow($fs->mkdir())->toReturn(null);
+            $written = [];
+            allow($fs->write())->toReturnUsing(function (string $p, string $c) use (&$written) {
+                $written[$p] = $c;
+            });
+
+            $config = new Configuration('.', $fs);
+            $agent = new GenerateAgent($config, $fs, fn() => json_encode(['path' => 'src/App/Calc.php', 'content' => "<?php\nclass Calc {}"]));
+            $dispatcher = new CommandDispatcher(
+                new SpecGenerator('spec', $fs),
+                new ClassGenerator('src', $fs),
+                $config,
+                $this->pairOutput,
+                false,
+                $fs,
+                generateAgent: $agent,
+            );
+
+            $dispatcher->dispatch('/generate a Calc class');
+
+            $out = $this->buffer->fetch();
+            expect($out)->toContain('[NEW FILE]');
+            expect($written)->toHaveLength(1);
+            expect(array_values($written)[0])->toContain('class Calc');
+        });
+    });
+
+    context('next-command suggestion (ghost hint)', function () {
+        it('suggests running the new spec after /describe', function (Filesystem $fs) {
             allow($fs->exists())->toReturn(false);
             allow($fs->mkdir())->toReturn(null);
             allow($fs->write())->toReturn(null);
 
-            $this->dispatcher->dispatch('describe Acme\\Foo');
-            $output = $this->buffer->fetch();
-            expect($output)->not()->toContain('Unknown command');
-        });
-    });
+            $this->dispatcher->dispatch('/describe App/Basket');
 
-    context('exceedsCommandArgLimit', function () {
-        it('returns false for run with single argument', function () {
-            expect(CommandDispatcher::exceedsCommandArgLimit('run', 'spec/App'))->toBeFalse();
+            expect($this->dispatcher->suggestion())->toBe('/run spec/App/Basket.spec.php');
         });
 
-        it('returns true for run with multiple arguments', function () {
-            expect(CommandDispatcher::exceedsCommandArgLimit('run', 'the scenarios and fix them'))->toBeTrue();
+        it('suggests /next after /run', function () {
+            $this->dispatcher->dispatch('/run');
+
+            expect($this->dispatcher->suggestion())->toBe('/next');
         });
 
-        it('returns false for describe with single argument', function () {
-            expect(CommandDispatcher::exceedsCommandArgLimit('describe', 'Acme\\Foo'))->toBeFalse();
+        it('suggests /run after /exemplify', function (Filesystem $fs) {
+            allow($fs->exists())->toReturn(true);
+            allow($fs->read())->toReturn("<?php\ndescribe(Calculator::class, function() {\n});");
+            allow($fs->write())->toReturn(null);
+
+            $this->dispatcher->dispatch('/exemplify App/Calc add');
+
+            expect($this->dispatcher->suggestion())->toBe('/run');
         });
 
-        it('returns true for describe with multiple arguments', function () {
-            expect(CommandDispatcher::exceedsCommandArgLimit('describe', 'a calculator class'))->toBeTrue();
-        });
+        it('clears the suggestion after a non-command prompt', function () {
+            $this->dispatcher->dispatch('/run');
+            $this->dispatcher->dispatch('hello there');
 
-        it('returns false for exemplify with two arguments', function () {
-            expect(CommandDispatcher::exceedsCommandArgLimit('exemplify', 'Acme\\Foo bar'))->toBeFalse();
-        });
-
-        it('returns true for exemplify with more than two arguments', function () {
-            expect(CommandDispatcher::exceedsCommandArgLimit('exemplify', 'a class that does things'))->toBeTrue();
-        });
-
-        it('returns false for unknown command', function () {
-            expect(CommandDispatcher::exceedsCommandArgLimit('unknown', 'some args here'))->toBeFalse();
+            expect($this->dispatcher->suggestion())->toBeNull();
         });
     });
 
@@ -378,18 +425,18 @@ describe(CommandDispatcher::class, function () {
             specRunner: $this->specRunner,
         ));
 
-        it('handles a bare next from suite state and returns CONTINUE', function () {
-            $result = $this->appDispatcher->dispatch('next');
+        it('handles /next from suite state and returns CONTINUE', function () {
+            $result = $this->appDispatcher->dispatch('/next');
             expect($result)->toBe(CommandDispatcher::CONTINUE);
         });
 
-        it('delegates refactor with argument', function () {
-            $result = $this->appDispatcher->dispatch('refactor App\\Calculator');
+        it('delegates /refactor with argument', function () {
+            $result = $this->appDispatcher->dispatch('/refactor App\\Calculator');
             expect($result)->toBe(CommandDispatcher::CONTINUE);
         });
 
-        it('routes next with natural language to unknown when no AI', function () {
-            $this->appDispatcher->dispatch('next what should I build');
+        it('routes non-slash prose to unknown when no AI', function () {
+            $this->appDispatcher->dispatch('what should I build next');
             $output = $this->buffer->fetch();
             expect($output)->toContain('Unknown command');
         });
@@ -414,21 +461,21 @@ describe(CommandDispatcher::class, function () {
             expect($output)->not()->toMatch('/Additional commands.*pair/s');
         });
 
-        it('silently ignores pair command input', function () {
+        it('silently ignores /pair command input', function () {
             $this->app->{method_exists($this->app, 'addCommand') ? 'addCommand' : 'add'}(new \PhpSpec\Console\Command\Pair(
                 new SpecGenerator('spec'),
                 new ClassGenerator('src'),
                 new Configuration('.'),
             ));
-            $result = $this->appDispatcher->dispatch('pair');
+            $result = $this->appDispatcher->dispatch('/pair');
             expect($result)->toBe(CommandDispatcher::CONTINUE);
             $output = $this->buffer->fetch();
             expect($output)->not()->toContain('Unknown command');
         });
 
-        it('shows error when delegated command fails', function () {
-            // refactor without required arg triggers an exception in bind
-            $result = $this->appDispatcher->dispatch('refactor');
+        it('shows error when a delegated command fails', function () {
+            // /refactor without its required arg triggers an exception in bind
+            $result = $this->appDispatcher->dispatch('/refactor');
             expect($result)->toBe(CommandDispatcher::CONTINUE);
             $output = $this->buffer->fetch();
             expect($output)->toContain('Not enough arguments');

--- a/spec/PhpSpec/Console/Command/Pair/LineEditor.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/LineEditor.spec.php
@@ -19,49 +19,49 @@ describe(LineEditor::class, function () {
     it('returns the typed characters on Enter', function () use ($keying) {
         $editor = $keying($this->pairOutput, ['h', 'i', "\n"]);
 
-        expect($editor->readLine('> '))->toBe('hi');
+        expect($editor->readLine('❯ '))->toBe('hi');
     });
 
     it('accepts the suggestion with the Right arrow', function () use ($keying) {
         $editor = $keying($this->pairOutput, ["\033[C", "\n"]);
 
-        expect($editor->readLine('> ', '/run spec/App/Todo.spec.php'))->toBe('/run spec/App/Todo.spec.php');
+        expect($editor->readLine('❯ ', '/run spec/App/Todo.spec.php'))->toBe('/run spec/App/Todo.spec.php');
     });
 
     it('accepts the suggestion with Tab', function () use ($keying) {
         $editor = $keying($this->pairOutput, ["\t", "\n"]);
 
-        expect($editor->readLine('> ', '/next'))->toBe('/next');
+        expect($editor->readLine('❯ ', '/next'))->toBe('/next');
     });
 
     it('lets typing dismiss the suggestion', function () use ($keying) {
         $editor = $keying($this->pairOutput, ['x', "\n"]);
 
-        expect($editor->readLine('> ', '/next'))->toBe('x');
+        expect($editor->readLine('❯ ', '/next'))->toBe('x');
     });
 
     it('deletes the last character on backspace', function () use ($keying) {
         $editor = $keying($this->pairOutput, ['a', 'b', "\177", "\n"]);
 
-        expect($editor->readLine('> '))->toBe('a');
+        expect($editor->readLine('❯ '))->toBe('a');
     });
 
     it('returns null when cancelled with Ctrl-C', function () use ($keying) {
         $editor = $keying($this->pairOutput, ['a', "\003"]);
 
-        expect($editor->readLine('> '))->toBeNull();
+        expect($editor->readLine('❯ '))->toBeNull();
     });
 
     it('recalls the most recent line with the Up arrow', function () use ($keying) {
         $editor = $keying($this->pairOutput, ["\033[A", "\n"]);
 
-        expect($editor->readLine('> ', null, ['/run', '/describe App/Todo']))->toBe('/describe App/Todo');
+        expect($editor->readLine('❯ ', null, ['/run', '/describe App/Todo']))->toBe('/describe App/Todo');
     });
 
     it('renders the suggestion dimmed', function () use ($keying) {
         $editor = $keying($this->pairOutput, ["\n"]);
 
-        $editor->readLine('> ', '/next');
+        $editor->readLine('❯ ', '/next');
 
         expect($this->buffer->fetch())->toContain("\033[2m");
     });
@@ -69,7 +69,7 @@ describe(LineEditor::class, function () {
     it('reads a whole line without a ghost when not a TTY', function () {
         $editor = new LineEditor($this->pairOutput, fn(): ?string => 'hello world');
 
-        expect($editor->readLine('> ', '/next'))->toBe('hello world');
+        expect($editor->readLine('❯ ', '/next'))->toBe('hello world');
     });
 
 });

--- a/spec/PhpSpec/Console/Command/Pair/LineEditor.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/LineEditor.spec.php
@@ -1,0 +1,75 @@
+<?php
+
+use PhpSpec\Console\Command\Pair\LineEditor;
+use PhpSpec\Console\Command\Pair\PairOutput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+describe(LineEditor::class, function () {
+
+    let('buffer', fn() => new BufferedOutput());
+    let('pairOutput', fn() => new PairOutput($this->buffer));
+
+    // Builds a LineEditor whose key reader replays a fixed token sequence.
+    $keying = function (PairOutput $output, array $seq): LineEditor {
+        return new LineEditor($output, null, function () use (&$seq) {
+            return array_shift($seq) ?? "\n";
+        });
+    };
+
+    it('returns the typed characters on Enter', function () use ($keying) {
+        $editor = $keying($this->pairOutput, ['h', 'i', "\n"]);
+
+        expect($editor->readLine('> '))->toBe('hi');
+    });
+
+    it('accepts the suggestion with the Right arrow', function () use ($keying) {
+        $editor = $keying($this->pairOutput, ["\033[C", "\n"]);
+
+        expect($editor->readLine('> ', '/run spec/App/Todo.spec.php'))->toBe('/run spec/App/Todo.spec.php');
+    });
+
+    it('accepts the suggestion with Tab', function () use ($keying) {
+        $editor = $keying($this->pairOutput, ["\t", "\n"]);
+
+        expect($editor->readLine('> ', '/next'))->toBe('/next');
+    });
+
+    it('lets typing dismiss the suggestion', function () use ($keying) {
+        $editor = $keying($this->pairOutput, ['x', "\n"]);
+
+        expect($editor->readLine('> ', '/next'))->toBe('x');
+    });
+
+    it('deletes the last character on backspace', function () use ($keying) {
+        $editor = $keying($this->pairOutput, ['a', 'b', "\177", "\n"]);
+
+        expect($editor->readLine('> '))->toBe('a');
+    });
+
+    it('returns null when cancelled with Ctrl-C', function () use ($keying) {
+        $editor = $keying($this->pairOutput, ['a', "\003"]);
+
+        expect($editor->readLine('> '))->toBeNull();
+    });
+
+    it('recalls the most recent line with the Up arrow', function () use ($keying) {
+        $editor = $keying($this->pairOutput, ["\033[A", "\n"]);
+
+        expect($editor->readLine('> ', null, ['/run', '/describe App/Todo']))->toBe('/describe App/Todo');
+    });
+
+    it('renders the suggestion dimmed', function () use ($keying) {
+        $editor = $keying($this->pairOutput, ["\n"]);
+
+        $editor->readLine('> ', '/next');
+
+        expect($this->buffer->fetch())->toContain("\033[2m");
+    });
+
+    it('reads a whole line without a ghost when not a TTY', function () {
+        $editor = new LineEditor($this->pairOutput, fn(): ?string => 'hello world');
+
+        expect($editor->readLine('> ', '/next'))->toBe('hello world');
+    });
+
+});

--- a/spec/PhpSpec/Console/Command/Pair/Repl.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/Repl.spec.php
@@ -1,0 +1,66 @@
+<?php
+
+use PhpSpec\CodeGeneration\ClassGenerator;
+use PhpSpec\CodeGeneration\SpecGenerator;
+use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Pair\CommandDispatcher;
+use PhpSpec\Console\Command\Pair\LineEditor;
+use PhpSpec\Console\Command\Pair\PairOutput;
+use PhpSpec\Console\Command\Pair\Repl;
+use PhpSpec\Console\Command\Pair\SpecRunner;
+use PhpSpec\Console\Command\Run\RunOutcome;
+use PhpSpec\Filesystem;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReplFakeRunner implements SpecRunner
+{
+    public function run(string $argument, OutputInterface $output): ?RunOutcome
+    {
+        return null;
+    }
+}
+
+describe(Repl::class, function () {
+
+    beforeEach(function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        allow($fs->isFile())->toReturn(false);
+        allow($fs->isDir())->toReturn(false);
+        allow($fs->scandir())->toReturn([]);
+    });
+
+    let('buffer', fn() => new BufferedOutput());
+    let('pairOutput', fn() => new PairOutput($this->buffer));
+    let('dispatcher', fn(Filesystem $fs) => new CommandDispatcher(
+        new SpecGenerator('spec', $fs),
+        new ClassGenerator('src', $fs),
+        new Configuration('.', $fs),
+        $this->pairOutput,
+        false,
+        $fs,
+        specRunner: new ReplFakeRunner(),
+    ));
+
+    // A LineEditor whose line reader replays a script, then EOF (null → break).
+    $scripted = function (PairOutput $out, array $lines): LineEditor {
+        return new LineEditor($out, function () use (&$lines) {
+            return array_shift($lines);
+        });
+    };
+
+    it('reads a line, dispatches it, and exits cleanly on EOF', function () use ($scripted) {
+        $repl = new Repl($this->dispatcher, $this->pairOutput, false, $scripted($this->pairOutput, ['/help']));
+
+        expect($repl->run())->toBe(0);
+        expect($this->buffer->fetch())->toContain('Available commands');
+    });
+
+    it('quits on /quit', function () use ($scripted) {
+        $repl = new Repl($this->dispatcher, $this->pairOutput, false, $scripted($this->pairOutput, ['/quit']));
+
+        expect($repl->run())->toBe(0);
+        expect($this->buffer->fetch())->toContain('Goodbye');
+    });
+
+});

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -19,6 +19,7 @@ use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Describe;
 use PhpSpec\Console\Command\Exemplify;
+use PhpSpec\Console\Command\Generate;
 use PhpSpec\Console\Command\Next;
 use PhpSpec\Console\Command\Pair;
 use PhpSpec\Console\Command\Refactor;
@@ -109,6 +110,7 @@ final class Application extends BaseApplication
         );
         $defaultCommands[] = new Refactor($config);
         $defaultCommands[] = new Next($config);
+        $defaultCommands[] = new Generate($config);
 
         foreach ($extensionLoader->getCommands() as $cmd) {
             $defaultCommands[] = $cmd;

--- a/src/PhpSpec/Console/Command/Generate.php
+++ b/src/PhpSpec/Console/Command/Generate.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Command;
+
+use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Generate\GenerateAgent;
+use PhpSpec\Console\Command\Refactor\Diff;
+use PhpSpec\Filesystem;
+use PhpSpec\RealFilesystem;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument as Argument;
+use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Output\OutputInterface as Output;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * @internal
+ * CLI command that turns a natural-language instruction into one file edit —
+ * a spec example or a piece of implementation code — authored by the AI, shown
+ * as a diff, and written after a confirmation. Requires an AI provider.
+ */
+final class Generate extends Command
+{
+    private Filesystem $filesystem;
+
+    /** @var (callable(array{provider: string, model?: string, api_key: string}, string): (array{path: string, content: string}|null))|null */
+    private $generateFn;
+
+    /**
+     * @param Configuration $config
+     * @param Filesystem|null $filesystem
+     * @param (callable(array{provider: string, model?: string, api_key: string}, string): (array{path: string, content: string}|null))|null $generateFn injectable AI seam for specs
+     */
+    public function __construct(
+        private readonly Configuration $config,
+        ?Filesystem $filesystem = null,
+        ?callable $generateFn = null,
+    ) {
+        $this->filesystem = $filesystem ?? new RealFilesystem();
+        $this->generateFn = $generateFn;
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('generate')
+            ->setDescription('Generate a spec example or code from a natural-language instruction (requires AI)')
+            ->addArgument('instruction', Argument::IS_ARRAY, 'What to build, in plain English');
+    }
+
+    protected function execute(Input $input, Output $output): int
+    {
+        $aiConfig = $this->config->getAiConfig();
+        if ($aiConfig === null) {
+            $output->writeln('<fg=red>AI configuration required. Add an "ai" section to your phpspec config.</>');
+
+            return 1;
+        }
+
+        $argument = $input->getArgument('instruction');
+        $instruction = trim(implode(' ', is_array($argument) ? $argument : []));
+        if ($instruction === '') {
+            $output->writeln('<fg=red>Usage: generate <what to build in plain English></>');
+
+            return 1;
+        }
+
+        $output->writeln('');
+        $output->writeln('  <fg=gray>Generating...</>');
+        $output->writeln('');
+
+        $agent = new GenerateAgent($this->config, $this->filesystem, $this->generateFn);
+        $proposal = $agent->propose($aiConfig, $instruction);
+
+        if ($proposal === null) {
+            $output->writeln('  <fg=yellow>Could not generate anything for that instruction. Try rephrasing.</>');
+
+            return 1;
+        }
+
+        $this->showDiff($output, $proposal);
+
+        if ($input->isInteractive() && !$this->confirm($input, $output)) {
+            $output->writeln('  <fg=gray>Left unchanged.</>');
+
+            return 0;
+        }
+
+        $agent->write($proposal);
+        $output->writeln(sprintf('  <fg=green>%s %s</>', $proposal['isNew'] ? 'Created' : 'Updated', $proposal['path']));
+
+        return 0;
+    }
+
+    /**
+     * Renders the proposed change as a labelled unified diff.
+     *
+     * @param array{path: string, old: string, new: string, isNew: bool} $proposal
+     */
+    private function showDiff(Output $output, array $proposal): void
+    {
+        $label = $proposal['isNew'] ? '[NEW FILE]' : '[MODIFIED]';
+        $output->writeln("  <fg=yellow>$label</> <fg=white>{$proposal['path']}</>");
+        $output->writeln('');
+
+        $old = $proposal['old'] === '' ? [] : explode("\n", $proposal['old']);
+        $new = explode("\n", $proposal['new']);
+        $output->writeln(Diff::format(Diff::compute($old, $new)));
+        $output->writeln('');
+    }
+
+    private function confirm(Input $input, Output $output): bool
+    {
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+
+        return (bool) $helper->ask($input, $output, new ConfirmationQuestion('  <fg=yellow>Apply this change?</> [Y/n] ', true));
+    }
+}

--- a/src/PhpSpec/Console/Command/Generate.php
+++ b/src/PhpSpec/Console/Command/Generate.php
@@ -36,21 +36,21 @@ final class Generate extends Command
 {
     private Filesystem $filesystem;
 
-    /** @var (callable(array{provider: string, model?: string, api_key: string}, string): (array{path: string, content: string}|null))|null */
-    private $generateFn;
+    /** @var (callable(array{provider: string, model?: string, api_key: string}, string): (string|null))|null */
+    private $chatFn;
 
     /**
      * @param Configuration $config
      * @param Filesystem|null $filesystem
-     * @param (callable(array{provider: string, model?: string, api_key: string}, string): (array{path: string, content: string}|null))|null $generateFn injectable AI seam for specs
+     * @param (callable(array{provider: string, model?: string, api_key: string}, string): (string|null))|null $chatFn injectable AI seam for specs
      */
     public function __construct(
         private readonly Configuration $config,
         ?Filesystem $filesystem = null,
-        ?callable $generateFn = null,
+        ?callable $chatFn = null,
     ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
-        $this->generateFn = $generateFn;
+        $this->chatFn = $chatFn;
         parent::__construct();
     }
 
@@ -83,7 +83,7 @@ final class Generate extends Command
         $output->writeln('  <fg=gray>Generating...</>');
         $output->writeln('');
 
-        $agent = new GenerateAgent($this->config, $this->filesystem, $this->generateFn);
+        $agent = new GenerateAgent($this->config, $this->filesystem, $this->chatFn);
         $proposal = $agent->propose($aiConfig, $instruction);
 
         if ($proposal === null) {

--- a/src/PhpSpec/Console/Command/Generate/GenerateAgent.php
+++ b/src/PhpSpec/Console/Command/Generate/GenerateAgent.php
@@ -24,8 +24,8 @@ use RuntimeException;
  * @internal
  * Turns a natural-language instruction into a single proposed file edit — a
  * spec example or a piece of implementation code — authored by the AI. It only
- * *proposes*: the caller shows the diff, confirms, and writes. A spec edit that
- * would drop an existing example is rejected, so growing a spec never loses one.
+ * *proposes*: the caller shows the diff, confirms, and writes, so any change
+ * (including one that removes an example) is visible before it lands.
  */
 final class GenerateAgent
 {
@@ -47,7 +47,7 @@ final class GenerateAgent
 
     /**
      * Proposes a single file edit for the instruction, or null when the AI
-     * produced nothing usable (or the edit would drop a spec example).
+     * produced nothing usable.
      *
      * @param array{provider: string, model?: string, api_key: string} $aiConfig
      * @return array{path: string, old: string, new: string, isNew: bool}|null
@@ -68,17 +68,8 @@ final class GenerateAgent
         $fullPath = $this->fullPath($relPath);
         $exists = $this->filesystem->exists($fullPath);
         $old = $exists ? $this->filesystem->read($fullPath) : '';
-        $new = $raw['content'];
 
-        // A spec edit must never drop an example — specs are grown, not shrunk.
-        if ($exists
-            && str_ends_with($relPath, $this->config->getSpecSuffix())
-            && $this->countExamples($new) < $this->countExamples($old)
-        ) {
-            return null;
-        }
-
-        return ['path' => $relPath, 'old' => $old, 'new' => $new, 'isNew' => !$exists];
+        return ['path' => $relPath, 'old' => $old, 'new' => $raw['content'], 'isNew' => !$exists];
     }
 
     /**
@@ -103,15 +94,6 @@ final class GenerateAgent
     private function fullPath(string $relPath): string
     {
         return getcwd() . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relPath);
-    }
-
-    /**
-     * Counts the it()/its() examples in spec source, so a rewrite can be
-     * checked against dropping one.
-     */
-    private function countExamples(string $content): int
-    {
-        return (int) preg_match_all('/\b(?:it|its)\s*\(/', $content);
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Generate/GenerateAgent.php
+++ b/src/PhpSpec/Console/Command/Generate/GenerateAgent.php
@@ -1,0 +1,248 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Command\Generate;
+
+use PhpSpec\Ai\Message;
+use PhpSpec\Ai\ProviderFactory;
+use PhpSpec\Configuration;
+use PhpSpec\Filesystem;
+use RuntimeException;
+
+/**
+ * @internal
+ * Turns a natural-language instruction into a single proposed file edit — a
+ * spec example or a piece of implementation code — authored by the AI. It only
+ * *proposes*: the caller shows the diff, confirms, and writes. A spec edit that
+ * would drop an existing example is rejected, so growing a spec never loses one.
+ */
+final class GenerateAgent
+{
+    /** @var (callable(array{provider: string, model?: string, api_key: string}, string): (string|null))|null the raw AI reply for a built context; injectable for specs */
+    private $chatFn;
+
+    /**
+     * @param Configuration $config the project configuration
+     * @param Filesystem $filesystem the filesystem abstraction
+     * @param (callable(array{provider: string, model?: string, api_key: string}, string): (string|null))|null $chatFn injectable AI-chat seam for specs
+     */
+    public function __construct(
+        private readonly Configuration $config,
+        private readonly Filesystem $filesystem,
+        ?callable $chatFn = null,
+    ) {
+        $this->chatFn = $chatFn;
+    }
+
+    /**
+     * Proposes a single file edit for the instruction, or null when the AI
+     * produced nothing usable (or the edit would drop a spec example).
+     *
+     * @param array{provider: string, model?: string, api_key: string} $aiConfig
+     * @return array{path: string, old: string, new: string, isNew: bool}|null
+     */
+    public function propose(array $aiConfig, string $instruction): ?array
+    {
+        $context = $this->buildContext($instruction);
+        $reply = $this->chatFn !== null
+            ? ($this->chatFn)($aiConfig, $context)
+            : $this->chat($aiConfig, $context);
+
+        $raw = is_string($reply) ? $this->parse($reply) : null;
+        if ($raw === null || $raw['path'] === '' || $raw['content'] === '') {
+            return null;
+        }
+
+        $relPath = ltrim(str_replace('\\', '/', $raw['path']), '/');
+        $fullPath = $this->fullPath($relPath);
+        $exists = $this->filesystem->exists($fullPath);
+        $old = $exists ? $this->filesystem->read($fullPath) : '';
+        $new = $raw['content'];
+
+        // A spec edit must never drop an example — specs are grown, not shrunk.
+        if ($exists
+            && str_ends_with($relPath, $this->config->getSpecSuffix())
+            && $this->countExamples($new) < $this->countExamples($old)
+        ) {
+            return null;
+        }
+
+        return ['path' => $relPath, 'old' => $old, 'new' => $new, 'isNew' => !$exists];
+    }
+
+    /**
+     * Writes an accepted proposal to disk, creating the directory when new.
+     *
+     * @param array{path: string, old: string, new: string, isNew: bool} $proposal
+     */
+    public function write(array $proposal): void
+    {
+        $fullPath = $this->fullPath($proposal['path']);
+        $dir = dirname($fullPath);
+        if ($proposal['isNew'] && !$this->filesystem->exists($dir)) {
+            $this->filesystem->mkdir($dir);
+        }
+
+        $this->filesystem->write($fullPath, $proposal['new']);
+    }
+
+    /**
+     * The absolute path for a project-relative path.
+     */
+    private function fullPath(string $relPath): string
+    {
+        return getcwd() . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relPath);
+    }
+
+    /**
+     * Counts the it()/its() examples in spec source, so a rewrite can be
+     * checked against dropping one.
+     */
+    private function countExamples(string $content): int
+    {
+        return (int) preg_match_all('/\b(?:it|its)\s*\(/', $content);
+    }
+
+    /**
+     * Sends the built context to the AI and returns its raw reply, or null when
+     * no provider can be built.
+     *
+     * @param array{provider: string, model?: string, api_key: string} $aiConfig
+     */
+    private function chat(array $aiConfig, string $context): ?string
+    {
+        try {
+            $provider = ProviderFactory::create($aiConfig);
+        } catch (RuntimeException) {
+            return null;
+        }
+
+        $model = $aiConfig['model'] ?? ProviderFactory::defaultModel($aiConfig['provider']);
+
+        return $provider->chat(
+            [
+                Message::system($this->systemPrompt()),
+                Message::user($context),
+            ],
+            ['model' => $model, 'maxTokens' => 8192, 'temperature' => 0.2],
+        )->text;
+    }
+
+    private function systemPrompt(): string
+    {
+        return <<<'PROMPT'
+        You turn one natural-language instruction into ONE file edit for a phpspec 9 project.
+
+        Return ONLY this JSON, nothing else:
+        {"path": "spec/App/Calculator.spec.php", "content": "<the complete new file content>"}
+
+        - path is project-relative. A spec goes under the spec dir with the .spec.php suffix;
+          implementation code goes under the src dir.
+        - content is the WHOLE file after your change, not a diff.
+        - Specs use the phpspec 9 functional DSL (describe/context/it/let/expect) — never the
+          old ObjectBehavior class syntax. Grow a spec: keep every existing example, add or
+          refine only what the instruction asks for.
+        - Implementation is plain PHP with the smallest change that satisfies the instruction.
+        - Make the smallest change that fulfils the instruction. Do not invent unrelated code.
+        PROMPT;
+    }
+
+    /**
+     * Builds the user message: the instruction, the project file tree, and the
+     * current contents of any spec/source files whose class the instruction names.
+     */
+    private function buildContext(string $instruction): string
+    {
+        $cwd = getcwd();
+        $specPath = ltrim($this->config->getSpecPath(), './');
+        $srcPath = ltrim($this->config->getSrcPath(), './');
+
+        $sections = ["# Instruction\n$instruction"];
+
+        $tree = $this->scanTree($cwd . '/' . $srcPath) . "\n" . $this->scanTree($cwd . '/' . $specPath);
+        if (trim($tree) !== '') {
+            $sections[] = "# Project files\n$tree";
+        }
+
+        foreach ($this->relevantFiles($instruction, $specPath, $srcPath) as $rel => $content) {
+            $sections[] = "# $rel\n$content";
+        }
+
+        return implode("\n\n", $sections);
+    }
+
+    /**
+     * The existing spec/source files for any class-like token in the instruction.
+     *
+     * @return array<string, string> relative path => contents
+     */
+    private function relevantFiles(string $instruction, string $specPath, string $srcPath): array
+    {
+        $files = [];
+        preg_match_all('/\b[A-Z][A-Za-z0-9]+\b/', $instruction, $matches);
+
+        foreach (array_unique($matches[0]) as $class) {
+            foreach (["$srcPath/$class.php", "$specPath/$class" . $this->config->getSpecSuffix()] as $rel) {
+                $full = getcwd() . '/' . $rel;
+                if ($this->filesystem->exists($full)) {
+                    $files[$rel] = $this->filesystem->read($full);
+                }
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * A shallow listing of the files under a directory, one per line.
+     */
+    private function scanTree(string $dir): string
+    {
+        if (!$this->filesystem->exists($dir) || !$this->filesystem->isDir($dir)) {
+            return '';
+        }
+
+        $lines = [];
+        foreach ($this->filesystem->scandir($dir) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $full = $dir . '/' . $entry;
+            $lines[] = $this->filesystem->isDir($full) ? "$entry/" : $entry;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Parses the AI reply into a {path, content} pair, or null when unusable.
+     *
+     * @return array{path: string, content: string}|null
+     */
+    private function parse(string $text): ?array
+    {
+        $json = $text;
+        if (preg_match('/```(?:json)?\s*(\{.*\})\s*```/s', $text, $m)) {
+            $json = $m[1];
+        }
+
+        $data = json_decode($json, true);
+        if (is_array($data) && is_string($data['path'] ?? null) && is_string($data['content'] ?? null)) {
+            return ['path' => $data['path'], 'content' => $data['content']];
+        }
+
+        return null;
+    }
+}

--- a/src/PhpSpec/Console/Command/Pair/AiAssistant.php
+++ b/src/PhpSpec/Console/Command/Pair/AiAssistant.php
@@ -298,7 +298,7 @@ final class AiAssistant
      */
     private function driverHandBack(): string
     {
-        return 'That\'s my one change for this turn. Run it, tell me the next step, or /swap to take the keyboard back.';
+        return 'That\'s my one change for this turn. /run it, tell me the next step, or /swap to take the keyboard back.';
     }
 
     /**
@@ -432,7 +432,7 @@ final class AiAssistant
         if ($role->aiIsNavigator()) {
             PairLogger::log('RESULT', 'Navigator refusal');
 
-            return ['error' => 'I\'m navigating — you\'re driving, so I won\'t write files. Use the commands (describe, exemplify, run), or /swap to hand me the keyboard.'];
+            return ['error' => 'I\'m navigating — you\'re driving, so I won\'t write files. Use the commands (/describe, /exemplify, /run), or /swap to hand me the keyboard.'];
         }
 
         if ($role->aiIsDriver() && $this->artifactWrittenThisHandle) {

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -19,6 +19,7 @@ use PhpSpec\CodeGeneration\ClassGenerator;
 use PhpSpec\CodeGeneration\ClassLocation;
 use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Generate\GenerateAgent;
 use PhpSpec\Console\Command\Pair;
 use PhpSpec\Console\Command\Run\CodeGenerator;
 use PhpSpec\Console\Command\Run\GenerationCandidates;
@@ -46,6 +47,7 @@ final class CommandDispatcher
     private readonly Chooser $chooser;
     private readonly SpecRunner $specRunner;
     private readonly RoleState $roleState;
+    private readonly GenerateAgent $generateAgent;
     private ?AiAssistant $ai = null;
 
     /**
@@ -54,6 +56,13 @@ final class CommandDispatcher
      * red/green state the human just saw.
      */
     private ?SuiteSummary $lastSituation = null;
+
+    /**
+     * The command to pre-fill the next prompt with as a dim ghost suggestion —
+     * the natural next step after the command just run (e.g. run the spec you
+     * just described). Null when there is nothing obvious to suggest.
+     */
+    private ?string $suggestion = null;
 
     /**
      * @param SpecGenerator $specGenerator the spec file generator
@@ -77,12 +86,14 @@ final class CommandDispatcher
         ?Chooser $chooser = null,
         ?SpecRunner $specRunner = null,
         ?RoleState $roleState = null,
+        ?GenerateAgent $generateAgent = null,
     ) {
         $this->parser = new InputParser();
         $this->filesystem = $filesystem ?? new RealFilesystem();
         $this->chooser = $chooser ?? new Chooser($output, $interactive);
         $this->specRunner = $specRunner ?? new SubprocessRunner();
         $this->roleState = $roleState ?? new RoleState();
+        $this->generateAgent = $generateAgent ?? new GenerateAgent($this->config, $this->filesystem);
         $this->registerAutoloader();
 
         $aiConfig = $this->config->getAiConfig();
@@ -166,52 +177,72 @@ final class CommandDispatcher
     {
         PairLogger::log('CMD', $input);
         $parsed = $this->parser->parse($input);
+        $command = $parsed['command'];
 
-        if ($this->shouldRouteToAi($parsed['command'], $parsed['argument'])) {
+        if ($command === '') {
+            return self::CONTINUE;
+        }
+
+        // A leading slash is the one signal that this line is a command; every
+        // other line is a prompt for the AI (or the unknown-command hint when no
+        // AI is configured). No keyword guessing, no argument-count heuristics.
+        if (!str_starts_with($command, '/')) {
+            $this->suggestion = null;
+
             return $this->handleAi($input);
         }
 
-        return match ($parsed['command']) {
-            'describe' => $this->handleDescribe($parsed['argument']),
-            'exemplify' => $this->handleExemplify($parsed['argument']),
-            'run' => $this->handleRun($parsed['argument']),
-            'clear' => $this->handleClear(),
+        $result = match ($command) {
+            '/describe' => $this->handleDescribe($parsed['argument']),
+            '/exemplify' => $this->handleExemplify($parsed['argument']),
+            '/run' => $this->handleRun($parsed['argument']),
+            '/next' => $this->handleNext(),
+            '/generate' => $this->handleGenerate($parsed['argument']),
+            '/clear' => $this->handleClear(),
             '/swap' => $this->handleSwap(),
             '/help' => $this->handleHelp(),
             '/quit', '/exit' => self::QUIT,
-            '' => self::CONTINUE,
-            default => $this->handleDefault($parsed['command'], $input),
+            default => $this->handleSlashCommand($command, $input),
+        };
+
+        // Set from the top-level command only, so a nested run (e.g. the "run
+        // now?" step of /describe) never clobbers the hint.
+        $this->suggestion = $this->suggestionFor($command, $parsed['argument']);
+
+        return $result;
+    }
+
+    /**
+     * The command to pre-fill the next prompt with, chosen from what was just
+     * run: describe a spec then run it, run then ask what's next, and so on.
+     */
+    public function suggestion(): ?string
+    {
+        return $this->suggestion;
+    }
+
+    /**
+     * The natural next command after the given one, or null when there is no
+     * obvious follow-up to ghost into the prompt.
+     */
+    private function suggestionFor(string $command, string $argument): ?string
+    {
+        return match ($command) {
+            '/describe' => $argument !== '' ? '/run ' . $this->specPathFor($argument) : null,
+            '/exemplify', '/generate' => '/run',
+            '/run' => '/next',
+            default => null,
         };
     }
 
     /**
-     * Checks whether input that matches a command keyword should be routed
-     * to AI instead, based on argument count exceeding what the command expects.
+     * The project-relative spec path for a described class argument.
      */
-    private function shouldRouteToAi(string $command, string $argument): bool
+    private function specPathFor(string $argument): string
     {
-        if ($this->ai === null || $argument === '') {
-            return false;
-        }
+        $spec = str_replace('\\', '/', $argument);
 
-        return self::exceedsCommandArgLimit($command, $argument);
-    }
-
-    /**
-     * Checks whether argument word count exceeds the expected limit for a command.
-     */
-    public static function exceedsCommandArgLimit(string $command, string $argument): bool
-    {
-        $maxArgs = match ($command) {
-            'run','describe' => 1,
-            'exemplify' => 2,
-            default => 0,
-        };
-
-        $tokens = preg_split('/\s+/', $argument);
-        $tokenCount = $tokens !== false ? count($tokens) : 0;
-
-        return $maxArgs > 0 && $tokenCount > $maxArgs;
+        return $this->specGenerator->getSpecPath() . '/' . $spec . $this->specGenerator->getSpecSuffix();
     }
 
     /**
@@ -220,7 +251,7 @@ final class CommandDispatcher
     private function handleDescribe(string $argument): int
     {
         if ($argument === '') {
-            $this->output->error('Usage: describe Acme\Greeter');
+            $this->output->error('Usage: /describe Acme\Greeter');
             return self::CONTINUE;
         }
 
@@ -294,7 +325,7 @@ final class CommandDispatcher
         $method = $parts[1] ?? '';
 
         if ($fqcn === '' || $method === '') {
-            $this->output->error('Usage: exemplify Acme\Calculator add');
+            $this->output->error('Usage: /exemplify Acme\Calculator add');
             return self::CONTINUE;
         }
 
@@ -403,56 +434,32 @@ final class CommandDispatcher
     }
 
     /**
-     * Tries to delegate to a registered Application command, falling back to AI.
+     * Handles a slash command that isn't one of the built-in arms: delegates to
+     * a registered Application command of the same name (minus the slash), or
+     * reports it as unknown.
      */
-    private function handleDefault(string $command, string $rawInput): int
+    private function handleSlashCommand(string $command, string $rawInput): int
     {
-        if ($command === 'next' && $this->parser->parse($rawInput)['argument'] === '') {
-            return $this->handleNext();
-        }
+        $name = ltrim($command, '/');
 
-        if ($this->application !== null && $this->application->has($command)) {
-            $cmd = $this->application->find($command);
+        if ($this->application !== null && $this->application->has($name)) {
+            $cmd = $this->application->find($name);
             if ($cmd instanceof Pair) {
                 return self::CONTINUE;
-            }
-
-            // If the argument exceeds what the command accepts, route to AI
-            $parsed = $this->parser->parse($rawInput);
-            if ($parsed['argument'] !== '' && $this->exceedsDefinitionArgLimit($cmd, $parsed['argument'])) {
-                return $this->handleAi($rawInput);
             }
 
             return $this->delegateToCommand($cmd, $command, $rawInput);
         }
 
-        return $this->handleAi($rawInput);
-    }
-
-    /**
-     * Checks whether argument word count exceeds a command's defined argument limit.
-     */
-    private function exceedsDefinitionArgLimit(Command $cmd, string $argument): bool
-    {
-        $def = $cmd->getDefinition();
-        $maxArgs = 0;
-        foreach ($def->getArguments() as $arg) {
-            if ($arg->isArray()) {
-                return false;
-            }
-            $maxArgs++;
-        }
-        $tokens = preg_split('/\s+/', $argument);
-        $tokenCount = $tokens !== false ? count($tokens) : 0;
-        return $maxArgs === 0 || $tokenCount > $maxArgs;
+        return $this->handleUnknown($command);
     }
 
     /**
      * Runs a Symfony console command with arguments parsed from raw input.
      */
-    private function delegateToCommand(Command $cmd, string $name, string $rawInput): int
+    private function delegateToCommand(Command $cmd, string $commandToken, string $rawInput): int
     {
-        $argString = trim(substr($rawInput, strlen($name)));
+        $argString = trim(substr($rawInput, strlen($commandToken)));
         $input = new StringInput($argString);
         $input->setInteractive($this->interactive);
 
@@ -461,6 +468,47 @@ final class CommandDispatcher
             $cmd->run($input, $this->output->getOutput());
         } catch (\Exception $e) {
             $this->output->error($e->getMessage());
+        }
+
+        return self::CONTINUE;
+    }
+
+    /**
+     * Turns a natural-language instruction into one AI-authored file edit, shows
+     * it as a diff, and writes it once confirmed. Requires an AI provider.
+     */
+    private function handleGenerate(string $argument): int
+    {
+        $instruction = trim($argument);
+        if ($instruction === '') {
+            $this->output->error('Usage: /generate <what to build in plain English>');
+
+            return self::CONTINUE;
+        }
+
+        $aiConfig = $this->config->getAiConfig();
+        if ($aiConfig === null) {
+            $this->output->error('AI configuration required for /generate — add an "ai" section to phpspec.yaml.');
+
+            return self::CONTINUE;
+        }
+
+        $proposal = $this->generateAgent->propose($aiConfig, $instruction);
+        if ($proposal === null) {
+            $this->output->error('Could not generate anything for that instruction. Try rephrasing.');
+
+            return self::CONTINUE;
+        }
+
+        if ($proposal['isNew']) {
+            $this->output->fileDisplay($proposal['path'], $proposal['new'], true);
+        } else {
+            $this->output->fileDiff($proposal['path'], $proposal['old'], $proposal['new']);
+        }
+
+        if ($this->chooser->choose('Apply this change?', 'generate', 'apply generated changes')) {
+            $this->generateAgent->write($proposal);
+            $this->output->success(($proposal['isNew'] ? 'Created ' : 'Updated ') . $proposal['path']);
         }
 
         return self::CONTINUE;
@@ -484,11 +532,13 @@ final class CommandDispatcher
         $out->writeln('');
         $out->writeln('  <fg=bright-blue;options=bold>Available commands:</>');
         $out->writeln('');
-        $out->writeln('  <fg=white>describe</> <fg=gray>Acme\Greeter</>           Generate a spec file');
-        $out->writeln('  <fg=white>exemplify</> <fg=gray>Acme\Greeter greet</>  Add an example for a method');
-        $out->writeln('  <fg=white>run</>                                Run all specs');
-        $out->writeln('  <fg=white>run</> <fg=gray>spec/path</>                    Run specs at path');
-        $out->writeln('  <fg=white>clear</>                     Clear the screen');
+        $out->writeln('  <fg=white>/describe</> <fg=gray>Acme\Greeter</>          Generate a spec file');
+        $out->writeln('  <fg=white>/exemplify</> <fg=gray>Acme\Greeter greet</> Add an example for a method');
+        $out->writeln('  <fg=white>/run</>                               Run all specs');
+        $out->writeln('  <fg=white>/run</> <fg=gray>spec/path</>                   Run specs at path');
+        $out->writeln('  <fg=white>/next</>                              Suggest the next step');
+        $out->writeln('  <fg=white>/generate</> <fg=gray>what to build</>        Generate a spec or code from words (AI)');
+        $out->writeln('  <fg=white>/clear</>                    Clear the screen');
         $out->writeln("  <fg=white>/swap</>                     Swap who drives (you \u{21c4} AI)");
         $out->writeln('  <fg=white>/help</>                     Show this help');
         $out->writeln('  <fg=white>/quit</>                     Exit pair mode');
@@ -505,7 +555,7 @@ final class CommandDispatcher
             $out->writeln('  <fg=bright-blue;options=bold>AI assistant</> <fg=gray>(not configured — add ai: section to phpspec.yml)</>');
         }
         $out->writeln('');
-        $out->writeln('  Anything that isn\'t a built-in command is sent to the AI assistant.');
+        $out->writeln('  Anything without a leading <fg=white>/</> is sent to the AI assistant.');
         $out->writeln('  It can generate specs, features, step definitions, and run your specs.');
         $out->writeln('');
         $out->writeln('  <fg=bright-blue>Examples:</>');
@@ -528,7 +578,7 @@ final class CommandDispatcher
             return;
         }
 
-        $skip = ['pair', 'describe', 'exemplify', 'run', 'list', 'help', 'completion', '_complete'];
+        $skip = ['pair', 'describe', 'exemplify', 'run', 'next', 'list', 'help', 'completion', '_complete'];
         $extra = [];
 
         foreach ($this->application->all() as $name => $cmd) {
@@ -547,7 +597,7 @@ final class CommandDispatcher
         $out->writeln('  <fg=bright-blue;options=bold>Additional commands:</>');
         $out->writeln('');
         foreach ($extra as $name => $description) {
-            $out->writeln(sprintf('  <fg=white>%s</>  %s', str_pad($name, 22), $description));
+            $out->writeln(sprintf('  <fg=white>%s</>  %s', str_pad('/' . $name, 22), $description));
         }
     }
 

--- a/src/PhpSpec/Console/Command/Pair/LineEditor.php
+++ b/src/PhpSpec/Console/Command/Pair/LineEditor.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Command\Pair;
+
+use Closure;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ * A raw-mode line editor for the pair REPL. Beyond reading a line, it can seed
+ * the input with a dim "ghost" suggestion (the next command) that the user
+ * accepts with Right-arrow or Tab — fish-shell style. Typing dismisses it.
+ *
+ * On a TTY a byte-by-byte key loop drives it (stty raw); piped input falls back
+ * to reading a whole line so scripted sessions keep working. Both the key reader
+ * and the line reader are injectable, so specs drive it without a real terminal.
+ */
+final class LineEditor
+{
+    private const DIM = "\033[2m";
+    private const RESET = "\033[0m";
+
+    private readonly Closure $reader;
+
+    private readonly ?Closure $keys;
+
+    private readonly bool $detectTty;
+
+    /**
+     * @param PairOutput $output the pair screen to paint the input line into
+     * @param Closure|null $reader reads one whole line (piped input); injectable
+     * @param Closure|null $keys reads one raw key token (TTY input); injectable —
+     *                           when given, key mode is used without touching the terminal
+     */
+    public function __construct(
+        private readonly PairOutput $output,
+        ?Closure $reader = null,
+        ?Closure $keys = null,
+    ) {
+        $this->reader = $reader ?? fn(): ?string => $this->readStdinLine();
+        $this->keys = $keys;
+        // Only probe the real terminal when no input source was injected, so
+        // specs behave the same whether run from a TTY or a pipe.
+        $this->detectTty = $reader === null && $keys === null;
+    }
+
+    /**
+     * Reads one line, optionally seeded with a dim suggestion the user accepts
+     * with Right-arrow or Tab. Up/Down walk the given history. Returns the line,
+     * or null on EOF / cancel.
+     *
+     * @param list<string> $history earlier lines, oldest first, for Up/Down recall
+     */
+    public function readLine(string $prompt, ?string $suggestion = null, array $history = []): ?string
+    {
+        // Raw key mode needs stty, so Windows terminals use line mode.
+        $keyCapable = DIRECTORY_SEPARATOR === '/' && $this->detectTty && stream_isatty(STDIN);
+
+        if ($this->keys !== null || $keyCapable) {
+            return $this->readByKey($prompt, $suggestion, $history);
+        }
+
+        return $this->readByLine($prompt);
+    }
+
+    /**
+     * Line mode (piped input): paints the prompt and reads one whole line. The
+     * suggestion is ignored — there is no cursor to preview it against.
+     */
+    private function readByLine(string $prompt): ?string
+    {
+        $this->output->rawOutput()->write($prompt, false, OutputInterface::OUTPUT_RAW);
+
+        return ($this->reader)();
+    }
+
+    /**
+     * Key mode (TTY): a per-keystroke loop that maintains the buffer, paints the
+     * ghost after it, accepts it on Right-arrow / Tab, and walks history on Up/Down.
+     *
+     * @param list<string> $history earlier lines, oldest first
+     */
+    private function readByKey(string $prompt, ?string $suggestion, array $history): ?string
+    {
+        $rawMode = $this->keys === null;
+        if ($rawMode) {
+            system('stty -icanon -echo');
+        }
+
+        $buffer = '';
+        $ghost = ($suggestion !== null && $suggestion !== '') ? $suggestion : null;
+        $histAt = count($history);
+
+        try {
+            $this->render($prompt, $buffer, $ghost);
+
+            while (true) {
+                $key = $this->keys !== null ? ($this->keys)() : $this->readKeyToken();
+
+                if ($key === "\n" || $key === "\r") {
+                    return $buffer;
+                }
+
+                if ($key === "\004") {
+                    return $buffer === '' ? null : $buffer;
+                }
+
+                if ($key === "\003" || $key === "\033") {
+                    return null;
+                }
+
+                if (($key === "\033[C" || $key === "\t") && $ghost !== null && $buffer === '') {
+                    $buffer = $ghost;
+                    $ghost = null;
+                } elseif ($key === "\033[A" && $histAt > 0) {
+                    $buffer = $history[--$histAt];
+                    $ghost = null;
+                } elseif ($key === "\033[B" && $histAt < count($history)) {
+                    $buffer = ++$histAt < count($history) ? $history[$histAt] : '';
+                    $ghost = null;
+                } elseif ($key === "\177" || $key === "\010") {
+                    $buffer = mb_substr($buffer, 0, -1);
+                } elseif (strlen($key) === 1 && ord($key) >= 32) {
+                    $buffer .= $key;
+                    $ghost = null;
+                } else {
+                    continue;
+                }
+
+                $this->render($prompt, $buffer, $ghost);
+            }
+        } finally {
+            if ($rawMode) {
+                system('stty icanon echo');
+            }
+        }
+    }
+
+    /**
+     * Repaints the input row in place: the prompt, the buffer in full colour,
+     * then the dim ghost — with the cursor moved back to sit before the ghost.
+     */
+    private function render(string $prompt, string $buffer, ?string $ghost): void
+    {
+        $line = "\r\033[K" . $prompt . $buffer;
+
+        if ($ghost !== null && $ghost !== '') {
+            $line .= self::DIM . $ghost . self::RESET . "\033[" . mb_strlen($ghost) . 'D';
+        }
+
+        $this->output->rawOutput()->write($line, false, OutputInterface::OUTPUT_RAW);
+    }
+
+    /**
+     * Reads one raw key token: a single character, or a complete escape sequence
+     * for the arrow keys (bare Esc stays a lone \033; EOF becomes Ctrl-D).
+     */
+    private function readKeyToken(): string
+    {
+        $char = fgetc(STDIN);
+
+        if ($char === false) {
+            return "\004";
+        }
+
+        if ($char !== "\033") {
+            return $char;
+        }
+
+        $read = [STDIN];
+        $write = $except = [];
+
+        if ((int) stream_select($read, $write, $except, 0, 20000) < 1) {
+            return "\033";
+        }
+
+        if (fgetc(STDIN) !== '[') {
+            return "\033";
+        }
+
+        return "\033[" . fgetc(STDIN);
+    }
+
+    /**
+     * Reads one whole line from stdin, or null on EOF.
+     */
+    private function readStdinLine(): ?string
+    {
+        $line = fgets(STDIN);
+
+        return $line === false ? null : rtrim($line, "\r\n");
+    }
+}

--- a/src/PhpSpec/Console/Command/Pair/PairOutput.php
+++ b/src/PhpSpec/Console/Command/Pair/PairOutput.php
@@ -68,6 +68,16 @@ final class PairOutput
     }
 
     /**
+     * Returns the undecorated console output, for writing directly at the fixed
+     * input row (the scroll-region decorator would reposition into the content
+     * area). This is how the line editor paints the prompt, buffer, and ghost.
+     */
+    public function rawOutput(): OutputInterface
+    {
+        return $this->output;
+    }
+
+    /**
      * Sets up the fixed terminal layout: header, scroll region, bottom divider, input line.
      *
      * @param bool $aiAvailable whether an AI provider is configured

--- a/src/PhpSpec/Console/Command/Pair/Repl.php
+++ b/src/PhpSpec/Console/Command/Pair/Repl.php
@@ -28,11 +28,20 @@ final readonly class Repl
     /**
      * @param bool $aiAvailable whether an AI provider is configured
      */
+    private readonly LineEditor $editor;
+
+    /**
+     * @param bool $aiAvailable whether an AI provider is configured
+     * @param LineEditor|null $editor the line reader; injectable for specs
+     */
     public function __construct(
         private CommandDispatcher $dispatcher,
         private PairOutput $output,
         private bool $aiAvailable = false,
-    ) {}
+        ?LineEditor $editor = null,
+    ) {
+        $this->editor = $editor ?? new LineEditor($this->output);
+    }
 
     /**
      * Runs the REPL loop: setup layout, read, dispatch, repeat until quit or EOF.
@@ -44,11 +53,14 @@ final readonly class Repl
         $this->output->setupLayout($this->aiAvailable);
         $this->dispatcher->greet();
 
+        $history = [];
+        $suggestion = null;
+
         while (true) {
             $this->output->prepareForInput();
-            $line = readline('> ');
+            $line = $this->editor->readLine('> ', $suggestion, $history);
 
-            if ($line === false) {
+            if ($line === null) {
                 break;
             }
 
@@ -56,7 +68,7 @@ final readonly class Repl
 
             $line = trim($line);
             if ($line !== '') {
-                readline_add_history($line);
+                $history[] = $line;
                 $this->output->echoInput($line);
             }
 
@@ -64,6 +76,9 @@ final readonly class Repl
             if ($result === CommandDispatcher::QUIT) {
                 break;
             }
+
+            // Ghost the natural next command into the next prompt.
+            $suggestion = $this->dispatcher->suggestion();
         }
 
         $this->output->showGoodbye();

--- a/src/PhpSpec/Console/Command/Pair/Repl.php
+++ b/src/PhpSpec/Console/Command/Pair/Repl.php
@@ -58,7 +58,7 @@ final readonly class Repl
 
         while (true) {
             $this->output->prepareForInput();
-            $line = $this->editor->readLine('> ', $suggestion, $history);
+            $line = $this->editor->readLine('❯ ', $suggestion, $history);
 
             if ($line === null) {
                 break;

--- a/src/PhpSpec/Console/Command/Pair/ScrollRegionOutput.php
+++ b/src/PhpSpec/Console/Command/Pair/ScrollRegionOutput.php
@@ -78,7 +78,7 @@ final class ScrollRegionOutput implements OutputInterface
      */
     public function prepareForInput(): void
     {
-        $divider = "\033[34m" . str_repeat("\u{2500}", $this->width) . "\033[0m";
+        $divider = "\033[36m" . str_repeat("\u{2500}", $this->width) . "\033[0m";
 
         $out = sprintf("\033[%d;1H\033[K%s", $this->topDividerRow, $divider);
 

--- a/src/PhpSpec/Console/Command/Pair/SuiteNarrator.php
+++ b/src/PhpSpec/Console/Command/Pair/SuiteNarrator.php
@@ -26,8 +26,8 @@ use PhpSpec\Console\Command\Run\SuiteSummary;
  */
 final class SuiteNarrator
 {
-    private const FOOTER_AI = '  <fg=gray>plain English works · next · /swap · /help · /quit</>';
-    private const FOOTER_COMMANDS = '  <fg=gray>describe · exemplify · run · next · /swap · /help · /quit</>';
+    private const FOOTER_AI = '  <fg=gray>plain English works · /next · /swap · /help · /quit</>';
+    private const FOOTER_COMMANDS = '  <fg=gray>/describe · /exemplify · /run · /next · /swap · /help · /quit</>';
 
     /**
      * The opening lines for a pairing session, chosen by suite state.
@@ -68,7 +68,7 @@ final class SuiteNarrator
 
         return [
             '  Nothing here yet. Let\'s start with a spec.',
-            '  <fg=gray>Try <fg=white>describe App\\Something</> to write your first one.</>',
+            '  <fg=gray>Try <fg=white>/describe App\\Something</> to write your first one.</>',
         ];
     }
 
@@ -133,7 +133,7 @@ final class SuiteNarrator
     private function describeFirstStep(): array
     {
         return [
-            'lines' => ['', '  Nothing to build on yet. Let\'s <fg=white>describe</> the first spec.'],
+            'lines' => ['', '  Nothing to build on yet. Let\'s <fg=white>/describe</> the first spec.'],
             'action' => 'describe',
             'target' => null,
         ];
@@ -148,7 +148,7 @@ final class SuiteNarrator
 
         $line = $role->aiIsDriver()
             ? sprintf('  We\'re red on <options=bold>%s</> — %s. I\'ll run it and generate what\'s missing.', $failure['subject'], $failure['example'])
-            : sprintf('  We\'re red on <options=bold>%s</> — %s. Type <fg=white>run</> and I\'ll offer to create what\'s missing.', $failure['subject'], $failure['example']);
+            : sprintf('  We\'re red on <options=bold>%s</> — %s. Type <fg=white>/run</> and I\'ll offer to create what\'s missing.', $failure['subject'], $failure['example']);
 
         return ['lines' => ['', $line], 'action' => 'run', 'target' => $failure['subject']];
     }
@@ -162,7 +162,7 @@ final class SuiteNarrator
 
         $line = $role->aiIsDriver()
             ? sprintf('  Green. Nearest gap — <options=bold>%s</>: %s. I\'ll make it real.', $gap['subject'], $gap['example'])
-            : sprintf('  Green. Nearest gap — <options=bold>%s</>: %s. Let\'s exemplify it.', $gap['subject'], $gap['example']);
+            : sprintf('  Green. Nearest gap — <options=bold>%s</>: %s. Let\'s <fg=white>/exemplify</> it.', $gap['subject'], $gap['example']);
 
         return ['lines' => ['', $line], 'action' => 'exemplify', 'target' => $gap['subject']];
     }

--- a/src/PhpSpec/InProcessRunner.php
+++ b/src/PhpSpec/InProcessRunner.php
@@ -214,6 +214,11 @@ final class InProcessRunner
                     }
                 } elseif ($command === 'refactor') {
                     $result['target'] = $part;
+                } elseif ($command === 'generate') {
+                    if (!isset($result['instruction']) || !is_array($result['instruction'])) {
+                        $result['instruction'] = [];
+                    }
+                    $result['instruction'][] = $part;
                 }
             }
         }


### PR DESCRIPTION
 - Slash-prefix every pair command (/describe, /run, /next, …): a leading slash marks a command and anything else is an AI prompt, replacing the brittle argument-count routing heuristics.
 - Add a /generate command (standalone and pair, AI-backed) that turns a plain-English instruction into a spec example or implementation code, shown as a diff and written after a confirmation.
 - Replace the readline prompt with a raw-mode line editor that pre-fills a dim next-command suggestion (Right-arrow or Tab to accept) and recalls history.