### PR TITLE
Cap the navigator at one offer and one registered suggestion per turn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - The navigator is capped at one offer and one registered suggestion per turn (the used-up tool is withheld, so the turn winds down into prose), and its prompts steer a run request to run_specs instead of turning it into an offer: pair `/next` no longer chains suggestion after suggestion.
+
 ## [9.0.0-beta.12](https://github.com/phpspec/phpspec/compare/9.0.0-beta.11...9.0.0-beta.12)
 
 ### Added

--- a/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
@@ -191,6 +191,59 @@ describe(AiAssistant::class, function () {
         expect($names)->not()->toContain('offer_change');
     });
 
+    it('allows at most one offer per turn, withholding and refusing the second', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("<?php\n// old");
+        allow($fs->mkdir())->toReturn(null);
+        $written = [];
+        allow($fs->write())->toReturnUsing(function (string $p, string $c) use (&$written) {
+            $written[$p] = $c;
+        });
+
+        $secondTurnTools = null;
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages, array $options) use (&$secondTurnTools, &$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [
+                    new ToolCall('t1', 'offer_change', ['path' => 'src/A.php', 'content' => "<?php\n// first", 'intent' => 'first change']),
+                    new ToolCall('t2', 'offer_change', ['path' => 'src/B.php', 'content' => "<?php\n// second", 'intent' => 'second change']),
+                ]);
+            }
+            $secondTurnTools = array_column($options['tools'], 'name');
+            $captured = $messages;
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $this->answers = ['1'];
+        $assistant->handle('thoughts?');
+
+        expect($written)->toHaveLength(1);                                 // only the first offer landed
+        expect((string) json_encode($captured))->toContain('One offer per turn');
+        expect($secondTurnTools)->not()->toContain('offer_change');        // and none advertised after
+    });
+
+    it('registers at most one suggestion per turn, ending the advice in prose', function (Filesystem $fs) {
+        $secondTurnTools = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages, array $options) use (&$secondTurnTools, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'suggest_next', ['type' => 'spec', 'target' => 'App\\First', 'reason' => 'one'])]);
+            }
+            $secondTurnTools = array_column($options['tools'], 'name');
+
+            return new Response('My advice in prose.');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $assistant->handle('what next?');
+
+        expect($assistant->lastSuggestion()['target'])->toBe('App\\First');
+        expect($secondTurnTools)->not()->toContain('suggest_next');        // one registration per turn
+    });
+
     it('registers the model suggestion for the dispatcher ghost', function (Filesystem $fs) {
         $turn = 0;
         $this->provider->responder = function () use (&$turn) {

--- a/src/PhpSpec/Ai/Prompts/navigator.txt
+++ b/src/PhpSpec/Ai/Prompts/navigator.txt
@@ -22,7 +22,9 @@ to be deleted. Better to flag it before the change than after.
 
 React to reality, not imagination: speak about the suite and the code after a run, not
 while they are mid-thought. Keep non-urgent observations to yourself — park a design nit
-rather than interrupting the flow.
+rather than interrupting the flow. Answer the ask in front of you: when the human asks
+to run, run (run_specs) and report; do not turn a run request into a suggestion or an
+offer.
 
 Voice: first person plural, "we". Short lines. One suggestion at a time. No praise filler,
 no lectures.

--- a/src/PhpSpec/Ai/Prompts/tools/offer_change.txt
+++ b/src/PhpSpec/Ai/Prompts/tools/offer_change.txt
@@ -1,6 +1,8 @@
 Offer ONE concrete file change while navigating: give the complete new content of
 one file, and the human sees it as a diff they accept or decline. Use it the moment
 your advice has become concrete (an exact example, a step definition, a small
-method) instead of asking the human to type it. Never re-offer a declined change:
-ask what they would prefer instead. A spec offer must grow the spec; dropping
-existing examples is rejected.
+method) instead of asking the human to type it. At most one offer per turn, and
+only when the human's current ask is about changing code: when they ask to run or
+inspect, do that and report; never turn a run request into an offer. Never re-offer
+a declined change: ask what they would prefer instead. A spec offer must grow the
+spec; dropping existing examples is rejected.

--- a/src/PhpSpec/Ai/Prompts/tools/suggest_next.txt
+++ b/src/PhpSpec/Ai/Prompts/tools/suggest_next.txt
@@ -1,3 +1,5 @@
 Register the single next-step suggestion in structured form: what to build next
 (spec, feature, or example), its target, and one short reason. In pair mode this
 feeds the prompt's ghost suggestion; keep advising the human in prose as well.
+Once per turn, and only when the human asks what to do next; never as a side
+effect of another request.

--- a/src/PhpSpec/Console/Command/Pair/AiAssistant.php
+++ b/src/PhpSpec/Console/Command/Pair/AiAssistant.php
@@ -103,6 +103,13 @@ final class AiAssistant
      */
     private ?array $lastSuggestion = null;
 
+    /**
+     * Whether an offer was resolved (accepted OR declined) this turn: the
+     * navigator gets ONE offer per turn, mirroring the driver's one artifact,
+     * so a turn always winds down into prose instead of chaining offers.
+     */
+    private bool $offerResolvedThisHandle = false;
+
     /** Tool rounds taken since the driving AI wrote its artifact this turn. */
     private int $postArtifactRounds = 0;
 
@@ -160,6 +167,7 @@ final class AiAssistant
             $this->artifactWrittenThisHandle = false;
             $this->postArtifactRounds = 0;
             $this->lastSuggestion = null;
+            $this->offerResolvedThisHandle = false;
             $this->messages = $this->window->apply($this->messages);
             $this->injectSituation($situation);
             $this->messages[] = Message::user($input);
@@ -375,11 +383,21 @@ final class AiAssistant
             ));
         }
 
