### PR TITLE
Offer to act on determined steps instead of printing advice and exiting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
  - Accepting a feature suggestion from `next` runs `generate`, so it writes the feature instead of describing a spec at the project root
+ - Determined steps offer too: `next` asks before writing the steps or implementing the failing class, instead of printing advice and exiting
+ - A degenerate failure whose subject matches its example is named once, not twice
  - Auto-verify runs the whole suite when the change touches a feature or steps file
  - A verified change ends the turn; no fresh suggestion rides on its back
  - `refactor` runs its baseline with the installed phpspec, wherever it lives (vendor installs failed to launch it and blamed the specs)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,11 +13,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The navigator offers directly; the chooser is the question, never "shall I offer?"
  - `refactor` shows the change and asks before applying; non-interactive runs keep auto-apply
  - `next` reads the journal: a polished, unchanged class is never re-suggested, and the model proposes the next scenario or feature instead
+ - A generated feature carries real model-written scenarios; the skeleton is only the fallback
+ - Every `next` suggestion offers to act (example, steps, implement, and refactor included), and the model can suggest steps and implement too
+ - A feature whose step bodies are pending reads as the working story: `next` steers to finishing it, never to a new feature
+ - When the working story is red, `next` shows the model its actual files, so the advice names the real gap
 
 ### Fixed
  - Accepting a feature suggestion from `next` runs `generate`, so it writes the feature instead of describing a spec at the project root
  - Determined steps offer too: `next` asks before writing the steps or implementing the failing class, instead of printing advice and exiting
+ - An accepted example or implement offer forwards the suggestion's reason, so `generate` makes the change the suggestion meant
+ - A named class with spec wording routes as a spec ask even when the sentence also says "feature"
  - A degenerate failure whose subject matches its example is named once, not twice
+ - A failing expectation on a list of objects reports the failure instead of crashing the message formatter
  - Auto-verify runs the whole suite when the change touches a feature or steps file
  - A verified change ends the turn; no fresh suggestion rides on its back
  - `refactor` runs its baseline with the installed phpspec, wherever it lives (vendor installs failed to launch it and blamed the specs)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The navigator offers directly; the chooser is the question, never "shall I offer?"
  - `refactor` shows the change and asks before applying; non-interactive runs keep auto-apply
  - `next` reads the journal: a polished, unchanged class is never re-suggested, and the model proposes the next scenario or feature instead
- - A generated feature carries real model-written scenarios; the skeleton is only the fallback
+ - A generated feature carries real model-written scenarios; the skeleton stands in when the model cannot be reached, with the failure shown beside it
  - Every `next` suggestion offers to act (example, steps, implement, and refactor included), and the model can suggest steps and implement too
  - A feature whose step bodies are pending reads as the working story: `next` steers to finishing it, never to a new feature
  - When the working story is red, `next` shows the model its actual files, so the advice names the real gap

