### PR TITLE
Route plain-English commands in pair and pass run options through

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - Pair commands work as plain English, with or without the slash: "run features", "run --all", "describe App\Basket", "refactor Todo", "generate a spec for addTask" all route to the command, guarded so conversation never does ("run me through the design" still reaches the AI). Suite keywords translate to their options (features to --story, all to --all), and options on any run form now actually reach the runner: /run --all was silently dropping the flag.
+
 ### Fixed
  - The navigator is capped at one offer and one registered suggestion per turn (the used-up tool is withheld, so the turn winds down into prose), and its prompts steer a run request to run_specs instead of turning it into an offer: pair `/next` no longer chains suggestion after suggestion.
 

--- a/docs/pair.md
+++ b/docs/pair.md
@@ -33,39 +33,47 @@ The greeting adapts to your configuration: with an AI provider configured it inv
 
 Pair mode is a pair, not a code agent: you share one keyboard and work in turns. Nobody hand-types code any more — the generators are the keyboard, and *driving* means deciding what gets generated and pulling the trigger. `/swap` changes who holds it (this needs an AI provider):
 
-- **You drive, the AI navigates** (the default). The AI reviews and suggests one step ahead — intent, then location, then the exact line only when you ask — but it never writes files on its own. You generate code by triggering it: `/describe`, `/exemplify`, `/run`, and the numbered choosers.
+- **You drive, the AI navigates** (the default). The AI reviews and suggests one step ahead (intent, then location, then the exact line only when you ask), but it never writes files unbidden. When its advice becomes concrete it **offers** the change instead of dictating code: you see the exact diff and accept or decline through the numbered chooser; an accepted offer lands through the same write gate as every other change and auto-verifies. One offer per turn, and a declined offer is never re-offered.
 - **The AI drives, you navigate** (after `/swap`). You give the intent; the AI makes it real one artifact at a time, shows the diff, runs the spec, and hands back.
 
 `/help` shows the current contract. Swap back at any time with another `/swap`.
 
 ### Built-in Commands
 
-These commands work without AI configuration:
-
-Every command starts with a slash. These work without AI configuration:
+These commands work without AI configuration, and each works with or without its leading slash:
 
 | Command | Description |
 |---|---|
 | `/describe <Class>` | Generate a spec file and optionally create the class |
 | `/exemplify <Class> <method>` | Add a method example to an existing spec |
-| `/run [path]` | Run specs and offer code generation for failures |
+| `/run [path\|keyword] [options]` | Run specs (or features) and offer code generation for failures |
 | `/next` | Suggest the next step from the real suite state |
 | `/generate <instruction>` | Turn plain English into a spec example or code — diff, then confirm (requires AI) |
 | `/clear` | Clear the terminal |
+| `/swap` | Swap who drives (needs an AI provider) |
 | `/help` | Show available commands and AI status |
 | `/quit`, `/exit` | Exit pair mode |
 
-Commands mirror the CLI but add interactive prompts. For example, `/describe` shows the generated spec, then asks whether to create the source class. `/run` displays results and offers to generate missing classes or methods.
+Commands mirror the CLI but add interactive prompts. For example, `/describe` shows the generated spec, then asks whether to create the source class. `/run` displays results and offers to generate missing classes or methods. Run options pass straight through to the runner: `/run --all`, `/run spec/App --stop-on-failure`.
 
-### Command or prompt: the slash rule
+### Command or prompt: how a line is read
 
-The leading slash is the one signal that a line is a command. Anything **without** a slash is sent to the AI assistant. With no working AI it doesn't call your sentence an "unknown command" — it explains that natural language needs a provider. No keyword guessing — `/describe App/Calculator` runs the command; `describe what the Loader class does` is a prompt.
+A leading slash always marks a command. A bare line routes as a command too when its first word unambiguously reads as one, so the conversation flows without syntax in the way:
+
+- `run` routes when everything after it is a path, a spec or feature file, a suite keyword, or an option: `run`, `run features`, `run --all`, `run spec/App`. Suite keywords translate to their options: `features`/`stories` mean `--story`, `all`/`everything` means `--all`, `specs` is the default run.
+- `describe`, `exemplify`, and `refactor` route when the first argument looks like a class: `describe App/Basket`, `exemplify App\Calculator add`, `refactor Todo`.
+- `generate` always routes: plain English is its argument.
+- `next`, `help`, `swap`, `clear`, `quit`, and `exit` route only as the bare word.
+
+Anything else is a prompt for the AI, and the guards keep conversation as conversation: "run me through the design", "help me understand this project", "next time we should tidy up" all reach the assistant, never a command. With no working AI your sentence isn't called an "unknown command": pair mode explains that natural language needs a provider.
 
 ```
 > /describe App/Calculator                      # runs the describe command
-> describe what the Loader class does           # no slash → routes to the AI
-> /run spec/App                                 # runs specs at a path
-> run my specs and explain the failures         # no slash → routes to the AI
+> describe App/Calculator                       # the same command, no slash needed
+> run features                                  # a story-only run (--story)
+> run --all                                     # specs and features together
+> describe what the Loader class does           # prose → routes to the AI
+> run my specs and explain the failures         # prose → routes to the AI
 ```
 
 ### Suggested next command (ghost text)
