### PR TITLE
Place a bare generated filename under its configured directory, never the project root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - `generate` places a bare filename under its configured directory (features, spec, or src), never the project root
+
 ## [9.0.0-beta.13](https://github.com/phpspec/phpspec/compare/9.0.0-beta.12...9.0.0-beta.13)
 
 ### Added

--- a/features/scenarios/cli/generate.feature
+++ b/features/scenarios/cli/generate.feature
@@ -22,6 +22,18 @@ Feature: Generate code from a natural-language instruction
     When I run phpspec command "generate a Calculator that adds two numbers"
     Then the output should contain "Generating"
 
+  Scenario: a bare feature filename lands under the features directory, not the project root
+    Given a phpspec.yaml config:
+      """
+      ai:
+        provider: google
+        api_key: test-key
+      """
+    When I run phpspec command "generate a feature for completing_a_task.feature"
+    Then a file "features/completing_a_task.feature" should be generated
+    And the file "features/completing_a_task.feature" should contain "Feature:"
+    And the output should contain "features/completing_a_task.feature"
+
   Scenario: generate writes step definitions for the last-touched feature deterministically
     Given a phpspec.yaml config:
       """

--- a/spec/PhpSpec/Ai/Agent/ToolRegistry.spec.php
+++ b/spec/PhpSpec/Ai/Agent/ToolRegistry.spec.php
@@ -70,6 +70,14 @@ describe(ToolRegistry::class, function () {
             expect($proposals[0]->path)->toBe('features/user_adds_tasks.feature');
         });
 
+        it('places a bare feature filename under the configured features path, never the project root', function () {
+            $step = new Step(Phase::WriteFeature, 'completing_a_task.feature', null, 'you named it');
+
+            $proposals = $this->registry->deterministic($step, Grounding::empty(), $this->genProfile);
+
+            expect($proposals[0]->path)->toBe('features/completing_a_task.feature');
+        });
+
         it('parses the subject feature and drafts its steps file deterministically', function (Filesystem $fs) {
             allow($fs->exists())->toReturnUsing(fn(string $path): bool => str_ends_with($path, 'features/adding_a_task.feature'));
             allow($fs->read())->toReturn("Feature: Adding\n  Scenario: Adding\n    Given I have a todo list\n    When I add the task \"Buy milk\"\n");
@@ -146,6 +154,24 @@ describe(ToolRegistry::class, function () {
 
             expect($proposals[0]->path)->toBe('spec/Coupon.spec.php');
             expect($proposals[0]->new)->toContain('Coupon');
+        });
+
+        it('places a bare spec filename from the step under the spec path', function () {
+            $step = new Step(Phase::WriteSpec, 'Coupon.spec.php', null, 'you named it');
+            $call = new ToolCall('1', 'propose_edit', ['path' => 'Coupon.spec.php', 'content' => "<?php\ndescribe('Coupon', fn() => null);"]);
+
+            $proposals = $this->registry->fromCalls([$call], $step);
+
+            expect($proposals[0]->path)->toBe('spec/Coupon.spec.php');
+        });
+
+        it('places a bare source filename from the step under the source path', function () {
+            $step = new Step(Phase::WriteCode, 'Coupon.php', null, 'you named it');
+            $call = new ToolCall('1', 'propose_edit', ['path' => 'Coupon.php', 'content' => "<?php\nclass Coupon {}"]);
+
+            $proposals = $this->registry->fromCalls([$call], $step);
+
+            expect($proposals[0]->path)->toBe('src/Coupon.php');
         });
 
         it('rejects a propose_edit spec written in ObjectBehavior syntax', function () {

--- a/src/PhpSpec/Ai/Agent/ToolRegistry.php
+++ b/src/PhpSpec/Ai/Agent/ToolRegistry.php
@@ -243,7 +243,7 @@ final class ToolRegistry
         }
 
         if ($step->path !== null) {
-            return $this->relative($step->path);
+            return $this->locatedPath($this->relative($step->path));
         }
 
         if ($step->subject === null) {
@@ -276,10 +276,41 @@ final class ToolRegistry
     private function featurePath(Step $step): ?string
     {
         if ($step->path !== null) {
-            return $this->relative($step->path);
+            return $this->locatedPath($this->relative($step->path));
         }
 
         return $this->slugPath($step->subject ?? '');
+    }
+
+    /**
+     * A bare file name is a name, not a location: the runner only discovers
+     * files under the configured directories, so the name is placed in the
+     * directory its suffix belongs to (feature, spec, or source). A path that
+     * already names a directory is honoured verbatim, and steps files are
+     * laid out beside their feature elsewhere.
+     */
+    private function locatedPath(string $path): string
+    {
+        if (str_starts_with($path, './')) {
+            $path = substr($path, 2);
+        }
+
+        if (str_contains($path, '/') || str_ends_with($path, '.steps.php')) {
+            return $path;
+        }
+
+        $dir = match (true) {
+            str_ends_with($path, '.feature') => trim($this->config->getFeaturesPath(), './'),
+            str_ends_with($path, $this->config->getSpecSuffix()) => ltrim(str_replace('\\', '/', $this->config->getSpecPath()), './'),
+            str_ends_with($path, '.php') => ltrim($this->config->getSrcPath(), './'),
+            default => null,
+        };
+
+        if ($dir === null) {
+            return $path;
+        }
+
+        return rtrim($dir, '/') . '/' . $path;
     }
 
     /**


### PR DESCRIPTION
Dogfood bug: `/generate a feature for completing_a_task.feature` created `completing_a_task.feature` at the project root instead of under `features/`.

The instruction parser extracts a filename mentioned in the instruction as an explicit path, and the registry honoured an explicit path verbatim. That rule is right for `features/x.feature` but wrong for a bare name: the user named a file, not a location, and the runner would never discover a feature at the root.

Fix: a step path with no directory in it is placed in the directory its suffix belongs to (`.feature` under the features path, the spec suffix under the spec path, `.php` under the source path). Paths that name a directory are honoured verbatim as before (the explicit-path eval E1 still passes), and steps files keep their feature-derived layout.

Covered outside-in: a generate.feature scenario reproducing the exact transcript, plus registry examples for the three suffixes and the verbatim guard.

Verified: 1634 examples and 1088 steps green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; coverage 91.8%; phpstan and php-cs-fixer clean.