-        // Offering is the navigator's channel; a driving AI writes instead.
-        if ($role->aiIsDriver()) {
+        // Offering is the navigator's channel (a driving AI writes instead),
+        // and it happens at most once per turn; likewise one registered
+        // suggestion per turn. Withholding the used-up tool is what lets the
+        // loop end in prose instead of chaining suggestion after suggestion.
+        $spent = [];
+        if ($role->aiIsDriver() || $this->offerResolvedThisHandle) {
+            $spent[] = 'offer_change';
+        }
+        if ($this->lastSuggestion !== null) {
+            $spent[] = 'suggest_next';
+        }
+        if ($spent !== []) {
             $tools = array_values(array_filter(
                 $tools,
-                fn(ToolInterface $tool) => $tool->getName() !== 'offer_change',
+                fn(ToolInterface $tool) => !in_array($tool->getName(), $spent, true),
             ));
         }
 
@@ -1047,6 +1065,10 @@ final class AiAssistant
                 'intent' => self::intentParameter(),
             ],
             handler: function (array $args) use ($filesystem, $specDir) {
+                if ($this->offerResolvedThisHandle) {
+                    return ['error' => 'One offer per turn. React to its outcome in prose, or wait for the human.'];
+                }
+
                 $path = $args['path'];
                 $content = $args['content'];
                 $absPath = getcwd() . '/' . ltrim($path, '/');
@@ -1064,6 +1086,8 @@ final class AiAssistant
                 } else {
                     $this->output->fileDiff($absPath, $proposal->old, $proposal->new);
                 }
+
+                $this->offerResolvedThisHandle = true;
 
                 if (!$this->chooser->choose($this->offerQuestion($args), 'offer-change', 'apply offered changes')) {
                     PairLogger::log('RESULT', 'Offer declined');
@@ -1132,7 +1156,11 @@ final class AiAssistant
                     'description' => 'One short sentence why',
                 ],
             ],
-            handler: function (array $args): string {
+            handler: function (array $args): string|array {
+                if ($this->lastSuggestion !== null) {
+                    return ['error' => 'One suggestion per turn is already registered. Advise in prose now.'];
+                }
+
                 $this->lastSuggestion = array_map(strval(...), array_filter($args, is_scalar(...)));
 
                 return 'Suggestion noted. Keep advising in prose; never repeat it as JSON.';


### PR DESCRIPTION
First dogfood of beta.12 found the offers feature lacking turn discipline, two symptoms:

- "run features" (an action request) was answered with suggest_next + an unrequested offer_change.
- Pair /next kept chaining suggestion after suggestion without the human asking again: auto-verify fed the navigator fresh state and nothing capped it, unlike the driver's one-artifact rule.

The fix mirrors the driver's discipline, enforced mechanically rather than pleaded in prose:

- At most ONE offer per turn (accepted or declined counts as resolved) and ONE registered suggestion per turn. The used-up tool is withheld from the advertised set for the rest of the turn, so the loop naturally winds down into prose; a call that slips through anyway is refused with a steer.
- Prompt discipline to match: offer_change and suggest_next descriptions now say once-per-turn and never as a side effect of another request, and navigator.txt says "when the human asks to run, run (run_specs) and report".

## Verification

1597 examples + 206 scenarios (1030 steps) green on PHP 8.2.30 / 8.3.16 / 8.4.4 / 8.5.3; phpstan level max whole-src clean; php-cs-fixer clean. New examples lock: a second offer in one turn is refused and unadvertised while the first landed; a second suggestion is refused and unadvertised while the first registered.