### PR TITLE
Serialise tools at the papi seam so one-shot commands declare them on the wire

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Asking `generate` for step bodies (or to grow an existing feature) consults the model instead of re-emitting a no-op scaffold
  - A `/generate` chooser note now runs a follow-up round with that note as the instruction
 
+## [Unreleased]
+
+### Fixed
+ - One-shot AI commands declare their tools on the wire again (they were sent as zero declarations, so the model answered empty)
+ - Composer now refuses papi-ai packages older than 0.13
+
 ## [9.0.0-beta.13](https://github.com/phpspec/phpspec/compare/9.0.0-beta.12...9.0.0-beta.13)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
     },
 
     "suggest": {
-        "papi-ai/papi-core": "Required for AI features (pair, next, refactor)",
-        "papi-ai/google": "Google Gemini AI provider",
+        "papi-ai/papi-core": "Required for AI features (pair, next, refactor); ^0.13 or newer",
+        "papi-ai/google": "Google Gemini AI provider; ^0.13 or newer",
         "papi-ai/anthropic": "Anthropic Claude AI provider",
         "papi-ai/openai": "OpenAI GPT AI provider",
         "ext-curl": "Required for AI features (pair, next, refactor)",
@@ -59,6 +59,11 @@
         "phpstan/phpstan": "^2.1",
         "papi-ai/papi-core": "^0.13",
         "papi-ai/google": "^0.13"
+    },
+
+    "conflict": {
+        "papi-ai/papi-core": "<0.13",
+        "papi-ai/google": "<0.13"
     },
 
     "bin": ["bin/phpspec"],

--- a/spec/PhpSpec/Ai/Papi/PapiProvider.spec.php
+++ b/spec/PhpSpec/Ai/Papi/PapiProvider.spec.php
@@ -1,0 +1,86 @@
+<?php
+
+use PhpSpec\Ai\Message;
+use PhpSpec\Ai\Papi\PapiProvider;
+use PhpSpec\Ai\Tool;
+
+// The adapter's whole job is that PhpSpec code never references PapiAI
+// directly, and papi providers only consume tool declarations in ARRAY shape
+// (objects are silently dropped, and the wire then carries zero tools). The
+// examples pin the conversion at the seam, where no eval replay can see it.
+describe(PapiProvider::class, function () {
+
+    beforeEach(function () {
+        $this->papi = new class implements \PapiAI\Core\Contracts\ProviderInterface {
+            /** @var array<string, mixed> */
+            public array $options = [];
+
+            public function chat(array $messages, array $options = []): \PapiAI\Core\Response
+            {
+                $this->options = $options;
+
+                return new \PapiAI\Core\Response(text: 'ok');
+            }
+
+            public function stream(array $messages, array $options = []): iterable
+            {
+                return [];
+            }
+
+            public function supportsTool(): bool
+            {
+                return true;
+            }
+
+            public function supportsVision(): bool
+            {
+                return false;
+            }
+
+            public function supportsStructuredOutput(): bool
+            {
+                return false;
+            }
+
+            public function getName(): string
+            {
+                return 'fake';
+            }
+        };
+        $this->provider = new PapiProvider($this->papi);
+    });
+
+    it('serialises Tool objects into the array shape papi providers consume', function () {
+        $tool = Tool::make(
+            name: 'suggest_next',
+            description: 'Register the next step.',
+            parameters: ['target' => ['type' => 'string', 'description' => 'the subject']],
+            handler: static fn(array $a): string => '',
+        );
+
+        $this->provider->chat([Message::user('hi')], ['tools' => [$tool]]);
+
+        $sent = $this->papi->options['tools'][0];
+        expect(is_array($sent))->toBeTrue();
+        expect($sent['name'])->toBe('suggest_next');
+        expect($sent['description'])->toBe('Register the next step.');
+        expect($sent['input_schema']['type'])->toBe('object');
+        expect($sent['input_schema']['properties']['target']['type'])->toBe('string');
+    });
+
+    it('passes already-serialised tool arrays through untouched', function () {
+        $asArray = ['name' => 'run_specs', 'description' => 'Run.', 'input_schema' => ['type' => 'object', 'properties' => []]];
+
+        $this->provider->chat([Message::user('hi')], ['tools' => [$asArray]]);
+
+        expect($this->papi->options['tools'][0])->toBe($asArray);
+    });
+
+    it('leaves the other options, toolChoice included, intact', function () {
+        $this->provider->chat([Message::user('hi')], ['toolChoice' => ['name' => 'suggest_next'], 'maxTokens' => 64]);
+
+        expect($this->papi->options['toolChoice'])->toBe(['name' => 'suggest_next']);
+        expect($this->papi->options['maxTokens'])->toBe(64);
+    });
+
+});

