### PR TITLE
Make `next` follow outside-in, feature-first TDD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [9.0.0-beta.8](https://github.com/phpspec/phpspec/compare/9.0.0-beta.7...9.0.0-beta.8)
+
+### Added
+ - `--format=agent` machine-readable JSON for coding agents; with `describe --agent`, `exemplify --agent`, and `--accept-offers`
+ - Slash commands in pair mode: `/describe`, `/exemplify`, `/run`, `/next`, `/generate`, `/clear` (joining `/swap`, `/help`, `/quit`)
+ - Generate command and `/generate` to turn a plain-English instruction into a spec example or code
+ - Ghost-text next step, the prompt pre-fills a dim suggestion of the next command (Right-arrow/Tab accepts)
+ - `next` follows outside-in, feature-first TDD — favours story tests and advises the next baby step from real suite state; works without AI.
+
+### Fixed
+ - Native PHP 8.4/8.5 deprecations in mock generation (nullable `?object` constructor param; dropped `setAccessible()`).
+ - Pair `ai:` status reflects whether the provider actually started (`ai: on` / `ai: unavailable` / `ai: off`)
+
 ## [9.0.0-beta.7](https://github.com/phpspec/phpspec/compare/9.0.0-beta.6...9.0.0-beta.7)
 
 ### Added

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -24,4 +24,4 @@
 
     (new PhpSpec\Console\Application($version))->run();
 
-})('9.0.0-beta.7');
+})('9.0.0-beta.8');

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,7 +38,7 @@ See [Pair Programming & AI](pair.md) for full documentation.
 
 ### `next`
 
-AI suggests what to describe or specify next.
+Coaches the single next step in outside-in, feature-first TDD — favouring story tests, grounded in the real suite state.
 
 ```bash
 bin/phpspec next

--- a/docs/pair.md
+++ b/docs/pair.md
@@ -235,7 +235,7 @@ When you're not sure what to work on next, ask PhpSpec:
 bin/phpspec next
 ```
 
-The command scans your project's source files, specs, and features, sends the context to the AI, and suggests the single most impactful next step. The suggestion follows the scenario-first workflow — it will recommend a feature scenario before a spec, and a spec before an implementation.
+The command coaches the single next step in **outside-in, story-first TDD**, favouring feature (story) tests. When feature files are present it runs the whole suite (`--all`) and reads the real red/green state: a red or unwritten scenario drives the inner spec cycle; when the features are green it offers one baby step over the files you last touched — refactor the last code, add a new scenario, or start a new feature. The shared coaching lives in `src/PhpSpec/Ai/Prompts/next.txt`. With no feature files it falls back to the spec cycle (describe the missing class, or make the nearest pending example real).
 
 Example output:
 