--- a/spec/PhpSpec/Ai/Agent/Agent.spec.php
+++ b/spec/PhpSpec/Ai/Agent/Agent.spec.php
@@ -51,16 +51,18 @@ describe(Agent::class, function () {
 
     let('config', fn(Filesystem $fs) => new Configuration('.', $fs));
 
-    it('acts deterministically for a fully determined step, never consulting the model', function (Filesystem $fs) {
-        $replay = new ReplayProvider([new Response('should not be used')]);
+    it('consults the model for a named new feature and keeps the derived path over its content', function (Filesystem $fs) {
+        $replay = new ReplayProvider([
+            new Response('', [new ToolCall('1', 'write_feature', ['content' => "Feature: Adding tasks\n  Scenario: Adds a task\n    Given an empty list\n    When I add \"milk\"\n    Then the list holds it"])]),
+        ]);
         $agent = new Agent($this->config, $fs, $replay);
 
         $outcome = $agent->do($this->profile, 'a simple scenario in features/user_adds_tasks.feature');
 
-        expect($replay->requests)->toBe([]);
+        expect($replay->requests)->toHaveLength(1);
         expect($outcome->step->phase)->toBe(Phase::WriteFeature);
         expect($outcome->proposals[0]->path)->toBe('features/user_adds_tasks.feature');
-        expect($outcome->proposals[0]->new)->toContain('Feature:');
+        expect($outcome->proposals[0]->new)->toContain('When I add "milk"');
     });
 
     it('asks the model on the tool channel and lands its call as a proposal', function (Filesystem $fs) {

--- a/spec/PhpSpec/Ai/Agent/Agent.spec.php
+++ b/spec/PhpSpec/Ai/Agent/Agent.spec.php
@@ -163,6 +163,16 @@ describe(Agent::class, function () {
         expect($outcome->prose)->toContain('API key not valid');
     });
 
+    it('stands in with the feature skeleton when the provider fails on a write-feature ask', function (Filesystem $fs) {
+        $agent = new Agent($this->config, $fs, new AgentSpecThrowingProvider());
+
+        $outcome = $agent->do($this->profile, 'a feature for completing_a_task.feature');
+
+        expect($outcome->proposals[0]->path)->toBe('features/completing_a_task.feature');
+        expect($outcome->proposals[0]->new)->toContain('Feature:');
+        expect($outcome->prose)->toContain('API key not valid');   // the failure stays visible beside the stand-in
+    });
+
     it('re-asks once when a tool_call command is answered in prose', function (Filesystem $fs) {
         $replay = new ReplayProvider([
             new Response('here is some chatty prose instead'),

--- a/spec/PhpSpec/Ai/Agent/Step.spec.php
+++ b/spec/PhpSpec/Ai/Agent/Step.spec.php
@@ -143,6 +143,21 @@ describe(Step::class, function () {
         expect($step->because)->toContain('it adds a task');
     });
 
+    it('names a degenerate failure once when its subject and example coincide', function () {
+        $suite = new SuiteSummary(
+            'red',
+            ['examples' => 1, 'passes' => 0, 'failures' => 1, 'errors' => 0, 'pending' => 0],
+            [['subject' => 'deleting_a_task', 'example' => 'deleting_a_task', 'error' => 'boom']],
+            [],
+            ['features' => 1, 'scenarios' => 1, 'steps' => 2, 'stepFailures' => 0, 'undefined' => 0],
+            [['path' => 'features/deleting_a_task.feature', 'status' => 'green', 'undefined' => 0]],
+        );
+
+        $step = Step::resolve('', new Grounding(suite: $suite));
+
+        expect($step->because)->toBe('the suite is red: deleting_a_task');
+    });
+
     it('derives refactor when features are green', function () {
         $suite = new SuiteSummary(
             'green',

--- a/spec/PhpSpec/Ai/Agent/Step.spec.php
+++ b/spec/PhpSpec/Ai/Agent/Step.spec.php
@@ -73,6 +73,13 @@ describe(Step::class, function () {
         expect($step->subject)->toContain('user');
     });
 
+    it('prefers the named class with spec wording over loose feature wording in the tail', function () {
+        $step = Step::resolve('add a spec example for App\\TodoList: drive the pending feature', Grounding::empty());
+
+        expect($step->phase)->toBe(Phase::WriteSpec);
+        expect($step->subject)->toBe('App\\TodoList');
+    });
+
     it('infers write-spec and the class from spec wording', function () {
         $step = Step::resolve('a spec for a Coupon that reduces a total', Grounding::empty());
 
@@ -156,6 +163,26 @@ describe(Step::class, function () {
         $step = Step::resolve('', new Grounding(suite: $suite));
 
         expect($step->because)->toBe('the suite is red: deleting_a_task');
+    });
+
+    it('derives write-steps for a feature whose steps are pending: finish the working story', function () {
+        $suite = new SuiteSummary(
+            'green',
+            ['examples' => 5, 'passes' => 5, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+            [],
+            [],
+            ['features' => 3, 'scenarios' => 4, 'steps' => 20, 'stepFailures' => 0, 'undefined' => 0],
+            [
+                ['path' => 'features/adding.feature', 'status' => 'green', 'undefined' => 0],
+                ['path' => 'features/clearing_completed_tasks.feature', 'status' => 'pending', 'undefined' => 0],
+            ],
+        );
+
+        $step = Step::resolve('', new Grounding(suite: $suite));
+
+        expect($step->phase)->toBe(Phase::WriteSteps);
+        expect($step->subject)->toBe('features/clearing_completed_tasks.feature');
+        expect($step->because)->toContain('pending');
     });
 
     it('derives refactor when features are green', function () {

--- a/spec/PhpSpec/Ai/Agent/ToolRegistry.spec.php
+++ b/spec/PhpSpec/Ai/Agent/ToolRegistry.spec.php
@@ -51,31 +51,23 @@ describe(ToolRegistry::class, function () {
 
     context('deterministic', function () {
 
-        it('resolves a write-feature step to a Gherkin skeleton at the explicit path', function () {
+        it('defers a new feature to the model: scenario content is imagination, not scaffolding', function () {
             $step = new Step(Phase::WriteFeature, 'features/user_adds_tasks.feature', null, 'you named it');
 
-            $proposals = $this->registry->deterministic($step, Grounding::empty(), $this->genProfile);
-
-            expect($proposals[0]->path)->toBe('features/user_adds_tasks.feature');
-            expect($proposals[0]->new)->toContain('Feature:');
-            expect($proposals[0]->new)->toContain('Scenario:');
-            expect($proposals[0]->origin)->toBe('write_feature');
+            expect($this->registry->deterministic($step, Grounding::empty(), $this->genProfile))->toBeNull();
         });
 
-        it('derives the feature path from the slug under the configured features path', function () {
+        it('stands in with the skeleton when a feature ask produced nothing usable', function () {
             $step = new Step(Phase::WriteFeature, null, 'user_adds_tasks', 'feature intent');
 
-            $proposals = $this->registry->deterministic($step, Grounding::empty(), $this->genProfile);
+            $proposal = $this->registry->featureFallback($step);
 
-            expect($proposals[0]->path)->toBe('features/user_adds_tasks.feature');
+            expect($proposal->path)->toBe('features/user_adds_tasks.feature');
+            expect($proposal->new)->toContain('Scenario:');
         });
 
-        it('places a bare feature filename under the configured features path, never the project root', function () {
-            $step = new Step(Phase::WriteFeature, 'completing_a_task.feature', null, 'you named it');
-
-            $proposals = $this->registry->deterministic($step, Grounding::empty(), $this->genProfile);
-
-            expect($proposals[0]->path)->toBe('features/completing_a_task.feature');
+        it('has no feature fallback for other steps', function () {
+            expect($this->registry->featureFallback(new Step(Phase::WriteCode, null, 'App\\X', 'code intent')))->toBeNull();
         });
 
         it('parses the subject feature and drafts its steps file deterministically', function (Filesystem $fs) {
@@ -239,6 +231,37 @@ describe(ToolRegistry::class, function () {
 
             expect($proposals[0]->path)->toBe('features/user_adds_tasks.feature');
             expect($proposals[0]->new)->toContain('Feature:');
+        });
+
+        it('writes the model Gherkin at the explicit step path', function () {
+            $step = new Step(Phase::WriteFeature, 'features/user_adds_tasks.feature', null, 'you named it');
+            $call = new ToolCall('1', 'write_feature', ['content' => "Feature: Adding tasks\n  Scenario: Adds a task\n    Given an empty list\n    When I add \"milk\"\n    Then the list holds it\n"]);
+
+            $proposals = $this->registry->fromCalls([$call], $step);
+
+            expect($proposals[0]->path)->toBe('features/user_adds_tasks.feature');
+            expect($proposals[0]->new)->toContain('When I add "milk"');
+            expect($proposals[0]->origin)->toBe('write_feature');
+        });
+
+        it('places a bare feature filename under the configured features path, never the project root', function () {
+            $step = new Step(Phase::WriteFeature, 'completing_a_task.feature', null, 'you named it');
+            $call = new ToolCall('1', 'write_feature', ['content' => "Feature: Completing\n  Scenario: Done\n    Given a task\n    When I complete it\n    Then it is done\n"]);
+
+            $proposals = $this->registry->fromCalls([$call], $step);
+
+            expect($proposals[0]->path)->toBe('features/completing_a_task.feature');
+        });
+
+        it('falls back to the skeleton when the model content is no Gherkin', function () {
+            $step = new Step(Phase::WriteFeature, null, 'user_adds_tasks', 'feature intent');
+            $call = new ToolCall('1', 'write_feature', ['content' => 'here is your feature, enjoy']);
+
+            $proposals = $this->registry->fromCalls([$call], $step);
+
+            expect($proposals[0]->path)->toBe('features/user_adds_tasks.feature');
+            expect($proposals[0]->new)->toContain('Feature:');
+            expect($proposals[0]->new)->toContain('Scenario:');
         });
 
         it('serves a write_steps call from the argument feature path when the step has none', function (Filesystem $fs) {

--- a/spec/PhpSpec/Ai/Eval/GenerateFeatureByIntent.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateFeatureByIntent.spec.php
@@ -9,8 +9,9 @@ require_once __DIR__ . '/../ReplayProvider.php';
 
 // E2 (eval) — when the instruction asks for a feature BY INTENT (no explicit
 // path in the words), generate must still produce a .feature under features/,
-// never a spec. Deterministic under the pipeline: the recorded bad reply (a
-// spec) is never consulted.
+// never a spec. The model is consulted for the scenario content; the recorded
+// bad reply (a spec, in prose) dies at the rails: one corrective re-ask, then
+// the skeleton at the derived path stands in.
 describe('E2 generate: feature by intent', function () {
 
     beforeEach(function (Filesystem $fs) {
@@ -32,11 +33,12 @@ describe('E2 generate: feature by intent', function () {
 
         // Assert on the value (not a boolean derived from it) so a failure carries
         // the actual path into --format=agent, keeping the JSON actionable.
-        expect($replay->requests)->toBe([]);
+        expect($replay->requests)->toHaveLength(2);                                // consulted, then re-asked once
         expect($outcome->proposals[0]->path)->toMatch('~^features/.+\.feature$~'); // a feature under features/
         expect($outcome->proposals[0]->path)->not()->toEndWith('.spec.php');       // not a spec
         expect($outcome->proposals[0]->new)->toContain('Feature:');                 // valid Gherkin
         expect($outcome->proposals[0]->new)->toContain('Scenario:');
+        expect($outcome->proposals[0]->new)->not()->toContain('describe(');         // the recorded spec died at the rail
     });
 
 });

--- a/spec/PhpSpec/Ai/Eval/GenerateFeatureExplicitPath.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateFeatureExplicitPath.spec.php
@@ -8,10 +8,10 @@ use PhpSpec\Filesystem;
 require_once __DIR__ . '/../ReplayProvider.php';
 
 // E1 (eval) — when the instruction names an explicit feature path, generate
-// must produce a .feature at THAT exact path, never a spec. Under the agent
-// pipeline this is fully deterministic: the recorded model reply (the actual
-// bad output from the bug: a spec at the model's own path) must never even be
-// consulted.
+// must produce a .feature at THAT exact path, never a spec. The model is
+// consulted for the scenario content, but the recorded bad reply (the actual
+// bug output: a spec at the model's own path) must not survive the rails: the
+// derived path wins and non-Gherkin content falls back to the skeleton.
 describe('E1 generate: feature at an explicit path', function () {
 
     beforeEach(function (Filesystem $fs) {
@@ -24,17 +24,18 @@ describe('E1 generate: feature at an explicit path', function () {
         allow($fs->write())->toReturn(null);
     });
 
-    it('writes a .feature at the requested path without consulting the model', function (Filesystem $fs) {
+    it('writes a .feature at the requested path even when the model answers with a spec', function (Filesystem $fs) {
         $rec = json_decode((string) file_get_contents(__DIR__ . '/recordings/generate-feature-explicit-path.json'), true);
         $replay = ReplayProvider::fromRecording($rec);
 
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
         $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
 
-        expect($replay->requests)->toBe([]);                                       // deterministic: no model
+        expect($replay->requests)->toHaveLength(2);                                // consulted, then re-asked once
         expect($outcome->proposals[0]->path)->toBe('features/user_adds_tasks.feature');
         expect($outcome->proposals[0]->new)->toContain('Feature:');                 // valid Gherkin
         expect($outcome->proposals[0]->new)->toContain('Scenario:');
+        expect($outcome->proposals[0]->new)->not()->toContain('describe(');         // the recorded spec died at the rail
     });
 
 });

--- a/spec/PhpSpec/Ai/Eval/GenerateRespectsProjectLayout.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateRespectsProjectLayout.spec.php
@@ -50,14 +50,17 @@ describe('E10 generate: inferred paths respect the project layout', function () 
         expect($outcome->proposals[0]->path)->toBe('test/spec/App/Coupon.spec.php');
     });
 
-    it('places an inferred feature under the configured features_path, without the model', function (Filesystem $fs) use ($agentFor) {
-        $replay = new ReplayProvider();
+    it('places an inferred feature under the configured features_path, whatever the model says', function (Filesystem $fs) use ($agentFor) {
+        $replay = new ReplayProvider([
+            new Response('', [new ToolCall('1', 'write_feature', ['path' => 'features/wrong_place.feature', 'content' => "Feature: Adding\n  Scenario: Adds\n    Given a list\n    When I add \"milk\"\n    Then it is there"])]),
+        ]);
         $agent = $agentFor($fs, "features_path: test/features\nai:\n  provider: google\n  api_key: x\n", $replay);
 
         $outcome = $agent->do(CommandProfile::load('generate'), 'a feature for adding a task');
 
-        expect($replay->requests)->toBe([]);
+        expect($replay->requests)->toHaveLength(1);
         expect($outcome->proposals[0]->path)->toMatch('~^test/features/.+\.feature$~');
+        expect($outcome->proposals[0]->new)->toContain('When I add "milk"');
     });
 
 });

--- a/spec/PhpSpec/Ai/Prompts.spec.php
+++ b/spec/PhpSpec/Ai/Prompts.spec.php
@@ -114,11 +114,25 @@ describe('prompt artifacts', function () {
         expect($raw('next'))->toContain('@include instructions/tdd-cycle');   // the cycle is single-sourced
     });
 
+    it('demands real scenario content from write_feature, never a placeholder', function () use ($read) {
+        $text = $read('tools/write_feature');
+
+        expect($text)->toContain('Gherkin content');
+        expect($text)->toContain('concrete');
+    });
+
     it('teaches next that a polished, unchanged class gets growth, not more polish', function () use ($read) {
         $text = $read('commands/next');
 
         expect($text)->toContain('journal');
         expect($text)->toContain('scenario or feature');
+    });
+
+    it('keeps next on the working story while its steps are pending', function () use ($read) {
+        $text = $read('commands/next');
+
+        expect($text)->toContain('pending');
+        expect($text)->toContain('working story');
     });
 
     it('keeps next.txt pure coaching, with no machine-readable contract to leak', function () use ($read) {

--- a/spec/PhpSpec/Console/Command/Next.spec.php
+++ b/spec/PhpSpec/Console/Command/Next.spec.php
@@ -592,12 +592,119 @@ describe(Next::class, function () {
             $replay = new ReplayProvider([new Response('should never be consulted')]);
             $cmd = new Next(new Configuration('.', $fs), $fs, null, $runner, $replay);
 
-            $tester = new CommandTester($cmd);
+            $app = new Application();
+            method_exists($app, 'addCommand') ? $app->addCommand($cmd) : $app->add($cmd);
+            $tester = new CommandTester($app->find('next'));
+            $tester->setInputs(['n']);
             $tester->execute([]);
 
             expect($replay->requests)->toBe([]);                                  // deterministic: no model
             expect($tester->getDisplay())->toContain('undefined steps');
             expect($tester->getDisplay())->toContain('Write the steps.');
+            expect($tester->getDisplay())->toContain('Would you like me to create that for you?');
+        });
+
+        it('actuates an accepted steps suggestion through generate', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'steps',
+                'target' => 'features/adding.feature',
+                'reason' => 'Undefined steps block the story.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $fakeGenerate = new class extends SymfonyCommand {
+                public string $received = '';
+                protected function configure(): void
+                {
+                    $this->setName('generate')->addArgument('instruction', InputArgument::IS_ARRAY);
+                }
+                protected function execute(InputInterface $input, OutputInterface $output): int
+                {
+                    $this->received = implode(' ', (array) $input->getArgument('instruction'));
+
+                    return 0;
+                }
+            };
+
+            $app = new Application();
+            foreach ([$cmd, $fakeGenerate] as $command) {
+                method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
+            }
+
+            $tester = new CommandTester($app->find('next'));
+            $tester->setInputs(['Y']);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('Write the steps for');
+            expect($fakeGenerate->received)->toBe('the steps for features/adding.feature');
+        });
+
+        it('actuates an accepted implement suggestion for a class through generate', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'implement',
+                'target' => 'App\\TodoList',
+                'reason' => 'The suite is red: App\\TodoList, it deletes a task.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $fakeGenerate = new class extends SymfonyCommand {
+                public string $received = '';
+                protected function configure(): void
+                {
+                    $this->setName('generate')->addArgument('instruction', InputArgument::IS_ARRAY);
+                }
+                protected function execute(InputInterface $input, OutputInterface $output): int
+                {
+                    $this->received = implode(' ', (array) $input->getArgument('instruction'));
+
+                    return 0;
+                }
+            };
+
+            $app = new Application();
+            foreach ([$cmd, $fakeGenerate] as $command) {
+                method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
+            }
+
+            $tester = new CommandTester($app->find('next'));
+            $tester->setInputs(['Y']);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('Implement');
+            expect($fakeGenerate->received)->toBe('implement App\\TodoList');
+        });
+
+        it('falls back to a run hint when the failing subject is no class', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'implement',
+                'target' => 'deleting_a_task',
+                'reason' => 'The suite is red: deleting_a_task. Make it green.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $tester = new CommandTester($cmd);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('run');
+            expect($tester->getDisplay())->not()->toContain('Would you like me to create that for you?');
         });
 
         it('passes AI config to the suggest function', function (Filesystem $fs) {

--- a/spec/PhpSpec/Console/Command/Next.spec.php
+++ b/spec/PhpSpec/Console/Command/Next.spec.php
@@ -289,7 +289,7 @@ describe(Next::class, function () {
             $cmd = new Next($configWithAi, $fs, $suggestFn);
 
             $tester = new CommandTester($cmd);
-            $exitCode = $tester->execute([]);
+            $exitCode = $tester->execute([], ['interactive' => false]);
 
             expect($exitCode)->toBe(0);
             expect($tester->getDisplay())->toContain('refactor App/TodoList');
@@ -320,7 +320,7 @@ describe(Next::class, function () {
             $cmd = new Next($configWithAi, $fs, $suggestFn);
 
             $tester = new CommandTester($cmd);
-            $exitCode = $tester->execute([]);
+            $exitCode = $tester->execute([], ['interactive' => false]);
 
             expect($exitCode)->toBe(0);
             expect($tester->getDisplay())->toContain('refactor App/TaskQueue');
@@ -374,17 +374,52 @@ describe(Next::class, function () {
             expect($tester->getDisplay())->toContain('clearing completed tasks');
         });
 
-        it('displays a refactor suggestion with the refactor hint', function (Filesystem $fs) {
+        it('actuates an accepted refactor suggestion by running the refactor command', function (Filesystem $fs) {
             $yamlPath = './phpspec.yaml';
-            allow($fs->exists())->toReturnUsing(function (string $path) use ($yamlPath): bool {
-                return $path === $yamlPath;
-            });
-            allow($fs->read())->toReturnUsing(function (string $path) use ($yamlPath): string {
-                if ($path === $yamlPath) {
-                    return "ai:\n  provider: google\n  api_key: test-key\n";
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'refactor',
+                'target' => 'App\\TodoList',
+                'reason' => 'The suite is green and complete() duplicates the lookup.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $fakeRefactor = new class extends SymfonyCommand {
+                public string $received = '';
+                protected function configure(): void
+                {
+                    $this->setName('refactor')->addArgument('target', InputArgument::REQUIRED);
                 }
-                return '';
-            });
+                protected function execute(InputInterface $input, OutputInterface $output): int
+                {
+                    $this->received = (string) $input->getArgument('target');
+
+                    return 0;
+                }
+            };
+
+            $app = new Application();
+            foreach ([$cmd, $fakeRefactor] as $command) {
+                method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
+            }
+
+            $tester = new CommandTester($app->find('next'));
+            $tester->setInputs(['Y']);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('Refactor');
+            expect($tester->getDisplay())->toContain('Would you like me to run it now?');
+            expect($fakeRefactor->received)->toBe('App/TodoList');
+        });
+
+        it('hints the refactor command when not interactive', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
 
             $configWithAi = new Configuration('.', $fs);
             $suggestFn = fn(array $aiConfig): array => [
@@ -395,25 +430,100 @@ describe(Next::class, function () {
             $cmd = new Next($configWithAi, $fs, $suggestFn);
 
             $tester = new CommandTester($cmd);
-            $exitCode = $tester->execute([]);
+            $exitCode = $tester->execute([], ['interactive' => false]);
 
             expect($exitCode)->toBe(0);
             expect($tester->getDisplay())->toContain('Refactor');
-            expect($tester->getDisplay())->toContain('App\\TodoList');
-            expect($tester->getDisplay())->toContain('bin/phpspec refactor App/TodoList');
+            expect($tester->getDisplay())->toContain('refactor App/TodoList');
         });
 
-        it('displays an example suggestion with exemplify hint', function (Filesystem $fs) {
+        it('actuates an accepted example suggestion through generate', function (Filesystem $fs) {
             $yamlPath = './phpspec.yaml';
-            allow($fs->exists())->toReturnUsing(function (string $path) use ($yamlPath): bool {
-                return $path === $yamlPath;
-            });
-            allow($fs->read())->toReturnUsing(function (string $path) use ($yamlPath): string {
-                if ($path === $yamlPath) {
-                    return "ai:\n  provider: google\n  api_key: test-key\n";
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'example',
+                'target' => 'App\\Calculator',
+                'reason' => 'The Calculator spec covers add() but not divide().',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $fakeGenerate = new class extends SymfonyCommand {
+                public string $received = '';
+                protected function configure(): void
+                {
+                    $this->setName('generate')->addArgument('instruction', InputArgument::IS_ARRAY);
                 }
-                return '';
-            });
+                protected function execute(InputInterface $input, OutputInterface $output): int
+                {
+                    $this->received = implode(' ', (array) $input->getArgument('instruction'));
+
+                    return 0;
+                }
+            };
+
+            $app = new Application();
+            foreach ([$cmd, $fakeGenerate] as $command) {
+                method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
+            }
+
+            $tester = new CommandTester($app->find('next'));
+            $tester->setInputs(['Y']);
+            $exitCode = $tester->execute([]);
+
+            expect($exitCode)->toBe(0);
+            expect($tester->getDisplay())->toContain('Add an example to');
+            expect($tester->getDisplay())->toContain('App\\Calculator');
+            expect($fakeGenerate->received)->toBe('add a spec example for App\\Calculator: The Calculator spec covers add() but not divide().');
+        });
+
+        it('strips file tokens from the reason it forwards, so routing stays on the spec', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'example',
+                'target' => 'App\\TodoList',
+                'reason' => 'Implement the pending scenario in features/clearing_completed_tasks.feature now.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $fakeGenerate = new class extends SymfonyCommand {
+                public string $received = '';
+                protected function configure(): void
+                {
+                    $this->setName('generate')->addArgument('instruction', InputArgument::IS_ARRAY);
+                }
+                protected function execute(InputInterface $input, OutputInterface $output): int
+                {
+                    $this->received = implode(' ', (array) $input->getArgument('instruction'));
+
+                    return 0;
+                }
+            };
+
+            $app = new Application();
+            foreach ([$cmd, $fakeGenerate] as $command) {
+                method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
+            }
+
+            $tester = new CommandTester($app->find('next'));
+            $tester->setInputs(['Y']);
+            $tester->execute([]);
+
+            expect($fakeGenerate->received)->toContain('add a spec example for App\\TodoList');
+            expect($fakeGenerate->received)->toContain('pending scenario');
+            expect($fakeGenerate->received)->not()->toContain('.feature');
+        });
+
+        it('hints the example generate line when not interactive', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
 
             $configWithAi = new Configuration('.', $fs);
             $suggestFn = fn(array $aiConfig): array => [
@@ -424,12 +534,10 @@ describe(Next::class, function () {
             $cmd = new Next($configWithAi, $fs, $suggestFn);
 
             $tester = new CommandTester($cmd);
-            $exitCode = $tester->execute([]);
+            $exitCode = $tester->execute([], ['interactive' => false]);
 
             expect($exitCode)->toBe(0);
-            expect($tester->getDisplay())->toContain('Add an example to');
-            expect($tester->getDisplay())->toContain('App\\Calculator');
-            expect($tester->getDisplay())->toContain('bin/phpspec exemplify');
+            expect($tester->getDisplay())->toContain('generate "add a spec example for App\\Calculator');
         });
 
         it('displays an info suggestion when well-covered', function (Filesystem $fs) {
@@ -491,6 +599,8 @@ describe(Next::class, function () {
             $featuresDir = getcwd() . '/features';
             allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath || $p === $featuresDir);
             allow($fs->isDir())->toReturnUsing(fn(string $p): bool => $p === $featuresDir);
+            allow($fs->scandir())->toReturnUsing(fn(string $d): array => $d === $featuresDir ? ['adding.feature'] : []);
+            allow($fs->mtime())->toReturn(100);
             allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
 
             $runner = new NextFakeRunner();
@@ -516,7 +626,8 @@ describe(Next::class, function () {
 
             expect($runner->arguments)->toContain('--all');
             expect($captured)->toContain('FEATURES');
-            expect($captured)->toContain('adding.feature');
+            expect($captured)->toContain('Last-touched feature: features/adding.feature');
+            expect($captured)->not()->toContain(getcwd());
         });
 
         it('does not run the suite when there are no features', function (Filesystem $fs) {
@@ -569,6 +680,57 @@ describe(Next::class, function () {
             expect($runner->arguments)->toContain('--all');
             expect($replay->requests[0]['messages'][1]->content)->toContain('FEATURES');    // suite grounding reached the model
             expect($replay->requests[0]['messages'][0]->content)->toContain('refactor');    // so did the derived step
+        });
+
+        it('shows the model the working story files when a feature is red', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            $cwd = getcwd();
+            $featuresDir = $cwd . '/features';
+            $known = [
+                $cwd . '/features/clearing.feature' => "Feature: Clearing\n  Scenario: Clears\n    When I clear completed tasks\n",
+                $cwd . '/features/steps/clearing.steps.php' => "<?php\nwhen('I clear completed tasks', fn() => \$this->todoList->getTasks());\n",
+                $cwd . '/spec/App/TodoList.spec.php' => "<?php\ndescribe('TodoList', function () { it('clears completed tasks', fn() => null); });\n",
+                $cwd . '/src/App/TodoList.php' => "<?php\nclass TodoList { public function tasks(): array { return []; } }\n",
+            ];
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath || $p === $featuresDir || isset($known[$p]) || in_array($p, [$cwd . '/spec', $cwd . '/src'], true));
+            allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, [$featuresDir, $cwd . '/spec', $cwd . '/src'], true));
+            allow($fs->scandir())->toReturnUsing(fn(string $d): array => match ($d) {
+                $cwd . '/spec' => ['App/TodoList.spec.php'],
+                $cwd . '/src' => ['App/TodoList.php'],
+                default => [],
+            });
+            allow($fs->isFile())->toReturnUsing(fn(string $p): bool => isset($known[$p]));
+            allow($fs->mtime())->toReturn(100);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : ($known[$p] ?? ''));
+            allow($fs->mkdir())->toReturn(null);
+            allow($fs->write())->toReturn(null);
+
+            $runner = new NextFakeRunner();
+            $runner->outcome = new RunOutcome(null, new SuiteSummary(
+                'red',
+                ['examples' => 3, 'passes' => 3, 'failures' => 0, 'errors' => 0, 'pending' => 0],
+                [],
+                [],
+                ['features' => 1, 'scenarios' => 1, 'steps' => 3, 'stepFailures' => 1, 'undefined' => 0],
+                [['path' => 'features/clearing.feature', 'status' => 'red', 'undefined' => 0]],
+            ));
+
+            $replay = new ReplayProvider([
+                new Response('', [new ToolCall('1', 'suggest_next', ['type' => 'implement', 'target' => 'App\\TodoList', 'reason' => 'The step calls getTasks() but the class only has tasks().'])]),
+            ]);
+            $cmd = new Next(new Configuration('.', $fs), $fs, null, $runner, $replay);
+
+            $app = new Application();
+            method_exists($app, 'addCommand') ? $app->addCommand($cmd) : $app->add($cmd);
+            $tester = new CommandTester($app->find('next'));
+            $tester->setInputs(['n']);
+            $tester->execute([]);
+
+            $context = $replay->requests[0]['messages'][1]->content;
+            expect($context)->toContain('features/clearing.feature');
+            expect($context)->toContain('I clear completed tasks');
+            expect($context)->toContain('getTasks');                    // the steps file content
+            expect($tester->getDisplay())->toContain('Implement');
         });
 
         it('suggests the determined step itself, without the model, when the suite determines it', function (Filesystem $fs) {
@@ -683,7 +845,7 @@ describe(Next::class, function () {
 
             expect($exitCode)->toBe(0);
             expect($tester->getDisplay())->toContain('Implement');
-            expect($fakeGenerate->received)->toBe('implement App\\TodoList');
+            expect($fakeGenerate->received)->toBe('implement App\\TodoList: The suite is red: App\\TodoList, it deletes a task.');
         });
 
         it('falls back to a run hint when the failing subject is no class', function (Filesystem $fs) {

--- a/spec/PhpSpec/Console/Command/Run/SuiteSummary.spec.php
+++ b/spec/PhpSpec/Console/Command/Run/SuiteSummary.spec.php
@@ -197,6 +197,46 @@ describe(SuiteSummary::class, function () {
         expect($summary->redFeature())->toBeNull();
     });
 
+    it('marks a feature with pending steps as pending, never green', function () {
+        $suite = new SuiteResult([
+            new FeatureResult('Clearing completed tasks', [
+                new ScenarioResult('Clearing completed tasks', [
+                    new StepResult('I have a todo list', 'passed'),
+                    new StepResult('I clear completed tasks', 'pending'),
+                ]),
+            ], 'features/clearing_completed_tasks.feature'),
+        ]);
+
+        $summary = SuiteSummary::fromSuiteResult($suite);
+
+        expect($summary->features()[0]['status'])->toBe('pending');
+        expect($summary->featuresAreGreen())->toBe(false);
+    });
+
+    it('keeps undefined steps ranked above pending ones in the feature verdict', function () {
+        $suite = new SuiteResult([
+            new FeatureResult('Adding', [
+                new ScenarioResult('Adds', [
+                    new StepResult('I add a task', 'pending'),
+                    new StepResult('the list holds it', 'undefined'),
+                ]),
+            ], 'features/adding.feature'),
+        ]);
+
+        $summary = SuiteSummary::fromSuiteResult($suite);
+
+        expect($summary->features()[0]['status'])->toBe('todo');
+    });
+
+    it('round-trips a pending feature status across the subprocess boundary', function () {
+        $summary = SuiteSummary::fromArray([
+            'status' => 'green',
+            'features' => [['path' => 'features/clearing.feature', 'status' => 'pending', 'undefined' => 0]],
+        ]);
+
+        expect($summary->features()[0]['status'])->toBe('pending');
+    });
+
     it('reports no features for a spec-only suite', function () {
         $suite = new SuiteResult([
             new SpecificationResult('App\\Greeter', [new ExampleResult('greets', [])]),

--- a/src/PhpSpec/Ai/Agent/Agent.php
+++ b/src/PhpSpec/Ai/Agent/Agent.php
@@ -166,6 +166,14 @@ final class Agent
         $this->recorder->capture($profile->name, $instruction, $step, $request, $aiConfig ?? [], $response, $proposals);
 
         if ($profile->answer === 'tool_call' && $proposals === [] && $data === []) {
+            // A write-feature ask that produced nothing usable still moves the
+            // loop: the skeleton at the derived path stands in, and only there
+            // (provider errors above stay errors).
+            $fallback = $this->registry->featureFallback($step);
+            if ($fallback !== null) {
+                return new Outcome($step, [$fallback]);
+            }
+
             $prose = trim($response->text);
 
             // Command-neutral: `next` has no instruction to rephrase, so the

--- a/src/PhpSpec/Ai/Agent/Agent.php
+++ b/src/PhpSpec/Ai/Agent/Agent.php
@@ -129,7 +129,11 @@ final class Agent
         } catch (RuntimeException|InvalidArgumentException $e) {
             $this->recorder->capture($profile->name, $instruction, $step, $request, $aiConfig ?? [], null);
 
-            return new Outcome($step, [], $e->getMessage());
+            // A missing ai section stays an honest config error; any other
+            // construction failure degrades like a failed call below.
+            return $aiConfig === null
+                ? new Outcome($step, [], $e->getMessage())
+                : $this->failedAsk($step, $e->getMessage());
         }
 
         $messages = [Message::system($request->system), Message::user($request->context)];
@@ -151,7 +155,7 @@ final class Agent
             // toolChoice) becomes prose for the human, never a crash.
             $this->recorder->capture($profile->name, $instruction, $step, $request, $aiConfig ?? [], null);
 
-            return new Outcome($step, [], $e->getMessage());
+            return $this->failedAsk($step, $e->getMessage());
         }
 
         try {
@@ -182,6 +186,21 @@ final class Agent
         }
 
         return new Outcome($step, $proposals, trim($response->text), $data);
+    }
+
+    /**
+     * The outcome of an ask the provider could not answer: for a write-feature
+     * step the derived skeleton stands in so the loop still moves offline,
+     * with the failure kept visible beside it; anything else is the error.
+     */
+    private function failedAsk(?Step $step, string $error): Outcome
+    {
+        $fallback = $this->registry->featureFallback($step);
+        if ($fallback !== null) {
+            return new Outcome($step, [$fallback], $error);
+        }
+
+        return new Outcome($step, [], $error);
     }
 
     /**

--- a/src/PhpSpec/Ai/Agent/Step.php
+++ b/src/PhpSpec/Ai/Agent/Step.php
@@ -89,13 +89,10 @@ final readonly class Step
             return new self($phase, $path, null, sprintf('you named "%s"', $path));
         }
 
-        if (preg_match('~\b(?:feature|scenario|story)\b~i', $instruction) === 1) {
-            $slug = self::slug($instruction);
-            if ($slug !== '') {
-                return new self(Phase::WriteFeature, null, $slug, 'you asked for a feature');
-            }
-        }
-
+        // A named class is the most specific anchor there is, so class-bound
+        // wording beats loose feature/scenario words later in the sentence
+        // ("a spec example for App\TodoList: drive the pending feature" is a
+        // spec ask, not a feature ask).
         $class = self::classToken($instruction);
         if ($class !== null && preg_match('~\bspec\b~i', $instruction) === 1) {
             return new self(Phase::WriteSpec, null, $class, sprintf('you asked for a spec for "%s"', $class));
@@ -103,6 +100,13 @@ final readonly class Step
 
         if ($class !== null && preg_match('~\b(?:implement|method|function)\b~i', $instruction) === 1) {
             return new self(Phase::WriteCode, null, $class, sprintf('you asked for code on "%s"', $class));
+        }
+
+        if (preg_match('~\b(?:feature|scenario|story)\b~i', $instruction) === 1) {
+            $slug = self::slug($instruction);
+            if ($slug !== '') {
+                return new self(Phase::WriteFeature, null, $slug, 'you asked for a feature');
+            }
         }
 
         return null;
@@ -135,6 +139,14 @@ final readonly class Step
             $todo = self::firstTodoFeature($suite);
             if ($todo !== null) {
                 return new self(Phase::WriteSteps, null, $todo['path'], sprintf('%d undefined steps in "%s"', $todo['undefined'], $todo['path']));
+            }
+
+            $wip = self::firstPendingFeature($suite);
+            if ($wip !== null) {
+                // Writing the bodies is the convergent move: against ready code
+                // they go green, against missing code they go red, and red
+                // names the class to implement. Pending names nothing.
+                return new self(Phase::WriteSteps, null, $wip['path'], sprintf('steps are pending in "%s": write their bodies to drive the code', $wip['path']));
             }
 
             return new self(Phase::Refactor, null, null, 'features are green: refactor, or grow the story');
@@ -179,6 +191,23 @@ final readonly class Step
     {
         foreach ($suite->features() as $feature) {
             if ($feature['status'] === 'todo') {
+                return $feature;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The first feature whose defined steps still await their implementation:
+     * the working story, to finish before any growth.
+     *
+     * @return array{path: string, status: string, undefined: int}|null
+     */
+    private static function firstPendingFeature(SuiteSummary $suite): ?array
+    {
+        foreach ($suite->features() as $feature) {
+            if ($feature['status'] === 'pending') {
                 return $feature;
             }
         }

--- a/src/PhpSpec/Ai/Agent/Step.php
+++ b/src/PhpSpec/Ai/Agent/Step.php
@@ -124,7 +124,7 @@ final readonly class Step
 
         if ($suite->hasFeatures()) {
             if ($failure !== null) {
-                return new self(Phase::WriteCode, null, $failure['subject'], sprintf('the suite is red: %s, %s', $failure['subject'], $failure['example']));
+                return new self(Phase::WriteCode, null, $failure['subject'], self::redBecause($failure));
             }
 
             $red = $suite->redFeature();
@@ -145,7 +145,7 @@ final readonly class Step
         }
 
         if ($suite->isRed()) {
-            return new self(Phase::WriteCode, null, $failure['subject'] ?? null, sprintf('the suite is red: %s, %s', $failure['subject'] ?? '', $failure['example'] ?? ''));
+            return new self(Phase::WriteCode, null, $failure['subject'] ?? null, self::redBecause($failure));
         }
 
         $gap = $suite->nearestPendingGap();
@@ -154,6 +154,20 @@ final readonly class Step
         }
 
         return new self(Phase::Refactor, null, null, 'green and clean: refactor, or pick the next behaviour');
+    }
+
+    /**
+     * The red-suite because, naming the failure's subject and example once
+     * each: a degenerate spec repeats its subject as the example, and printing
+     * it twice reads like a stutter.
+     *
+     * @param array{subject?: string, example?: string}|null $failure
+     */
+    private static function redBecause(?array $failure): string
+    {
+        $parts = array_unique(array_filter([$failure['subject'] ?? '', $failure['example'] ?? '']));
+
+        return 'the suite is red' . ($parts === [] ? '' : ': ' . implode(', ', $parts));
     }
 
     /**

--- a/src/PhpSpec/Ai/Agent/ToolRegistry.php
+++ b/src/PhpSpec/Ai/Agent/ToolRegistry.php
@@ -42,6 +42,7 @@ final class ToolRegistry
         'write_feature' => [
             'name' => ['type' => 'string', 'description' => 'Short feature name (a snake_case slug)', 'default' => ''],
             'path' => ['type' => 'string', 'description' => 'Explicit project-relative .feature path', 'default' => ''],
+            'content' => ['type' => 'string', 'description' => 'The complete Gherkin content, starting with "Feature:" and holding at least one concrete Scenario', 'default' => ''],
         ],
         'write_steps' => [
             'feature_path' => ['type' => 'string', 'description' => 'Project-relative path of the .feature to write steps for', 'default' => ''],
@@ -51,8 +52,8 @@ final class ToolRegistry
             'content' => ['type' => 'string', 'description' => 'The complete new file content, not a diff'],
         ],
         'suggest_next' => [
-            'type' => ['type' => 'string', 'enum' => ['spec', 'feature', 'example', 'refactor', 'info'], 'description' => 'What to do next: spec (a class to describe), feature (a user-facing behaviour), example (grow an existing spec), refactor (the suite is green and a class deserves cleaning), or info'],
-            'target' => ['type' => 'string', 'description' => 'The class name, feature name, or spec the suggestion is about'],
+            'type' => ['type' => 'string', 'enum' => ['spec', 'feature', 'example', 'steps', 'implement', 'refactor', 'info'], 'description' => 'What to do next: spec (a class to describe), feature (a user-facing behaviour), example (grow an existing spec with a NEW example), steps (a feature\'s step definitions need writing, or their bodies are pending or failing; target is the .feature path), implement (source code must change to make the suite green; target is the class), refactor (the suite is green and a class deserves cleaning), or info'],
+            'target' => ['type' => 'string', 'description' => 'The class name, feature path, or spec the suggestion is about'],
             'reason' => ['type' => 'string', 'description' => 'One short sentence on why this is the next baby step'],
         ],
     ];
@@ -123,16 +124,6 @@ final class ToolRegistry
             return null;
         }
 
-        if ($step->phase === Phase::WriteFeature && in_array('write_feature', $profile->tools, true)) {
-            $path = $this->featurePath($step);
-            if ($path === null || $this->filesystem->exists($this->absolute($path))) {
-                // An existing feature is grown by the model, never re-scaffolded.
-                return null;
-            }
-
-            return [$this->featureProposal($path)];
-        }
-
         if ($step->phase === Phase::WriteSteps && in_array('write_steps', $profile->tools, true)) {
             $feature = $step->subject ?? $this->featureBesideSteps($step->path);
             if ($feature === null) {
@@ -187,7 +178,13 @@ final class ToolRegistry
             $proposal = match ($call->name) {
                 'write_feature' => $this->featureCall($step, $call->arguments),
                 'write_steps' => $this->stepsCall($step, $call->arguments),
-                'propose_edit' => $this->editCall($step, $call->arguments),
+                // The step owns the artifact type: a write-feature step turns
+                // any edit answer into feature content (Gherkin or fallback),
+                // so a model that reaches for the wrong tool cannot write a
+                // spec where a feature belongs.
+                'propose_edit' => $step?->phase === Phase::WriteFeature
+                    ? $this->featureCall($step, $call->arguments)
+                    : $this->editCall($step, $call->arguments),
                 default => null,
             };
 
@@ -200,8 +197,30 @@ final class ToolRegistry
     }
 
     /**
+     * The skeleton stand-in for a write-feature step whose ask produced no
+     * usable proposal, so the loop still moves with a valid artifact at the
+     * derived path. Null when the step is no write-feature, no path derives,
+     * or the file exists (an existing feature is never scaffolded over).
+     */
+    public function featureFallback(?Step $step): ?Proposal
+    {
+        if ($step === null || $step->phase !== Phase::WriteFeature) {
+            return null;
+        }
+
+        $path = $this->featurePath($step);
+        if ($path === null || $this->filesystem->exists($this->absolute($path))) {
+            return null;
+        }
+
+        return $this->featureProposal($path);
+    }
+
+    /**
      * A write_feature call: the step's own path or slug wins over the model's
-     * arguments; with neither, nothing is proposed.
+     * arguments (with neither, nothing is proposed), and the model's Gherkin
+     * is the content. The skeleton stands in only when no Gherkin arrived: a
+     * feature's scenarios are imagination, never scaffolding.
      *
      * @param array<string, mixed> $arguments
      */
@@ -215,7 +234,12 @@ final class ToolRegistry
             return null;
         }
 
-        return $this->featureProposal($this->relative($path));
+        $content = trim((string) ($arguments['content'] ?? ''));
+        if (!str_contains($content, 'Feature:')) {
+            return $this->featureProposal($this->relative($path));
+        }
+
+        return $this->proposal($this->relative($path), $content . "\n", 'write_feature');
     }
 
     /**

--- a/src/PhpSpec/Ai/Prompts/commands/next.txt
+++ b/src/PhpSpec/Ai/Prompts/commands/next.txt
@@ -11,11 +11,17 @@ build next.
 
 Answer by calling suggest_next exactly once. type is spec (a new class to
 describe; target is its fully qualified name), feature (a user-facing behaviour;
-target is a short name), example (grow an existing spec; target is the class),
+target is a short name), example (grow an existing spec with a NEW example;
+target is the class), steps (a feature's step bodies need writing or are
+failing; target is the .feature path), implement (code must change to make the
+suite green; target is the class; prefer this over example when the behaviour
+is already specified),
 or refactor (the suite is green and a class deserves cleaning; target is the
 class). On a green suite, weigh refactor first: red, green, REFACTOR is the
 cycle, so only pass over it when the code is genuinely clean. Never suggest
 refactor for a class the refactoring journal lists as unchanged since its
 refactoring: that polish already happened, so propose the scenario or feature
-that grows the story, and name the new behaviour in reason. Use type info
-only when nothing concrete applies. Keep reason to one short sentence.
+that grows the story, and name the new behaviour in reason. A feature whose
+steps are pending is the working story: suggest the spec or example that
+implements it, never a new feature while it waits. Use type info only when
+nothing concrete applies. Keep reason to one short sentence.

--- a/src/PhpSpec/Ai/Prompts/tools/write_feature.txt
+++ b/src/PhpSpec/Ai/Prompts/tools/write_feature.txt
@@ -1,4 +1,6 @@
-Creates a Gherkin .feature skeleton for a feature file that does not exist yet.
-phpspec owns the path and the Gherkin shape; give it the feature's name (a short
-slug) or an explicit project-relative path. Grow an existing feature file with
-propose_edit instead.
+Creates a Gherkin .feature file that does not exist yet. phpspec owns the path:
+give it the feature's name (a short slug) or an explicit project-relative path.
+You own the Gherkin content: a Feature line and at least one concrete Scenario
+whose Given/When/Then describe the real behaviour asked for, with real values,
+never placeholder steps. Grow an existing feature file with propose_edit
+instead.

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -18,14 +18,17 @@ use PhpSpec\Ai\Agent\Agent;
 use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Ai\Agent\Grounding;
 use PhpSpec\Ai\Agent\Phase;
+use PhpSpec\Ai\Agent\ProjectPath;
 use PhpSpec\Ai\Agent\Request;
 use PhpSpec\Ai\Agent\Step;
 use PhpSpec\Ai\Contracts\ProviderInterface;
 use PhpSpec\Ai\RefactorJournal;
+use PhpSpec\CodeGeneration\FeatureLayout;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Pair\SpecRunner;
 use PhpSpec\Console\Command\Pair\SubprocessRunner;
 use PhpSpec\Console\Command\Run\RecencyScanner;
+use PhpSpec\Console\Command\Run\SuiteSummary;
 use PhpSpec\Filesystem;
 use PhpSpec\RealFilesystem;
 use Symfony\Component\Console\Command\Command;
@@ -145,15 +148,15 @@ final class Next extends Command
         }
 
         if ($suggestion['type'] === 'implement') {
-            return $this->offerImplement($input, $output, $suggestion['target']);
+            return $this->offerImplement($input, $output, $suggestion['target'], $suggestion['reason']);
         }
 
         if ($suggestion['type'] === 'example') {
-            return $this->offerExemplify($input, $output, $suggestion['target']);
+            return $this->offerExemplify($input, $output, $suggestion['target'], $suggestion['reason']);
         }
 
         if ($suggestion['type'] === 'refactor') {
-            return $this->offerRefactor($output, $suggestion['target']);
+            return $this->offerRefactor($input, $output, $suggestion['target']);
         }
 
         return 0;
@@ -277,7 +280,7 @@ final class Next extends Command
      * subject that is no class (a story slug, a bare string) has no one-shot
      * actuator, so the hint is the run that shows the failure.
      */
-    private function offerImplement(Input $input, Output $output, string $target): int
+    private function offerImplement(Input $input, Output $output, string $target, string $reason): int
     {
         if (preg_match('~^[A-Z][A-Za-z0-9]*(?:\\\\[A-Z][A-Za-z0-9]*)*$~', $target) !== 1) {
             $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . ' run');
@@ -285,7 +288,7 @@ final class Next extends Command
             return 0;
         }
 
-        $instruction = 'implement ' . $target;
+        $instruction = $this->taskInstruction('implement ' . $target, $reason);
 
         return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
     }
@@ -296,7 +299,7 @@ final class Next extends Command
      *
      * @param array<string, mixed> $args the bound arguments for the command
      */
-    private function offerToRun(Input $input, Output $output, string $hint, string $command, array $args): int
+    private function offerToRun(Input $input, Output $output, string $hint, string $command, array $args, string $ask = 'Would you like me to create that for you?'): int
     {
         if (!$input->isInteractive()) {
             $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . ' ' . $hint);
@@ -306,10 +309,7 @@ final class Next extends Command
 
         /** @var QuestionHelper $helper */
         $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion(
-            '  <fg=yellow>Would you like me to create that for you?</> [Y/n] ',
-            true,
-        );
+        $question = new ConfirmationQuestion("  <fg=yellow>$ask</> [Y/n] ", true);
 
         if (!$helper->ask($input, $output, $question)) {
             return 0;
@@ -323,13 +323,28 @@ final class Next extends Command
         return $application->find($command)->run(new ArrayInput($args), $output);
     }
 
-    private function offerExemplify(Input $input, Output $output, string $target): int
+    /**
+     * An example suggestion actuates through `generate`, whose spec wording
+     * routes to growing the existing spec (same phrasing the pair ghost uses).
+     */
+    private function offerExemplify(Input $input, Output $output, string $target, string $reason): int
     {
-        $classArg = str_replace('\\', '/', $target);
+        $instruction = $this->taskInstruction('add a spec example for ' . $target, $reason);
 
-        $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . " exemplify $classArg <method>");
+        return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
+    }
 
-        return 0;
+    /**
+     * The generate instruction for an offer: the task, then the suggestion's
+     * reason so the one-shot makes the change the suggestion meant. File
+     * tokens are stripped from the reason, because a path in it would reroute
+     * the instruction to that file's artifact.
+     */
+    private function taskInstruction(string $task, string $reason): string
+    {
+        $hint = trim((string) preg_replace(['~[A-Za-z0-9_./\\\\-]+\.(?:feature|php)~', '~\s+~'], ['', ' '], $reason));
+
+        return $task . ($hint !== '' ? ': ' . $hint : '');
     }
 
     /**
@@ -361,17 +376,14 @@ final class Next extends Command
     }
 
     /**
-     * The green-suite step: point at the refactor command for the suggested
-     * target. A hint, not a run, because refactoring starts with a baseline
-     * the human should see.
+     * The green-suite step: offer to run the refactor command, which shows
+     * its baseline and asks its own consent before anything is applied.
      */
-    private function offerRefactor(Output $output, string $target): int
+    private function offerRefactor(Input $input, Output $output, string $target): int
     {
         $classArg = str_replace('\\', '/', $target);
 
-        $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . " refactor $classArg");
-
-        return 0;
+        return $this->offerToRun($input, $output, "refactor $classArg", 'refactor', ['target' => $classArg], 'Would you like me to run it now?');
     }
 
     /**
@@ -431,9 +443,49 @@ final class Next extends Command
 
         return new Grounding(
             $summary,
-            $recency->mostRecentFeature($featuresDir),
-            $recency->mostRecentSource(getcwd() . '/' . ltrim($this->config->getSrcPath(), './')),
+            ProjectPath::relativeOrNull($recency->mostRecentFeature($featuresDir)),
+            ProjectPath::relativeOrNull($recency->mostRecentSource(getcwd() . '/' . ltrim($this->config->getSrcPath(), './'))),
+            namedFiles: $this->workingStoryFiles($summary, $recency),
         );
+    }
+
+    /**
+     * The files of the story being worked on, for the model to actually read:
+     * a red feature with no failing example means judgement is needed (is the
+     * behaviour specified and the code lagging, or the other way round?), and
+     * that judgement is impossible from file names alone. Empty when no
+     * feature is red, keeping the leaner context everywhere else.
+     *
+     * @return array<string, string> relative path => contents
+     */
+    private function workingStoryFiles(SuiteSummary $summary, RecencyScanner $recency): array
+    {
+        $red = $summary->redFeature();
+        if ($red === null) {
+            return [];
+        }
+
+        $cwd = getcwd() ?: '.';
+        $layout = new FeatureLayout();
+        $feature = ProjectPath::normalize($red['path']);
+        $candidates = [$feature, $layout->stepsPathFor($feature)];
+
+        $spec = $recency->mostRecentSource($cwd . '/' . ltrim($this->config->getSpecPath(), './'));
+        $source = $recency->mostRecentSource($cwd . '/' . ltrim($this->config->getSrcPath(), './'));
+        foreach ([$spec, $source] as $absolute) {
+            if ($absolute !== null) {
+                $candidates[] = ProjectPath::relativeOrNull($absolute) ?? $absolute;
+            }
+        }
+
+        $files = [];
+        foreach ($candidates as $rel) {
+            if ($this->filesystem->exists($cwd . '/' . $rel)) {
+                $files[$rel] = $this->filesystem->read($cwd . '/' . $rel);
+            }
+        }
+
+        return $files;
     }
 
     private function loadBootstrap(): bool

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -140,6 +140,14 @@ final class Next extends Command
             return $this->offerFeature($input, $output, $suggestion['target']);
         }
 
+        if ($suggestion['type'] === 'steps') {
+            return $this->offerSteps($input, $output, $suggestion['target']);
+        }
+
+        if ($suggestion['type'] === 'implement') {
+            return $this->offerImplement($input, $output, $suggestion['target']);
+        }
+
         if ($suggestion['type'] === 'example') {
             return $this->offerExemplify($input, $output, $suggestion['target']);
         }
@@ -212,6 +220,8 @@ final class Next extends Command
         $typeLabel = match ($suggestion['type']) {
             'spec' => 'Describe a spec for',
             'feature' => 'Write a feature scenario for',
+            'steps' => 'Write the steps for',
+            'implement' => 'Implement',
             'example' => 'Add an example to',
             'refactor' => 'Refactor',
             default => '',
@@ -246,6 +256,36 @@ final class Next extends Command
     private function offerFeature(Input $input, Output $output, string $target): int
     {
         $instruction = 'a feature for ' . $target;
+
+        return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
+    }
+
+    /**
+     * A steps suggestion actuates through `generate`, whose step resolution
+     * writes the step definitions for the named feature deterministically.
+     */
+    private function offerSteps(Input $input, Output $output, string $target): int
+    {
+        $instruction = 'the steps for ' . $target;
+
+        return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
+    }
+
+    /**
+     * A failing class actuates through `generate`, whose "implement" wording
+     * routes to the write-code step with the class and its spec in context. A
+     * subject that is no class (a story slug, a bare string) has no one-shot
+     * actuator, so the hint is the run that shows the failure.
+     */
+    private function offerImplement(Input $input, Output $output, string $target): int
+    {
+        if (preg_match('~^[A-Z][A-Za-z0-9]*(?:\\\\[A-Z][A-Za-z0-9]*)*$~', $target) !== 1) {
+            $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . ' run');
+
+            return 0;
+        }
+
+        $instruction = 'implement ' . $target;
 
         return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
     }
@@ -362,8 +402,8 @@ final class Next extends Command
         }
 
         return match ($step->phase) {
-            Phase::WriteSteps => ['type' => 'info', 'target' => $step->subject, 'reason' => ucfirst($step->because) . '. Write the steps.'],
-            Phase::WriteCode => ['type' => 'info', 'target' => $step->subject, 'reason' => ucfirst($step->because) . '. Make it green.'],
+            Phase::WriteSteps => ['type' => 'steps', 'target' => $step->subject, 'reason' => ucfirst($step->because) . '. Write the steps.'],
+            Phase::WriteCode => ['type' => 'implement', 'target' => $step->subject, 'reason' => ucfirst($step->because) . '. Make it green.'],
             Phase::WriteSpec => ['type' => 'example', 'target' => $step->subject, 'reason' => ucfirst($step->because) . '.'],
             default => null,
         };

--- a/src/PhpSpec/Console/Command/Run/SuiteSummary.php
+++ b/src/PhpSpec/Console/Command/Run/SuiteSummary.php
@@ -43,7 +43,7 @@ final readonly class SuiteSummary
      * @param list<array{subject: string, example: string, error: string}> $failing
      * @param list<array{subject: string, example: string, error: string}> $pending
      * @param array{features: int, scenarios: int, steps: int, stepFailures: int, undefined: int} $featureCounts
-     * @param list<array{path: string, status: 'red'|'green'|'todo', undefined: int}> $features
+     * @param list<array{path: string, status: 'red'|'green'|'todo'|'pending', undefined: int}> $features
      */
     public function __construct(
         private string $status,
@@ -92,16 +92,18 @@ final readonly class SuiteSummary
     }
 
     /**
-     * Reduces a feature to a single red/green/todo verdict plus its undefined-step
-     * count: red if any step failed, todo if any step is still undefined (steps to
-     * write), green otherwise.
+     * Reduces a feature to a single verdict plus its undefined-step count: red
+     * if any step failed, todo if any step is still undefined (steps to
+     * write), pending if any defined step awaits its implementation (the
+     * working story), green otherwise.
      *
-     * @return array{path: string, status: 'red'|'green'|'todo', undefined: int}
+     * @return array{path: string, status: 'red'|'green'|'todo'|'pending', undefined: int}
      */
     private static function summariseFeature(FeatureResult $feature): array
     {
         $failures = 0;
         $undefined = 0;
+        $pending = 0;
         foreach ($feature->getResults() as $scenario) {
             if (!$scenario instanceof ScenarioResult) {
                 continue;
@@ -116,11 +118,18 @@ final readonly class SuiteSummary
                     ++$failures;
                 } elseif ($step->isUndefined()) {
                     ++$undefined;
+                } elseif ($step->isPending()) {
+                    ++$pending;
                 }
             }
         }
 
-        $status = $failures > 0 ? 'red' : ($undefined > 0 ? 'todo' : 'green');
+        $status = match (true) {
+            $failures > 0 => 'red',
+            $undefined > 0 => 'todo',
+            $pending > 0 => 'pending',
+            default => 'green',
+        };
 
         return ['path' => $feature->getPath(), 'status' => $status, 'undefined' => $undefined];
     }
@@ -240,10 +249,11 @@ final readonly class SuiteSummary
     {
         return $this->hasFeatures()
             && $this->featureCounts['stepFailures'] === 0
-            && $this->featureCounts['undefined'] === 0;
+            && $this->featureCounts['undefined'] === 0
+            && !in_array('pending', array_column($this->features, 'status'), true);
     }
 
-    /** @return list<array{path: string, status: 'red'|'green'|'todo', undefined: int}> */
+    /** @return list<array{path: string, status: 'red'|'green'|'todo'|'pending', undefined: int}> */
     public function features(): array
     {
         return $this->features;
@@ -252,7 +262,7 @@ final readonly class SuiteSummary
     /**
      * The first feature with a failing step, or null when none is red.
      *
-     * @return array{path: string, status: 'red'|'green'|'todo', undefined: int}|null
+     * @return array{path: string, status: 'red'|'green'|'todo'|'pending', undefined: int}|null
      */
     public function redFeature(): ?array
     {
@@ -325,7 +335,7 @@ final readonly class SuiteSummary
      * subprocess) is simply read as having no features.
      *
      * @param mixed $items the decoded features list, of unknown shape
-     * @return list<array{path: string, status: 'red'|'green'|'todo', undefined: int}>
+     * @return list<array{path: string, status: 'red'|'green'|'todo'|'pending', undefined: int}>
      */
     private static function normaliseFeatures(mixed $items): array
     {
@@ -343,7 +353,7 @@ final readonly class SuiteSummary
 
             $normalised[] = [
                 'path' => is_string($item['path'] ?? null) ? $item['path'] : '',
-                'status' => in_array($status, ['red', 'green', 'todo'], true) ? $status : 'green',
+                'status' => in_array($status, ['red', 'green', 'todo', 'pending'], true) ? $status : 'green',
                 'undefined' => is_int($item['undefined'] ?? null) ? $item['undefined'] : 0,
             ];
         }

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -813,12 +813,33 @@ class Expectation
                 'object' => self::replaceOne('%s', get_class($value) . '#' . spl_object_id($value), $message),
                 'string' => self::replaceOne('%s', '"' . $value . '"', $message),
                 'boolean' => self::replaceOne('%s', $value ? 'true' : 'false', $message),
-                'array' => self::replaceOne('%s', '[' . implode(', ', $value) . ']', $message),
+                'array' => self::replaceOne('%s', self::formatArray($value), $message),
                 'NULL' => self::replaceOne('%s', 'null', $message),
                 default => self::replaceOne('%s', (string) $value, $message)
             };
         }
         return $message;
+    }
+
+    /**
+     * Renders an array for a failure message, element-safe: objects appear as
+     * Class#id and nested arrays by size, so a failing expectation on a list
+     * of objects reports the failure instead of crashing the formatter.
+     *
+     * @param array<array-key, mixed> $value
+     */
+    private static function formatArray(array $value): string
+    {
+        $parts = array_map(static fn(mixed $item): string => match (gettype($item)) {
+            'object' => get_class($item) . '#' . spl_object_id($item),
+            'array' => 'array(' . count($item) . ')',
+            'string' => '"' . $item . '"',
+            'boolean' => $item ? 'true' : 'false',
+            'NULL' => 'null',
+            default => (string) $item,
+        }, $value);
+
+        return '[' . implode(', ', $parts) . ']';
     }
 
     /**


### PR DESCRIPTION
Dogfood: on a red suite, next printed \"The suite is red: deleting_a_task, deleting_a_task. Make it green.\" and exited. Two defects in one line: the determined steps (write the steps, make it green) resolved to a type with no offer arm, so the deterministic fast path never asked the [Y/n] every other suggestion asks; and the reason printed the failure's subject and example even when they are the same string.

Now the determined steps actuate like the rest:

- A write-steps step offers to run generate \"the steps for <feature>\", which writes the step definitions for that feature deterministically.
- A make-it-green step with a class subject offers generate \"implement <Class>\", whose wording routes to the write-code step with the class and its red spec in context. A subject that is no class (a story slug from a degenerate spec) has no honest one-shot actuator, so it prints the run hint instead of a fake offer.
- The red-suite reason names a subject that matches its example once.

Verification: 1683 examples green on 8.2.30/8.3.16/8.4.4/8.5.3, phpstan clean, cs-fixer clean.