### PR TITLE
Actuate an accepted feature suggestion through generate, never describe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - `next` reads the journal: a polished, unchanged class is never re-suggested, and the model proposes the next scenario or feature instead
 
 ### Fixed
+ - Accepting a feature suggestion from `next` runs `generate`, so it writes the feature instead of describing a spec at the project root
  - Auto-verify runs the whole suite when the change touches a feature or steps file
  - A verified change ends the turn; no fresh suggestion rides on its back
  - `refactor` runs its baseline with the installed phpspec, wherever it lives (vendor installs failed to launch it and blamed the specs)

--- a/spec/PhpSpec/Console/Command/Next.spec.php
+++ b/spec/PhpSpec/Console/Command/Next.spec.php
@@ -9,6 +9,9 @@ use PhpSpec\Console\Command\Run\RunOutcome;
 use PhpSpec\Console\Command\Run\SuiteSummary;
 use PhpSpec\Filesystem;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -151,6 +154,82 @@ describe(Next::class, function () {
             expect($tester->getDisplay())->toContain('Write a feature scenario for');
             expect($tester->getDisplay())->toContain('user registration');
             expect($tester->getDisplay())->toContain('Would you like me to create that for you?');
+        });
+
+        it('actuates an accepted feature suggestion through generate, never describe', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'feature',
+                'target' => 'deleting_a_task',
+                'reason' => 'The suite is green; grow the story.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $fakeGenerate = new class extends SymfonyCommand {
+                public string $received = '';
+                protected function configure(): void
+                {
+                    $this->setName('generate')->addArgument('instruction', InputArgument::IS_ARRAY);
+                }
+                protected function execute(InputInterface $input, OutputInterface $output): int
+                {
+                    $this->received = implode(' ', (array) $input->getArgument('instruction'));
+                    $output->writeln('feature written');
+
+                    return 0;
+                }
+            };
+            $fakeDescribe = new class extends SymfonyCommand {
+                protected function configure(): void
+                {
+                    $this->setName('describe')->addArgument('class', InputArgument::REQUIRED);
+                }
+                protected function execute(InputInterface $input, OutputInterface $output): int
+                {
+                    $output->writeln('Specification created');
+
+                    return 0;
+                }
+            };
+
+            $app = new Application();
+            foreach ([$cmd, $fakeGenerate, $fakeDescribe] as $command) {
+                method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
+            }
+
+            $tester = new CommandTester($app->find('next'));
+            $tester->setInputs(['Y']);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($fakeGenerate->received)->toBe('a feature for deleting_a_task');
+            expect($tester->getDisplay())->toContain('feature written');
+            expect($tester->getDisplay())->not()->toContain('Specification');
+        });
+
+        it('hints generate for a feature suggestion when not interactive', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'feature',
+                'target' => 'deleting_a_task',
+                'reason' => 'The suite is green; grow the story.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $tester = new CommandTester($cmd);
+            $exitCode = $tester->execute([], ['interactive' => false]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('generate "a feature for deleting_a_task"');
+            expect($tester->getDisplay())->not()->toContain('describe');
         });
 
         it('steers to growth instead of re-refactoring a target unchanged since the last refactoring', function (Filesystem $fs) {

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -132,8 +132,12 @@ final class Next extends Command
             return 0;
         }
 
-        if ($suggestion['type'] === 'spec' || $suggestion['type'] === 'feature') {
+        if ($suggestion['type'] === 'spec') {
             return $this->offerDescribe($input, $output, $suggestion['target']);
+        }
+
+        if ($suggestion['type'] === 'feature') {
+            return $this->offerFeature($input, $output, $suggestion['target']);
         }
 
         if ($suggestion['type'] === 'example') {
@@ -231,8 +235,32 @@ final class Next extends Command
     {
         $classArg = str_replace('\\', '/', $target);
 
+        return $this->offerToRun($input, $output, "describe $classArg", 'describe', ['class' => $classArg]);
+    }
+
+    /**
+     * A feature suggestion actuates through `generate`, which owns Gherkin,
+     * the features directory, and the scenario content; `describe` would turn
+     * the story name into a spec.
+     */
+    private function offerFeature(Input $input, Output $output, string $target): int
+    {
+        $instruction = 'a feature for ' . $target;
+
+        return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
+    }
+
+    /**
+     * Offers to act on the suggestion: a printed hint when not interactive, a
+     * [Y/n] confirmation and the command run when it is.
+     *
+     * @param array<string, mixed> $args the bound arguments for the command
+     */
+    private function offerToRun(Input $input, Output $output, string $hint, string $command, array $args): int
+    {
         if (!$input->isInteractive()) {
-            $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . " describe $classArg");
+            $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . ' ' . $hint);
+
             return 0;
         }
 
@@ -252,10 +280,7 @@ final class Next extends Command
             return 1;
         }
 
-        return $application->find('describe')->run(
-            new ArrayInput(['class' => $classArg]),
-            $output,
-        );
+        return $application->find($command)->run(new ArrayInput($args), $output);
     }
 
     private function offerExemplify(Input $input, Output $output, string $target): int


### PR DESCRIPTION
Dogfood bug: next proposed \"Write a feature scenario for deleting_a_task\" (the journal-grounded growth suggestion working as intended), the human accepted, and the offer arm ran describe with the story name, producing spec/deleting_a_task.spec.php at the spec root. A spec is the wrong artifact for a feature suggestion, and a snake_case story name is no class.

Now the feature arm delegates to generate with the same instruction pair mode ghosts for this suggestion type (\"a feature for deleting_a_task\"), so the artifact routing, the features directory, the Gherkin syntax, and the scenario content all come from the command that owns them. Non-interactive runs hint that generate invocation instead of a describe line. The spec arm still describes; the two now share one offer helper (hint when not interactive, [Y/n] then run when interactive).

Verification: 1679 examples green on 8.2.30/8.3.16/8.4.4/8.5.3, phpstan clean, cs-fixer clean.