--- a/src/PhpSpec/Ai/Papi/PapiProvider.php
+++ b/src/PhpSpec/Ai/Papi/PapiProvider.php
@@ -18,6 +18,7 @@ use PapiAI\Core\Contracts\ProviderInterface as PapiProviderInterface;
 use PapiAI\Core\Message as PapiMessage;
 use PapiAI\Core\ToolCall as PapiToolCall;
 use PhpSpec\Ai\Contracts\ProviderInterface;
+use PhpSpec\Ai\Contracts\ToolInterface;
 use PhpSpec\Ai\Message;
 use PhpSpec\Ai\Response;
 use PhpSpec\Ai\Role;
@@ -43,9 +44,36 @@ final class PapiProvider implements ProviderInterface
     {
         $papiMessages = array_map(self::toPapiMessage(...), $messages);
 
+        // Papi providers only consume tool declarations in array shape; an
+        // object slips through their conversion silently and the request goes
+        // out declaring NO tools at all, so the adapter serialises here.
+        if (isset($options['tools']) && is_array($options['tools'])) {
+            $options['tools'] = array_map(self::toPapiTool(...), $options['tools']);
+        }
+
         $papiResponse = $this->provider->chat($papiMessages, $options);
 
         return self::fromPapiResponse($papiResponse);
+    }
+
+    /**
+     * The array shape papi providers consume for one tool declaration; a tool
+     * already in array shape passes through untouched.
+     *
+     * @param ToolInterface|array<string, mixed> $tool
+     * @return array<string, mixed>
+     */
+    private static function toPapiTool(ToolInterface|array $tool): array
+    {
+        if ($tool instanceof ToolInterface) {
+            return [
+                'name' => $tool->getName(),
+                'description' => $tool->getDescription(),
+                'input_schema' => $tool->getParameterSchema(),
+            ];
+        }
+
+        return $tool;
     }
 
     private static function toPapiMessage(Message $message): PapiMessage


### PR DESCRIPTION
Findings from the /tmp/todo dogfood assignment, traced end to end with last-request.json, direct papi probes, and a raw HTTP probe.

**Root cause of every empty one-shot answer.** Papi providers only consume tool declarations in array shape: `GoogleProvider::convertTools` iterates with `if (is_array($tool))` and silently skips objects (0.10 and 0.13 alike). Pair serialises its tools to arrays (`AiAssistant` sends `{name, description, input_schema}`), which is why pair tool-calling always worked. The one-shot pipeline passed `PhpSpec\Ai\Tool` OBJECTS, so every one-shot model request went out with `functionDeclarations: []`: the model was ordered to answer only by tool call while holding zero tools, and returned an empty candidate. A raw HTTP probe with the same prompt and a proper declarations array gets a perfect functionCall back, so the model and API were never at fault. The deterministic fast paths masked the breakage, and the replay evals cannot see the wire.

**Fix.** The `PapiProvider` adapter (whose stated job is that PhpSpec never references papi shapes directly) now serialises `ToolInterface` objects into the array shape at the seam; arrays pass through untouched, as do toolChoice and the other options. Pinned by a new adapter spec, red with the exact production error first.

**Version guard.** A fresh `composer require papi-ai/papi-core` can land on 0.10 (zero-major caret pins), where the google default model is the retired `gemini-3-pro-preview` and toolChoice does not exist. composer.json now conflicts with papi-ai/papi-core and papi-ai/google below 0.13, and the suggest entries name the minimum.

**Live verification**: with the fix, `phpspec next` against gemini-3.1-pro-preview returns a real suggestion end to end (and incidentally demonstrated the known #53 mis-offer, which is next on the board).

Suite: 1652 examples green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; 1094 steps; coverage 92.0%; phpstan and php-cs-fixer clean.