### PR TITLE
Offer without asking, verify to the artifact's scope, and end the turn at a verified change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+ - The navigator offers directly; the chooser is the question, never "shall I offer?"
+
+### Fixed
+ - Auto-verify runs the whole suite when the change touches a feature or steps file
+ - A verified change ends the turn; no fresh suggestion rides on its back
+
 ## [9.0.0-beta.14](https://github.com/phpspec/phpspec/compare/9.0.0-beta.13...9.0.0-beta.14)
 
 ### Added

--- a/spec/PhpSpec/Ai/Prompts.spec.php
+++ b/spec/PhpSpec/Ai/Prompts.spec.php
@@ -18,6 +18,8 @@ describe('prompt artifacts', function () {
         expect($text)->toContain('Intent');
         expect($text)->toContain('park');
         expect($text)->toContain('Guard the design');
+        expect($text)->toContain('never ask whether to offer');
+        expect($text)->toContain('report the outcome and hand back');
     });
 
     it('ships a driver prompt that runs the collaboration cycle and caps one artifact per turn', function () use ($read) {

--- a/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
@@ -57,8 +57,13 @@ describe(AiAssistant::class, function () {
         $this->specRunner = new class implements SpecRunner {
             public ?RunOutcome $outcome = null;
 
+            /** @var list<string> */
+            public array $arguments = [];
+
             public function run(string $argument, OutputInterface $output): ?RunOutcome
             {
+                $this->arguments[] = $argument;
+
                 return $this->outcome;
             }
         };
@@ -143,6 +148,97 @@ describe(AiAssistant::class, function () {
 
         expect($fs->write())->not()->toHaveBeenCalled();
         expect((string) json_encode($captured))->toContain('declined this offer');
+    });
+
+    it('verifies a feature offer with the whole suite, not specs alone', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("Feature: Adding\n  Scenario: One\n    Given something\n");
+        allow($fs->write())->toReturn(null);
+        allow($fs->mkdir())->toReturn(null);
+
+        $turn = 0;
+        $this->provider->responder = function () use (&$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'offer_change', [
+                    'path' => 'features/adding.feature',
+                    'content' => "Feature: Adding\n  Scenario: One\n    Given something\n    Then it lands\n",
+                    'intent' => 'grow the scenario',
+                ])]);
+            }
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $this->answers = ['1'];
+        $assistant->handle('tighten the feature');
+
+        expect($this->specRunner->arguments)->toContain('--all');
+    });
+
+    it('keeps the plain spec run when the landed artifact is a spec', function (Filesystem $fs) {
+        allow($fs->write())->toReturn(null);
+        allow($fs->mkdir())->toReturn(null);
+
+        $turn = 0;
+        $this->provider->responder = function () use (&$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'describe', [
+                    'class_name' => 'App/Wanted',
+                ])]);
+            }
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, $this->aiDrives, $this->specRunner);
+        $this->answers = ['1'];
+        $assistant->handle('spec App/Wanted');
+
+        expect($this->specRunner->arguments)->toContain('');
+        expect($this->specRunner->arguments)->not()->toContain('--all');
+    });
+
+    it('winds the turn down after a verified change instead of registering another suggestion', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn("Feature: Adding\n  Scenario: One\n    Given something\n");
+        allow($fs->write())->toReturn(null);
+        allow($fs->mkdir())->toReturn(null);
+
+        $captured = null;
+        $toolsByRound = [];
+        $turn = 0;
+        $this->provider->responder = function (array $messages, array $options) use (&$turn, &$captured, &$toolsByRound) {
+            $toolsByRound[] = array_map(fn(array $tool) => $tool['name'], $options['tools'] ?? []);
+
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'offer_change', [
+                    'path' => 'features/adding.feature',
+                    'content' => "Feature: Adding\n  Scenario: One\n    Given something\n    Then more\n",
+                    'intent' => 'grow the scenario',
+                ])]);
+            }
+
+            if ($turn === 2) {
+                return new Response('', [new ToolCall('t2', 'suggest_next', [
+                    'type' => 'example',
+                    'target' => 'App\\TodoList',
+                    'reason' => 'next up',
+                ])]);
+            }
+
+            $captured = $messages;
+
+            return new Response('done, handing back');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, null, $this->specRunner);
+        $this->answers = ['1'];
+        $assistant->handle('tighten the feature');
+
+        expect($toolsByRound[1] ?? [])->not()->toContain('suggest_next');
+        expect((string) json_encode($captured))->toContain('hand back');
+        expect($assistant->lastSuggestion())->toBeNull();
     });
 
     it('hands the acceptance note to the model when an offer is applied', function (Filesystem $fs) {

--- a/src/PhpSpec/Ai/Prompts/navigator.txt
+++ b/src/PhpSpec/Ai/Prompts/navigator.txt
@@ -4,9 +4,15 @@ The golden rule: you never write files unbidden in this role. Your ideas reach t
 code only through the human's decisions. When your advice has become concrete (an
 exact example, a step definition, a small method), OFFER it with offer_change: the
 human sees the diff and accepts or declines, and that decision is theirs alone.
-Never re-offer a declined change; ask what they would prefer instead. Everything
-else the human generates themselves with the commands (describe, exemplify, run)
-and the numbered choosers, or they hand you the keyboard with /swap.
+And never ask whether to offer ("shall I offer this change?"): the offer IS the
+question, and the human can decline it with a note. Ask first only when several
+directions genuinely compete. Never re-offer a declined change; ask what they
+would prefer instead. Everything else the human generates themselves with the
+commands (describe, exemplify, run) and the numbered choosers, or they hand you
+the keyboard with /swap.
+
+After a verified change, close the loop: report the outcome and hand back. Never
+open the next step unbidden; the human asks for it.
 
 Navigate strong-style, always one step ahead, choosing your level of abstraction:
 1. Intent — name the behaviour we pin down next.

--- a/src/PhpSpec/Ai/Prompts/tools/offer_change.txt
+++ b/src/PhpSpec/Ai/Prompts/tools/offer_change.txt
@@ -1,7 +1,8 @@
 Offer ONE concrete file change while navigating: give the complete new content of
 one file, and the human sees it as a diff they accept or decline. Use it the moment
 your advice has become concrete (an exact example, a step definition, a small
-method) instead of asking the human to type it. At most one offer per turn, and
+method) instead of asking the human to type it, and never ask permission to offer:
+the chooser is the question. At most one offer per turn, and
 only when the human's current ask is about changing code: when they ask to run or
 inspect, do that and report; never turn a run request into an offer. Never re-offer
 a declined change: ask what they would prefer instead. A spec offer must grow the

