### PR TITLE
Prepare 9.0.0-beta.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [9.0.0-beta.11](https://github.com/phpspec/phpspec/compare/9.0.0-beta.10...9.0.0-beta.11)
 
 ### Fixed
  - The google default model is `gemini-3.1-pro-preview`: its predecessor `gemini-3-pro-preview` was retired from the API and answered every request with a 404. Set `ai.model` to choose differently.

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -24,4 +24,4 @@
 
     (new PhpSpec\Console\Application($version))->run();
 
-})('9.0.0-beta.10');
+})('9.0.0-beta.11');


### PR DESCRIPTION
Release prep for 9.0.0-beta.11: the Unreleased changelog section becomes the versioned one, and `bin/phpspec` reports the new version.

Ships the first dogfood fixes for beta.10 (#1546): the retired google default model replaced with `gemini-3.1-pro-preview`, and `generate` grounded in the real project (bare subjects resolved against the tree, labelled deeper file listings, reasoning-model output headroom, and the pair `/generate` plain-English hint).