@@ -82,6 +90,10 @@ step — describe a spec and it suggests running it, run and it suggests `/next`
 Press **Right-arrow** or **Tab** to accept it (it turns full colour, cursor to the end),
 or just start typing to dismiss it. **Up/Down** walk your history. On a terminal that
 can't enter raw mode (or piped input) the prompt falls back to a plain line reader.
+
+After `/next` with an AI provider, the ghost is built from the suggestion the AI
+registers: a matching `/generate ...` pre-filled in the prompt, so acting on the
+advice is Tab and Enter, never retyping it.
 
 ## AI Configuration
 
@@ -104,19 +116,27 @@ ai:
 
 | Key | Required | Description |
 |---|---|---|
-| `provider` | Yes | `google`, `anthropic`, or `openai` |
+| `provider` | Yes | `google`, `anthropic`, `openai`, `grok`, `deepseek`, or `ollama` |
 | `model` | No | Model identifier (see defaults below) |
-| `api_key` | Yes | API key for the provider |
+| `api_key` | Yes (hosted providers) | API key for the provider |
+| `max_tokens` | No | Output-token ceiling per reply |
+| `effort` | No | Reasoning effort forwarded to the provider (where supported) |
+
+Your `model` and `max_tokens` always beat the shipped defaults, and the pair
+status bar shows the resolved model next to the provider.
 
 ### Providers and Default Models
 
 | Provider | Default Model | Auth |
 |---|---|---|
-| `google` | `gemini-2.5-pro` | API key |
-| `anthropic` | `claude-sonnet-4-20250514` | API key |
-| `openai` | `gpt-4o` | API key |
+| `google` | `gemini-3.1-pro-preview` | API key |
+| `anthropic` | `claude-sonnet-5` | API key |
+| `openai` | `gpt-5.1` | API key |
+| `grok` | `grok-4` | API key |
+| `deepseek` | `deepseek-chat` | API key |
+| `ollama` | `llama3.1` | local, no key |
 
-All three providers support tool calling, vision, and streaming.
+The hosted providers support tool calling, vision, and streaming.
 
 Each provider needs its PapiAI package installed alongside `papi-ai/papi-core`:
 
@@ -165,6 +185,8 @@ The AI assistant has access to these tools during a pair session:
 | `ask_user` | Ask you a yes/no question through the numbered chooser |
 | `read_file` | Read a project file for context |
 | `list_files` | List directory contents |
+| `offer_change` | Navigator only: offer one concrete file change, shown to you as a diff to accept or decline |
+| `suggest_next` | Register the next-step suggestion that pre-fills the prompt after `/next` |
 
 Specs are never written whole-file: the assistant starts one with `describe`
 and grows it one example at a time with `add_example`, so your existing examples