--- a/src/PhpSpec/Console/Command/Pair/AiAssistant.php
+++ b/src/PhpSpec/Console/Command/Pair/AiAssistant.php
@@ -96,6 +96,14 @@ final class AiAssistant
     private bool $artifactWrittenThisHandle = false;
 
     /**
+     * Whether this handle's auto-verify must run the whole suite (--all): a
+     * spec, or source the specs exercise, is verified by the spec run alone,
+     * but a feature or steps change (or any other artifact) can only be
+     * verified by running the stories too.
+     */
+    private bool $verifyWholeSuite = false;
+
+    /**
      * The structured next-step suggestion the model registered this turn via
      * suggest_next, for the dispatcher to turn into a ghost prompt.
      *
@@ -165,6 +173,7 @@ final class AiAssistant
             PairLogger::log('INPUT', $input);
             $this->ensureInitialised();
             $this->artifactWrittenThisHandle = false;
+            $this->verifyWholeSuite = false;
             $this->postArtifactRounds = 0;
             $this->lastSuggestion = null;
             $this->offerResolvedThisHandle = false;
@@ -228,6 +237,34 @@ final class AiAssistant
     }
 
     /**
+     * Records the artifact that landed this handle and widens the auto-verify
+     * scope when the spec run alone cannot vouch for it. A null path means a
+     * spec generator wrote it (describe, add_example), which specs verify.
+     */
+    private function noteArtifact(?string $path): void
+    {
+        $this->artifactWrittenThisHandle = true;
+
+        if ($path !== null && !self::specsCanVerify($path)) {
+            $this->verifyWholeSuite = true;
+        }
+    }
+
+    /**
+     * Whether the spec run alone verifies an artifact at this path: a spec, or
+     * source code the specs exercise. Features, steps files, and anything else
+     * need the whole suite.
+     */
+    private static function specsCanVerify(string $path): bool
+    {
+        if (str_ends_with($path, '.steps.php') || str_ends_with($path, '.feature')) {
+            return false;
+        }
+
+        return str_ends_with($path, '.php');
+    }
+
+    /**
      * After the AI's one artifact lands this round, runs the suite and feeds the
      * fresh red/green back as a message, so the model learns the outcome of its
      * own change without having to choose to run. The run is a read — it never
@@ -242,7 +279,7 @@ final class AiAssistant
 
         $this->output->getOutput()->writeln('  <fg=gray>Verifying your change...</>');
 
-        $outcome = $this->specRunner->run('', $this->output->getOutput());
+        $outcome = $this->specRunner->run($this->verifyWholeSuite ? '--all' : '', $this->output->getOutput());
 
         if ($outcome === null) {
             return;
@@ -391,7 +428,9 @@ final class AiAssistant
         if ($role->aiIsDriver() || $this->offerResolvedThisHandle) {
             $spent[] = 'offer_change';
         }
-        if ($this->lastSuggestion !== null) {
+        // A verified change ends the turn: no fresh suggestion rides on its
+        // back; the human asks for the next step.
+        if ($this->lastSuggestion !== null || $this->artifactWrittenThisHandle) {
             $spent[] = 'suggest_next';
         }
         if ($spent !== []) {
@@ -453,7 +492,8 @@ final class AiAssistant
             // spec) did not land, so it does not count as the turn's artifact —
             // the model may retry it in the correct form this same turn.
             if ($isWrite && !(is_array($result) && isset($result['error']))) {
-                $this->artifactWrittenThisHandle = true;
+                $path = $toolCall->arguments['path'] ?? null;
+                $this->noteArtifact(is_string($path) ? $path : null);
 
                 if ($note !== '' && is_string($result)) {
                     $result .= sprintf(' The human added: "%s".', $note);
@@ -1118,7 +1158,7 @@ final class AiAssistant
                 $note = $this->chooser->lastNote();
 
                 (new Writer($filesystem))->apply($proposal);
-                $this->artifactWrittenThisHandle = true;
+                $this->noteArtifact($path);
 
                 if ($note !== '') {
                     return sprintf('Change applied to %s. The human added: "%s".', $absPath, $note);
@@ -1190,6 +1230,9 @@ final class AiAssistant
                 ],
             ],
             handler: function (array $args): string|array {
+                if ($this->artifactWrittenThisHandle) {
+                    return ['error' => 'The change just landed and was verified. Report the outcome and hand back; the human will ask for the next step.'];
+                }
                 if ($this->lastSuggestion !== null) {
                     return ['error' => 'One suggestion per turn is already registered. Advise in prose now.'];
                 }


### PR DESCRIPTION
The three notes from the beta.14 flow transcript, as one turn contract: advice, offer, chooser, verify, report, hand back.

**Note 2: no more "shall I offer?".** The chooser is the consent (diff first, Yes/Always/No, decline with a note), so asking permission to offer wastes a turn. The navigator prompt and the offer_change tool description now say it outright: never ask whether to offer; ask first only when several directions genuinely compete. Prompt-level, locked by Prompts.spec substrings.

**Note 3: verify to the artifact's scope.** "Verifying your change..." always ran specs only, so an accepted feature or steps offer verified green even if it broke the stories. The rule, per review: specs alone vouch for a spec or for source the specs exercise; anything else (features, steps files, unknown artifacts) verifies with --all. The applied artifact's path decides, on both the offer path and the driver write path.

**Note 1: a verified change ends the turn.** After an accepted offer and its verify, the model would register a fresh suggestion and open the next advisory cycle unprompted (the per-turn suggestion slot was still unspent). Mechanically mirrored on the caps pattern: once the artifact lands, suggest_next joins the withheld tools and its handler refuses with "report the outcome and hand back", plus the matching navigator line. A suggestion registered before the write (the /next ghost) is untouched.

Covered by three new AiAssistant examples (whole-suite verify for a feature offer, plain spec run for a spec artifact, and the wind-down: tool withheld, refusal reaches the model, no ghost registered) plus the prompt locks.

Suite: 1657 examples green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; 1094 steps; coverage 92.0%; phpstan and php-cs-fixer clean.