@@ -249,9 +249,9 @@ Example output:
   drive the step definitions and any missing specs.
 ```
 
-The `next` command requires AI configuration (the same `ai:` section in `phpspec.yaml`). If it suggests a class whose spec already exists, it will not send you round in circles describing it again — it points you at `bin/phpspec run` to drive out the missing class.
+The standalone `next` command requires AI configuration (the same `ai:` section in `phpspec.yaml`). If it suggests a class whose spec already exists, it will not send you round in circles describing it again — it points you at `bin/phpspec run` to drive out the missing class.
 
-Inside pair mode, `next` reads the real suite state rather than guessing: a red spec means run it and generate what's missing; a pending example is the nearest gap to make real. This works even without an AI provider.
+Inside pair mode, `/next` reads the real suite state rather than guessing, and follows the same outside-in, feature-first logic — a red scenario drops into the inner cycle, undefined steps get written, and green features prompt a baby step over the last-touched feature and source. **This works even without an AI provider**: the deterministic narrator gives the advice, and `next.txt` enriches it when a provider is configured (the navigator advises, the driver takes the step).
 
 ## The `refactor` Command
 

--- a/features/scenarios/cli/pair-next.feature
+++ b/features/scenarios/cli/pair-next.feature
@@ -33,3 +33,55 @@ Feature: Pair mode next coaches the next step from real suite state
     When I run phpspec pair with input "/next"
     Then the output should contain "reconciles entries"
     And the output should not contain "Specification for"
+
+  Scenario: next favours the feature and points at the steps to write when they are undefined
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/adding.feature":
+      """
+      Feature: Adding
+        Scenario: Add two numbers
+          Given a calculator
+          When I add 2 and 3
+          Then the total is 5
+      """
+    When I run phpspec pair with input "/next"
+    Then the output should contain "adding.feature"
+    And the output should contain "steps"
+
+  Scenario: next offers a baby step over the last-touched files when the features are green
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a class "src/App/Greeter.php":
+      """
+      <?php
+      namespace App;
+
+      class Greeter
+      {
+          public function greet(): string
+          {
+              return 'hi';
+          }
+      }
+      """
+    And a feature file "features/greeting.feature":
+      """
+      Feature: Greeting
+        Scenario: Greet
+          Given a greeter
+          Then it greets
+      """
+    And a step file "features/steps/greeting.steps.php":
+      """
+      <?php
+      given('a greeter', function () {
+          $this->greeter = new \App\Greeter();
+      });
+
+      then('it greets', function () {
+          expect($this->greeter->greet())->toBe('hi');
+      });
+      """
+    When I run phpspec pair with input "/next"
+    Then the output should contain "Features green"
+    And the output should contain "new feature"
+    And the output should contain "Greeter.php"

--- a/spec/PhpSpec/Ai/PromptLibrary.spec.php
+++ b/spec/PhpSpec/Ai/PromptLibrary.spec.php
@@ -1,0 +1,23 @@
+<?php
+
+use PhpSpec\Ai\PromptLibrary;
+use PhpSpec\Filesystem;
+
+describe(PromptLibrary::class, function () {
+
+    it('reads a prompt artifact by name from the Prompts directory', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturnUsing(fn(string $p): string => str_ends_with($p, '/Prompts/next.txt') ? 'OUTSIDE-IN coaching' : '');
+        $library = new PromptLibrary($fs);
+
+        expect($library->read('next'))->toBe('OUTSIDE-IN coaching');
+    });
+
+    it('returns an empty string when the artifact is absent', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        $library = new PromptLibrary($fs);
+
+        expect($library->read('missing'))->toBe('');
+    });
+
+});

--- a/spec/PhpSpec/Ai/Prompts.spec.php
+++ b/spec/PhpSpec/Ai/Prompts.spec.php
@@ -31,4 +31,25 @@ describe('pair role prompt artifacts', function () {
         expect($text)->toContain('Use ask_user only for a straight yes/no.');
     });
 
+    it('ships a next prompt that teaches the outside-in, feature-first cycle in baby steps', function () use ($read) {
+        $text = $read('next.txt');
+
+        expect($text)->toContain('OUTSIDE-IN');
+        expect($text)->toContain('FEATURE FIRST');
+        expect($text)->toContain('OUTER CYCLE');
+        expect($text)->toContain('INNER CYCLE');
+        expect($text)->toContain('BARELY-ENOUGH-DESIGN');
+        expect($text)->toContain('BABY STEP');
+        expect($text)->toContain('NO FEATURES');
+        expect($text)->toContain('Voice:');
+    });
+
+    it('keeps the machine-readable suggestion contract at the tail of the next prompt', function () use ($read) {
+        $text = $read('next.txt');
+
+        expect($text)->toContain('"type"');
+        expect($text)->toContain('"target"');
+        expect($text)->toContain('"reason"');
+    });
+
 });

--- a/spec/PhpSpec/Console/Command/Next.spec.php
+++ b/spec/PhpSpec/Console/Command/Next.spec.php
@@ -2,9 +2,30 @@
 
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Next;
+use PhpSpec\Console\Command\Pair\SpecRunner;
+use PhpSpec\Console\Command\Run\RunOutcome;
+use PhpSpec\Console\Command\Run\SuiteSummary;
 use PhpSpec\Filesystem;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+
+// A fake SpecRunner that records its argument and returns a scripted outcome, so
+// the features-present path can be exercised without spawning a real run.
+class NextFakeRunner implements SpecRunner
+{
+    /** @var list<string> */
+    public array $arguments = [];
+
+    public ?RunOutcome $outcome = null;
+
+    public function run(string $argument, OutputInterface $output): ?RunOutcome
+    {
+        $this->arguments[] = $argument;
+
+        return $this->outcome;
+    }
+}
 
 describe(Next::class, function () {
 
@@ -209,6 +230,53 @@ describe(Next::class, function () {
 
             expect($exitCode)->toBe(1);
             expect($tester->getDisplay())->toContain('Could not get a suggestion');
+        });
+
+        it('runs the features (--all) and grounds the suggestion in their state when features are present', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            $featuresDir = getcwd() . '/features';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath || $p === $featuresDir);
+            allow($fs->isDir())->toReturnUsing(fn(string $p): bool => $p === $featuresDir);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $runner = new NextFakeRunner();
+            $runner->outcome = new RunOutcome(null, new SuiteSummary(
+                'green',
+                ['examples' => 0, 'passes' => 0, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+                [],
+                [],
+                ['features' => 1, 'scenarios' => 1, 'steps' => 3, 'stepFailures' => 0, 'undefined' => 3],
+                [['path' => 'features/adding.feature', 'status' => 'todo', 'undefined' => 3]],
+            ));
+
+            $captured = '';
+            $suggestFn = function (array $aiConfig, string $context) use (&$captured): array {
+                $captured = $context;
+
+                return ['type' => 'info', 'target' => '', 'reason' => 'ok'];
+            };
+            $cmd = new Next(new Configuration('.', $fs), $fs, $suggestFn, $runner);
+
+            $tester = new CommandTester($cmd);
+            $tester->execute([]);
+
+            expect($runner->arguments)->toContain('--all');
+            expect($captured)->toContain('FEATURES');
+            expect($captured)->toContain('adding.feature');
+        });
+
+        it('does not run the suite when there are no features', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $runner = new NextFakeRunner();
+            $cmd = new Next(new Configuration('.', $fs), $fs, fn(array $aiConfig): array => ['type' => 'info', 'target' => '', 'reason' => 'ok'], $runner);
+
+            $tester = new CommandTester($cmd);
+            $tester->execute([]);
+
+            expect($runner->arguments)->toBe([]);
         });
 
         it('passes AI config to the suggest function', function (Filesystem $fs) {

--- a/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
@@ -1,13 +1,19 @@
 <?php
 
+use PhpSpec\Ai\Contracts\ProviderInterface;
+use PhpSpec\Ai\Response;
 use PhpSpec\CodeGeneration\ClassGenerator;
 use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Generate\GenerateAgent;
+use PhpSpec\Console\Command\Pair\AiAssistant;
+use PhpSpec\Console\Command\Pair\Chooser;
 use PhpSpec\Console\Command\Pair\CommandDispatcher;
 use PhpSpec\Console\Command\Pair\PairOutput;
+use PhpSpec\Console\Command\Pair\RoleState;
 use PhpSpec\Console\Command\Pair\SpecRunner;
 use PhpSpec\Console\Command\Run\RunOutcome;
+use PhpSpec\Console\Command\Run\SuiteSummary;
 use PhpSpec\Filesystem;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -20,11 +26,13 @@ class CommandDispatcherFakeRunner implements SpecRunner
     /** @var list<string> */
     public array $arguments = [];
 
+    public ?RunOutcome $outcome = null;
+
     public function run(string $argument, OutputInterface $output): ?RunOutcome
     {
         $this->arguments[] = $argument;
 
-        return null;
+        return $this->outcome;
     }
 }
 
@@ -319,6 +327,69 @@ describe(CommandDispatcher::class, function () {
             $output = $this->buffer->fetch();
             expect($output)->toContain('natural language');
             expect($output)->not()->toContain('Unknown command');
+        });
+    });
+
+    context('next favours features, outside-in', function () {
+        it('runs the features too (--all) when suggesting the next step', function () {
+            $this->dispatcher->dispatch('/next');
+
+            expect($this->specRunner->arguments)->toContain('--all');
+        });
+
+        it('prints feature-first advice when features are present and no AI is configured', function () {
+            $this->specRunner->outcome = new RunOutcome(null, new SuiteSummary(
+                'green',
+                ['examples' => 0, 'passes' => 0, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+                [],
+                [],
+                ['features' => 1, 'scenarios' => 1, 'steps' => 3, 'stepFailures' => 0, 'undefined' => 3],
+                [['path' => 'features/adding.feature', 'status' => 'todo', 'undefined' => 3]],
+            ));
+
+            $this->dispatcher->dispatch('/next');
+
+            expect($this->buffer->fetch())->toContain('adding.feature');
+        });
+
+        it('hands the AI the outside-in next.txt coaching, in both roles', function (Filesystem $fs) {
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '/Prompts/next.txt'));
+            allow($fs->read())->toReturnUsing(fn(string $p): string => str_ends_with($p, '/Prompts/next.txt') ? 'OUTSIDE-IN feature-first BABY STEP coaching' : '');
+
+            foreach ([new RoleState(\PhpSpec\Console\Command\Pair\PairRole::HumanDrives), new RoleState(\PhpSpec\Console\Command\Pair\PairRole::AiDrives)] as $roleState) {
+                $captured = null;
+                $provider = new class implements ProviderInterface {
+                    /** @var callable|null */
+                    public $responder = null;
+
+                    public function chat(array $messages, array $options = []): Response
+                    {
+                        return ($this->responder)($messages, $options);
+                    }
+                };
+                $provider->responder = function (array $messages) use (&$captured): Response {
+                    $captured = $messages;
+
+                    return new Response('Suggested the next scenario.');
+                };
+
+                $ai = new AiAssistant($provider, $this->config, $this->pairOutput, 'test-model', $fs, false, null, new Chooser($this->pairOutput, false), $roleState, $this->specRunner);
+                $dispatcher = new CommandDispatcher(
+                    new SpecGenerator('spec', $fs),
+                    new ClassGenerator('src', $fs),
+                    $this->config,
+                    $this->pairOutput,
+                    false,
+                    $fs,
+                    specRunner: $this->specRunner,
+                    roleState: $roleState,
+                    ai: $ai,
+                );
+
+                $dispatcher->dispatch('/next');
+
+                expect((string) json_encode($captured))->toContain('OUTSIDE-IN');
+            }
         });
     });
 

--- a/spec/PhpSpec/Console/Command/Pair/SituationReport.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/SituationReport.spec.php
@@ -62,6 +62,35 @@ describe(SituationReport::class, function () {
         expect($report)->toContain('one-step plan');
     });
 
+    it('adds a FEATURES line with tallies and names each non-green feature', function () {
+        $summary = new SuiteSummary(
+            'red',
+            ['examples' => 0, 'passes' => 0, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+            [],
+            [],
+            ['features' => 2, 'scenarios' => 3, 'steps' => 9, 'stepFailures' => 1, 'undefined' => 2],
+            [
+                ['path' => 'features/adding.feature', 'status' => 'red', 'undefined' => 0],
+                ['path' => 'features/subtracting.feature', 'status' => 'todo', 'undefined' => 2],
+            ],
+        );
+        $report = SituationReport::fromSummary($summary, PairRole::HumanDrives)->render();
+
+        expect($report)->toContain('FEATURES: 2 features, 3 scenarios, 9 steps');
+        expect($report)->toContain('adding.feature');
+        expect($report)->toContain('subtracting.feature');
+    });
+
+    it('omits the FEATURES line for a spec-only suite', function () {
+        $summary = new SuiteSummary(
+            'green',
+            ['examples' => 1, 'passes' => 1, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+        );
+        $report = SituationReport::fromSummary($summary, PairRole::HumanDrives)->render();
+
+        expect($report)->not()->toContain('FEATURES:');
+    });
+
     it('renders without ANSI escape codes', function () {
         $summary = new SuiteSummary(
             'red',

--- a/spec/PhpSpec/Console/Command/Pair/SuiteNarrator.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/SuiteNarrator.spec.php
@@ -149,4 +149,86 @@ describe(SuiteNarrator::class, function () {
         expect(implode("\n", $next['lines']))->toContain("I'll");
     });
 
+    // next() — feature-first, outside-in. Features lead when present.
+
+    it('advises writing the steps when a feature still has undefined steps', function () {
+        $outcome = new RunOutcome(null, new SuiteSummary(
+            'green',
+            ['examples' => 0, 'passes' => 0, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+            [],
+            [],
+            ['features' => 1, 'scenarios' => 1, 'steps' => 3, 'stepFailures' => 0, 'undefined' => 3],
+            [['path' => 'features/adding.feature', 'status' => 'todo', 'undefined' => 3]],
+        ));
+
+        $next = $this->narrator->next($outcome, PairRole::HumanDrives);
+
+        $text = implode("\n", $next['lines']);
+        expect($text)->toContain('adding.feature');
+        expect($text)->toContain('steps');
+    });
+
+    it('drops into the inner cycle, naming the failing example, when a scenario is red', function () {
+        $outcome = new RunOutcome(null, new SuiteSummary(
+            'red',
+            ['examples' => 1, 'passes' => 0, 'failures' => 0, 'errors' => 1, 'pending' => 0],
+            [['subject' => 'App\\Calculator', 'example' => 'adds numbers']],
+            [],
+            ['features' => 1, 'scenarios' => 1, 'steps' => 2, 'stepFailures' => 1, 'undefined' => 0],
+            [['path' => 'features/adding.feature', 'status' => 'red', 'undefined' => 0]],
+        ));
+
+        $next = $this->narrator->next($outcome, PairRole::HumanDrives);
+
+        expect($next['action'])->toBe('run');
+        expect(implode("\n", $next['lines']))->toContain('App\\Calculator');
+    });
+
+    it('advises running to drive out the behaviour a red scenario needs, even with no failing example yet', function () {
+        $outcome = new RunOutcome(null, new SuiteSummary(
+            'red',
+            ['examples' => 0, 'passes' => 0, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+            [],
+            [],
+            ['features' => 1, 'scenarios' => 1, 'steps' => 2, 'stepFailures' => 1, 'undefined' => 0],
+            [['path' => 'features/checkout.feature', 'status' => 'red', 'undefined' => 0]],
+        ));
+
+        $next = $this->narrator->next($outcome, PairRole::HumanDrives);
+
+        expect($next['action'])->toBe('run');
+        expect(implode("\n", $next['lines']))->toContain('checkout.feature');
+    });
+
+    it('offers refactor, a new scenario, or a new feature when the features are green', function () {
+        $outcome = new RunOutcome(null, new SuiteSummary(
+            'green',
+            ['examples' => 2, 'passes' => 2, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+            [],
+            [],
+            ['features' => 1, 'scenarios' => 2, 'steps' => 6, 'stepFailures' => 0, 'undefined' => 0],
+            [['path' => 'features/adding.feature', 'status' => 'green', 'undefined' => 0]],
+        ));
+
+        $next = $this->narrator->next($outcome, PairRole::HumanDrives, 'features/adding.feature', 'src/App/Calculator.php');
+
+        $text = implode("\n", $next['lines']);
+        expect($text)->toContain('refactor');
+        expect($text)->toContain('Calculator.php');
+        expect($text)->toContain('new scenario');
+        expect($text)->toContain('adding.feature');
+        expect($text)->toContain('new feature');
+    });
+
+    it('falls back to the spec flow when there are no features', function () {
+        $outcome = new RunOutcome(null, new SuiteSummary(
+            'green',
+            ['examples' => 1, 'passes' => 1, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+        ));
+
+        $next = $this->narrator->next($outcome, PairRole::HumanDrives);
+
+        expect($next['action'])->toBe('observe');
+    });
+
 });

--- a/spec/PhpSpec/Console/Command/Run/RecencyScanner.spec.php
+++ b/spec/PhpSpec/Console/Command/Run/RecencyScanner.spec.php
@@ -1,0 +1,79 @@
+<?php
+
+use PhpSpec\Console\Command\Run\RecencyScanner;
+use PhpSpec\Filesystem;
+
+describe(RecencyScanner::class, function () {
+
+    it('returns the most recently modified .feature file', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->isDir())->toReturnUsing(fn(string $p): bool => $p === 'features');
+        allow($fs->scandir())->toReturn(['.', '..', 'a.feature', 'b.feature', 'notes.txt']);
+        allow($fs->mtime())->toReturnUsing(fn(string $p): int => match ($p) {
+            'features/a.feature' => 100,
+            'features/b.feature' => 200,
+            default => 0,
+        });
+
+        $scanner = new RecencyScanner($fs);
+
+        expect($scanner->mostRecentFeature('features'))->toBe('features/b.feature');
+    });
+
+    it('finds the most recent .feature in nested subdirectories', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, ['features', 'features/cli'], true));
+        allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+            'features' => ['.', '..', 'top.feature', 'cli'],
+            'features/cli' => ['.', '..', 'deep.feature'],
+            default => [],
+        });
+        allow($fs->mtime())->toReturnUsing(fn(string $p): int => match ($p) {
+            'features/top.feature' => 50,
+            'features/cli/deep.feature' => 500,
+            default => 0,
+        });
+
+        $scanner = new RecencyScanner($fs);
+
+        expect($scanner->mostRecentFeature('features'))->toBe('features/cli/deep.feature');
+    });
+
+    it('returns null when the features directory does not exist', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+
+        $scanner = new RecencyScanner($fs);
+
+        expect($scanner->mostRecentFeature('features'))->toBeNull();
+    });
+
+    it('returns null when no .feature files are present', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->isDir())->toReturnUsing(fn(string $p): bool => $p === 'features');
+        allow($fs->scandir())->toReturn(['.', '..', 'readme.md']);
+
+        $scanner = new RecencyScanner($fs);
+
+        expect($scanner->mostRecentFeature('features'))->toBeNull();
+    });
+
+    it('returns the most recently modified source file, recursing into subdirectories', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->isDir())->toReturnUsing(fn(string $p): bool => $p === 'src' || $p === 'src/App');
+        allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+            'src' => ['.', '..', 'App'],
+            'src/App' => ['.', '..', 'Calculator.php', 'Basket.php'],
+            default => [],
+        });
+        allow($fs->mtime())->toReturnUsing(fn(string $p): int => match ($p) {
+            'src/App/Calculator.php' => 10,
+            'src/App/Basket.php' => 20,
+            default => 0,
+        });
+
+        $scanner = new RecencyScanner($fs);
+
+        expect($scanner->mostRecentSource('src'))->toBe('src/App/Basket.php');
+    });
+
+});

--- a/spec/PhpSpec/Console/Command/Run/SuiteSummary.spec.php
+++ b/spec/PhpSpec/Console/Command/Run/SuiteSummary.spec.php
@@ -3,7 +3,10 @@
 use PhpSpec\Console\Command\Run\SuiteSummary;
 use PhpSpec\Result\ContextResult;
 use PhpSpec\Result\ExampleResult;
+use PhpSpec\Result\FeatureResult;
+use PhpSpec\Result\ScenarioResult;
 use PhpSpec\Result\SpecificationResult;
+use PhpSpec\Result\StepResult;
 use PhpSpec\Result\SuiteResult;
 
 describe(SuiteSummary::class, function () {
@@ -149,6 +152,88 @@ describe(SuiteSummary::class, function () {
             'example' => 'applies a discount code',
             'error' => '',
         ]);
+    });
+
+    it('summarises features: hasFeatures, per-feature red/todo status, and featuresAreGreen', function () {
+        $suite = new SuiteResult([
+            new FeatureResult('Adding', [
+                new ScenarioResult('adds two numbers', [
+                    new StepResult('Given a calculator', 'passed'),
+                    new StepResult('When I add 2 and 3', 'failure'),
+                ]),
+            ], 'features/adding.feature'),
+            new FeatureResult('Subtracting', [
+                new ScenarioResult('subtracts two numbers', [
+                    new StepResult('Given a calculator', 'undefined'),
+                ]),
+            ], 'features/subtracting.feature'),
+        ]);
+
+        $summary = SuiteSummary::fromSuiteResult($suite);
+
+        expect($summary->hasFeatures())->toBe(true);
+        expect($summary->featuresAreGreen())->toBe(false);
+        expect($summary->features())->toBe([
+            ['path' => 'features/adding.feature', 'status' => 'red', 'undefined' => 0],
+            ['path' => 'features/subtracting.feature', 'status' => 'todo', 'undefined' => 1],
+        ]);
+        expect($summary->redFeature())->toBe(['path' => 'features/adding.feature', 'status' => 'red', 'undefined' => 0]);
+    });
+
+    it('reports features as green when every step passes', function () {
+        $suite = new SuiteResult([
+            new FeatureResult('Adding', [
+                new ScenarioResult('adds', [
+                    new StepResult('Given a calculator', 'passed'),
+                    new StepResult('Then it sums', 'passed'),
+                ]),
+            ], 'features/adding.feature'),
+        ]);
+
+        $summary = SuiteSummary::fromSuiteResult($suite);
+
+        expect($summary->hasFeatures())->toBe(true);
+        expect($summary->featuresAreGreen())->toBe(true);
+        expect($summary->redFeature())->toBeNull();
+    });
+
+    it('reports no features for a spec-only suite', function () {
+        $suite = new SuiteResult([
+            new SpecificationResult('App\\Greeter', [new ExampleResult('greets', [])]),
+        ]);
+
+        $summary = SuiteSummary::fromSuiteResult($suite);
+
+        expect($summary->hasFeatures())->toBe(false);
+        expect($summary->featuresAreGreen())->toBe(false);
+        expect($summary->features())->toBe([]);
+    });
+
+    it('round-trips feature data through toArray/fromArray', function () {
+        $suite = new SuiteResult([
+            new FeatureResult('Adding', [
+                new ScenarioResult('adds', [new StepResult('Given a calculator', 'undefined')]),
+            ], 'features/adding.feature'),
+        ]);
+        $summary = SuiteSummary::fromSuiteResult($suite);
+
+        $restored = SuiteSummary::fromArray($summary->toArray());
+
+        expect($restored->hasFeatures())->toBe(true);
+        expect($restored->features())->toBe($summary->features());
+        expect($restored->featureCounts())->toBe($summary->featureCounts());
+    });
+
+    it('treats a legacy report without feature data as having no features', function () {
+        $summary = SuiteSummary::fromArray([
+            'status' => 'green',
+            'counts' => ['examples' => 1, 'passes' => 1, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+            'failing' => [],
+            'pending' => [],
+        ]);
+
+        expect($summary->hasFeatures())->toBe(false);
+        expect($summary->features())->toBe([]);
     });
 
     it('keeps the subject when examples are nested in a context', function () {

--- a/src/PhpSpec/Ai/PromptLibrary.php
+++ b/src/PhpSpec/Ai/PromptLibrary.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Ai;
+
+use PhpSpec\Filesystem;
+use PhpSpec\RealFilesystem;
+
+/**
+ * @internal
+ * Loads a named prompt artifact from the Ai/Prompts directory, so the coaching
+ * text lives in an editable `.txt` file rather than inline in a command. Returns
+ * an empty string when the artifact is missing, letting callers fall back.
+ */
+final class PromptLibrary
+{
+    private readonly Filesystem $filesystem;
+
+    /**
+     * @param Filesystem|null $filesystem filesystem abstraction for testability
+     */
+    public function __construct(?Filesystem $filesystem = null)
+    {
+        $this->filesystem = $filesystem ?? new RealFilesystem();
+    }
+
+    /**
+     * Returns the contents of the named prompt artifact (`<name>.txt`), or an
+     * empty string when it cannot be read.
+     */
+    public function read(string $name): string
+    {
+        $path = __DIR__ . '/Prompts/' . $name . '.txt';
+
+        return $this->filesystem->exists($path) ? $this->filesystem->read($path) : '';
+    }
+}

--- a/src/PhpSpec/Ai/Prompts/next.txt
+++ b/src/PhpSpec/Ai/Prompts/next.txt
@@ -1,0 +1,44 @@
+You advise the single next step in OUTSIDE-IN, story-first TDD. Name one BABY STEP — never a
+plan, never a list. The outside drives the inside, so FEATURE FIRST: a feature (story) test
+leads, the unit specs follow.
+
+Work from the acceptance test inward:
+
+OUTER CYCLE — write a feature/scenario, generate its empty steps, write the steps, watch it go
+red, drop into the INNER CYCLE until the scenario is green, then begin the next scenario.
+
+INNER CYCLE — BARELY-ENOUGH-DESIGN first (tell-don't-ask, respect the Law of Demeter, name for
+the domain, CRC for what this object knows and does right now, not some imagined future). Then
+spec the next method and let phpspec generate it, watch it go red, write the smallest code that
+goes green, REFACTOR on green (delete duplication, reorganise), observe the design that is
+emerging, and re-run the scenario.
+
+Choose the step from the current suite state:
+
+- A scenario is red, or its steps are undefined — we are mid-OUTER. Name the step to write, or
+  the inner example that makes the next step pass. Stay in the inner loop until the scenario is
+  green.
+- Features are all green — pick exactly one: REFACTOR the code we just added, a NEW SCENARIO on
+  the feature we last touched, or a NEW FEATURE when that story feels complete. Prefer refining
+  or extending the current story over opening a new one, unless it is truly done.
+- NO FEATURES yet — fall back to the spec cycle: describe the class the domain is missing, or
+  make the nearest pending example real.
+
+Always the smallest next move: one artifact, then reassess.
+
+Pair framing. As the NAVIGATOR you advise and the human drives — name the intent, drop to where
+or the exact line only when asked, and speak up the moment a step breaks the design. As the
+DRIVER you take exactly that one step, show the diff, and hand back.
+
+Voice: first person plural, "we". Short lines. One suggestion at a time. No praise filler, no
+lectures.
+
+When a machine-readable answer is asked for, respond with ONLY this JSON — nothing else — with
+"reason" kept to one short sentence:
+
+{"type": "feature", "target": "checkout discounts", "reason": "No scenario yet pins down how a coupon lowers the basket total."}
+
+type is one of:
+- feature: a user-facing behaviour to specify as a scenario. target = short name.
+- spec: a new class to describe. target = fully qualified class name.
+- example: a new example for an existing spec. target = fully qualified class name.

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -15,8 +15,12 @@
 namespace PhpSpec\Console\Command;
 
 use PhpSpec\Ai\Message;
+use PhpSpec\Ai\PromptLibrary;
 use PhpSpec\Ai\ProviderFactory;
 use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Pair\SpecRunner;
+use PhpSpec\Console\Command\Pair\SubprocessRunner;
+use PhpSpec\Console\Command\Run\RecencyScanner;
 use PhpSpec\Filesystem;
 use PhpSpec\RealFilesystem;
 use RuntimeException;
@@ -24,6 +28,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -41,21 +46,26 @@ final class Next extends Command
 
     private Filesystem $filesystem;
 
-    /** @var (callable(array{provider: string, model?: string, api_key: string}): array{type: string, target: string, reason: string})|null */
+    private readonly SpecRunner $specRunner;
+
+    /** @var (callable(array{provider: string, model?: string, api_key: string}, string): array{type: string, target: string, reason: string})|null */
     private $suggestFn;
 
     /**
      * @param Configuration $config
      * @param Filesystem|null $filesystem
-     * @param (callable(array{provider: string, model?: string, api_key: string}): array{type: string, target: string, reason: string})|null $suggestFn
+     * @param (callable(array{provider: string, model?: string, api_key: string}, string): array{type: string, target: string, reason: string})|null $suggestFn injectable suggestion seam; receives the AI config and the built context
+     * @param SpecRunner|null $specRunner runs the suite for feature grounding; defaults to a subprocess
      */
     public function __construct(
         private readonly Configuration $config,
         ?Filesystem $filesystem = null,
         ?callable $suggestFn = null,
+        ?SpecRunner $specRunner = null,
     ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
         $this->suggestFn = $suggestFn;
+        $this->specRunner = $specRunner ?? new SubprocessRunner();
         parent::__construct();
     }
 
@@ -143,8 +153,12 @@ final class Next extends Command
      */
     private function getSuggestion(array $aiConfig): array
     {
+        // Feature (story) state grounds the suggestion so `next` can favour
+        // features when they are present; it is empty for a spec-only project.
+        $situation = $this->featureSituation();
+
         if ($this->suggestFn !== null) {
-            return ($this->suggestFn)($aiConfig);
+            return ($this->suggestFn)($aiConfig, $situation);
         }
 
         try {
@@ -156,6 +170,9 @@ final class Next extends Command
         $model = $aiConfig['model'] ?? ProviderFactory::defaultModel($aiConfig['provider']);
 
         $projectContext = $this->getCachedProjectContext();
+        if ($situation !== '') {
+            $projectContext = $situation . "\n\n" . $projectContext;
+        }
         $systemPrompt = $this->buildSystemPrompt();
 
         $messages = [
@@ -311,8 +328,65 @@ final class Next extends Command
         return 0;
     }
 
+    /**
+     * The live feature (story) grounding for the suggestion: a run of the whole
+     * suite (--all) rendered as a compact FEATURES block plus the last-touched
+     * feature and source. Empty for a spec-only project (no `features/` dir, or a
+     * run that executed no feature), so `next` keeps its spec-only behaviour then.
+     */
+    private function featureSituation(): string
+    {
+        $featuresDir = getcwd() . '/features';
+        if (!$this->filesystem->exists($featuresDir) || !$this->filesystem->isDir($featuresDir)) {
+            return '';
+        }
+
+        $summary = $this->specRunner->run('--all', new BufferedOutput())?->summary;
+        if ($summary === null || !$summary->hasFeatures()) {
+            return '';
+        }
+
+        $c = $summary->featureCounts();
+        $lines = [sprintf(
+            "# Suite state\nFEATURES: %d features, %d scenarios, %d steps (%d failing, %d undefined). Favour these — the outside drives the inside.",
+            $c['features'],
+            $c['scenarios'],
+            $c['steps'],
+            $c['stepFailures'],
+            $c['undefined'],
+        )];
+
+        foreach ($summary->features() as $feature) {
+            if ($feature['status'] !== 'green') {
+                $lines[] = sprintf('- %s: %s', $feature['status'], $feature['path']);
+            }
+        }
+
+        $recency = new RecencyScanner($this->filesystem);
+        $recentFeature = $recency->mostRecentFeature($featuresDir);
+        if ($recentFeature !== null) {
+            $lines[] = 'Last-touched feature: ' . $recentFeature;
+        }
+
+        $recentSource = $recency->mostRecentSource(getcwd() . '/' . ltrim($this->config->getSrcPath(), './'));
+        if ($recentSource !== null) {
+            $lines[] = 'Last-touched source: ' . $recentSource;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * The outside-in coaching prompt, shared with pair-mode `next` via the
+     * `next.txt` artifact, falling back to an inline prompt if it cannot be read.
+     */
     private function buildSystemPrompt(): string
     {
+        $prompt = (new PromptLibrary($this->filesystem))->read('next');
+        if (trim($prompt) !== '') {
+            return $prompt . "\n\nRespond now with ONLY the JSON suggestion described above.";
+        }
+
         return <<<'PROMPT'
 You are a BDD coach advising what to build next in a PHP project. Study the project structure and suggest ONE concrete next step — a new class, a new feature scenario, or a new example for an existing spec.
 

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -15,6 +15,7 @@
 namespace PhpSpec\Console\Command\Pair;
 
 use Exception;
+use PhpSpec\Ai\PromptLibrary;
 use PhpSpec\Ai\ProviderFactory;
 use PhpSpec\CodeGeneration\ClassGenerator;
 use PhpSpec\CodeGeneration\ClassLocation;
@@ -24,6 +25,7 @@ use PhpSpec\Console\Command\Generate\GenerateAgent;
 use PhpSpec\Console\Command\Pair;
 use PhpSpec\Console\Command\Run\CodeGenerator;
 use PhpSpec\Console\Command\Run\GenerationCandidates;
+use PhpSpec\Console\Command\Run\RecencyScanner;
 use PhpSpec\Console\Command\Run\SuiteSummary;
 use PhpSpec\Extensions\ExtensionLoader;
 use PhpSpec\Filesystem;
@@ -96,6 +98,7 @@ final class CommandDispatcher
         ?SpecRunner $specRunner = null,
         ?RoleState $roleState = null,
         ?GenerateAgent $generateAgent = null,
+        ?AiAssistant $ai = null,
     ) {
         $this->parser = new InputParser();
         $this->filesystem = $filesystem ?? new RealFilesystem();
@@ -104,6 +107,12 @@ final class CommandDispatcher
         $this->roleState = $roleState ?? new RoleState();
         $this->generateAgent = $generateAgent ?? new GenerateAgent($this->config, $this->filesystem);
         $this->registerAutoloader();
+
+        if ($ai !== null) {
+            $this->ai = $ai;
+
+            return;
+        }
 
         $aiConfig = $this->config->getAiConfig();
         if ($aiConfig !== null) {
@@ -173,29 +182,55 @@ final class CommandDispatcher
     }
 
     /**
-     * Suggests the single next step from a real suite run rather than a guess,
-     * so it never loops describing a spec that already exists: red means run and
-     * fix, a pending example is the nearest gap, an empty project starts a spec.
-     * While the human navigates it coaches; while the AI drives it takes the
-     * step itself (one artifact).
+     * Suggests the single next step from a real suite run, following outside-in,
+     * feature-first TDD. Features run too (--all), so a red or unwritten scenario
+     * leads; when features are green it points at a baby step over the last-touched
+     * files. With AI it hands the shared outside-in coaching to the assistant (the
+     * navigator advises, the driver takes the step); without AI it prints the
+     * deterministic, feature-aware narrator.
      */
     private function handleNext(): int
     {
-        $outcome = $this->specRunner->run('', new BufferedOutput());
+        // --all runs features too, so the advice can favour them. A fake SpecRunner
+        // in specs ignores the argument; SubprocessRunner appends it to the child
+        // argv (an empty argument would mean specs only).
+        $outcome = $this->specRunner->run('--all', new BufferedOutput());
         $this->lastSituation = $outcome->summary ?? $this->lastSituation;
-        $role = $this->roleState->current();
-        $next = (new SuiteNarrator())->next($outcome, $role);
+
+        if ($this->ai !== null) {
+            $this->ai->handle($this->nextInstruction(), $this->lastSituation);
+
+            return self::CONTINUE;
+        }
+
+        $recency = new RecencyScanner($this->filesystem);
+        $cwd = getcwd() ?: '.';
+        $recentFeature = $recency->mostRecentFeature($cwd . '/features');
+        $recentSource = $recency->mostRecentSource($cwd . '/' . ltrim($this->config->getSrcPath(), './'));
+
+        $next = (new SuiteNarrator())->next($outcome, $this->roleState->current(), $recentFeature, $recentSource);
 
         $console = $this->output->getOutput();
         foreach ($next['lines'] as $line) {
             $console->writeln($line);
         }
 
-        if ($role->aiIsDriver() && $this->ai !== null && $next['action'] !== 'observe') {
-            $this->ai->handle('Take the single most valuable next step now, as one artifact, then hand back.', $this->lastSituation);
+        return self::CONTINUE;
+    }
+
+    /**
+     * The `next` coaching handed to the AI: the shared outside-in prompt file plus
+     * a short ask. The role in force (navigator advises, driver executes) is already
+     * encoded in the AI's cached system prompt, so the ask stays role-agnostic.
+     */
+    private function nextInstruction(): string
+    {
+        $coaching = (new PromptLibrary($this->filesystem))->read('next');
+        if (trim($coaching) === '') {
+            $coaching = 'Follow outside-in, feature-first TDD — favour feature (story) tests, always a baby step.';
         }
 
-        return self::CONTINUE;
+        return $coaching . "\n\n" . 'Based on our current suite state, name and take the single next baby step now — one artifact, then hand back.';
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Pair/SituationReport.php
+++ b/src/PhpSpec/Console/Command/Pair/SituationReport.php
@@ -58,6 +58,10 @@ final readonly class SituationReport
     {
         $lines = [$this->suiteLine()];
 
+        foreach ($this->featureLines() as $line) {
+            $lines[] = $line;
+        }
+
         foreach ($this->exampleLines('FAILING', $this->summary?->failing() ?? []) as $line) {
             $lines[] = $line;
         }
@@ -94,6 +98,40 @@ final readonly class SituationReport
         );
 
         return sprintf('SUITE: %s — %d examples: %s', $this->summary->status(), $c['examples'], $breakdown);
+    }
+
+    /**
+     * The feature (story) grounding: a FEATURES tally line, then each non-green
+     * feature named so the model knows which scenario to drive. Empty for a
+     * spec-only suite, so nothing about features leaks into that report.
+     *
+     * @return list<string>
+     */
+    private function featureLines(): array
+    {
+        if ($this->summary === null || !$this->summary->hasFeatures()) {
+            return [];
+        }
+
+        $c = $this->summary->featureCounts();
+        $lines = [sprintf(
+            'FEATURES: %d features, %d scenarios, %d steps (%d failing, %d undefined)',
+            $c['features'],
+            $c['scenarios'],
+            $c['steps'],
+            $c['stepFailures'],
+            $c['undefined'],
+        )];
+
+        foreach ($this->summary->features() as $feature) {
+            if ($feature['status'] === 'red') {
+                $lines[] = sprintf('  - red scenario in %s', $feature['path']);
+            } elseif ($feature['status'] === 'todo') {
+                $lines[] = sprintf('  - steps to write in %s (%d undefined)', $feature['path'], $feature['undefined']);
+            }
+        }
+
+        return $lines;
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Pair/SuiteNarrator.php
+++ b/src/PhpSpec/Console/Command/Pair/SuiteNarrator.php
@@ -113,11 +113,20 @@ final class SuiteNarrator
      * lines are phrased for the current role; the action lets the caller act when
      * the AI is driving.
      *
+     * When the suite includes feature (story) tests they lead — outside-in — and
+     * the last-touched feature/source ground the green-suite advice.
+     *
+     * @param string|null $recentFeature the most recently modified `.feature`, for green advice
+     * @param string|null $recentSource the most recently modified source file, for green advice
      * @return array{lines: list<string>, action: 'run'|'exemplify'|'describe'|'observe', target: ?string}
      */
-    public function next(?RunOutcome $outcome, PairRole $role): array
+    public function next(?RunOutcome $outcome, PairRole $role, ?string $recentFeature = null, ?string $recentSource = null): array
     {
         $summary = $outcome?->summary;
+
+        if ($summary !== null && $summary->hasFeatures()) {
+            return $this->featureStep($summary, $role, $recentFeature, $recentSource);
+        }
 
         return match (true) {
             $summary === null || $summary->isEmpty() => $this->describeFirstStep(),
@@ -125,6 +134,100 @@ final class SuiteNarrator
             $summary->nearestPendingGap() !== null => $this->exemplifyStep($summary, $role),
             default => $this->observeStep(),
         };
+    }
+
+    /**
+     * The next step when the suite includes features, favouring them: a concrete
+     * red example is the inner step; a red scenario with nothing failing yet is
+     * run to drive out its behaviour; undefined steps get written; and a green
+     * feature suite offers one baby step over the last-touched files.
+     *
+     * @return array{lines: list<string>, action: 'run'|'exemplify'|'describe'|'observe', target: ?string}
+     */
+    private function featureStep(SuiteSummary $summary, PairRole $role, ?string $recentFeature, ?string $recentSource): array
+    {
+        if ($summary->failing() !== []) {
+            return $this->runStep($summary, $role);
+        }
+
+        $red = $summary->redFeature();
+        if ($red !== null) {
+            return $this->redFeatureStep($red, $role);
+        }
+
+        $todo = $this->firstTodoFeature($summary);
+        if ($todo !== null) {
+            return $this->writeStepsStep($todo, $role);
+        }
+
+        return $this->greenFeatureStep($role, $recentFeature, $recentSource);
+    }
+
+    /**
+     * @param array{path: string, status: string, undefined: int} $red
+     * @return array{lines: list<string>, action: 'run', target: string}
+     */
+    private function redFeatureStep(array $red, PairRole $role): array
+    {
+        $name = basename($red['path']);
+
+        $line = $role->aiIsDriver()
+            ? sprintf('  <fg=red>Red scenario</> in <options=bold>%s</> — I\'ll run and spec the behaviour its steps need.', $name)
+            : sprintf('  <fg=red>Red scenario</> in <options=bold>%s</> — <fg=white>/run</>, then we spec the behaviour its steps need.', $name);
+
+        return ['lines' => ['', $line], 'action' => 'run', 'target' => $red['path']];
+    }
+
+    /**
+     * @param array{path: string, status: string, undefined: int} $todo
+     * @return array{lines: list<string>, action: 'observe', target: string}
+     */
+    private function writeStepsStep(array $todo, PairRole $role): array
+    {
+        $name = basename($todo['path']);
+
+        $line = $role->aiIsDriver()
+            ? sprintf('  <options=bold>%s</> has undefined steps — I\'ll write the steps so the scenario can drive the code.', $name)
+            : sprintf('  <options=bold>%s</> has undefined steps — let\'s write the steps so the scenario can drive the code.', $name);
+
+        return ['lines' => ['', $line], 'action' => 'observe', 'target' => $todo['path']];
+    }
+
+    /**
+     * @return array{lines: list<string>, action: 'observe', target: ?string}
+     */
+    private function greenFeatureStep(PairRole $role, ?string $recentFeature, ?string $recentSource): array
+    {
+        $options = [];
+        if ($recentSource !== null) {
+            $options[] = sprintf('<fg=white>refactor</> the last code (<options=bold>%s</>)', basename($recentSource));
+        }
+
+        if ($recentFeature !== null) {
+            $options[] = sprintf('a <fg=white>new scenario</> on <options=bold>%s</>', basename($recentFeature));
+        }
+
+        $options[] = 'a <fg=white>new feature</> if that story feels complete';
+
+        return [
+            'lines' => ['', '  <fg=green>Features green.</> One baby step — ' . implode('; or ', $options) . '.'],
+            'action' => 'observe',
+            'target' => $recentFeature,
+        ];
+    }
+
+    /**
+     * @return array{path: string, status: string, undefined: int}|null
+     */
+    private function firstTodoFeature(SuiteSummary $summary): ?array
+    {
+        foreach ($summary->features() as $feature) {
+            if ($feature['status'] === 'todo') {
+                return $feature;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Run/RecencyScanner.php
+++ b/src/PhpSpec/Console/Command/Run/RecencyScanner.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Command\Run;
+
+use PhpSpec\Filesystem;
+use PhpSpec\RealFilesystem;
+
+/**
+ * @internal
+ * Finds the most recently modified files by modification time, so `next` can
+ * point at the last-touched feature or source without reaching for git. The
+ * newest `.feature` also doubles as the deterministic "do features exist?" gate.
+ */
+final class RecencyScanner
+{
+    private readonly Filesystem $filesystem;
+
+    /**
+     * @param Filesystem|null $filesystem filesystem abstraction for testability
+     */
+    public function __construct(?Filesystem $filesystem = null)
+    {
+        $this->filesystem = $filesystem ?? new RealFilesystem();
+    }
+
+    /**
+     * The path of the most recently modified `.feature` file under the given
+     * directory, or null when the directory is absent or holds no feature.
+     */
+    public function mostRecentFeature(string $featuresDir): ?string
+    {
+        return $this->mostRecentByExtension($featuresDir, '.feature');
+    }
+
+    /**
+     * The path of the most recently modified `.php` file under the given source
+     * directory, or null when the directory is absent or holds no source.
+     */
+    public function mostRecentSource(string $srcDir): ?string
+    {
+        return $this->mostRecentByExtension($srcDir, '.php');
+    }
+
+    private function mostRecentByExtension(string $dir, string $extension): ?string
+    {
+        if (!$this->filesystem->exists($dir) || !$this->filesystem->isDir($dir)) {
+            return null;
+        }
+
+        $mostRecent = null;
+        $mostRecentMtime = -1;
+
+        foreach ($this->filesInTree($dir, $extension) as $file) {
+            $mtime = $this->filesystem->mtime($file);
+            if ($mtime > $mostRecentMtime) {
+                $mostRecentMtime = $mtime;
+                $mostRecent = $file;
+            }
+        }
+
+        return $mostRecent;
+    }
+
+    /**
+     * Every file under a directory (recursively) whose name ends in $extension.
+     *
+     * @return list<string>
+     */
+    private function filesInTree(string $dir, string $extension): array
+    {
+        $files = [];
+
+        foreach ($this->filesystem->scandir($dir) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            if ($this->filesystem->isDir($path)) {
+                $files = array_merge($files, $this->filesInTree($path, $extension));
+
+                continue;
+            }
+
+            if (str_ends_with($entry, $extension)) {
+                $files[] = $path;
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/PhpSpec/Console/Command/Run/SuiteSummary.php
+++ b/src/PhpSpec/Console/Command/Run/SuiteSummary.php
@@ -16,7 +16,10 @@ namespace PhpSpec\Console\Command\Run;
 
 use PhpSpec\Result\Counts;
 use PhpSpec\Result\ExampleResult;
+use PhpSpec\Result\FeatureResult;
+use PhpSpec\Result\ScenarioResult;
 use PhpSpec\Result\SpecificationResult;
+use PhpSpec\Result\StepResult;
 use PhpSpec\Result\SuiteResult;
 use PhpSpec\Results;
 
@@ -39,12 +42,16 @@ final readonly class SuiteSummary
      * @param array{examples: int, passes: int, failures: int, errors: int, pending: int} $counts
      * @param list<array{subject: string, example: string, error: string}> $failing
      * @param list<array{subject: string, example: string, error: string}> $pending
+     * @param array{features: int, scenarios: int, steps: int, stepFailures: int, undefined: int} $featureCounts
+     * @param list<array{path: string, status: 'red'|'green'|'todo', undefined: int}> $features
      */
     public function __construct(
         private string $status,
         private array $counts = ['examples' => 0, 'passes' => 0, 'failures' => 0, 'errors' => 0, 'pending' => 0],
         private array $failing = [],
         private array $pending = [],
+        private array $featureCounts = ['features' => 0, 'scenarios' => 0, 'steps' => 0, 'stepFailures' => 0, 'undefined' => 0],
+        private array $features = [],
     ) {}
 
     /**
@@ -62,15 +69,60 @@ final readonly class SuiteSummary
             'errors' => $c['errors'],
             'pending' => $c['pending'],
         ];
+        $featureCounts = [
+            'features' => $c['features'],
+            'scenarios' => $c['scenarios'],
+            'steps' => $c['steps'],
+            'stepFailures' => $c['stepFailures'],
+            'undefined' => $c['undefined'],
+        ];
 
         $failing = [];
         $pending = [];
+        $features = [];
         foreach ($result->getResults() as $node) {
             $subject = $node instanceof SpecificationResult ? $node->getTitle() : '';
             self::classify($node, $subject, $failing, $pending);
+            if ($node instanceof FeatureResult) {
+                $features[] = self::summariseFeature($node);
+            }
         }
 
-        return new self($result->status() === 0 ? 'green' : 'red', $counts, $failing, $pending);
+        return new self($result->status() === 0 ? 'green' : 'red', $counts, $failing, $pending, $featureCounts, $features);
+    }
+
+    /**
+     * Reduces a feature to a single red/green/todo verdict plus its undefined-step
+     * count: red if any step failed, todo if any step is still undefined (steps to
+     * write), green otherwise.
+     *
+     * @return array{path: string, status: 'red'|'green'|'todo', undefined: int}
+     */
+    private static function summariseFeature(FeatureResult $feature): array
+    {
+        $failures = 0;
+        $undefined = 0;
+        foreach ($feature->getResults() as $scenario) {
+            if (!$scenario instanceof ScenarioResult) {
+                continue;
+            }
+
+            foreach ($scenario->getResults() as $step) {
+                if (!$step instanceof StepResult) {
+                    continue;
+                }
+
+                if ($step->isFailure()) {
+                    ++$failures;
+                } elseif ($step->isUndefined()) {
+                    ++$undefined;
+                }
+            }
+        }
+
+        $status = $failures > 0 ? 'red' : ($undefined > 0 ? 'todo' : 'green');
+
+        return ['path' => $feature->getPath(), 'status' => $status, 'undefined' => $undefined];
     }
 
     /**
@@ -170,7 +222,57 @@ final readonly class SuiteSummary
     }
 
     /**
-     * @return array{status: string, counts: array<string, int>, failing: list<array{subject: string, example: string, error: string}>, pending: list<array{subject: string, example: string, error: string}>}
+     * Whether the run executed any feature (story) tests. Outside-in advice keys
+     * off this: with features present `next` favours them; without, it falls back
+     * to the spec-only flow.
+     */
+    public function hasFeatures(): bool
+    {
+        return $this->features !== [];
+    }
+
+    /**
+     * Whether every feature step passed. Checked explicitly against failures and
+     * undefined steps because the suite status stays green on undefined-only
+     * steps, so "features are done" needs more than a green status.
+     */
+    public function featuresAreGreen(): bool
+    {
+        return $this->hasFeatures()
+            && $this->featureCounts['stepFailures'] === 0
+            && $this->featureCounts['undefined'] === 0;
+    }
+
+    /** @return list<array{path: string, status: 'red'|'green'|'todo', undefined: int}> */
+    public function features(): array
+    {
+        return $this->features;
+    }
+
+    /**
+     * The first feature with a failing step, or null when none is red.
+     *
+     * @return array{path: string, status: 'red'|'green'|'todo', undefined: int}|null
+     */
+    public function redFeature(): ?array
+    {
+        foreach ($this->features as $feature) {
+            if ($feature['status'] === 'red') {
+                return $feature;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array{features: int, scenarios: int, steps: int, stepFailures: int, undefined: int} */
+    public function featureCounts(): array
+    {
+        return $this->featureCounts;
+    }
+
+    /**
+     * @return array{status: string, counts: array<string, int>, failing: list<array{subject: string, example: string, error: string}>, pending: list<array{subject: string, example: string, error: string}>, feature_counts: array<string, int>, features: list<array{path: string, status: string, undefined: int}>}
      */
     public function toArray(): array
     {
@@ -179,6 +281,8 @@ final readonly class SuiteSummary
             'counts' => $this->counts,
             'failing' => $this->failing,
             'pending' => $this->pending,
+            'feature_counts' => $this->featureCounts,
+            'features' => $this->features,
         ];
     }
 
@@ -189,6 +293,9 @@ final readonly class SuiteSummary
     {
         /** @var array<string, int> $counts */
         $counts = is_array($data['counts'] ?? null) ? $data['counts'] : [];
+
+        /** @var array<string, int> $featureCounts */
+        $featureCounts = is_array($data['feature_counts'] ?? null) ? $data['feature_counts'] : [];
 
         return new self(
             ($data['status'] ?? 'green') === 'red' ? 'red' : 'green',
@@ -201,7 +308,47 @@ final readonly class SuiteSummary
             ],
             self::normaliseExamples($data['failing'] ?? null),
             self::normaliseExamples($data['pending'] ?? null),
+            [
+                'features' => $featureCounts['features'] ?? 0,
+                'scenarios' => $featureCounts['scenarios'] ?? 0,
+                'steps' => $featureCounts['steps'] ?? 0,
+                'stepFailures' => $featureCounts['stepFailures'] ?? 0,
+                'undefined' => $featureCounts['undefined'] ?? 0,
+            ],
+            self::normaliseFeatures($data['features'] ?? null),
         );
+    }
+
+    /**
+     * Rebuilds the per-feature list from decoded data, defaulting any missing
+     * field so a child report written before feature data existed (a mid-upgrade
+     * subprocess) is simply read as having no features.
+     *
+     * @param mixed $items the decoded features list, of unknown shape
+     * @return list<array{path: string, status: 'red'|'green'|'todo', undefined: int}>
+     */
+    private static function normaliseFeatures(mixed $items): array
+    {
+        if (!is_array($items)) {
+            return [];
+        }
+
+        $normalised = [];
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $status = $item['status'] ?? null;
+
+            $normalised[] = [
+                'path' => is_string($item['path'] ?? null) ? $item['path'] : '',
+                'status' => in_array($status, ['red', 'green', 'todo'], true) ? $status : 'green',
+                'undefined' => is_int($item['undefined'] ?? null) ? $item['undefined'] : 0,
+            ];
+        }
+
+        return $normalised;
     }
 
     /**

--- a/src/PhpSpec/Filesystem.php
+++ b/src/PhpSpec/Filesystem.php
@@ -84,4 +84,12 @@ interface Filesystem
      * @param string $path PHP file to require
      */
     public function requirePhp(string $path): mixed;
+
+    /**
+     * Returns a file's last-modified time as a Unix timestamp, or 0 when it
+     * cannot be determined.
+     *
+     * @param string $path file to inspect
+     */
+    public function mtime(string $path): int;
 }

--- a/src/PhpSpec/RealFilesystem.php
+++ b/src/PhpSpec/RealFilesystem.php
@@ -81,4 +81,10 @@ final class RealFilesystem implements Filesystem
     {
         return require $path;
     }
+
+    /** {@inheritdoc} */
+    public function mtime(string $path): int
+    {
+        return @filemtime($path) ?: 0;
+    }
 }


### PR DESCRIPTION
 - Both `next` paths (standalone and pair `/next`) now run the whole suite (`--all`) and advise the next baby step outside-in, favouring feature tests, via a shared `Ai/Prompts/next.txt`: a red or unwritten scenario drives the inner spec cycle, and green features suggest a refactor, a new scenario, or a new feature over the last-touched files — falling back to the spec cycle when there are no features.
 - Teach `SuiteSummary`, `SuiteNarrator`, and `SituationReport` about features (per-feature red/green/todo, serialised across the pair subprocess so pair `/next` reacts to real story state).
 - Add `Filesystem::mtime()` + `RecencyScanner` (last-touched lookup by mtime) and `PromptLibrary` (loads the shared coaching, inline fallback); the deterministic narrator works without AI and `next.txt` enriches it when a provider is configured.