--- a/features/scenarios/cli/pair-plain-english.feature
+++ b/features/scenarios/cli/pair-plain-english.feature
@@ -1,0 +1,153 @@
+Feature: Pair mode understands commands typed as plain English
+  As a developer pairing with phpspec
+  I want command words to work with or without a leading slash
+  So that the conversation flows without command syntax in the way
+
+  Scenario: run without a slash runs the specs
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a spec file "spec/App/Alpha.spec.php":
+      """
+      <?php
+      describe('App\Alpha', function () {
+          it('flags the spec marker', fn() => expect('spec-marker')->toBe('spec-marker-pass'));
+      });
+      """
+    And a feature file "features/marker.feature":
+      """
+      Feature: Marker
+        Scenario: Feature marker scenario
+          Then the feature marker holds
+      """
+    And a step file "features/steps/marker.steps.php":
+      """
+      <?php
+      then('the feature marker holds', fn() => expect('feature-marker')->toBe('feature-marker-pass'));
+      """
+    When I run phpspec pair with input "run"
+    Then the output should contain "spec-marker"
+    And the output should not contain "feature-marker"
+    And the output should not contain "No AI provider"
+
+  Scenario: run features without a slash runs the story suite
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a spec file "spec/App/Alpha.spec.php":
+      """
+      <?php
+      describe('App\Alpha', function () {
+          it('flags the spec marker', fn() => expect('spec-marker')->toBe('spec-marker-pass'));
+      });
+      """
+    And a feature file "features/marker.feature":
+      """
+      Feature: Marker
+        Scenario: Feature marker scenario
+          Then the feature marker holds
+      """
+    And a step file "features/steps/marker.steps.php":
+      """
+      <?php
+      then('the feature marker holds', fn() => expect('feature-marker')->toBe('feature-marker-pass'));
+      """
+    When I run phpspec pair with input "run features"
+    Then the output should contain "feature-marker"
+    And the output should not contain "spec-marker"
+    And the output should not contain "No AI provider"
+
+  Scenario: run --all without a slash runs both suites
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a spec file "spec/App/Alpha.spec.php":
+      """
+      <?php
+      describe('App\Alpha', function () {
+          it('flags the spec marker', fn() => expect('spec-marker')->toBe('spec-marker-pass'));
+      });
+      """
+    And a feature file "features/marker.feature":
+      """
+      Feature: Marker
+        Scenario: Feature marker scenario
+          Then the feature marker holds
+      """
+    And a step file "features/steps/marker.steps.php":
+      """
+      <?php
+      then('the feature marker holds', fn() => expect('feature-marker')->toBe('feature-marker-pass'));
+      """
+    When I run phpspec pair with input "run --all"
+    Then the output should contain "spec-marker"
+    And the output should contain "feature-marker"
+
+  Scenario: options on a slash command reach the runner
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a spec file "spec/App/Alpha.spec.php":
+      """
+      <?php
+      describe('App\Alpha', function () {
+          it('flags the spec marker', fn() => expect('spec-marker')->toBe('spec-marker-pass'));
+      });
+      """
+    And a feature file "features/marker.feature":
+      """
+      Feature: Marker
+        Scenario: Feature marker scenario
+          Then the feature marker holds
+      """
+    And a step file "features/steps/marker.steps.php":
+      """
+      <?php
+      then('the feature marker holds', fn() => expect('feature-marker')->toBe('feature-marker-pass'));
+      """
+    When I run phpspec pair with input "/run --all"
+    Then the output should contain "spec-marker"
+    And the output should contain "feature-marker"
+
+  Scenario: a path and an option travel together to the runner
+    Given a PSR-4 project with "spec" and "src" directories
+    And a spec file "spec/App/Alpha.spec.php":
+      """
+      <?php
+      describe('App\Alpha', function () {
+          it('fails first', fn() => expect('alpha-marker')->toBe('alpha-marker-pass'));
+      });
+      """
+    And a spec file "spec/App/Beta.spec.php":
+      """
+      <?php
+      describe('App\Beta', function () {
+          it('fails second', fn() => expect('beta-marker')->toBe('beta-marker-pass'));
+      });
+      """
+    When I run phpspec pair with input "/run spec --stop-on-failure"
+    Then the output should contain "alpha-marker"
+    And the output should not contain "beta-marker"
+
+  Scenario: plain English that merely starts with a command word stays conversation
+    Given a PSR-4 project with "spec" and "src" directories
+    And a spec file "spec/App/Alpha.spec.php":
+      """
+      <?php
+      describe('App\Alpha', function () {
+          it('flags the spec marker', fn() => expect('spec-marker')->toBe('spec-marker-pass'));
+      });
+      """
+    When I run phpspec pair with input "run me through the design; help me understand this project; next time we should refactor"
+    Then the output should contain "No AI provider is configured"
+    And the output should not contain "Available commands"
+    And the output should not contain "spec-marker"
+
+  Scenario: help as a bare word shows the help screen
+    Given a PSR-4 project with "spec" and "src" directories
+    When I run phpspec pair with input "help"
+    Then the output should contain "Available commands"
+
+  Scenario: describe with a class routes to the describe command
+    Given a PSR-4 project with "spec" and "src" directories
+    When I run phpspec pair with input "describe App/Basket"
+    Then the output should contain "Specification for"
+    And a spec file "spec/App/Basket.spec.php" should be generated
+
+  Scenario: generate routes to the generate command even in plain English
+    Given a PSR-4 project with "spec" and "src" directories
+    When I run phpspec pair with input "generate a spec for addTask"
+    Then the output should contain "AI configuration required"
+    And the output should not contain "No AI provider is configured"

--- a/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
@@ -302,7 +302,7 @@ describe(CommandDispatcher::class, function () {
         expect($this->specRunner->arguments)->toBe(['spec/NonExistent']);
     });
 
