### PR TITLE
Navigator offers concrete changes as diffs, and /next ghost-prefills /generate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+ - The pair navigator can OFFER a concrete change: the human sees it as a diff and accepts or declines through the numbered chooser (1. Yes / 2. Always / 3. No), the accepted change lands through the shared write gate and auto-verifies, and unbidden writes stay forbidden. Spec offers must grow the spec, exactly like writes.
+ - Pair `/next` pre-fills the prompt with a matching `/generate` ghost built from the suggestion the AI registers (via `suggest_next`), so acting on the advice is Tab and Enter, never retyping it.
+
 ## [9.0.0-beta.11](https://github.com/phpspec/phpspec/compare/9.0.0-beta.10...9.0.0-beta.11)
 
 ### Fixed

--- a/spec/PhpSpec/Ai/Prompts.spec.php
+++ b/spec/PhpSpec/Ai/Prompts.spec.php
@@ -67,6 +67,15 @@ describe('prompt artifacts', function () {
         expect($read('tools/generate_steps'))->toContain('.steps.php');
         expect($read('tools/write_file'))->toContain('not covered by describe');
         expect($read('tools/update_file'))->toContain('add_example');
+        expect($read('tools/offer_change'))->toContain('diff');
+        expect($read('tools/suggest_next'))->toContain('suggestion');
+    });
+
+    it('teaches the navigator to offer concrete changes instead of dictating typing', function () use ($read) {
+        $text = $read('navigator');
+
+        expect($text)->toContain('offer_change');
+        expect($text)->toContain('never write');   // unbidden writes stay forbidden
     });
 
     it('ships the refactor command as a manifest with its rules as editable prose', function () use ($read) {

--- a/spec/PhpSpec/Console/Command/Generate.spec.php
+++ b/spec/PhpSpec/Console/Command/Generate.spec.php
@@ -66,7 +66,7 @@ describe(Generate::class, function () {
 
         $tester->execute(['instruction' => ['x']], ['interactive' => false]);
 
-        expect($tester->getDisplay())->toContain('did not produce a usable artifact');
+        expect($tester->getDisplay())->toContain('no usable answer');
     });
 
 });

--- a/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
@@ -82,6 +82,137 @@ describe(AiAssistant::class, function () {
         expect($options['effort'])->toBe('high');
     });
 
