### PR TITLE
Teach next the refactor step and fix pair command delegation binding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - One-shot AI commands declare their tools on the wire again (they were sent as zero declarations, so the model answered empty)
  - Composer now refuses papi-ai packages older than 0.13
 
+## [Unreleased]
+
+### Added
+ - On a green suite, `next` can recommend refactoring, pointing at (or ghosting) `refactor` with the target
+
+### Fixed
+ - Pair delegates commands with their arguments actually bound, so `/refactor App/TodoList` runs
+
 ## [9.0.0-beta.13](https://github.com/phpspec/phpspec/compare/9.0.0-beta.12...9.0.0-beta.13)
 
 ### Added

--- a/spec/PhpSpec/Console/Command/Next.spec.php
+++ b/spec/PhpSpec/Console/Command/Next.spec.php
@@ -153,6 +153,35 @@ describe(Next::class, function () {
             expect($tester->getDisplay())->toContain('Would you like me to create that for you?');
         });
 
+        it('displays a refactor suggestion with the refactor hint', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(function (string $path) use ($yamlPath): bool {
+                return $path === $yamlPath;
+            });
+            allow($fs->read())->toReturnUsing(function (string $path) use ($yamlPath): string {
+                if ($path === $yamlPath) {
+                    return "ai:\n  provider: google\n  api_key: test-key\n";
+                }
+                return '';
+            });
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'refactor',
+                'target' => 'App\\TodoList',
+                'reason' => 'The suite is green and complete() duplicates the lookup.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $tester = new CommandTester($cmd);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('Refactor');
+            expect($tester->getDisplay())->toContain('App\\TodoList');
+            expect($tester->getDisplay())->toContain('bin/phpspec refactor App/TodoList');
+        });
+
         it('displays an example suggestion with exemplify hint', function (Filesystem $fs) {
             $yamlPath = './phpspec.yaml';
             allow($fs->exists())->toReturnUsing(function (string $path) use ($yamlPath): bool {

--- a/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/CommandDispatcher.spec.php
@@ -665,6 +665,48 @@ describe(CommandDispatcher::class, function () {
             expect($dispatcher->suggestion())->toBe('/generate add a spec example for App\\TodoList');
         });
 
+        it('pre-fills a /refactor ghost from a refactor suggestion the AI registered on /next', function (Filesystem $fs) {
+            allow($fs->exists())->toReturn(false);
+            allow($fs->isDir())->toReturn(false);
+            allow($fs->isFile())->toReturn(false);
+            allow($fs->scandir())->toReturn([]);
+            allow($fs->read())->toReturn('');
+
+            $provider = new class implements ProviderInterface {
+                public int $turn = 0;
+
+                public function chat(array $messages, array $options = []): Response
+                {
+                    if (++$this->turn === 1) {
+                        return new Response('', [new ToolCall('t1', 'suggest_next', [
+                            'type' => 'refactor',
+                            'target' => 'App\\TodoList',
+                            'reason' => 'The suite is green; complete() and isComplete() duplicate the lookup.',
+                        ])]);
+                    }
+
+                    return new Response('Green: time to clean up.');
+                }
+            };
+
+            $config = new Configuration('.', $fs);
+            $assistant = new AiAssistant($provider, $config, $this->pairOutput, 'test-model', $fs, false, null, new Chooser($this->pairOutput, false), null, $this->specRunner);
+            $dispatcher = new CommandDispatcher(
+                new SpecGenerator('spec', $fs),
+                new ClassGenerator('src', $fs),
+                $config,
+                $this->pairOutput,
+                false,
+                $fs,
+                specRunner: $this->specRunner,
+                ai: $assistant,
+            );
+
+            $dispatcher->dispatch('/next');
+
+            expect($dispatcher->suggestion())->toBe('/refactor App\\TodoList');
+        });
+
         it('suggests running the new spec after /describe', function (Filesystem $fs) {
             allow($fs->exists())->toReturn(false);
             allow($fs->mkdir())->toReturn(null);
@@ -749,17 +791,22 @@ describe(CommandDispatcher::class, function () {
             expect($result)->toBe(CommandDispatcher::CONTINUE);
         });
 
-        it('delegates /refactor with argument', function () {
+        it('delegates /refactor with its target actually bound', function () {
             $result = $this->appDispatcher->dispatch('/refactor App\\Calculator');
+            $output = $this->buffer->fetch();
             expect($result)->toBe(CommandDispatcher::CONTINUE);
+            // The target must reach the command: binding past the arguments and
+            // into execute, which asks for the missing AI config by name.
+            expect($output)->not()->toContain('Not enough arguments');
+            expect($output)->toContain('AI configuration required');
         });
 
         it('delegates a bare "refactor Class" to the refactor command', function () {
             $result = $this->appDispatcher->dispatch('refactor App\\Calculator');
             $output = $this->buffer->fetch();
             expect($result)->toBe(CommandDispatcher::CONTINUE);
-            expect($output)->not()->toContain('natural language');
-            expect($output)->not()->toContain('Unknown command');
+            expect($output)->not()->toContain('Not enough arguments');
+            expect($output)->toContain('AI configuration required');
         });
 
         it('explains AI is off for non-slash prose when no AI', function () {

--- a/src/PhpSpec/Ai/Agent/ToolRegistry.php
+++ b/src/PhpSpec/Ai/Agent/ToolRegistry.php
@@ -51,7 +51,7 @@ final class ToolRegistry
             'content' => ['type' => 'string', 'description' => 'The complete new file content, not a diff'],
         ],
         'suggest_next' => [
-            'type' => ['type' => 'string', 'enum' => ['spec', 'feature', 'example', 'info'], 'description' => 'What to build next: spec (a class to describe), feature (a user-facing behaviour), example (grow an existing spec), or info'],
+            'type' => ['type' => 'string', 'enum' => ['spec', 'feature', 'example', 'refactor', 'info'], 'description' => 'What to do next: spec (a class to describe), feature (a user-facing behaviour), example (grow an existing spec), refactor (the suite is green and a class deserves cleaning), or info'],
             'target' => ['type' => 'string', 'description' => 'The class name, feature name, or spec the suggestion is about'],
             'reason' => ['type' => 'string', 'description' => 'One short sentence on why this is the next baby step'],
         ],

--- a/src/PhpSpec/Ai/Prompts/commands/next.txt
+++ b/src/PhpSpec/Ai/Prompts/commands/next.txt
@@ -11,6 +11,8 @@ build next.
 
 Answer by calling suggest_next exactly once. type is spec (a new class to
 describe; target is its fully qualified name), feature (a user-facing behaviour;
-target is a short name), or example (grow an existing spec; target is the class).
-Use type info only when nothing concrete applies. Keep reason to one short
-sentence.
+target is a short name), example (grow an existing spec; target is the class),
+or refactor (the suite is green and a class deserves cleaning; target is the
+class). On a green suite, weigh refactor first: red, green, REFACTOR is the
+cycle, so only pass over it when the code is genuinely clean. Use type info
+only when nothing concrete applies. Keep reason to one short sentence.

--- a/src/PhpSpec/Ai/Prompts/tools/suggest_next.txt
+++ b/src/PhpSpec/Ai/Prompts/tools/suggest_next.txt
@@ -1,5 +1,5 @@
-Register the single next-step suggestion in structured form: what to build next
-(spec, feature, or example), its target, and one short reason. In pair mode this
-feeds the prompt's ghost suggestion; keep advising the human in prose as well.
-Once per turn, and only when the human asks what to do next; never as a side
-effect of another request.
+Register the single next-step suggestion in structured form: what to do next
+(spec, feature, example, or refactor on a green suite), its target, and one
+short reason. In pair mode this feeds the prompt's ghost suggestion; keep
+advising the human in prose as well. Once per turn, and only when the human
+asks what to do next; never as a side effect of another request.

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -134,6 +134,10 @@ final class Next extends Command
             return $this->offerExemplify($input, $output, $suggestion['target']);
         }
 
+        if ($suggestion['type'] === 'refactor') {
+            return $this->offerRefactor($output, $suggestion['target']);
+        }
+
         return 0;
     }
 
@@ -199,6 +203,7 @@ final class Next extends Command
             'spec' => 'Describe a spec for',
             'feature' => 'Write a feature scenario for',
             'example' => 'Add an example to',
+            'refactor' => 'Refactor',
             default => '',
         };
 
@@ -252,6 +257,20 @@ final class Next extends Command
         $classArg = str_replace('\\', '/', $target);
 
         $output->writeln("  <fg=gray>Run:</> bin/phpspec exemplify $classArg <method>");
+
+        return 0;
+    }
+
+    /**
+     * The green-suite step: point at the refactor command for the suggested
+     * target. A hint, not a run, because refactoring starts with a baseline
+     * the human should see.
+     */
+    private function offerRefactor(Output $output, string $target): int
+    {
+        $classArg = str_replace('\\', '/', $target);
+
+        $output->writeln("  <fg=gray>Run:</> bin/phpspec refactor $classArg");
 
         return 0;
     }

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -260,6 +260,7 @@ final class CommandDispatcher
             'feature' => '/generate a feature for ' . $target,
             'spec' => '/generate a spec for ' . $target,
             'example' => '/generate add a spec example for ' . $target,
+            'refactor' => '/refactor ' . $target,
             default => null,
         };
     }
@@ -581,28 +582,32 @@ final class CommandDispatcher
         $name = ltrim($command, '/');
 
         if ($this->application !== null && $this->application->has($name)) {
-            $cmd = $this->application->find($name);
-            if ($cmd instanceof Pair) {
+            if ($this->application->find($name) instanceof Pair) {
                 return self::CONTINUE;
             }
 
-            return $this->delegateToCommand($cmd, $tail);
+            return $this->delegateToCommand($name, $tail);
         }
 
         return $this->handleUnknown($command);
     }
 
     /**
-     * Runs a Symfony console command with the raw argument tail of the input.
+     * Runs a registered command with the raw argument tail of the input,
+     * through the Application itself (the canonical path), so argument
+     * binding and definition merging behave exactly as on the command line.
      */
-    private function delegateToCommand(Command $cmd, string $argString): int
+    private function delegateToCommand(string $name, string $argString): int
     {
-        $input = new StringInput($argString);
+        if ($this->application === null) {
+            return self::CONTINUE;
+        }
+
+        $input = new StringInput(trim($name . ' ' . $argString));
         $input->setInteractive($this->interactive);
 
         try {
-            $input->bind($cmd->getDefinition());
-            $cmd->run($input, $this->output->getOutput());
+            $this->application->doRun($input, $this->output->getOutput());
         } catch (Exception $e) {
             $this->output->error($e->getMessage());
         }


### PR DESCRIPTION
Two findings from the same green-suite dogfood question ("should next recommend refactoring?").

**next could not say refactor.** Red, green, REFACTOR is the cycle, and the refactor-phase instructions even describe it, but `suggest_next`'s schema only knew spec/feature/example/info, so on green the model had no structural way to answer "refactor X" and bent its advice into story-growing shapes. The type now exists end to end: schema enum, the next prompt (weigh refactor first on green), standalone display ("Refactor App\TodoList") with a `bin/phpspec refactor App/TodoList` hint, and the pair ghost pre-fills `/refactor App\TodoList`. Verified live: a green sandbox suite now gets "Refactor App\TodoList ... Run: bin/phpspec refactor App/TodoList".

**And that ghost needs a working /refactor, which pair never had.** Delegation ran the found command directly with a StringInput of the bare arguments; the application definition merge puts the command NAME in the first argument slot, so `/refactor App/TodoList` failed with 'Not enough arguments (missing: "target")' since the day delegation was written, and the specs only asserted "returns CONTINUE", which an error satisfies. Delegation now goes through `Application::doRun` with the command name prepended (the canonical path, so binding behaves exactly as on the command line), and the specs assert the target actually reaches the command's execute.

Suite: 1654 examples green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; 1094 steps; coverage 92.0%; phpstan and php-cs-fixer clean.