### PR TITLE
Run the refactor baseline with the installed phpspec and hint the invoked binary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - `refactor` runs its baseline with the installed phpspec, wherever it lives (vendor installs failed to launch it and blamed the specs)
+ - Standalone hints name the binary you invoked, never a hardcoded bin/phpspec
+
 ## [9.0.0-beta.14](https://github.com/phpspec/phpspec/compare/9.0.0-beta.13...9.0.0-beta.14)
 
 ### Added

--- a/features/scenarios/cli/refactoring.feature
+++ b/features/scenarios/cli/refactoring.feature
@@ -32,6 +32,35 @@ Feature: AI-powered refactoring
     Then the exit code should not be 0
     And the output should contain "Specs must pass before refactoring"
 
+  Scenario: The baseline runs the installed phpspec, wherever it lives
+    Given a phpspec.yaml config:
+      """
+      ai:
+        provider: google
+        api_key: test-key-123
+      """
+    And a spec file "spec/App/Solid.spec.php":
+      """
+      <?php
+      use App\Solid;
+
+      describe(Solid::class, function () {
+          it('works', function () {
+              expect(new Solid())->toBeAnInstanceOf(Solid::class);
+          });
+      });
+      """
+    And a class "src/App/Solid.php":
+      """
+      <?php
+      namespace App;
+
+      class Solid {}
+      """
+    When I run phpspec refactor "App\Solid"
+    Then the output should not contain "Could not open input file"
+    And the output should not contain "Specs must pass"
+
   Scenario: Require AI configuration
     Given no phpspec.json config
     And a phpspec.yaml config:

--- a/src/PhpSpec/Ai/SpecSubprocess.php
+++ b/src/PhpSpec/Ai/SpecSubprocess.php
@@ -14,6 +14,8 @@
 
 namespace PhpSpec\Ai;
 
+use PhpSpec\Parallel\ParallelRunner;
+
 /** @internal */
 
 final class SpecSubprocess
@@ -108,12 +110,10 @@ final class SpecSubprocess
      */
     private static function buildCommand(string $specPath): array
     {
-        $phpspecBin = realpath(getcwd() . '/bin/phpspec') ?: getcwd() . '/bin/phpspec';
-
         return [
             PHP_BINARY,
             '-d', 'xdebug.mode=off',
-            $phpspecBin,
+            ParallelRunner::findPhpspecBin(),
             'run',
             $specPath,
             '--no-ansi',

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -112,7 +112,7 @@ final class Next extends Command
         // just loops) — coach to run so the missing class is driven out instead.
         if ($suggestion['type'] === 'spec' && $this->specFileExists($suggestion['target'])) {
             $output->writeln(sprintf('  A spec for <fg=bright-blue;options=bold>%s</> already exists.', $suggestion['target']));
-            $output->writeln('  <fg=gray>Run it to drive out the class:</> bin/phpspec run');
+            $output->writeln('  <fg=gray>Run it to drive out the class:</> ' . self::invokedBinary() . ' run');
             $output->writeln('');
 
             return 0;
@@ -226,7 +226,7 @@ final class Next extends Command
         $classArg = str_replace('\\', '/', $target);
 
         if (!$input->isInteractive()) {
-            $output->writeln("  <fg=gray>Run:</> bin/phpspec describe $classArg");
+            $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . " describe $classArg");
             return 0;
         }
 
@@ -256,7 +256,7 @@ final class Next extends Command
     {
         $classArg = str_replace('\\', '/', $target);
 
-        $output->writeln("  <fg=gray>Run:</> bin/phpspec exemplify $classArg <method>");
+        $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . " exemplify $classArg <method>");
 
         return 0;
     }
@@ -270,9 +270,21 @@ final class Next extends Command
     {
         $classArg = str_replace('\\', '/', $target);
 
-        $output->writeln("  <fg=gray>Run:</> bin/phpspec refactor $classArg");
+        $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . " refactor $classArg");
 
         return 0;
+    }
+
+    /**
+     * The phpspec invocation as the user typed it, so a hint points at a
+     * binary that exists in their install (vendor/bin/phpspec, bin/phpspec,
+     * or a global phpspec), never at a hardcoded path.
+     */
+    private static function invokedBinary(): string
+    {
+        $argv0 = $_SERVER['argv'][0] ?? '';
+
+        return is_string($argv0) && $argv0 !== '' ? $argv0 : 'phpspec';
     }
 
     /**


### PR DESCRIPTION
Dogfood, vendor-installed project: `phpspec refactor App/TodoList` on a fully green suite refused with "Specs must pass before refactoring" and "Could not open input file: /app/bin/phpspec".

Two hardcoded paths behind it. The refactor baseline runner (`SpecSubprocess::buildCommand`) built `getcwd() . '/bin/phpspec'`, which does not exist in a vendor install, so the baseline failed to LAUNCH and the non-zero exit was misread as failing specs. It now uses `ParallelRunner::findPhpspecBin()`, the same discovery pair mode already relies on (it resolves the installed package's own binary). Notably, the existing "Refuse when specs are failing" scenario was passing for the wrong reason: its temp world has no bin/phpspec either, so the message appeared without any spec ever running; the new scenario (green suite, AI configured) discriminates, and after the fix the old one passes for the right reason.

Second, the standalone `next` hints printed a literal `bin/phpspec` ("Run: bin/phpspec refactor App/TodoList"), a path that does not exist in the very install showing it. Hints now name the binary as the user invoked it (argv[0]): `vendor/bin/phpspec` there, `bin/phpspec` in a checkout.

Suite: 1654 examples green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; 1100 steps; coverage 92.0%; phpstan and php-cs-fixer clean.

Note: independent of the open turn-contract PR; both add an Unreleased section, so whichever merges second gets the usual trivial CHANGES conflict.