### PR TITLE
Prepare 9.0.0-beta.15

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [9.0.0-beta.15](https://github.com/phpspec/phpspec/compare/9.0.0-beta.14...9.0.0-beta.15)
 
 ### Added
  - Applied refactorings are journalled (.phpspec/ai/journal.jsonl); reversing one demands a stated rationale

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -24,4 +24,4 @@
 
     (new PhpSpec\Console\Application($version))->run();
 
-})('9.0.0-beta.14');
+})('9.0.0-beta.15');


### PR DESCRIPTION
Stamps the Unreleased block as 9.0.0-beta.15 and bumps the version in bin/phpspec.

The release closes the loop the beta.14 dogfooding opened: applied refactorings are journalled and reversing one demands a rationale, refactor asks before applying, next reads the journal and proposes growth itself, every suggestion offers to act through the command that owns the artifact, a pending story reads as the working story and steers to its step bodies, and a red story grounds the model in the actual files. Plus the audited rails: model-written Gherkin with skeleton stand-in on provider failure, reason forwarding into generate, class-over-feature routing precedence, and the object-list failure-message formatter fix.

Verification: 1698 examples and 27 features / 1100 steps green (spec and story suites), version string checked.