### PR TITLE
Show the refactoring and ask before applying it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Auto-verify runs the whole suite when the change touches a feature or steps file
  - A verified change ends the turn; no fresh suggestion rides on its back
 
+## [Unreleased]
+
+### Changed
+ - `refactor` shows the change and asks before applying; non-interactive runs keep auto-apply
+
 ## [9.0.0-beta.14](https://github.com/phpspec/phpspec/compare/9.0.0-beta.13...9.0.0-beta.14)
 
 ### Added

--- a/spec/PhpSpec/Console/Command/Refactor.spec.php
+++ b/spec/PhpSpec/Console/Command/Refactor.spec.php
@@ -1,10 +1,66 @@
 <?php
 
+use PhpSpec\Ai\Contracts\ProviderInterface;
+use PhpSpec\Ai\Response;
+use PhpSpec\Ai\ToolCall;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Refactor;
 use PhpSpec\Console\Command\Refactor\RefactorResult;
 use PhpSpec\Filesystem;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+
+// Builds a Refactor command wired to a scripted provider that proposes one
+// Extract Method refactoring, over a mocked project, capturing writes; the
+// consent examples drive the REAL agent flow, not the refactorFn shortcut.
+function refactorConsentWorld(Filesystem $fs, array &$written): Refactor
+{
+    $yamlPath = './phpspec.yaml';
+    $cwd = getcwd();
+    $srcPath = $cwd . '/src/App/Good.php';
+    $specPath = $cwd . '/spec/App/Good.spec.php';
+
+    allow($fs->exists())->toReturnUsing(fn(string $path): bool => in_array($path, [$yamlPath, $srcPath, $specPath], true));
+    allow($fs->read())->toReturnUsing(function (string $path) use ($yamlPath): string {
+        if ($path === $yamlPath) {
+            return "ai:\n  provider: google\n  api_key: test-key\n";
+        }
+
+        return "<?php\nclass Good {}\n";
+    });
+    allow($fs->write())->toReturnUsing(function (string $path, string $content) use (&$written) {
+        $written[$path] = $content;
+    });
+
+    $provider = new class implements ProviderInterface {
+        public int $turn = 0;
+
+        public function chat(array $messages, array $options = []): Response
+        {
+            if (++$this->turn === 1) {
+                return new Response('', [new ToolCall('t1', 'apply_refactoring', [
+                    'content' => "<?php\nclass Good { /* extracted */ }\n",
+                    'technique' => 'Extract Method',
+                    'description' => 'Pull the guard out',
+                ])]);
+            }
+
+            return new Response('done');
+        }
+    };
+
+    $specRunner = fn(string $path): array => [0, '1 pass'];
+
+    $cmd = new Refactor(new Configuration('.', $fs), $fs, $specRunner, null, $provider);
+
+    // Registered on an application so the command has a helper set: the
+    // consent question needs the question helper, exactly as in production.
+    $app = new Application('phpspec-test', '1.0');
+    $app->setAutoExit(false);
+    $app->{method_exists($app, 'addCommand') ? 'addCommand' : 'add'}($cmd);
+
+    return $cmd;
+}
 
 describe(Refactor::class, function () {
 
@@ -12,6 +68,50 @@ describe(Refactor::class, function () {
         allow($fs->exists())->toReturn(false);
         allow($fs->isFile())->toReturn(false);
         allow($fs->isDir())->toReturn(false);
+    });
+
+    context('consent before applying', function () {
+
+        it('shows the proposal and asks before applying; declining leaves the file untouched', function (Filesystem $fs) {
+            $written = [];
+            $cmd = refactorConsentWorld($fs, $written);
+
+            $tester = new CommandTester($cmd);
+            $tester->setInputs(['n']);
+            $exitCode = $tester->execute(['target' => 'App\\Good']);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('Extract Method');
+            expect($tester->getDisplay())->toContain('Apply this refactoring?');
+            expect($tester->getDisplay())->toContain('Not applied');
+            expect(count($written))->toBe(0);
+        });
+
+        it('applies on yes and verifies', function (Filesystem $fs) {
+            $written = [];
+            $cmd = refactorConsentWorld($fs, $written);
+
+            $tester = new CommandTester($cmd);
+            $tester->setInputs(['']);
+            $exitCode = $tester->execute(['target' => 'App\\Good']);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('Specs still pass');
+            expect(implode('', $written))->toContain('extracted');
+        });
+
+        it('applies without asking when non-interactive', function (Filesystem $fs) {
+            $written = [];
+            $cmd = refactorConsentWorld($fs, $written);
+
+            $tester = new CommandTester($cmd);
+            $exitCode = $tester->execute(['target' => 'App\\Good'], ['interactive' => false]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->not()->toContain('Apply this refactoring?');
+            expect(implode('', $written))->toContain('extracted');
+        });
+
     });
 
     it('instantiates', function (Filesystem $fs) {

--- a/src/PhpSpec/Console/Command/Refactor.php
+++ b/src/PhpSpec/Console/Command/Refactor.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec\Console\Command;
 
+use PhpSpec\Ai\Contracts\ProviderInterface;
 use PhpSpec\Ai\ProviderFactory;
 use PhpSpec\Ai\SpecSubprocess;
 use PhpSpec\Configuration;
@@ -22,9 +23,11 @@ use PhpSpec\Console\Command\Refactor\RefactorResult;
 use PhpSpec\Filesystem;
 use PhpSpec\RealFilesystem;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument as Argument;
 use Symfony\Component\Console\Input\InputInterface as Input;
 use Symfony\Component\Console\Output\OutputInterface as Output;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * @internal
@@ -49,12 +52,14 @@ final class Refactor extends Command
      * @param Filesystem|null $filesystem
      * @param (callable(string): array{0: int, 1: string})|null $specRunner
      * @param (callable(string, string, ?string): RefactorResult)|null $refactorFn
+     * @param ProviderInterface|null $provider injectable AI seam for the agent
      */
     public function __construct(
         private readonly Configuration $config,
         ?Filesystem $filesystem = null,
         ?callable $specRunner = null,
         ?callable $refactorFn = null,
+        private readonly ?ProviderInterface $provider = null,
     ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
         $this->specRunner = $specRunner;
@@ -117,38 +122,72 @@ final class Refactor extends Command
             return 1;
         }
 
-        // 6. Run refactoring
+        // 6. Run refactoring; the proposal is shown and confirmed BEFORE the
+        // write, so nothing reaches disk unbidden.
         $output->writeln('  <fg=gray>Analysing code for refactoring opportunities...</>');
         $output->writeln('');
 
-        $result = $this->performRefactoring($aiConfig, $srcPath, $specPath, $method);
+        $displayed = false;
+        $confirm = function (string $technique, string $description, string $diff) use ($input, $output, $srcPath, &$displayed): bool {
+            $displayed = true;
+            $this->displayProposal($output, $technique, $description, $diff, $srcPath);
+
+            if (!$input->isInteractive()) {
+                return true;
+            }
+
+            /** @var QuestionHelper $helper */
+            $helper = $this->getHelper('question');
+
+            return (bool) $helper->ask($input, $output, new ConfirmationQuestion('  <fg=yellow>Apply this refactoring?</> [Y/n] ', true));
+        };
+
+        $result = $this->performRefactoring($aiConfig, $srcPath, $specPath, $method, $confirm);
 
         // 7. Display result
-        return $this->displayResult($output, $result, $srcPath);
+        return $this->displayResult($output, $result, $srcPath, $displayed);
     }
 
     /**
-     * Displays the refactoring result and returns the exit code.
+     * Displays the proposed refactoring: technique, description, and the diff.
      */
-    private function displayResult(Output $output, RefactorResult $result, string $srcPath): int
+    private function displayProposal(Output $output, string $technique, string $description, string $diff, string $srcPath): void
+    {
+        $output->writeln("  <fg=white;options=bold>Refactoring technique:</> $technique");
+        $output->writeln('');
+        $output->writeln("  $description");
+        $output->writeln('');
+
+        if ($diff !== '') {
+            $relativeSrc = $this->relativePath($srcPath);
+            $output->writeln("  <fg=white>$relativeSrc</>");
+            $output->writeln($diff);
+        }
+
+        $output->writeln('');
+    }
+
+    /**
+     * Displays the refactoring result and returns the exit code. When the
+     * confirm hook already showed the proposal, it is not repeated.
+     */
+    private function displayResult(Output $output, RefactorResult $result, string $srcPath, bool $alreadyDisplayed = false): int
     {
         if (!$result->success && $result->technique === 'None') {
             $output->writeln("  <fg=yellow>$result->description</>");
             return 0;
         }
 
-        $output->writeln("  <fg=white;options=bold>Refactoring technique:</> $result->technique");
-        $output->writeln('');
-        $output->writeln("  $result->description");
-        $output->writeln('');
-
-        if ($result->diff !== '') {
-            $relativeSrc = $this->relativePath($srcPath);
-            $output->writeln("  <fg=white>$relativeSrc</>");
-            $output->writeln($result->diff);
+        if (!$alreadyDisplayed) {
+            $this->displayProposal($output, $result->technique, $result->description, $result->diff, $srcPath);
         }
 
-        $output->writeln('');
+        if (!$result->applied) {
+            $output->writeln('  <fg=yellow>Not applied; the file is untouched.</>');
+
+            return 0;
+        }
+
         if ($result->success) {
             $output->writeln('  <fg=green>Specs still pass ✓</>');
             return 0;
@@ -209,15 +248,16 @@ final class Refactor extends Command
      * Performs the refactoring via injected callable or RefactorAgent.
      *
      * @param array{provider: string, model?: string, api_key: string, effort?: string} $aiConfig
+     * @param callable(string, string, string): bool $confirm asked with (technique, description, diff) before the write
      */
-    private function performRefactoring(array $aiConfig, string $srcPath, string $specPath, ?string $method): RefactorResult
+    private function performRefactoring(array $aiConfig, string $srcPath, string $specPath, ?string $method, callable $confirm): RefactorResult
     {
         if ($this->refactorFn !== null) {
             return ($this->refactorFn)($srcPath, $specPath, $method);
         }
 
         try {
-            $provider = ProviderFactory::create($aiConfig);
+            $provider = $this->provider ?? ProviderFactory::create($aiConfig);
         } catch (\RuntimeException $e) {
             return new RefactorResult(
                 success: false,
@@ -230,7 +270,7 @@ final class Refactor extends Command
 
         $model = $aiConfig['model'] ?? ProviderFactory::defaultModel($aiConfig['provider']);
 
-        return (new RefactorAgent($provider, $model, $this->filesystem, $aiConfig['effort'] ?? null))->refactor($srcPath, $specPath, $method);
+        return (new RefactorAgent($provider, $model, $this->filesystem, $aiConfig['effort'] ?? null, $this->specRunner, $confirm))->refactor($srcPath, $specPath, $method);
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Refactor/RefactorAgent.php
+++ b/src/PhpSpec/Console/Command/Refactor/RefactorAgent.php
@@ -57,13 +57,27 @@ final class RefactorAgent
      * @param Filesystem|null $filesystem filesystem abstraction for testability
      * @param string|null $effort the configured reasoning effort, passed through to the provider
      */
+    /** @var callable(string): array{0: int, 1: string} */
+    private $specRunner;
+
+    /** @var (callable(string, string, string): bool)|null */
+    private $confirm;
+
+    /**
+     * @param callable(string): array{0: int, 1: string}|null $specRunner runs the spec file; defaults to a subprocess
+     * @param (callable(string, string, string): bool)|null $confirm asked with (technique, description, diff) before the write; null applies without asking
+     */
     public function __construct(
         private readonly ProviderInterface $provider,
         private readonly ?string $model = null,
         ?Filesystem $filesystem = null,
         private readonly ?string $effort = null,
+        ?callable $specRunner = null,
+        ?callable $confirm = null,
     ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
+        $this->specRunner = $specRunner ?? SpecSubprocess::run(...);
+        $this->confirm = $confirm;
     }
 
     /**
@@ -217,11 +231,26 @@ final class RefactorAgent
                 $diffEntries = Diff::compute($oldLines, $newLines);
                 $diffText = Diff::format($diffEntries);
 
+                // The change is the human's to accept: the diff is shown and
+                // answered before anything reaches disk.
+                if ($this->confirm !== null && !($this->confirm)($technique, $description, $diffText)) {
+                    $this->result = new RefactorResult(
+                        success: true,
+                        technique: $technique,
+                        description: $description,
+                        diff: $diffText,
+                        specOutput: '',
+                        applied: false,
+                    );
+
+                    return 'The human declined this refactoring. Do not retry it; end your turn.';
+                }
+
                 // Write new content
                 $this->filesystem->write($srcPath, $newContent);
 
                 // Run specs
-                [$exitCode, $output] = self::runSpecs($specPath);
+                [$exitCode, $output] = $this->runSpecs($specPath);
 
                 if ($exitCode !== 0) {
                     // Revert
@@ -254,9 +283,9 @@ final class RefactorAgent
     /**
      * @return array{0: int, 1: string} [exitCode, output]
      */
-    private static function runSpecs(string $specPath): array
+    private function runSpecs(string $specPath): array
     {
-        return SpecSubprocess::run($specPath);
+        return ($this->specRunner)($specPath);
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Refactor/RefactorResult.php
+++ b/src/PhpSpec/Console/Command/Refactor/RefactorResult.php
@@ -33,5 +33,6 @@ final readonly class RefactorResult
         public string $description,
         public string $diff,
         public string $specOutput,
+        public bool $applied = true,
     ) {}
 }


### PR DESCRIPTION
Dogfood: `phpspec refactor App/TodoList` applied the Extract Method change straight to disk; the only gate was the after-the-fact spec run. It was the last write path with no consent step: generate confirms, pair offers confirm, next's describe offer confirms.

The flow is now: propose, display (technique, description, diff), ask "Apply this refactoring? [Y/n]", and only then write, verify, and keep-or-revert as before. Declining writes nothing and reports "Not applied; the file is untouched", with the model told not to retry. Non-interactive runs keep the auto-apply behaviour so scripts and CI are unchanged.

Mechanically: the consent hook is injected into RefactorAgent and fires between diff computation and the write; RefactorResult carries an applied flag; the agent's verify runner is now injectable (it hardcoded the SpecSubprocess static, the same asymmetry the command's baseline seam had already solved), and the command gains a provider seam so the consent examples drive the REAL agent flow with a scripted provider, not the refactorFn shortcut. Three new examples: decline leaves the file untouched, accept applies and verifies, non-interactive applies without asking.

Suite: 1660 examples green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; 1094 steps; coverage 91.9%; phpstan and php-cs-fixer clean.

Note: the usual single-heading CHANGES overlap with the other open PR; whichever merges second gets the one-line resolution.