### PR TITLE
Let the chooser take a typed note on Yes or No, flowing it to the model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+ - Tab on the chooser's Yes or No opens an editable note ("1. Yes, rename the method to tasks" / "3. No, make it a Feature instead"): the note travels with the answer into the AI's tool result, so an accepted change carries the human's amendment and a declined offer carries the direction to take instead of a mute no. Piped answers carry a note after a comma.
+
 ## [9.0.0-beta.12](https://github.com/phpspec/phpspec/compare/9.0.0-beta.11...9.0.0-beta.12)
 
 ### Added

--- a/docs/pair.md
+++ b/docs/pair.md
@@ -196,6 +196,23 @@ answer "always" to class creation and PhpSpec stops asking about classes,
 while other questions (running specs, applying AI file changes) still prompt.
 Nothing is persisted between sessions.
 
+Press **Tab** on Yes or No to annotate the answer before giving it: the
+highlighted line becomes an editable trailer.
+
+```
+  Apply this offered change?
+   ▸ 1. Yes, rename the method to tasks▮
+     2. Yes, and don't ask again -- always apply offered changes
+     3. No
+```
+
+Type the note, backspace to edit, Enter to answer with it, Esc to drop it.
+The note travels with the answer: accept an AI offer with "Yes, rename the
+method to tasks" and the model reads exactly that amendment; decline with
+"No, make it a Feature instead" and that becomes the direction it takes next,
+instead of guessing why you said no. Piped input carries a note after a comma
+(an answer line of "3, make it a Feature instead").
+
 ### Project Context
 
 On each request, the AI receives:

--- a/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
@@ -145,6 +145,66 @@ describe(AiAssistant::class, function () {
         expect((string) json_encode($captured))->toContain('declined this offer');
     });
 
