### PR TITLE
Journal applied refactorings so refactor never oscillates and next moves to growth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
- - Applied refactorings are journalled (.phpspec/ai/journal.jsonl); the model never undoes or redoes them, and `next` steers to growth when the target has not changed since
+ - Applied refactorings are journalled (.phpspec/ai/journal.jsonl); reversing one demands a stated rationale, and `next` steers to growth when the target has not changed since
 
 ### Changed
  - `refactor` shows the change and asks before applying; non-interactive runs keep auto-apply

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - Applied refactorings are journalled (.phpspec/ai/journal.jsonl); the model never undoes or redoes them, and `next` steers to growth when the target has not changed since
+
 ### Changed
  - `refactor` shows the change and asks before applying; non-interactive runs keep auto-apply
 

--- a/spec/PhpSpec/Ai/Prompts.spec.php
+++ b/spec/PhpSpec/Ai/Prompts.spec.php
@@ -86,6 +86,7 @@ describe('prompt artifacts', function () {
         expect($text)->toContain('temperature: 0.3');
         expect($text)->toContain('ONE baby-step refactoring');
         expect($text)->toContain('apply_refactoring');
+        expect($text)->toContain('no refactoring is worthwhile');
     });
 
     it('ships the pair base guidance with layout placeholders, composed from the primers', function () use ($read, $raw) {

--- a/spec/PhpSpec/Console/Command/Next.spec.php
+++ b/spec/PhpSpec/Console/Command/Next.spec.php
@@ -153,6 +153,69 @@ describe(Next::class, function () {
             expect($tester->getDisplay())->toContain('Would you like me to create that for you?');
         });
 
+        it('steers to growth instead of re-refactoring a target unchanged since the last refactoring', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            $cwd = getcwd();
+            $srcFile = $cwd . '/src/App/TodoList.php';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath || $p === $srcFile || str_contains($p, 'journal.jsonl'));
+            allow($fs->read())->toReturnUsing(function (string $p) use ($yamlPath): string {
+                if ($p === $yamlPath) {
+                    return "ai:\n  provider: google\n  api_key: test-key\n";
+                }
+                if (str_contains($p, 'journal.jsonl')) {
+                    return '{"at":1000,"command":"refactor","target":"App\\\\TodoList","technique":"Inline Method","description":"x"}' . "\n";
+                }
+                return '';
+            });
+            allow($fs->mtime())->toReturn(900);
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'refactor',
+                'target' => 'App\\TodoList',
+                'reason' => 'The suite is green.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $tester = new CommandTester($cmd);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('already refactored');
+            expect($tester->getDisplay())->not()->toContain('refactor App/TodoList');
+        });
+
+        it('keeps the refactor suggestion when the target changed after the last refactoring', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            $cwd = getcwd();
+            $srcFile = $cwd . '/src/App/TodoList.php';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath || $p === $srcFile || str_contains($p, 'journal.jsonl'));
+            allow($fs->read())->toReturnUsing(function (string $p) use ($yamlPath): string {
+                if ($p === $yamlPath) {
+                    return "ai:\n  provider: google\n  api_key: test-key\n";
+                }
+                if (str_contains($p, 'journal.jsonl')) {
+                    return '{"at":1000,"command":"refactor","target":"App\\\\TodoList","technique":"Inline Method","description":"x"}' . "\n";
+                }
+                return '';
+            });
+            allow($fs->mtime())->toReturn(1100);
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'refactor',
+                'target' => 'App\\TodoList',
+                'reason' => 'The suite is green.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $tester = new CommandTester($cmd);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('refactor App/TodoList');
+        });
+
         it('displays a refactor suggestion with the refactor hint', function (Filesystem $fs) {
             $yamlPath = './phpspec.yaml';
             allow($fs->exists())->toReturnUsing(function (string $path) use ($yamlPath): bool {

--- a/spec/PhpSpec/Console/Command/Refactor.spec.php
+++ b/spec/PhpSpec/Console/Command/Refactor.spec.php
@@ -13,17 +13,22 @@ use Symfony\Component\Console\Tester\CommandTester;
 // Builds a Refactor command wired to a scripted provider that proposes one
 // Extract Method refactoring, over a mocked project, capturing writes; the
 // consent examples drive the REAL agent flow, not the refactorFn shortcut.
-function refactorConsentWorld(Filesystem $fs, array &$written): Refactor
+// A non-empty $journal seeds .phpspec/ai/journal.jsonl with prior entries.
+function refactorConsentWorld(Filesystem $fs, array &$written, string $journal = ''): Refactor
 {
     $yamlPath = './phpspec.yaml';
     $cwd = getcwd();
     $srcPath = $cwd . '/src/App/Good.php';
     $specPath = $cwd . '/spec/App/Good.spec.php';
 
-    allow($fs->exists())->toReturnUsing(fn(string $path): bool => in_array($path, [$yamlPath, $srcPath, $specPath], true));
-    allow($fs->read())->toReturnUsing(function (string $path) use ($yamlPath): string {
+    allow($fs->exists())->toReturnUsing(fn(string $path): bool => in_array($path, [$yamlPath, $srcPath, $specPath], true)
+        || ($journal !== '' && str_contains($path, 'journal.jsonl')));
+    allow($fs->read())->toReturnUsing(function (string $path) use ($yamlPath, $journal): string {
         if ($path === $yamlPath) {
             return "ai:\n  provider: google\n  api_key: test-key\n";
+        }
+        if (str_contains($path, 'journal.jsonl')) {
+            return $journal;
         }
 
         return "<?php\nclass Good {}\n";
@@ -31,6 +36,7 @@ function refactorConsentWorld(Filesystem $fs, array &$written): Refactor
     allow($fs->write())->toReturnUsing(function (string $path, string $content) use (&$written) {
         $written[$path] = $content;
     });
+    allow($fs->mkdir())->toReturn(null);
 
     $provider = new class implements ProviderInterface {
         public int $turn = 0;
@@ -38,6 +44,11 @@ function refactorConsentWorld(Filesystem $fs, array &$written): Refactor
         public function chat(array $messages, array $options = []): Response
         {
             if (++$this->turn === 1) {
+                $GLOBALS['refactor_seen_prompt'] = implode("\n", array_map(
+                    fn($message) => is_string($message->content ?? null) ? $message->content : '',
+                    $messages,
+                ));
+
                 return new Response('', [new ToolCall('t1', 'apply_refactoring', [
                     'content' => "<?php\nclass Good { /* extracted */ }\n",
                     'technique' => 'Extract Method',
@@ -110,6 +121,42 @@ describe(Refactor::class, function () {
             expect($exitCode)->toBe(0);
             expect($tester->getDisplay())->not()->toContain('Apply this refactoring?');
             expect(implode('', $written))->toContain('extracted');
+        });
+
+        it('records an applied refactoring in the journal, and a declined one not at all', function (Filesystem $fs) {
+            $written = [];
+            $cmd = refactorConsentWorld($fs, $written);
+
+            $tester = new CommandTester($cmd);
+            $tester->setInputs(['']);
+            $tester->execute(['target' => 'App\\Good']);
+
+            $journal = implode('', array_filter($written, fn(string $p) => str_contains($p, 'journal.jsonl'), ARRAY_FILTER_USE_KEY));
+            expect($journal)->toContain('Extract Method');
+            expect($journal)->toContain('App\\\\Good');
+        });
+
+        it('does not record a declined refactoring', function (Filesystem $fs) {
+            $written = [];
+            $cmd = refactorConsentWorld($fs, $written);
+
+            $tester = new CommandTester($cmd);
+            $tester->setInputs(['n']);
+            $tester->execute(['target' => 'App\\Good']);
+
+            expect(count($written))->toBe(0);
+        });
+
+        it('grounds the model with the recent refactorings so it never undoes them', function (Filesystem $fs) {
+            $written = [];
+            $cmd = refactorConsentWorld($fs, $written, '{"at":100,"command":"refactor","target":"App\\\\Good","technique":"Inline Method","description":"Inlined helper"}' . "\n");
+
+            $tester = new CommandTester($cmd);
+            $tester->setInputs(['n']);
+            $tester->execute(['target' => 'App\\Good']);
+
+            expect($GLOBALS['refactor_seen_prompt'] ?? '')->toContain('Inline Method');
+            expect($GLOBALS['refactor_seen_prompt'] ?? '')->toContain('do not undo');
         });
 
     });

--- a/spec/PhpSpec/Console/Command/Refactor.spec.php
+++ b/spec/PhpSpec/Console/Command/Refactor.spec.php
@@ -147,7 +147,7 @@ describe(Refactor::class, function () {
             expect(count($written))->toBe(0);
         });
 
-        it('grounds the model with the recent refactorings so it never undoes them', function (Filesystem $fs) {
+        it('grounds the model with the recent refactorings, reversals demanding a rationale', function (Filesystem $fs) {
             $written = [];
             $cmd = refactorConsentWorld($fs, $written, '{"at":100,"command":"refactor","target":"App\\\\Good","technique":"Inline Method","description":"Inlined helper"}' . "\n");
 
@@ -156,7 +156,7 @@ describe(Refactor::class, function () {
             $tester->execute(['target' => 'App\\Good']);
 
             expect($GLOBALS['refactor_seen_prompt'] ?? '')->toContain('Inline Method');
-            expect($GLOBALS['refactor_seen_prompt'] ?? '')->toContain('do not undo');
+            expect($GLOBALS['refactor_seen_prompt'] ?? '')->toContain('clear rationale');
         });
 
     });

--- a/spec/PhpSpec/Console/Command/Refactor/RefactorJournal.spec.php
+++ b/spec/PhpSpec/Console/Command/Refactor/RefactorJournal.spec.php
@@ -1,0 +1,68 @@
+<?php
+
+use PhpSpec\Console\Command\Refactor\RefactorJournal;
+use PhpSpec\Filesystem;
+
+describe(RefactorJournal::class, function () {
+
+    beforeEach(function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        allow($fs->isDir())->toReturn(false);
+        allow($fs->mkdir())->toReturn(null);
+    });
+
+    it('records an applied refactoring as one JSON line with a timestamp', function (Filesystem $fs) {
+        $written = [];
+        allow($fs->write())->toReturnUsing(function (string $path, string $content) use (&$written) {
+            $written[$path] = $content;
+        });
+
+        (new RefactorJournal($fs))->record('App\\TodoList', 'Extract Method', 'Pulled hasTask out');
+
+        $path = array_key_first($written);
+        expect($path)->toContain('.phpspec/ai/journal.jsonl');
+        $entry = json_decode(trim($written[$path]), true);
+        expect($entry['target'])->toBe('App\\TodoList');
+        expect($entry['technique'])->toBe('Extract Method');
+        expect($entry['at'])->toBeGreaterThan(0);
+    });
+
+    it('appends to an existing journal instead of overwriting it', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => str_contains($p, 'journal.jsonl'));
+        allow($fs->read())->toReturn('{"at":100,"command":"refactor","target":"App\\\\Old","technique":"Rename","description":"x"}' . "\n");
+        $written = [];
+        allow($fs->write())->toReturnUsing(function (string $path, string $content) use (&$written) {
+            $written[$path] = $content;
+        });
+
+        (new RefactorJournal($fs))->record('App\\TodoList', 'Inline Method', 'Inlined it');
+
+        $content = implode('', $written);
+        expect($content)->toContain('App\\\\Old');
+        expect($content)->toContain('Inline Method');
+    });
+
+    it('reports the last refactoring timestamp, and null for an empty journal', function (Filesystem $fs) {
+        expect((new RefactorJournal($fs))->lastRefactoringAt())->toBeNull();
+
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => str_contains($p, 'journal.jsonl'));
+        allow($fs->read())->toReturn(
+            '{"at":100,"command":"refactor","target":"A","technique":"Rename","description":"x"}' . "\n"
+            . '{"at":200,"command":"refactor","target":"B","technique":"Extract Method","description":"y"}' . "\n",
+        );
+
+        expect((new RefactorJournal($fs))->lastRefactoringAt())->toBe(200);
+    });
+
+    it('renders the recent entries for a prompt', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => str_contains($p, 'journal.jsonl'));
+        allow($fs->read())->toReturn('{"at":100,"command":"refactor","target":"App\\\\TodoList","technique":"Extract Method","description":"Pulled hasTask out"}' . "\n");
+
+        $rendered = (new RefactorJournal($fs))->rendered();
+
+        expect($rendered)->toContain('Extract Method');
+        expect($rendered)->toContain('App\\TodoList');
+        expect($rendered)->toContain('Pulled hasTask out');
+    });
+
+});

--- a/src/PhpSpec/Ai/Prompts/commands/refactor.txt
+++ b/src/PhpSpec/Ai/Prompts/commands/refactor.txt
@@ -28,8 +28,11 @@ behaviour-preserving refactorings on PHP classes.
 6. If a method focus is given, only refactor that method and its immediate helpers.
 7. Provide the complete file content in `apply_refactoring`, not a partial diff.
 8. Choose the most impactful single refactoring that improves code quality.
-9. If the code is already clean and no meaningful refactoring is possible,
-   say so and do not call `apply_refactoring`.
+9. If the code is already clean and no refactoring is worthwhile, say so and do
+   not call `apply_refactoring`. Saying so is a good outcome, never a failure.
+10. Never undo or redo a refactoring listed under "Recent refactorings" in the
+    user message (inlining what was extracted, extracting what was inlined, or
+    reversing a rename is a taste swap, not an improvement).
 
 ## Process
 

--- a/src/PhpSpec/Ai/Prompts/commands/refactor.txt
+++ b/src/PhpSpec/Ai/Prompts/commands/refactor.txt
@@ -30,9 +30,11 @@ behaviour-preserving refactorings on PHP classes.
 8. Choose the most impactful single refactoring that improves code quality.
 9. If the code is already clean and no refactoring is worthwhile, say so and do
    not call `apply_refactoring`. Saying so is a good outcome, never a failure.
-10. Never undo or redo a refactoring listed under "Recent refactorings" in the
-    user message (inlining what was extracted, extracting what was inlined, or
-    reversing a rename is a taste swap, not an improvement).
+10. Reversing a refactoring listed under "Recent refactorings" (inlining what
+    was extracted, re-extracting what was inlined, undoing a rename) is allowed
+    only when you genuinely judge the earlier design better. Name the change
+    you are reversing and give a clear rationale in your description; a silent
+    taste swap is not an improvement.
 
 ## Process
 

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -24,6 +24,7 @@ use PhpSpec\Ai\Contracts\ProviderInterface;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Pair\SpecRunner;
 use PhpSpec\Console\Command\Pair\SubprocessRunner;
+use PhpSpec\Console\Command\Refactor\RefactorJournal;
 use PhpSpec\Console\Command\Run\RecencyScanner;
 use PhpSpec\Filesystem;
 use PhpSpec\RealFilesystem;
@@ -117,6 +118,11 @@ final class Next extends Command
 
             return 0;
         }
+
+        // 4c. Red, green, REFACTOR happens once: a refactor suggestion for a
+        // target unchanged since the last recorded refactoring steers to
+        // growth instead of polishing the same class forever.
+        $suggestion = $this->steerAwayFromStaleRefactor($suggestion);
 
         // 5. Display
         $this->displaySuggestion($output, $suggestion);
@@ -259,6 +265,38 @@ final class Next extends Command
         $output->writeln("  <fg=gray>Run:</> bin/phpspec exemplify $classArg <method>");
 
         return 0;
+    }
+
+    /**
+     * Replaces a refactor suggestion with a growth steer when its target has
+     * not changed since the last recorded refactoring: the file's mtime at or
+     * before the journal's last entry means the polish step already happened.
+     *
+     * @param array{type: string, target: string, reason: string} $suggestion
+     * @return array{type: string, target: string, reason: string}
+     */
+    private function steerAwayFromStaleRefactor(array $suggestion): array
+    {
+        if ($suggestion['type'] !== 'refactor' || $suggestion['target'] === '') {
+            return $suggestion;
+        }
+
+        $last = (new RefactorJournal($this->filesystem))->lastRefactoringAt();
+        if ($last === null) {
+            return $suggestion;
+        }
+
+        $srcDir = ltrim($this->config->getSrcPath(), './');
+        $srcFile = getcwd() . '/' . $srcDir . '/' . str_replace('\\', '/', $suggestion['target']) . '.php';
+        if (!$this->filesystem->exists($srcFile) || $this->filesystem->mtime($srcFile) > $last) {
+            return $suggestion;
+        }
+
+        return [
+            'type' => 'info',
+            'target' => '',
+            'reason' => sprintf('"%s" was already refactored and has not changed since. Grow the story instead: add the next scenario or feature.', $suggestion['target']),
+        ];
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Refactor.php
+++ b/src/PhpSpec/Console/Command/Refactor.php
@@ -19,6 +19,7 @@ use PhpSpec\Ai\ProviderFactory;
 use PhpSpec\Ai\SpecSubprocess;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Refactor\RefactorAgent;
+use PhpSpec\Console\Command\Refactor\RefactorJournal;
 use PhpSpec\Console\Command\Refactor\RefactorResult;
 use PhpSpec\Filesystem;
 use PhpSpec\RealFilesystem;
@@ -269,8 +270,33 @@ final class Refactor extends Command
         }
 
         $model = $aiConfig['model'] ?? ProviderFactory::defaultModel($aiConfig['provider']);
+        $journal = new RefactorJournal($this->filesystem);
 
-        return (new RefactorAgent($provider, $model, $this->filesystem, $aiConfig['effort'] ?? null, $this->specRunner, $confirm))->refactor($srcPath, $specPath, $method);
+        $agent = new RefactorAgent($provider, $model, $this->filesystem, $aiConfig['effort'] ?? null, $this->specRunner, $confirm);
+        $result = $agent->refactor($srcPath, $specPath, $method, $journal->rendered());
+
+        // Only a kept change becomes memory: the journal is what stops a later
+        // run from undoing this refactoring or redoing it forever.
+        if ($result->success && $result->applied && $result->technique !== 'None') {
+            $journal->record($this->relativeClass($srcPath), $result->technique, $result->description);
+        }
+
+        return $result;
+    }
+
+    /**
+     * The class-ish name a source path denotes, for the journal (src/App/X.php
+     * reads as App\X).
+     */
+    private function relativeClass(string $srcPath): string
+    {
+        $relative = $this->relativePath($srcPath);
+        $srcDir = ltrim($this->config->getSrcPath(), './');
+        if (str_starts_with($relative, $srcDir . '/')) {
+            $relative = substr($relative, strlen($srcDir) + 1);
+        }
+
+        return str_replace('/', '\\', preg_replace('/\.php$/', '', $relative) ?? $relative);
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Refactor/RefactorAgent.php
+++ b/src/PhpSpec/Console/Command/Refactor/RefactorAgent.php
@@ -87,7 +87,7 @@ final class RefactorAgent
      * @param string $specPath absolute path to the spec file
      * @param string|null $method optional method to focus refactoring on
      */
-    public function refactor(string $srcPath, string $specPath, ?string $method): RefactorResult
+    public function refactor(string $srcPath, string $specPath, ?string $method, string $history = ''): RefactorResult
     {
         $this->ensureInitialised($srcPath, $specPath);
 
@@ -95,10 +95,13 @@ final class RefactorAgent
         $specContent = $this->filesystem->read($specPath);
 
         $focus = $method !== null ? "\n\nFocus your refactoring on the `$method()` method only." : '';
+        $memory = $history !== ''
+            ? "\n\nRecent refactorings, do not undo or redo any of these (say no refactoring is worthwhile instead):\n$history"
+            : '';
 
         $this->messages[] = Message::user(
             "Refactor this class. Here is the source file ($srcPath):\n\n```php\n$sourceContent\n```\n\n"
-            . "Here is the spec file ($specPath):\n\n```php\n$specContent\n```$focus",
+            . "Here is the spec file ($specPath):\n\n```php\n$specContent\n```$focus$memory",
         );
 
         $this->runLoop();

--- a/src/PhpSpec/Console/Command/Refactor/RefactorAgent.php
+++ b/src/PhpSpec/Console/Command/Refactor/RefactorAgent.php
@@ -96,7 +96,7 @@ final class RefactorAgent
 
         $focus = $method !== null ? "\n\nFocus your refactoring on the `$method()` method only." : '';
         $memory = $history !== ''
-            ? "\n\nRecent refactorings, do not undo or redo any of these (say no refactoring is worthwhile instead):\n$history"
+            ? "\n\nRecent refactorings:\n$history\nReverse one of these only when you genuinely judge the earlier design better, and then name it with a clear rationale in your description; a silent taste swap is not an improvement. When nothing worthwhile remains, say no refactoring is worthwhile."
             : '';
 
         $this->messages[] = Message::user(

--- a/src/PhpSpec/Console/Command/Refactor/RefactorJournal.php
+++ b/src/PhpSpec/Console/Command/Refactor/RefactorJournal.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Command\Refactor;
+
+use PhpSpec\Filesystem;
+
+/**
+ * @internal
+ * Append-only memory of the applied refactorings (.phpspec/ai/journal.jsonl),
+ * one JSON line each. Later runs read it so the model never undoes or redoes
+ * a recent refactoring, and `next` can steer to growth when nothing changed
+ * since the last one.
+ */
+final class RefactorJournal
+{
+    private const PATH = '.phpspec/ai/journal.jsonl';
+
+    public function __construct(private readonly Filesystem $filesystem) {}
+
+    /**
+     * Appends one applied refactoring to the journal.
+     */
+    public function record(string $target, string $technique, string $description): void
+    {
+        $entry = json_encode([
+            'at' => time(),
+            'command' => 'refactor',
+            'target' => $target,
+            'technique' => $technique,
+            'description' => $description,
+        ]) . "\n";
+
+        $path = $this->path();
+        $dir = dirname($path);
+        if (!$this->filesystem->exists($dir)) {
+            $this->filesystem->mkdir($dir);
+        }
+
+        $existing = $this->filesystem->exists($path) ? $this->filesystem->read($path) : '';
+        $this->filesystem->write($path, $existing . $entry);
+    }
+
+    /**
+     * The timestamp of the most recent refactoring, or null for none yet.
+     */
+    public function lastRefactoringAt(): ?int
+    {
+        $entries = $this->entries();
+        $last = end($entries);
+
+        return $last === false ? null : (int) $last['at'];
+    }
+
+    /**
+     * The recent entries rendered for a prompt, newest last; empty when the
+     * journal holds nothing.
+     */
+    public function rendered(int $limit = 5): string
+    {
+        $lines = [];
+        foreach (array_slice($this->entries(), -$limit) as $entry) {
+            $lines[] = sprintf('- %s on %s: %s', $entry['technique'], $entry['target'], $entry['description']);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @return list<array{at: int, target: string, technique: string, description: string}>
+     */
+    private function entries(): array
+    {
+        $path = $this->path();
+        if (!$this->filesystem->exists($path)) {
+            return [];
+        }
+
+        $entries = [];
+        foreach (explode("\n", trim($this->filesystem->read($path))) as $line) {
+            $entry = json_decode($line, true);
+            if (is_array($entry) && isset($entry['at'], $entry['target'], $entry['technique'], $entry['description'])) {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
+    }
+
+    private function path(): string
+    {
+        return (getcwd() ?: '.') . '/' . self::PATH;
+    }
+}


### PR DESCRIPTION
STACKED on the refactor-consent PR (merge that first; this PR then shrinks to its own commit).

Dogfood found the oscillation: one session's Extract Method was undone by the next session's Inline Method, each locally defensible, and `next` kept suggesting "Refactor App\TodoList" forever because applying a refactor keeps the file the most recently touched. One-shots had zero cross-invocation memory.

The fix is a small append-only journal (.phpspec/ai/journal.jsonl), one JSON line per APPLIED refactoring (timestamp, target, technique, description). Declined and reverted changes are never recorded. Two consumers:

- `refactor` grounds the model with the recent entries ("do not undo or redo any of these; say no refactoring is worthwhile instead"), and the prompt now legitimises the none outcome explicitly, killing the extract/inline ping-pong.
- `next` applies the timestamp rule deterministically: a refactor suggestion whose target's mtime is at or before the last journalled refactoring becomes a growth steer ("already refactored and has not changed since; grow the story"). A target genuinely changed after the last refactoring keeps its refactor suggestion, which is exactly the changed-after-the-timestamp semantics from review.

Covered by a RefactorJournal spec (record, append, last timestamp, prompt rendering), command examples (applied is journalled, declined is not, the model sees the history), and two next examples pinning both sides of the timestamp rule.

Suite: 1669 examples green on PHP 8.2.30, 8.3.16, 8.4.4, and 8.5.3; 1094 steps; coverage 92.0%; phpstan and php-cs-fixer clean.