+    it('shows a navigator offer as a diff and applies it on yes', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("<?php\nnamespace App;\nclass TodoList {}\n");
+        $written = [];
+        allow($fs->write())->toReturnUsing(function (string $p, string $c) use (&$written) {
+            $written[$p] = $c;
+        });
+        allow($fs->mkdir())->toReturn(null);
+
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'offer_change', [
+                    'path' => 'src/App/TodoList.php',
+                    'content' => "<?php\nnamespace App;\nclass TodoList {\n    public function tasks(): array { return []; }\n}\n",
+                    'intent' => 'add a tasks() accessor so the example can assert on it',
+                ])]);
+            }
+            $captured = $messages;
+
+            return new Response('done');
+        };
+
+        // Default role: the human drives, the AI navigates and may only offer.
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $this->answers = ['1'];
+        $assistant->handle('how do we make this real?');
+
+        $text = $this->buffer->fetch();
+        expect($text)->toContain('add a tasks() accessor');   // the stated intent at the chooser
+        expect($written)->toHaveLength(1);
+        expect((string) json_encode($captured))->toContain('applied');
+    });
+
+    it('keeps a declined offer unwritten and steers the model to re-plan', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("<?php\n// old");
+        allow($fs->mkdir())->toReturn(null);
+
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'offer_change', [
+                    'path' => 'src/App/TodoList.php',
+                    'content' => "<?php\n// new",
+                    'intent' => 'rewrite it',
+                ])]);
+            }
+            $captured = $messages;
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $this->answers = ['3'];
+        $assistant->handle('thoughts?');
+
+        expect($fs->write())->not()->toHaveBeenCalled();
+        expect((string) json_encode($captured))->toContain('declined this offer');
+    });
+
+    it('rejects an offer that would drop spec examples, before any chooser', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("<?php\ndescribe('TodoList', function () {\n    it(\"should add\", fn() => expect(null)->toBe(null));\n    it(\"should tasks\", fn() => expect(null)->toBe(null));\n});\n");
+
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'offer_change', [
+                    'path' => 'spec/App/TodoList.spec.php',
+                    'content' => "<?php\ndescribe('TodoList', function () {\n    it('keeps track of added tasks', fn() => expect(true)->toBe(true));\n});\n",
+                    'intent' => 'replace the anemic examples',
+                ])]);
+            }
+            $captured = $messages;
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $this->answers = ['1'];
+        $assistant->handle('sharpen the spec');
+
+        expect($fs->write())->not()->toHaveBeenCalled();
+        expect((string) json_encode($captured))->toContain('drop existing examples');
+    });
+
+    it('offers replace writes while navigating, and writes replace offers while driving', function (Filesystem $fs) {
+        $names = null;
+        $this->provider->responder = function (array $messages, array $options) use (&$names) {
+            $names = array_column($options['tools'], 'name');
+
+            return new Response('done');
+        };
+
+        $navigator = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $navigator->handle('hello');
+        expect($names)->toContain('offer_change');
+        expect($names)->not()->toContain('write_file');
+
+        $driver = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, $this->aiDrives, $this->specRunner);
+        $driver->handle('hello');
+        expect($names)->toContain('write_file');
+        expect($names)->not()->toContain('offer_change');
+    });
+
+    it('registers the model suggestion for the dispatcher ghost', function (Filesystem $fs) {
+        $turn = 0;
+        $this->provider->responder = function () use (&$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'suggest_next', [
+                    'type' => 'example',
+                    'target' => 'App\\TodoList',
+                    'reason' => 'The current examples assert null.',
+                ])]);
+            }
+
+            return new Response('Let us make the example real.');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        expect($assistant->lastSuggestion())->toBeNull();
+
+        $assistant->handle('what next?');
+
+        expect($assistant->lastSuggestion())->toBe(['type' => 'example', 'target' => 'App\\TodoList', 'reason' => 'The current examples assert null.']);
+    });
+
     it('routes ask_user tool calls from the model through the chooser', function (Filesystem $fs) {
         $captured = null;
         $turn = 0;

--- a/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
@@ -483,6 +483,48 @@ describe(CommandDispatcher::class, function () {
     });
 
     context('next-command suggestion (ghost hint)', function () {
+        it('pre-fills a /generate ghost from the suggestion the AI registered on /next', function (Filesystem $fs) {
+            allow($fs->exists())->toReturn(false);
+            allow($fs->isDir())->toReturn(false);
+            allow($fs->isFile())->toReturn(false);
+            allow($fs->scandir())->toReturn([]);
+            allow($fs->read())->toReturn('');
+
+            $provider = new class implements ProviderInterface {
+                public int $turn = 0;
+
+                public function chat(array $messages, array $options = []): Response
+                {
+                    if (++$this->turn === 1) {
+                        return new Response('', [new ToolCall('t1', 'suggest_next', [
+                            'type' => 'example',
+                            'target' => 'App\\TodoList',
+                            'reason' => 'The current examples assert null.',
+                        ])]);
+                    }
+
+                    return new Response('Let us make the example real.');
+                }
+            };
+
+            $config = new Configuration('.', $fs);
+            $assistant = new AiAssistant($provider, $config, $this->pairOutput, 'test-model', $fs, false, null, new Chooser($this->pairOutput, false), null, $this->specRunner);
+            $dispatcher = new CommandDispatcher(
+                new SpecGenerator('spec', $fs),
+                new ClassGenerator('src', $fs),
+                $config,
+                $this->pairOutput,
+                false,
+                $fs,
+                specRunner: $this->specRunner,
+                ai: $assistant,
+            );
+
+            $dispatcher->dispatch('/next');
+
+            expect($dispatcher->suggestion())->toBe('/generate add a spec example for App\\TodoList');
+        });
+
         it('suggests running the new spec after /describe', function (Filesystem $fs) {
             allow($fs->exists())->toReturn(false);
             allow($fs->mkdir())->toReturn(null);

--- a/src/PhpSpec/Ai/Agent/Agent.php
+++ b/src/PhpSpec/Ai/Agent/Agent.php
@@ -163,7 +163,9 @@ final class Agent
         if ($profile->answer === 'tool_call' && $proposals === [] && $data === []) {
             $prose = trim($response->text);
 
-            return new Outcome($step, [], $prose !== '' ? $prose : 'The model did not produce a usable artifact. Try rephrasing.');
+            // Command-neutral: `next` has no instruction to rephrase, so the
+            // fallback names the likely levers instead.
+            return new Outcome($step, [], $prose !== '' ? $prose : 'The model returned no usable answer. Try again, or set ai.model to a stronger model.');
         }
 
         return new Outcome($step, $proposals, trim($response->text), $data);

--- a/src/PhpSpec/Ai/Prompts/navigator.txt
+++ b/src/PhpSpec/Ai/Prompts/navigator.txt
@@ -1,17 +1,19 @@
 You are pairing as the NAVIGATOR. The human is driving.
 
-The golden rule: you never write files in this role. Your ideas reach the code only
-through the human's hands. Do not call any tool that writes, creates, or edits a file —
-the human decides what gets generated and triggers it with the commands (describe,
-exemplify, run) and the numbered choosers. If they want you to write, they will hand you
-the keyboard with /swap.
+The golden rule: you never write files unbidden in this role. Your ideas reach the
+code only through the human's decisions. When your advice has become concrete (an
+exact example, a step definition, a small method), OFFER it with offer_change: the
+human sees the diff and accepts or declines, and that decision is theirs alone.
+Never re-offer a declined change; ask what they would prefer instead. Everything
+else the human generates themselves with the commands (describe, exemplify, run)
+and the numbered choosers, or they hand you the keyboard with /swap.
 
 Navigate strong-style, always one step ahead, choosing your level of abstraction:
 1. Intent — name the behaviour we pin down next.
 2. Location — where it goes (which spec, after which example), only when they hesitate or
    ask "where?".
-3. Details — the exact expect() line or method body, only when they ask ("give me the
-   expectation", "type it out"). Print it for them to use.
+3. Details — the exact expect() line or method body. Offer it with offer_change so
+   they can accept it as a diff instead of retyping it.
 Drop to a lower level only when the driver asks for it.
 
 Guard the design. Speak up when a step breaks a rule or drifts from what we intended —

--- a/src/PhpSpec/Ai/Prompts/tools/offer_change.txt
+++ b/src/PhpSpec/Ai/Prompts/tools/offer_change.txt
@@ -1,0 +1,6 @@
+Offer ONE concrete file change while navigating: give the complete new content of
+one file, and the human sees it as a diff they accept or decline. Use it the moment
+your advice has become concrete (an exact example, a step definition, a small
+method) instead of asking the human to type it. Never re-offer a declined change:
+ask what they would prefer instead. A spec offer must grow the spec; dropping
+existing examples is rejected.

--- a/src/PhpSpec/Ai/Prompts/tools/suggest_next.txt
+++ b/src/PhpSpec/Ai/Prompts/tools/suggest_next.txt
@@ -1,0 +1,3 @@
+Register the single next-step suggestion in structured form: what to build next
+(spec, feature, or example), its target, and one short reason. In pair mode this
+feeds the prompt's ghost suggestion; keep advising the human in prose as well.

--- a/src/PhpSpec/Console/Command/Pair/AiAssistant.php
+++ b/src/PhpSpec/Console/Command/Pair/AiAssistant.php
@@ -95,6 +95,14 @@ final class AiAssistant
     /** Whether the AI has written its one artifact this turn (while driving). */
     private bool $artifactWrittenThisHandle = false;
 
+    /**
+     * The structured next-step suggestion the model registered this turn via
+     * suggest_next, for the dispatcher to turn into a ghost prompt.
+     *
+     * @var array<string, string>|null
+     */
+    private ?array $lastSuggestion = null;
+
     /** Tool rounds taken since the driving AI wrote its artifact this turn. */
     private int $postArtifactRounds = 0;
 
@@ -151,6 +159,7 @@ final class AiAssistant
             $this->ensureInitialised();
             $this->artifactWrittenThisHandle = false;
             $this->postArtifactRounds = 0;
+            $this->lastSuggestion = null;
             $this->messages = $this->window->apply($this->messages);
             $this->injectSituation($situation);
             $this->messages[] = Message::user($input);
@@ -167,6 +176,18 @@ final class AiAssistant
         } catch (Throwable $e) {
             $this->output->error("AI error: {$e->getMessage()}");
         }
+    }
+
+    /**
+     * The structured suggestion the model registered on its last turn (via the
+     * suggest_next tool), or null when it registered none. The dispatcher turns
+     * it into a ghost-prefilled /generate.
+     *
+     * @return array<string, string>|null
+     */
+    public function lastSuggestion(): ?array
+    {
+        return $this->lastSuggestion;
     }
 
     /**
@@ -340,9 +361,10 @@ final class AiAssistant
         $tools = array_values($this->tools);
         $role = $this->roleState->current();
 
-        // Withhold the write tools when the AI is navigating (it never writes),
-        // and — while it drives — once it has already written its one artifact
-        // this turn, so it can only read and run for the rest of the turn.
+        // Withhold the write tools when the AI is navigating (it never writes
+        // unbidden; it OFFERS instead), and — while it drives — once it has
+        // already written its one artifact this turn, so it can only read and
+        // run for the rest of the turn.
         $withholdWrites = $role->aiIsNavigator()
             || ($role->aiIsDriver() && $this->artifactWrittenThisHandle);
 
@@ -350,6 +372,14 @@ final class AiAssistant
             $tools = array_values(array_filter(
                 $tools,
                 fn(ToolInterface $tool) => !in_array($tool->getName(), self::WRITE_TOOLS, true),
+            ));
+        }
+
+        // Offering is the navigator's channel; a driving AI writes instead.
+        if ($role->aiIsDriver()) {
+            $tools = array_values(array_filter(
+                $tools,
+                fn(ToolInterface $tool) => $tool->getName() !== 'offer_change',
             ));
         }
 
@@ -545,6 +575,8 @@ final class AiAssistant
             $this->generateStepsTool(),
             $this->writeFileTool(),
             $this->updateFileTool(),
+            $this->offerChangeTool(),
+            $this->suggestNextTool(),
             $this->runSpecsTool(),
             $this->inspectSymbolTool(),
             $this->askUserTool(),
@@ -985,6 +1017,125 @@ final class AiAssistant
                 $this->applyProposal($this->proposalFor($absPath, $content, 'update_file'));
 
                 return "File updated: $absPath";
+            },
+        );
+    }
+
+    /**
+     * The navigator's channel for concrete advice: an offered change is shown
+     * to the human as a diff FIRST, then accepted or declined through the
+     * chooser, and only an accepted offer reaches disk (through the shared
+     * Writer). The spec guards apply to offers exactly as to writes.
+     */
+    private function offerChangeTool(): Tool
+    {
+        $filesystem = $this->filesystem;
+        $specDir = $this->specDir();
+
+        return Tool::make(
+            name: 'offer_change',
+            description: self::toolDescription('offer_change'),
+            parameters: [
+                'path' => [
+                    'type' => 'string',
+                    'description' => 'Relative path from project root (e.g. "src/App/Service.php")',
+                ],
+                'content' => [
+                    'type' => 'string',
+                    'description' => 'The complete new file content',
+                ],
+                'intent' => self::intentParameter(),
+            ],
+            handler: function (array $args) use ($filesystem, $specDir) {
+                $path = $args['path'];
+                $content = $args['content'];
+                $absPath = getcwd() . '/' . ltrim($path, '/');
+
+                $rejection = self::specWriteRejection($absPath, $specDir, $content, $filesystem->exists($absPath) ? $filesystem->read($absPath) : '');
+                if ($rejection !== null) {
+                    return $rejection;
+                }
+
+                $proposal = $this->proposalFor($absPath, $content, 'offer_change');
+
+                // The diff IS the offer: the human sees it before deciding.
+                if ($proposal->isNew) {
+                    $this->output->fileDisplay($absPath, $proposal->new, true);
+                } else {
+                    $this->output->fileDiff($absPath, $proposal->old, $proposal->new);
+                }
+
+                if (!$this->chooser->choose($this->offerQuestion($args), 'offer-change', 'apply offered changes')) {
+                    PairLogger::log('RESULT', 'Offer declined');
+
+                    return self::offerDeclined();
+                }
+
+                (new Writer($filesystem))->apply($proposal);
+                $this->artifactWrittenThisHandle = true;
+
+                return "Change applied to $absPath.";
+            },
+        );
+    }
+
+    /**
+     * The offer's confirm prompt: the stated intent so the human decides on the
+     * plan, not just the mechanics.
+     *
+     * @param array<string, mixed> $args
+     */
+    private function offerQuestion(array $args): string
+    {
+        $intent = $args['intent'] ?? null;
+
+        if (is_string($intent) && trim($intent) !== '') {
+            return 'Plan: ' . trim($intent) . "\n  Apply this change?";
+        }
+
+        return 'Apply this offered change?';
+    }
+
+    /**
+     * The reply handed back when the human declines an offer: re-plan, never
+     * re-offer.
+     *
+     * @return array{error: string}
+     */
+    private static function offerDeclined(): array
+    {
+        return ['error' => 'The human declined this offer. Ask what they would prefer or refine the '
+            . 'suggestion; do not re-offer the same change.'];
+    }
+
+    /**
+     * Registers the model's structured next-step suggestion, so the dispatcher
+     * can pre-fill the prompt with a matching /generate ghost.
+     */
+    private function suggestNextTool(): Tool
+    {
+        return Tool::make(
+            name: 'suggest_next',
+            description: self::toolDescription('suggest_next'),
+            parameters: [
+                'type' => [
+                    'type' => 'string',
+                    'enum' => ['spec', 'feature', 'example', 'info'],
+                    'description' => 'What to build next',
+                ],
+                'target' => [
+                    'type' => 'string',
+                    'description' => 'The class or feature the suggestion is about',
+                ],
+                'reason' => [
+                    'type' => 'string',
+                    'description' => 'One short sentence why',
+                ],
+            ],
+            handler: function (array $args): string {
+                $this->lastSuggestion = array_map(strval(...), array_filter($args, is_scalar(...)));
+
+                return 'Suggestion noted. Keep advising in prose; never repeat it as JSON.';
             },
         );
     }

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -202,6 +202,13 @@ final class CommandDispatcher
         if ($this->ai !== null) {
             $this->ai->handle($this->nextInstruction(), $this->lastSituation);
 
+            // A registered suggestion becomes a ghost-prefilled /generate, so
+            // acting on the advice is Tab + Enter, never retyping it.
+            $ghost = self::generateGhost($this->ai->lastSuggestion());
+            if ($ghost !== null) {
+                $this->suggestion = $ghost;
+            }
+
             return self::CONTINUE;
         }
 
@@ -232,7 +239,29 @@ final class CommandDispatcher
             $coaching = 'Follow outside-in, feature-first TDD — favour feature (story) tests, always a baby step.';
         }
 
-        return $coaching . "\n\n" . 'Based on our current suite state, name and take the single next baby step now — one artifact, then hand back.';
+        return $coaching . "\n\n" . 'Based on our current suite state, name and take the single next baby step now: one artifact, then hand back. Register the step with suggest_next first, then advise in prose.';
+    }
+
+    /**
+     * The /generate ghost a registered suggestion maps to, phrased so the
+     * one-shot's step resolution routes it (feature/spec wording, a class to
+     * resolve), or null for suggestions with nothing concrete to prefill.
+     *
+     * @param array<string, string>|null $suggestion
+     */
+    private static function generateGhost(?array $suggestion): ?string
+    {
+        $target = trim($suggestion['target'] ?? '');
+        if ($target === '') {
+            return null;
+        }
+
+        return match ($suggestion['type'] ?? '') {
+            'feature' => '/generate a feature for ' . $target,
+            'spec' => '/generate a spec for ' . $target,
+            'example' => '/generate add a spec example for ' . $target,
+            default => null,
+        };
     }
 
     /**
@@ -275,7 +304,9 @@ final class CommandDispatcher
 
         // Set from the top-level command only, so a nested run (e.g. the "run
         // now?" step of /describe) never clobbers the hint.
-        $this->suggestion = $this->suggestionFor($command, $parsed['argument']);
+        // The static follow-up table never overrides a ghost the handler itself
+        // set (e.g. /next prefilling a /generate from the AI's suggestion).
+        $this->suggestion = $this->suggestionFor($command, $parsed['argument']) ?? $this->suggestion;
 
         return $result;
     }


### PR DESCRIPTION
Fixes the pair-flow friction found dogfooding beta.10/11: the navigator would dictate exact code and then ask the human to type it. Nobody types dictated code. Two remedies, both landing the decision in the human's hands:

## The navigator can OFFER

A new navigator-only `offer_change` tool: the moment advice becomes concrete (an exact example, a step definition, a small method), it arrives as a diff the human accepts or declines through the numbered chooser (1. Yes / 2. Always / 3. No). Deliberately inverted from the write tools: the diff is shown BEFORE the consent, because the diff IS the offer. An accepted offer lands through the shared Writer gate and auto-verifies; a declined one steers the model to re-plan, never re-offer. The spec guards apply to offers exactly as to writes (grow-only, no ObjectBehavior), and unbidden writes stay forbidden: `navigator.txt`'s golden rule is now "never write files unbidden". A driving AI has real write tools instead, so `offer_change` is withheld while driving.

## /next leaves a ghost

The pair assistant registers its structured suggestion via a `suggest_next` tool (whose description file also now exists for the standalone command), and `/next` pre-fills the prompt with a matching `/generate` ghost ("/generate add a spec example for App\TodoList"), worded so the one-shot's step resolution routes it. Acting on the advice is Tab and Enter, never retyping. Found and fixed on the way: the dispatcher's static follow-up table was clobbering handler-set ghosts.

## Polish

The empty-model-answer fallback is command-neutral now ("The model returned no usable answer. Try again, or set ai.model to a stronger model."): `next` has no instruction to "rephrase", so it no longer says that.

## Verification

1595 examples + 206 scenarios (1030 steps) green on PHP 8.2.30 / 8.3.16 / 8.4.4 / 8.5.3; coverage 91.7% (gate 90); phpstan level max whole-src clean; php-cs-fixer clean. Prompts.spec locks the new tool descriptions and the navigator's revised contract.