+    it('hands the acceptance note to the model when an offer is applied', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("<?php\nnamespace App;\nclass TodoList {}\n");
+        allow($fs->write())->toReturn(null);
+        allow($fs->mkdir())->toReturn(null);
+
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'offer_change', [
+                    'path' => 'src/App/TodoList.php',
+                    'content' => "<?php\nnamespace App;\nclass TodoList {\n    public function items(): array { return []; }\n}\n",
+                    'intent' => 'add an accessor',
+                ])]);
+            }
+            $captured = $messages;
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $this->answers = ['1, rename the method to tasks'];
+        $assistant->handle('how do we make this real?');
+
+        $text = (string) json_encode($captured);
+        expect($text)->toContain('The human added');
+        expect($text)->toContain('rename the method to tasks');
+    });
+
+    it('hands the decline note to the model as the direction to take instead', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("<?php\n// old");
+        allow($fs->mkdir())->toReturn(null);
+
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'offer_change', [
+                    'path' => 'src/App/TodoList.php',
+                    'content' => "<?php\n// new",
+                    'intent' => 'rewrite it',
+                ])]);
+            }
+            $captured = $messages;
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $this->answers = ['3, make it a Feature instead'];
+        $assistant->handle('thoughts?');
+
+        expect($fs->write())->not()->toHaveBeenCalled();
+        $text = (string) json_encode($captured);
+        expect($text)->toContain('make it a Feature instead');
+        expect($text)->toContain('Address that');
+    });
+
     it('rejects an offer that would drop spec examples, before any chooser', function (Filesystem $fs) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturn("<?php\ndescribe('TodoList', function () {\n    it(\"should add\", fn() => expect(null)->toBe(null));\n    it(\"should tasks\", fn() => expect(null)->toBe(null));\n});\n");
@@ -299,6 +359,41 @@ describe(AiAssistant::class, function () {
         expect($fs->write())->not()->toHaveBeenCalled();
         // Declining steers the driver back into the cycle, rather than a bare "declined".
         expect((string) json_encode($captured))->toContain('declined this step');
+    });
+
+    it('hands the confirm-step notes to the driving model, on yes and on no', function (Filesystem $fs) {
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'describe', [
+                    'class_name' => 'App/Wanted',
+                ])]);
+            }
+            $captured = $messages;
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, $this->aiDrives, $this->specRunner);
+        $this->answers = ['3, exemplify addTask first'];
+        $assistant->handle('spec App/Wanted');
+
+        $text = (string) json_encode($captured);
+        expect($text)->toContain('exemplify addTask first');
+        expect($text)->toContain('Address that');
+
+        $captured = null;
+        $turn = 0;
+        allow($fs->write())->toReturn(null);
+        allow($fs->mkdir())->toReturn(null);
+        $accepting = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, new RoleState(PairRole::AiDrives), $this->specRunner);
+        $this->answers = ['1, then run it'];
+        $accepting->handle('spec App/Wanted');
+
+        $text = (string) json_encode($captured);
+        expect($text)->toContain('The human added');
+        expect($text)->toContain('then run it');
     });
 
     it('ends the driver turn after one artifact instead of chasing a bigger goal', function (Filesystem $fs) {

--- a/spec/PhpSpec/Console/Command/Pair/Chooser.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/Chooser.spec.php
@@ -144,4 +144,96 @@ describe(Chooser::class, function () {
         expect($this->reads)->toBe(0);
         expect($this->buffer->fetch())->toContain('Create class App\Auto?');
     });
+
+    context('Tab annotates the answer with a note', function () {
+        it('captures a note after Tab on Yes and exposes it', function () {
+            $keys = ["\t", 'r', 'e', 'n', 'a', 'm', 'e', "\n"];
+            $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+                return array_shift($keys) ?? "\n";
+            });
+
+            expect($chooser->choose('Apply?', 'k', 'do it'))->toBeTrue();
+            expect($chooser->lastNote())->toBe('rename');
+            expect($this->buffer->fetch())->toContain('1. Yes, rename');
+        });
+
+        it('captures a note after Tab on No', function () {
+            $keys = ["\033[B", "\033[B", "\t", 'u', 's', 'e', ' ', 'X', "\n"];
+            $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+                return array_shift($keys) ?? "\n";
+            });
+
+            expect($chooser->choose('Apply?', 'k', 'do it'))->toBeFalse();
+            expect($chooser->lastNote())->toBe('use X');
+            expect($this->buffer->fetch())->toContain('3. No, use X');
+        });
+
+        it('edits the note with backspace', function () {
+            $keys = ["\t", 'a', 'b', "\x7f", "\n"];
+            $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+                return array_shift($keys) ?? "\n";
+            });
+
+            expect($chooser->choose('Apply?', 'k', 'do it'))->toBeTrue();
+            expect($chooser->lastNote())->toBe('a');
+        });
+
+        it('cancels the note on escape but keeps the selection', function () {
+            $keys = ["\t", 'a', "\033", "\n"];
+            $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+                return array_shift($keys) ?? "\n";
+            });
+
+            expect($chooser->choose('Apply?', 'k', 'do it'))->toBeTrue();
+            expect($chooser->lastNote())->toBe('');
+        });
+
+        it('ignores Tab on the always option', function () {
+            $keys = ["\033[B", "\t", "\n"];
+            $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+                return array_shift($keys) ?? "\n";
+            });
+
+            expect($chooser->choose('Apply?', 'k', 'do it'))->toBeTrue();
+            expect($chooser->hasAlways('k'))->toBeTrue();
+            expect($chooser->lastNote())->toBe('');
+        });
+
+        it('resets the note between questions', function () {
+            $keys = ["\t", 'x', "\n", "\n"];
+            $chooser = new Chooser($this->output, true, null, function () use (&$keys) {
+                return array_shift($keys) ?? "\n";
+            });
+
+            $chooser->choose('First?', 'k', 'do it');
+            expect($chooser->lastNote())->toBe('x');
+
+            $chooser->choose('Second?', 'k2', 'do it');
+            expect($chooser->lastNote())->toBe('');
+        });
+
+        it('reads a note after a comma in line mode', function () {
+            $chooser = new Chooser($this->output, true, $this->reader);
+
+            $this->answers = ['1, rename it to tasks'];
+            expect($chooser->choose('Apply?', 'k', 'do it'))->toBeTrue();
+            expect($chooser->lastNote())->toBe('rename it to tasks');
+        });
+
+        it('reads a decline note after a comma in line mode', function () {
+            $chooser = new Chooser($this->output, true, $this->reader);
+
+            $this->answers = ['n, make it a Feature instead'];
+            expect($chooser->choose('Apply?', 'k', 'do it'))->toBeFalse();
+            expect($chooser->lastNote())->toBe('make it a Feature instead');
+        });
+
+        it('leaves the note empty for a plain line answer', function () {
+            $chooser = new Chooser($this->output, true, $this->reader);
+
+            $this->answers = ['3'];
+            expect($chooser->choose('Apply?', 'k', 'do it'))->toBeFalse();
+            expect($chooser->lastNote())->toBe('');
+        });
+    });
 });