-    context('slash marks a command; anything else is an AI prompt', function () {
+    context('commands read as commands with or without the slash; prose stays with the AI', function () {
         it('runs a slash command with a path argument', function () {
             $result = $this->dispatcher->dispatch('/run spec/App');
             expect($result)->toBe(CommandDispatcher::CONTINUE);
@@ -312,17 +312,72 @@ describe(CommandDispatcher::class, function () {
         it('routes non-slash prose to the AI (explains AI is off without a provider)', function () {
             $this->dispatcher->dispatch('run the scenarios and fix them');
             $output = $this->buffer->fetch();
-            // No leading slash → an AI prompt; with no AI it explains, without calling it an unknown command.
+            // Prose after the command word → an AI prompt; with no AI it explains, without calling it an unknown command.
             expect($output)->toContain('natural language');
             expect($output)->not()->toContain('Unknown command');
+            expect($this->specRunner->arguments)->toBe([]);
         });
 
-        it('routes a bare command word (no slash) to the AI, not the command', function () {
-            $this->dispatcher->dispatch('describe Acme\\Foo');
-            $output = $this->buffer->fetch();
-            // `describe` without a slash is prose now, so no spec is generated.
-            expect($output)->not()->toContain('Specification for');
-            expect($this->specRunner->arguments)->toBe([]);
+        it('routes a bare "describe Class" to the describe command', function (Filesystem $fs) {
+            $written = [];
+            allow($fs->write())->toReturnUsing(function (string $path, string $content) use (&$written) {
+                $written[$path] = $content;
+            });
+
+            $this->dispatcher->dispatch('describe Acme\Foo');
+
+            expect($this->buffer->fetch())->toContain('Specification for');
+            $specFiles = array_filter(
+                $written,
+                fn(string $path) => str_ends_with(str_replace('\\', '/', $path), 'spec/Acme/Foo.spec.php'),
+                ARRAY_FILTER_USE_KEY,
+            );
+            expect($specFiles)->not()->toBe([]);
+        });
+
+        it('routes a bare "next" like /next', function () {
+            $this->dispatcher->dispatch('next');
+            expect($this->specRunner->arguments)->toContain('--all');
+        });
+
+        it('translates "run features" into a story-only run', function () {
+            $this->dispatcher->dispatch('run features');
+            expect($this->specRunner->arguments)->toBe(['--story']);
+        });
+
+        it('translates "run all" into a full-suite run', function () {
+            $this->dispatcher->dispatch('run all');
+            expect($this->specRunner->arguments)->toBe(['--all']);
+        });
+
+        it('translates "run specs" into the default spec run', function () {
+            $this->dispatcher->dispatch('run specs');
+            expect($this->specRunner->arguments)->toBe(['']);
+        });
+
+        it('passes "run --all" through without a slash', function () {
+            $this->dispatcher->dispatch('run --all');
+            expect($this->specRunner->arguments)->toBe(['--all']);
+        });
+
+        it('translates "/run features" the same as the plain form', function () {
+            $this->dispatcher->dispatch('/run features');
+            expect($this->specRunner->arguments)->toBe(['--story']);
+        });
+
+        it('passes options through /run to the runner', function () {
+            $this->dispatcher->dispatch('/run --stop-on-failure');
+            expect($this->specRunner->arguments)->toBe(['--stop-on-failure']);
+        });
+
+        it('keeps a path and its option together for the runner', function () {
+            $this->dispatcher->dispatch('/run spec/App --stop-on-failure');
+            expect($this->specRunner->arguments)->toBe(['spec/App --stop-on-failure']);
+        });
+
+        it('never rewrites an option value that matches a suite keyword', function () {
+            $this->dispatcher->dispatch('/run --filter features');
+            expect($this->specRunner->arguments)->toBe(['--filter features']);
         });
 
         it('routes unrecognized prose to the AI fallback', function () {
@@ -612,6 +667,14 @@ describe(CommandDispatcher::class, function () {
         it('delegates /refactor with argument', function () {
             $result = $this->appDispatcher->dispatch('/refactor App\\Calculator');
             expect($result)->toBe(CommandDispatcher::CONTINUE);
+        });
+
+        it('delegates a bare "refactor Class" to the refactor command', function () {
+            $result = $this->appDispatcher->dispatch('refactor App\\Calculator');
+            $output = $this->buffer->fetch();
+            expect($result)->toBe(CommandDispatcher::CONTINUE);
+            expect($output)->not()->toContain('natural language');
+            expect($output)->not()->toContain('Unknown command');
         });
 
         it('explains AI is off for non-slash prose when no AI', function () {

--- a/spec/PhpSpec/Console/Command/Pair/InputParser.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/InputParser.spec.php
@@ -7,83 +7,145 @@ describe(InputParser::class, function () {
 
     it('instantiates', fn() => expect($this->parser)->toBeAnInstanceOf(InputParser::class));
 
-    it('parses describe with class argument', function () {
-        $result = $this->parser->parse('describe Acme\Greeter');
-        expect($result)->toBe(['command' => 'describe', 'argument' => 'Acme\Greeter']);
-    });
-
     it('parses /help with no argument', function () {
         $result = $this->parser->parse('/help');
-        expect($result)->toBe(['command' => '/help', 'argument' => '']);
+        expect($result)->toBe(['command' => '/help', 'argument' => '', 'tail' => '']);
     });
 
     it('parses /quit with no argument', function () {
         $result = $this->parser->parse('/quit');
-        expect($result)->toBe(['command' => '/quit', 'argument' => '']);
-    });
-
-    it('parses run with no argument', function () {
-        $result = $this->parser->parse('run');
-        expect($result)->toBe(['command' => 'run', 'argument' => '']);
-    });
-
-    it('parses run with a path argument', function () {
-        $result = $this->parser->parse('run spec/Acme');
-        expect($result)->toBe(['command' => 'run', 'argument' => 'spec/Acme']);
-    });
-
-    it('handles leading whitespace', function () {
-        $result = $this->parser->parse('  describe   Acme\Greeter');
-        expect($result)->toBe(['command' => 'describe', 'argument' => 'Acme\Greeter']);
-    });
-
-    it('returns empty command for empty input', function () {
-        $result = $this->parser->parse('');
-        expect($result)->toBe(['command' => '', 'argument' => '']);
-    });
-
-    it('returns empty command for whitespace-only input', function () {
-        $result = $this->parser->parse('   ');
-        expect($result)->toBe(['command' => '', 'argument' => '']);
-    });
-
-    it('lowercases the command part', function () {
-        $result = $this->parser->parse('DESCRIBE Acme\Greeter');
-        expect($result)->toBe(['command' => 'describe', 'argument' => 'Acme\Greeter']);
+        expect($result)->toBe(['command' => '/quit', 'argument' => '', 'tail' => '']);
     });
 
     it('parses /exit command', function () {
         $result = $this->parser->parse('/exit');
-        expect($result)->toBe(['command' => '/exit', 'argument' => '']);
+        expect($result)->toBe(['command' => '/exit', 'argument' => '', 'tail' => '']);
     });
 
-    it('parses clear command', function () {
-        $result = $this->parser->parse('clear');
-        expect($result)->toBe(['command' => 'clear', 'argument' => '']);
+    it('returns empty command for empty input', function () {
+        $result = $this->parser->parse('');
+        expect($result)->toBe(['command' => '', 'argument' => '', 'tail' => '']);
     });
 
-    it('collects all non-option tokens as the argument', function () {
-        $result = $this->parser->parse('exemplify App\Calculator add');
-        expect($result)->toBe(['command' => 'exemplify', 'argument' => 'App\Calculator add']);
+    it('returns empty command for whitespace-only input', function () {
+        $result = $this->parser->parse('   ');
+        expect($result)->toBe(['command' => '', 'argument' => '', 'tail' => '']);
     });
 
-    it('skips option flags between tokens', function () {
-        $result = $this->parser->parse('describe PhpSpec\Newton -e gravitate');
-        expect($result)->toBe(['command' => 'describe', 'argument' => 'PhpSpec\Newton gravitate']);
+    it('keeps the raw tail of a slash command, options in their place', function () {
+        $result = $this->parser->parse('/run --filter spec/Acme');
+        expect($result)->toBe(['command' => '/run', 'argument' => 'spec/Acme', 'tail' => '--filter spec/Acme']);
     });
 
-    it('skips option flags before the argument', function () {
-        $result = $this->parser->parse('describe -e PhpSpec\Greeter greet');
-        expect($result)->toBe(['command' => 'describe', 'argument' => 'PhpSpec\Greeter greet']);
+    context('command words route without a slash when the line reads as a command', function () {
+        it('routes describe with a class argument', function () {
+            $result = $this->parser->parse('describe Acme\Greeter');
+            expect($result)->toBe(['command' => '/describe', 'argument' => 'Acme\Greeter', 'tail' => 'Acme\Greeter']);
+        });
+
+        it('routes describe with a slash-path class', function () {
+            $result = $this->parser->parse('describe App/Basket');
+            expect($result)->toBe(['command' => '/describe', 'argument' => 'App/Basket', 'tail' => 'App/Basket']);
+        });
+
+        it('lowercases the command word before routing', function () {
+            $result = $this->parser->parse('DESCRIBE Acme\Greeter');
+            expect($result)->toBe(['command' => '/describe', 'argument' => 'Acme\Greeter', 'tail' => 'Acme\Greeter']);
+        });
+
+        it('handles leading whitespace', function () {
+            $result = $this->parser->parse('  describe   Acme\Greeter');
+            expect($result)->toBe(['command' => '/describe', 'argument' => 'Acme\Greeter', 'tail' => 'Acme\Greeter']);
+        });
+
+        it('routes exemplify with a class and method', function () {
+            $result = $this->parser->parse('exemplify App\Calculator add');
+            expect($result)->toBe(['command' => '/exemplify', 'argument' => 'App\Calculator add', 'tail' => 'App\Calculator add']);
+        });
+
+        it('routes refactor with a class target', function () {
+            $result = $this->parser->parse('refactor Todo');
+            expect($result)->toBe(['command' => '/refactor', 'argument' => 'Todo', 'tail' => 'Todo']);
+        });
+
+        it('routes refactor with a method target', function () {
+            $result = $this->parser->parse('refactor App\Todo::addTask');
+            expect($result)->toBe(['command' => '/refactor', 'argument' => 'App\Todo::addTask', 'tail' => 'App\Todo::addTask']);
+        });
+
+        it('routes a bare run', function () {
+            $result = $this->parser->parse('run');
+            expect($result)->toBe(['command' => '/run', 'argument' => '', 'tail' => '']);
+        });
+
+        it('routes run with a path argument', function () {
+            $result = $this->parser->parse('run spec/Acme');
+            expect($result)->toBe(['command' => '/run', 'argument' => 'spec/Acme', 'tail' => 'spec/Acme']);
+        });
+
+        it('routes run with a feature file argument', function () {
+            $result = $this->parser->parse('run adding.feature');
+            expect($result)->toBe(['command' => '/run', 'argument' => 'adding.feature', 'tail' => 'adding.feature']);
+        });
+
+        it('routes run with a suite keyword', function () {
+            $result = $this->parser->parse('run features');
+            expect($result)->toBe(['command' => '/run', 'argument' => 'features', 'tail' => 'features']);
+        });
+
+        it('routes run with only options', function () {
+            $result = $this->parser->parse('run --all');
+            expect($result)->toBe(['command' => '/run', 'argument' => '', 'tail' => '--all']);
+        });
+
+        it('routes run with an option and a path, keeping the tail order', function () {
+            $result = $this->parser->parse('run --filter spec/Acme');
+            expect($result)->toBe(['command' => '/run', 'argument' => 'spec/Acme', 'tail' => '--filter spec/Acme']);
+        });
+
+        it('routes bare command words that take no argument', function () {
+            expect($this->parser->parse('next')['command'])->toBe('/next');
+            expect($this->parser->parse('help')['command'])->toBe('/help');
+            expect($this->parser->parse('swap')['command'])->toBe('/swap');
+            expect($this->parser->parse('clear')['command'])->toBe('/clear');
+            expect($this->parser->parse('quit')['command'])->toBe('/quit');
+            expect($this->parser->parse('exit')['command'])->toBe('/exit');
+        });
+
+        it('always routes generate, whose argument is plain English', function () {
+            $result = $this->parser->parse('generate a spec for addTask');
+            expect($result)->toBe(['command' => '/generate', 'argument' => 'a spec for addTask', 'tail' => 'a spec for addTask']);
+        });
+
+        it('routes a bare generate so its usage hint answers', function () {
+            expect($this->parser->parse('generate')['command'])->toBe('/generate');
+        });
     });
 
-    it('skips long option flags before the argument', function () {
-        $result = $this->parser->parse('run --filter spec/Acme');
-        expect($result)->toBe(['command' => 'run', 'argument' => 'spec/Acme']);
-    });
+    context('lines that merely start with a command word stay conversational', function () {
+        it('keeps run followed by prose for the AI', function () {
+            expect($this->parser->parse('run me through the design')['command'])->toBe('run');
+        });
 
-    it('returns empty argument when only options are present', function () {
-        $result = $this->parser->parse('run --stop-on-failure');
-        expect($result)->toBe(['command' => 'run', 'argument' => '']);
+        it('keeps next followed by prose for the AI', function () {
+            expect($this->parser->parse('next time we should refactor')['command'])->toBe('next');
+        });
+
+        it('keeps help followed by prose for the AI', function () {
+            expect($this->parser->parse('help me understand this project')['command'])->toBe('help');
+        });
+
+        it('keeps describe without a class-like target for the AI', function () {
+            expect($this->parser->parse('describe what you mean')['command'])->toBe('describe');
+        });
+
+        it('keeps refactor without a class-like target for the AI', function () {
+            expect($this->parser->parse('refactor this mess')['command'])->toBe('refactor');
+        });
+
+        it('keeps plain prose untouched', function () {
+            $result = $this->parser->parse('hello world');
+            expect($result)->toBe(['command' => 'hello', 'argument' => 'world', 'tail' => 'world']);
+        });
     });
 });

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -280,9 +280,11 @@ final class CommandDispatcher
             return self::CONTINUE;
         }
 
-        // A leading slash is the one signal that this line is a command; every
-        // other line is a prompt for the AI (or the unknown-command hint when no
-        // AI is configured). No keyword guessing, no argument-count heuristics.
+        // A leading slash always marks a command, and a bare line reaches these
+        // arms only when the parser routed it as one: its first word read
+        // unambiguously as a command (see InputParser::route()). Every other
+        // line is a prompt for the AI (or the unknown-command hint when no AI
+        // is configured).
         if (!str_starts_with($command, '/')) {
             $this->suggestion = null;
 
@@ -292,14 +294,14 @@ final class CommandDispatcher
         $result = match ($command) {
             '/describe' => $this->handleDescribe($parsed['argument']),
             '/exemplify' => $this->handleExemplify($parsed['argument']),
-            '/run' => $this->handleRun($parsed['argument']),
+            '/run' => $this->handleRun($this->runArgument($parsed['tail'])),
             '/next' => $this->handleNext(),
             '/generate' => $this->handleGenerate($parsed['argument']),
             '/clear' => $this->handleClear(),
             '/swap' => $this->handleSwap(),
             '/help' => $this->handleHelp(),
             '/quit', '/exit' => self::QUIT,
-            default => $this->handleSlashCommand($command, $input),
+            default => $this->handleSlashCommand($command, $parsed['tail']),
         };
 
         // Set from the top-level command only, so a nested run (e.g. the "run
@@ -493,6 +495,43 @@ final class CommandDispatcher
     }
 
     /**
+     * Turns leading suite keywords into their run options ("features" into
+     * --story, "all" into --all, "specs" into the default), leaving everything
+     * from the first non-keyword token on untouched, so an option value that
+     * happens to match a keyword (--filter features) is never rewritten.
+     */
+    private function runArgument(string $tail): string
+    {
+        $tail = trim($tail);
+        if ($tail === '') {
+            return '';
+        }
+
+        $tokens = preg_split('/\s+/', $tail) ?: [];
+        $translated = [];
+        foreach ($tokens as $i => $token) {
+            $mapped = match (strtolower($token)) {
+                'features', 'feature', 'stories', 'story' => '--story',
+                'all', 'everything' => '--all',
+                'specs', 'spec' => '',
+                default => null,
+            };
+
+            if ($mapped === null) {
+                $translated = array_merge($translated, array_slice($tokens, $i));
+
+                break;
+            }
+
+            if ($mapped !== '') {
+                $translated[] = $mapped;
+            }
+        }
+
+        return implode(' ', $translated);
+    }
+
+    /**
      * Runs specs, then offers to generate any missing code.
      *
      * The run is delegated to the SpecRunner (a fresh subprocess in production)
@@ -533,11 +572,11 @@ final class CommandDispatcher
     }
 
     /**
-     * Handles a slash command that isn't one of the built-in arms: delegates to
-     * a registered Application command of the same name (minus the slash), or
+     * Handles a command that isn't one of the built-in arms: delegates to a
+     * registered Application command of the same name (minus the slash), or
      * reports it as unknown.
      */
-    private function handleSlashCommand(string $command, string $rawInput): int
+    private function handleSlashCommand(string $command, string $tail): int
     {
         $name = ltrim($command, '/');
 
@@ -547,18 +586,17 @@ final class CommandDispatcher
                 return self::CONTINUE;
             }
 
-            return $this->delegateToCommand($cmd, $command, $rawInput);
+            return $this->delegateToCommand($cmd, $tail);
         }
 
         return $this->handleUnknown($command);
     }
 
     /**
-     * Runs a Symfony console command with arguments parsed from raw input.
+     * Runs a Symfony console command with the raw argument tail of the input.
      */
-    private function delegateToCommand(Command $cmd, string $commandToken, string $rawInput): int
+    private function delegateToCommand(Command $cmd, string $argString): int
     {
-        $argString = trim(substr($rawInput, strlen($commandToken)));
         $input = new StringInput($argString);
         $input->setInteractive($this->interactive);
 
@@ -668,7 +706,8 @@ final class CommandDispatcher
             $out->writeln('  <fg=bright-blue;options=bold>AI assistant</> <fg=gray>(not configured — add ai: section to phpspec.yml)</>');
         }
         $out->writeln('');
-        $out->writeln('  Anything without a leading <fg=white>/</> is sent to the AI assistant.');
+        $out->writeln('  Commands also work as plain words: <fg=gray>run features</>, <fg=gray>run --all</>, <fg=gray>describe App\Basket</>.');
+        $out->writeln('  Anything else without a leading <fg=white>/</> is sent to the AI assistant.');
         $out->writeln('  It can generate specs, features, step definitions, and run your specs.');
         $out->writeln('');
         $out->writeln('  <fg=bright-blue>Examples:</>');

--- a/src/PhpSpec/Console/Command/Pair/InputParser.php
+++ b/src/PhpSpec/Console/Command/Pair/InputParser.php
@@ -16,35 +16,115 @@ namespace PhpSpec\Console\Command\Pair;
 
 /**
  * @internal
- * Parses raw REPL input into a command name and argument string.
+ * Parses raw REPL input into a command name, an argument string, and the raw
+ * tail. Commands work with or without a leading slash: a bare first word is
+ * routed as a command only when the rest of the line unambiguously reads as
+ * that command's arguments, so conversation is never swallowed by a command.
  */
 final readonly class InputParser
 {
+    private const BARE_ONLY = ['next', 'help', 'swap', 'clear', 'quit', 'exit'];
+    private const CLASS_FIRST = ['describe', 'exemplify', 'refactor'];
+    private const RUN_KEYWORDS = ['features', 'feature', 'stories', 'story', 'specs', 'spec', 'all', 'everything'];
+
     /**
-     * Splits raw input into a command and its argument.
+     * Splits raw input into a command, its argument, and the raw tail.
+     *
+     * The argument collects the non-option tokens; the tail is everything
+     * after the first word verbatim, so option order (and option values)
+     * survive for handlers that forward to a real command line.
      *
      * @param string $input the raw user input
-     * @return array{command: string, argument: string}
+     * @return array{command: string, argument: string, tail: string}
      */
     public function parse(string $input): array
     {
         $input = trim($input);
 
         if ($input === '') {
-            return ['command' => '', 'argument' => ''];
+            return ['command' => '', 'argument' => '', 'tail' => ''];
         }
 
         $parts = preg_split('/\s+/', $input) ?: [$input];
         $command = strtolower($parts[0]);
+        $tail = ltrim(substr($input, strlen($parts[0])));
 
-        // Collect all non-option tokens after the command
         $args = [];
+        $options = [];
         for ($i = 1, $count = count($parts); $i < $count; $i++) {
-            if (!str_starts_with($parts[$i], '-')) {
+            if (str_starts_with($parts[$i], '-')) {
+                $options[] = $parts[$i];
+            } else {
                 $args[] = $parts[$i];
             }
         }
 
-        return ['command' => $command, 'argument' => implode(' ', $args)];
+        if (!str_starts_with($command, '/')) {
+            $command = $this->route($command, $args, $options) ?? $command;
+        }
+
+        return ['command' => $command, 'argument' => implode(' ', $args), 'tail' => $tail];
+    }
+
+    /**
+     * The slash command a bare first word maps to, or null when the line reads
+     * as conversation. Guarded per command: bare-only words route alone
+     * ("help", never "help me understand"), run routes when every token is
+     * runnable, class-first commands need a class-like target, and generate
+     * always routes because plain English is its argument.
+     *
+     * @param string $word the lowercased first word
+     * @param list<string> $args the non-option tokens after the first word
+     * @param list<string> $options the option tokens after the first word
+     */
+    private function route(string $word, array $args, array $options): ?string
+    {
+        if ($word === 'generate') {
+            return '/generate';
+        }
+
+        if (in_array($word, self::BARE_ONLY, true)) {
+            return $args === [] && $options === [] ? '/' . $word : null;
+        }
+
+        if ($word === 'run') {
+            foreach ($args as $arg) {
+                if (!$this->readsAsRunTarget($arg)) {
+                    return null;
+                }
+            }
+
+            return '/run';
+        }
+
+        if (in_array($word, self::CLASS_FIRST, true)) {
+            return $args !== [] && $this->readsAsClass($args[0]) ? '/' . $word : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether a run token reads as something runnable (a path, a spec or
+     * feature file, a suite keyword) and never a word of prose.
+     */
+    private function readsAsRunTarget(string $token): bool
+    {
+        if (str_contains($token, '/') || str_ends_with($token, '.feature') || str_ends_with($token, '.php')) {
+            return true;
+        }
+
+        return in_array(strtolower($token), self::RUN_KEYWORDS, true);
+    }
+
+    /**
+     * Whether a token reads as a class-like target: identifier characters
+     * (with namespace, path, or ::method separators) including at least one
+     * capital letter, which prose words do not have.
+     */
+    private function readsAsClass(string $token): bool
+    {
+        return preg_match('#^[A-Za-z0-9_\\\\/:.]+$#', $token) === 1
+            && preg_match('/[A-Z]/', $token) === 1;
     }
 }

--- a/src/PhpSpec/Console/Command/Pair/SubprocessRunner.php
+++ b/src/PhpSpec/Console/Command/Pair/SubprocessRunner.php
@@ -45,8 +45,12 @@ final class SubprocessRunner implements SpecRunner
                 ParallelRunner::findPhpspecBin(),
                 'run',
             ];
+            // The argument is a command-line fragment ("spec/App --stop-on-failure"),
+            // so each token must become its own argv element for the child.
             if ($argument !== '') {
-                $command[] = $argument;
+                foreach (preg_split('/\s+/', $argument) ?: [] as $token) {
+                    $command[] = $token;
+                }
             }
             $command[] = '-f';
             $command[] = 'dot';


### PR DESCRIPTION
Pair commands now work with or without the leading slash. A bare first word routes as a command only when the rest of the line unambiguously reads as that command's arguments, so conversation is never swallowed by a command:

- `run` routes when every token is a path, a spec/feature file, a suite keyword, or an option: `run`, `run features`, `run --all`, `run spec/App`. Leading suite keywords translate to their options (`features`/`stories` to `--story`, `all`/`everything` to `--all`, `specs` to the default run), and the translation never rewrites an option value (`--filter features` is left alone).
- `describe`, `exemplify`, and `refactor` route when the first argument looks like a class: `describe App/Basket`, `refactor Todo` (delegated to the standalone command as before), `exemplify App\Calculator add`.
- `generate` always routes: plain English is its argument.
- `next`, `help`, `swap`, `clear`, `quit`, and `exit` route only as the exact bare word.
- Guards keep prose with the AI: "run me through the design", "help me understand this project", "next time we should refactor" all stay conversation.

Options now actually reach the runner on every form. The parser kept only non-option tokens, so `/run --all` silently dropped the flag, and the subprocess runner passed the whole argument as one argv element, so `spec/App --stop-on-failure` could never have worked. The parser now carries the raw tail alongside the cleaned argument, `/run` forwards it after keyword translation, and the runner splits it into argv tokens.

Also catches docs/pair.md up: the routing contract, the beta.12 navigator offers and `/next` ghost, and the stale provider/model tables.

Verified: 1617 examples and 1083 steps green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; coverage 91.7% against the 90 minimum; phpstan and php-cs-fixer clean.

Note: this adds a CHANGES `[Unreleased]` section that will conflict trivially with #1550 when the second of the two merges.