--- a/src/PhpSpec/Console/Command/Pair/AiAssistant.php
+++ b/src/PhpSpec/Console/Command/Pair/AiAssistant.php
@@ -418,11 +418,15 @@ final class AiAssistant
 
         // Writes the role allows still need the user's go-ahead, shown against
         // the driver's stated plan so the navigator confirms a real decision.
+        // Either answer may carry a typed note (Tab on the chooser), which is
+        // handed to the model as part of the outcome.
         if ($isWrite && !$this->chooser->choose($this->confirmQuestion($toolCall), 'write-files', 'apply file changes')) {
             PairLogger::log('RESULT', 'User declined');
 
-            return self::declineSteer();
+            return self::declineSteer($this->chooser->lastNote());
         }
+
+        $note = $isWrite ? $this->chooser->lastNote() : '';
 
         try {
             $result = $tool->execute($toolCall->arguments);
@@ -432,6 +436,10 @@ final class AiAssistant
             // the model may retry it in the correct form this same turn.
             if ($isWrite && !(is_array($result) && isset($result['error']))) {
                 $this->artifactWrittenThisHandle = true;
+
+                if ($note !== '' && is_string($result)) {
+                    $result .= sprintf(' The human added: "%s".', $note);
+                }
             }
 
             PairLogger::log('RESULT', is_string($result) ? $result : (json_encode($result) ?: ''));
@@ -462,13 +470,20 @@ final class AiAssistant
 
     /**
      * The reply handed back to the model when the navigator declines a write at
-     * the confirm step: it steers back into the cycle — re-clarify, don't retry.
+     * the confirm step: it steers back into the cycle (re-clarify, don't retry),
+     * carrying the typed note as the direction to take when one was given.
      *
+     * @param string $note the note typed alongside the decline, empty when none
      * @return array{error: string}
      */
-    private static function declineSteer(): array
+    private static function declineSteer(string $note): array
     {
-        return ['error' => 'You declined this step. Don\'t repeat the same write — ask what I should '
+        if ($note !== '') {
+            return ['error' => sprintf('You declined this step, saying: "%s". Address that instead; '
+                . 'don\'t repeat the same write. Or /swap to take the keyboard back.', $note)];
+        }
+
+        return ['error' => 'You declined this step. Don\'t repeat the same write, ask what I should '
             . 'change instead, then re-plan. Or /swap to take the keyboard back.'];
     }
 
@@ -1068,11 +1083,17 @@ final class AiAssistant
                 if (!$this->chooser->choose($this->offerQuestion($args), 'offer-change', 'apply offered changes')) {
                     PairLogger::log('RESULT', 'Offer declined');
 
-                    return self::offerDeclined();
+                    return self::offerDeclined($this->chooser->lastNote());
                 }
+
+                $note = $this->chooser->lastNote();
 
                 (new Writer($filesystem))->apply($proposal);
                 $this->artifactWrittenThisHandle = true;
+
+                if ($note !== '') {
+                    return sprintf('Change applied to %s. The human added: "%s".', $absPath, $note);
+                }
 
                 return "Change applied to $absPath.";
             },
@@ -1098,12 +1119,19 @@ final class AiAssistant
 
     /**
      * The reply handed back when the human declines an offer: re-plan, never
-     * re-offer.
+     * re-offer, and when the decline carried a typed note, that note is the
+     * direction to take instead.
      *
+     * @param string $note the note typed alongside the decline, empty when none
      * @return array{error: string}
      */
-    private static function offerDeclined(): array
+    private static function offerDeclined(string $note): array
     {
+        if ($note !== '') {
+            return ['error' => sprintf('The human declined this offer, saying: "%s". Address that '
+                . 'instead; do not re-offer the same change.', $note)];
+        }
+
         return ['error' => 'The human declined this offer. Ask what they would prefer or refine the '
             . 'suggestion; do not re-offer the same change.'];
     }

--- a/src/PhpSpec/Console/Command/Pair/Chooser.php
+++ b/src/PhpSpec/Console/Command/Pair/Chooser.php
@@ -15,6 +15,7 @@
 namespace PhpSpec\Console\Command\Pair;
 
 use Closure;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 
 /**
  * @internal
@@ -37,6 +38,12 @@ final class Chooser
 {
     /** @var array<string, true> question kinds answered with "always" this session */
     private array $always = [];
+
+    /**
+     * The note typed alongside the latest answer (Tab on Yes/No opens an
+     * editable trailer; line mode reads it after a comma), empty when none.
+     */
+    private string $note = '';
 
     private readonly Closure $reader;
 
@@ -76,6 +83,8 @@ final class Chooser
      */
     public function choose(string $question, string $kind, string $action): bool
     {
+        $this->note = '';
+
         if (isset($this->always[$kind])) {
             return true;
         }
@@ -110,6 +119,17 @@ final class Chooser
     }
 
     /**
+     * The note the human typed alongside the latest answer: Tab on Yes or No
+     * opens an editable trailer ("1. Yes, rename it"), and a piped answer line
+     * carries it after a comma ("3, make it a Feature instead"). Empty when the
+     * answer came without one.
+     */
+    public function lastNote(): string
+    {
+        return $this->note;
+    }
+
+    /**
      * Applies the chosen option: records "always", reports acceptance.
      *
      * @param int $choice the selected option (1 yes, 2 always, 3 no)
@@ -127,7 +147,9 @@ final class Chooser
 
     /**
      * Key mode (TTY): a single keypress decides, the arrow keys move the
-     * highlight and Enter confirms it.
+     * highlight and Enter confirms it. Tab on Yes or No opens an editable note
+     * trailer on the highlighted line (Enter confirms answer and note together,
+     * Esc discards the note, backspace edits it).
      *
      * @param string $action verb phrase for option 2
      * @return int the selected option (1, 2 or 3)
@@ -136,6 +158,7 @@ final class Chooser
     {
         $selected = 1;
         $rendered = false;
+        $note = null;
         $rawMode = $this->keys === null;
 
         if ($rawMode) {
@@ -148,12 +171,41 @@ final class Chooser
             while (true) {
                 $key = $this->keys !== null ? ($this->keys)() : $this->readKeyToken();
 
+                if ($note !== null) {
+                    switch ($key) {
+                        case "\n":
+                        case "\r":
+                            $this->note = trim($note);
+
+                            return $selected;
+                        case "\033":
+                            $note = null;
+                            break;
+                        case "\x7f":
+                        case "\x08":
+                            $note = substr($note, 0, -1);
+                            break;
+                        default:
+                            if (strlen($key) === 1 && $key >= ' ') {
+                                $note .= $key;
+                            }
+                    }
+
+                    $this->renderOptions($selected, $action, $rendered, $note);
+                    continue;
+                }
+
                 switch ($key) {
                     case "\033[A":
                         $selected = max(1, $selected - 1);
                         break;
                     case "\033[B":
                         $selected = min(3, $selected + 1);
+                        break;
+                    case "\t":
+                        if ($selected !== 2) {
+                            $note = '';
+                        }
                         break;
                     case "\n":
                     case "\r":
@@ -181,7 +233,7 @@ final class Chooser
                         continue 2;
                 }
 
-                $this->renderOptions($selected, $action, $rendered);
+                $this->renderOptions($selected, $action, $rendered, $note);
             }
         } finally {
             if ($rawMode) {
@@ -192,6 +244,8 @@ final class Chooser
 
     /**
      * Line mode (piped input): prints the options and reads one answer line.
+     * Anything after a comma is kept as the answer's note ("3, make it a
+     * Feature instead").
      *
      * @param string $action verb phrase for option 2
      * @return int the selected option (1, 2 or 3)
@@ -201,7 +255,13 @@ final class Chooser
         $rendered = false;
         $this->renderOptions(1, $action, $rendered);
 
-        return match (strtolower(trim(($this->reader)()))) {
+        $answer = trim(($this->reader)());
+        if (str_contains($answer, ',')) {
+            [$answer, $note] = explode(',', $answer, 2);
+            $this->note = trim($note);
+        }
+
+        return match (strtolower(trim($answer))) {
             '2', 'a' => 2,
             '3', 'n' => 3,
             default => 1,
@@ -210,13 +270,15 @@ final class Chooser
 
     /**
      * Renders the three options with the current highlight, redrawing in
-     * place after the first paint.
+     * place after the first paint. A non-null note renders as an editable
+     * trailer on the highlighted line ("Yes, rename it▮").
      *
      * @param int $selected the highlighted option
      * @param string $action verb phrase for option 2
      * @param bool $rendered whether a previous paint must be overwritten (by reference)
+     * @param string|null $note the note being typed, null when not in note mode
      */
-    private function renderOptions(int $selected, string $action, bool &$rendered): void
+    private function renderOptions(int $selected, string $action, bool &$rendered, ?string $note = null): void
     {
         $console = $this->output->getOutput();
 
@@ -231,6 +293,10 @@ final class Chooser
             2 => "Yes, and don't ask again — always $action",
             3 => 'No',
         ];
+
+        if ($note !== null && $selected !== 2) {
+            $labels[$selected] .= ', ' . OutputFormatter::escape($note) . '▮';
+        }
 
         foreach ($labels as $number => $label) {
             if ($number === $selected) {


### PR DESCRIPTION
Pressing Tab on option 1 or 3 of the numbered chooser opens an editable trailer on the highlighted line:

```
  Apply this offered change?
   ▸ 1. Yes, rename the method to tasks▮
     2. Yes, and don't ask again -- always apply offered changes
     3. No
```

Type the note, backspace to edit, Enter answers with it, Esc drops it (Tab on option 2 is ignored). Piped input carries a note after a comma ("3, make it a Feature instead"), so scripted sessions keep working.

The note travels with the answer into the AI's tool result, closing the loop the beta.12 offers opened, where declining was mute and the model had to guess why:

- Offer accepted: "Change applied to X. The human added: ..."
- Offer declined: "The human declined this offer, saying: ... Address that instead; do not re-offer the same change."
- Driver write confirm, both ways, through the same seam.

API stays minimal: `Chooser::choose()` keeps returning bool; new `lastNote(): string` (reset per question) is read only by the callers that care.

Verified: 1607 examples and 1030 steps green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; coverage 91.7% against the 90 minimum; phpstan and php-cs-fixer clean.

Note: independent of #1551, but both add a CHANGES `[Unreleased]` section, so whichever merges second trivially conflicts there (same as #1550).