### PR TITLE
Error on duplicate step titles and generate one stub per title

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - Two step definitions sharing a title now error at load, naming both locations; matching is keyword-blind, so the duplicate could only shadow silently
+ - A step used twice in a scenario generates one definition, not two
+
 ## [9.0.0-beta.15](https://github.com/phpspec/phpspec/compare/9.0.0-beta.14...9.0.0-beta.15)
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
  - Two step definitions sharing a title now error at load, naming both locations; matching is keyword-blind, so the duplicate could only shadow silently
  - A step used twice in a scenario generates one definition, not two
+ - AI-written steps respect the vocabulary too: content redefining a title another steps file owns is rejected with a pointer to reuse it, and scaffolds skip titles defined elsewhere
 
 ## [9.0.0-beta.15](https://github.com/phpspec/phpspec/compare/9.0.0-beta.14...9.0.0-beta.15)
 

--- a/features/scenarios/story-bdd/story-bdd.feature
+++ b/features/scenarios/story-bdd/story-bdd.feature
@@ -259,3 +259,40 @@ Feature: Story BDD with Gherkin
       """
       then("another outcome"
       """
+
+  Scenario: Two step definitions sharing a title error, whatever their keywords
+    Given a feature file "features/filtering.feature":
+      """
+      Feature: Filtering
+        Scenario: Filtering
+          Given I filter the list
+      """
+    And a step file "features/steps/filtering.steps.php":
+      """
+      <?php
+
+      given("I filter the list", function () {
+          pending();
+      });
+
+      when("I filter the list", function () {
+          pending();
+      });
+      """
+    When I run phpspec run "features/"
+    Then the exit code should be 1
+    And the output should contain "already defined"
+    And the output should contain "I filter the list"
+
+  Scenario: A step used twice in a scenario generates one definition, not two
+    Given a feature file "features/repeats.feature":
+      """
+      Feature: Repeats
+        Scenario: Repeats
+          Given I add a "pending" task "Buy milk"
+          And I add a "completed" task "Buy eggs"
+          When I look at the list
+          Then I see 2 tasks
+      """
+    When I run phpspec run "features/" and answer "y" to generation prompts
+    Then the file "features/steps/repeats.steps.php" should contain "I add a {string} task {string}" exactly 1 times

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -72,6 +72,16 @@ then('the output should contain {string} exactly {int} times', function (string 
     }
 });
 
+then('the file {string} should contain {string} exactly {int} times', function (string $path, string $text, int $times) {
+    $content = (string) file_get_contents($this->projectDir . '/' . $path);
+    $found = substr_count($content, $text);
+    if ($found !== $times) {
+        throw new \RuntimeException(
+            "Expected \"{$path}\" to contain \"{$text}\" exactly {$times} time(s), found {$found}.\nContent:\n{$content}",
+        );
+    }
+});
+
 then('the output should be valid JSON', function () {
     try {
         json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
@@ -138,8 +148,16 @@ then('the class {string} should contain {string}', function (string $path, strin
 });
 
 then('the file {string} should contain {string}', function (string $path, string $text) {
-    $content = file_get_contents($this->projectDir . '/' . $path);
-    expect($content)->toContain($text);
+    $full = $this->projectDir . '/' . $path;
+    if (!file_exists($full)) {
+        throw new \RuntimeException("File not found: $full");
+    }
+    $content = (string) file_get_contents($full);
+    if (!str_contains($content, $text)) {
+        throw new \RuntimeException(
+            "Expected file \"$path\" to contain \"$text\".\nActual content:\n$content",
+        );
+    }
 });
 
 then('the file {string} should contain:', function (string $path, string $text) {

--- a/features/steps/extensions.steps.php
+++ b/features/steps/extensions.steps.php
@@ -2,20 +2,9 @@
 
 /**
  * Extension steps — steps for testing the extension system.
+ * File-content assertions live in assertions.steps.php; step titles are
+ * unique across all steps files.
  */
-
-then('the file {string} should contain {string}', function (string $path, string $expected) {
-    $full = $this->projectDir . '/' . $path;
-    if (!file_exists($full)) {
-        throw new \RuntimeException("File not found: $full");
-    }
-    $content = file_get_contents($full);
-    if (!str_contains($content, $expected)) {
-        throw new \RuntimeException(
-            "Expected file \"$path\" to contain \"$expected\".\nActual content:\n$content"
-        );
-    }
-});
 
 when('I run phpspec command {string}', function (string $command) {
     _phpspec_exec($this, $command);

--- a/spec/PhpSpec/Ai/Agent/ToolRegistry.spec.php
+++ b/spec/PhpSpec/Ai/Agent/ToolRegistry.spec.php
@@ -264,6 +264,71 @@ describe(ToolRegistry::class, function () {
             expect($proposals[0]->new)->toContain('Scenario:');
         });
 
+        it('rejects a steps edit that redefines a title another steps file owns', function (Filesystem $fs) {
+            $cwd = getcwd();
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $cwd . '/features');
+            allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, [$cwd . '/features', $cwd . '/features/steps'], true));
+            allow($fs->isFile())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '.steps.php'));
+            allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+                $cwd . '/features' => ['steps'],
+                $cwd . '/features/steps' => ['adding.steps.php'],
+                default => [],
+            });
+            allow($fs->read())->toReturn("<?php\ngiven('I have a todo list', function () {});\n");
+
+            $call = new ToolCall('1', 'propose_edit', [
+                'path' => 'features/steps/clearing.steps.php',
+                'content' => "<?php\ngiven('I have a todo list', function () { pending(); });\n",
+            ]);
+
+            expect(fn() => $this->registry->fromCalls([$call], null))
+                ->toThrow(RuntimeException::class);
+        });
+
+        it('lets a steps edit replace the titles of the file it targets', function (Filesystem $fs) {
+            $cwd = getcwd();
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $cwd . '/features');
+            allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, [$cwd . '/features', $cwd . '/features/steps'], true));
+            allow($fs->isFile())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '.steps.php'));
+            allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+                $cwd . '/features' => ['steps'],
+                $cwd . '/features/steps' => ['clearing.steps.php'],
+                default => [],
+            });
+            allow($fs->read())->toReturn("<?php\nwhen('I clear the list', function () { pending(); });\n");
+
+            $call = new ToolCall('1', 'propose_edit', [
+                'path' => 'features/steps/clearing.steps.php',
+                'content' => "<?php\nwhen('I clear the list', function () { \$this->list->clear(); });\n",
+            ]);
+
+            $proposals = $this->registry->fromCalls([$call], null);
+
+            expect($proposals[0]->new)->toContain('clear()');
+        });
+
+        it('scaffolds no stub for a step another steps file already defines', function (Filesystem $fs) {
+            $cwd = getcwd();
+            $feature = $cwd . '/features/clearing.feature';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $feature || $p === $cwd . '/features');
+            allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, [$cwd . '/features', $cwd . '/features/steps'], true));
+            allow($fs->isFile())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '.steps.php'));
+            allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+                $cwd . '/features' => ['steps'],
+                $cwd . '/features/steps' => ['adding.steps.php'],
+                default => [],
+            });
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $feature
+                ? "Feature: Clearing\n  Scenario: Clears\n    Given I have a todo list\n    When I clear the list\n"
+                : "<?php\ngiven('I have a todo list', function () {});\n");
+
+            $step = new Step(Phase::WriteSteps, null, 'features/clearing.feature', 'steps are undefined');
+            $proposals = $this->registry->deterministic($step, Grounding::empty(), $this->genProfile);
+
+            expect($proposals[0]->new)->not()->toContain('I have a todo list');
+            expect($proposals[0]->new)->toContain('I clear the list');
+        });
+
         it('serves a write_steps call from the argument feature path when the step has none', function (Filesystem $fs) {
             allow($fs->exists())->toReturnUsing(fn(string $path): bool => str_ends_with($path, 'features/adding.feature'));
             allow($fs->read())->toReturn("Feature: Adding\n  Scenario: A\n    Given a list\n");

--- a/spec/PhpSpec/CodeGeneration/StepGenerator.spec.php
+++ b/spec/PhpSpec/CodeGeneration/StepGenerator.spec.php
@@ -95,4 +95,23 @@ describe(StepGenerator::class, function () {
         expect(substr_count($content, 'I have a todo list'))->toBe(1); // kept, not duplicated
         expect($content)->toContain('then("I should have {int} task on my list"');
     });
+
+    it('emits one definition for a step used twice, whatever its values', function () {
+        $content = (new StepGenerator($this->filesystem))->skeleton([
+            ['keyword' => 'Given', 'text' => 'I add a "pending" task "Buy milk"'],
+            ['keyword' => 'And', 'text' => 'I add a "completed" task "Buy eggs"'],
+        ]);
+
+        expect(substr_count($content, 'I add a {string} task {string}'))->toBe(1);
+    });
+
+    it('recognises a single-quoted existing definition as already defined', function () {
+        $existing = "<?php\n\ngiven('I have a todo list', function () {\n    pending();\n});\n";
+
+        $content = (new StepGenerator($this->filesystem))->skeleton([
+            ['keyword' => 'Given', 'text' => 'I have a todo list'],
+        ], $existing);
+
+        expect(substr_count($content, 'I have a todo list'))->toBe(1);
+    });
 });

--- a/spec/PhpSpec/CodeGeneration/StepGenerator.spec.php
+++ b/spec/PhpSpec/CodeGeneration/StepGenerator.spec.php
@@ -105,6 +105,16 @@ describe(StepGenerator::class, function () {
         expect(substr_count($content, 'I add a {string} task {string}'))->toBe(1);
     });
 
+    it('never scaffolds a title another steps file already defines', function () {
+        $content = (new StepGenerator($this->filesystem))->skeleton([
+            ['keyword' => 'Given', 'text' => 'I have a todo list'],
+            ['keyword' => 'When', 'text' => 'I clear the list'],
+        ], '', ['I have a todo list']);
+
+        expect($content)->not()->toContain('I have a todo list');
+        expect($content)->toContain('when("I clear the list"');
+    });
+
     it('recognises a single-quoted existing definition as already defined', function () {
         $existing = "<?php\n\ngiven('I have a todo list', function () {\n    pending();\n});\n";
 

--- a/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
+++ b/spec/PhpSpec/Console/Command/Pair/AiAssistant.spec.php
@@ -628,6 +628,43 @@ describe(AiAssistant::class, function () {
         expect((string) json_encode($captured))->toContain('describe(');
     });
 
+    it('rejects steps content redefining a title another steps file owns, steering to reuse', function (Filesystem $fs) {
+        $cwd = getcwd();
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => in_array($p, [$cwd . '/features', $cwd . '/features/steps/adding.steps.php'], true));
+        allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, [$cwd . '/features', $cwd . '/features/steps'], true));
+        allow($fs->isFile())->toReturnUsing(fn(string $p): bool => str_ends_with($p, 'adding.steps.php'));
+        allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+            $cwd . '/features' => ['steps'],
+            $cwd . '/features/steps' => ['adding.steps.php'],
+            default => [],
+        });
+        allow($fs->read())->toReturnUsing(fn(string $p): string => str_ends_with($p, 'adding.steps.php')
+            ? "<?php\ngiven('I have a todo list', function () { \$this->list = new App\\TodoList(); });\n"
+            : '');
+
+        $captured = null;
+        $turn = 0;
+        $this->provider->responder = function (array $messages) use (&$captured, &$turn) {
+            if (++$turn === 1) {
+                return new Response('', [new ToolCall('t1', 'generate_steps', [
+                    'feature_name' => 'clearing',
+                    'content' => "<?php\ngiven(\"I have a todo list\", function () {\n    \$this->todoList = new App\\TodoList();\n});\n",
+                ])]);
+            }
+            $captured = $messages;
+
+            return new Response('done');
+        };
+
+        $assistant = new AiAssistant($this->provider, $this->config, $this->pairOutput, 'test-model', $fs, true, null, $this->chooser, $this->aiDrives, $this->specRunner);
+        $this->answers = ['1'];
+        $assistant->handle('write the steps for clearing');
+
+        expect($fs->write())->not()->toHaveBeenCalled();
+        expect((string) json_encode($captured))->toContain('already defined in');
+        expect((string) json_encode($captured))->toContain('reuse');
+    });
+
     it('rejects shouldXxx spec content even without the ObjectBehavior literal', function (Filesystem $fs) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturn("<?php\ndescribe(Basket::class, function () {});\n");

--- a/spec/PhpSpec/StoryBDD/StepRegistry.spec.php
+++ b/spec/PhpSpec/StoryBDD/StepRegistry.spec.php
@@ -11,6 +11,41 @@ describe(StepRegistry::class, function () {
         expect($this->registry)->toBeAnInstanceOf(StepRegistry::class);
     });
 
+    it("rejects a second definition with the same title", function () {
+        $this->registry->addStep("I filter the list", function () {});
+
+        expect(fn() => $this->registry->addStep("I filter the list", function () {}))
+            ->toThrow(RuntimeException::class);
+    });
+
+    it("rejects the duplicate whatever its keyword, because matching is keyword-blind", function () {
+        given("the list is filtered", function () {});
+
+        expect(fn() => then("the list is filtered", function () {}))
+            ->toThrow(RuntimeException::class);
+
+        PhpSpec\StoryBDD\StoryBDDRegistry::init();
+    });
+
+    it("names both definitions in the duplicate error", function () {
+        $this->registry->addStep("I filter the list", function () {});
+
+        try {
+            $this->registry->addStep("I filter the list", function () {});
+        } catch (RuntimeException $e) {
+            expect($e->getMessage())->toContain('"I filter the list"');
+            expect($e->getMessage())->toContain('StepRegistry.spec.php');
+        }
+    });
+
+    it("accepts the same title again after a clear", function () {
+        $this->registry->addStep("I filter the list", function () {});
+        $this->registry->clear();
+        $this->registry->addStep("I filter the list", function () {});
+
+        expect($this->registry->count())->toBe(1);
+    });
+
     it("returns null for unmatched step", function () {
         expect($this->registry->match("no such step"))->toBeNull();
     });

--- a/spec/PhpSpec/StoryBDD/StepVocabulary.spec.php
+++ b/spec/PhpSpec/StoryBDD/StepVocabulary.spec.php
@@ -1,0 +1,97 @@
+<?php
+
+use PhpSpec\Filesystem;
+use PhpSpec\StoryBDD\StepVocabulary;
+
+describe(StepVocabulary::class, function () {
+
+    beforeEach(function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(false);
+        allow($fs->isDir())->toReturn(false);
+        allow($fs->isFile())->toReturn(false);
+        allow($fs->scandir())->toReturn([]);
+    });
+
+    it('parses definition titles out of steps content, whatever the keyword or quoting', function (Filesystem $fs) {
+        $titles = (new StepVocabulary($fs))->titlesIn(
+            "<?php\n\ngiven('I have a todo list', function () {});\n"
+            . "when(\"I add a {string} task\", function (string \$t) {});\n"
+            . "step_and('something else happens', function () {});\n",
+        );
+
+        expect($titles)->toBe(['I have a todo list', 'I add a {string} task', 'something else happens']);
+    });
+
+    it('maps every title to the steps file defining it under a features root', function (Filesystem $fs) {
+        $root = '/project/features';
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $root);
+        allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, [$root, $root . '/steps'], true));
+        allow($fs->isFile())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '.steps.php'));
+        allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+            $root => ['steps', 'adding.feature'],
+            $root . '/steps' => ['adding.steps.php'],
+            default => [],
+        });
+        allow($fs->read())->toReturn("<?php\ngiven('I have a todo list', function () {});\n");
+
+        $titles = (new StepVocabulary($fs))->definedTitles($root);
+
+        expect($titles)->toBe(['I have a todo list' => '/project/features/steps/adding.steps.php']);
+    });
+
+    it('rejects content defining the same title twice', function (Filesystem $fs) {
+        $message = (new StepVocabulary($fs))->rejectionFor(
+            "<?php\ngiven('I filter the list', function () {});\nwhen('I filter the list', function () {});\n",
+            'features/steps/filtering.steps.php',
+            '/project/features',
+        );
+
+        expect($message)->toContain('"I filter the list"');
+        expect($message)->toContain('twice');
+    });
+
+    it('rejects content redefining a title another steps file owns, naming that file', function (Filesystem $fs) {
+        $root = '/project/features';
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $root);
+        allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, [$root, $root . '/steps'], true));
+        allow($fs->isFile())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '.steps.php'));
+        allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+            $root => ['steps'],
+            $root . '/steps' => ['adding.steps.php'],
+            default => [],
+        });
+        allow($fs->read())->toReturn("<?php\ngiven('I have a todo list', function () {});\n");
+
+        $message = (new StepVocabulary($fs))->rejectionFor(
+            "<?php\ngiven('I have a todo list', function () {});\n",
+            'features/steps/clearing.steps.php',
+            $root,
+        );
+
+        expect($message)->toContain('"I have a todo list"');
+        expect($message)->toContain('adding.steps.php');
+        expect($message)->toContain('reuse');
+    });
+
+    it('allows a file to redefine its own titles: an edit replaces the file', function (Filesystem $fs) {
+        $root = '/project/features';
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $root);
+        allow($fs->isDir())->toReturnUsing(fn(string $p): bool => in_array($p, [$root, $root . '/steps'], true));
+        allow($fs->isFile())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '.steps.php'));
+        allow($fs->scandir())->toReturnUsing(fn(string $p): array => match ($p) {
+            $root => ['steps'],
+            $root . '/steps' => ['clearing.steps.php'],
+            default => [],
+        });
+        allow($fs->read())->toReturn("<?php\ngiven('I clear the list', function () { pending(); });\n");
+
+        $message = (new StepVocabulary($fs))->rejectionFor(
+            "<?php\ngiven('I clear the list', function () { \$this->list->clear(); });\n",
+            'features/steps/clearing.steps.php',
+            $root,
+        );
+
+        expect($message)->toBeNull();
+    });
+
+});

--- a/src/PhpSpec/Ai/Agent/ToolRegistry.php
+++ b/src/PhpSpec/Ai/Agent/ToolRegistry.php
@@ -25,6 +25,7 @@ use PhpSpec\CodeGeneration\LegacySpecDetector;
 use PhpSpec\CodeGeneration\StepGenerator;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
+use PhpSpec\StoryBDD\StepVocabulary;
 use RuntimeException;
 
 /**
@@ -66,6 +67,8 @@ final class ToolRegistry
 
     private readonly FeatureLayout $layout;
 
+    private readonly StepVocabulary $vocabulary;
+
     /**
      * @param Configuration $config the project configuration (layout paths)
      * @param Filesystem $filesystem filesystem abstraction for testability
@@ -80,6 +83,7 @@ final class ToolRegistry
         $this->featureGenerator = new FeatureGenerator();
         $this->stepGenerator = new StepGenerator($filesystem);
         $this->layout = new FeatureLayout();
+        $this->vocabulary = new StepVocabulary($filesystem);
     }
 
     /**
@@ -290,6 +294,13 @@ final class ToolRegistry
             throw new RuntimeException('The proposed spec uses phpspec 8 ObjectBehavior syntax; phpspec 9 specs use the describe/it/expect DSL, so it was rejected.');
         }
 
+        if (str_ends_with($path, '.steps.php')) {
+            $rejection = $this->vocabulary->rejectionFor($content, $path, $this->featuresRoot());
+            if ($rejection !== null) {
+                throw new RuntimeException($rejection);
+            }
+        }
+
         return $this->proposal($path, $content, 'propose_edit');
     }
 
@@ -419,7 +430,25 @@ final class ToolRegistry
         $absSteps = $this->absolute($relSteps);
         $existing = $this->filesystem->exists($absSteps) ? $this->filesystem->read($absSteps) : '';
 
-        return new Proposal($relSteps, $existing, $this->stepGenerator->skeleton($steps, $existing), $existing === '', 'write_steps');
+        // A title another steps file owns is already defined for the whole
+        // suite, so the scaffold skips it instead of planting a duplicate
+        // that would error at the next load.
+        $foreign = [];
+        foreach ($this->vocabulary->definedTitles($this->featuresRoot()) as $title => $file) {
+            if (basename($file) !== basename($relSteps)) {
+                $foreign[] = $title;
+            }
+        }
+
+        return new Proposal($relSteps, $existing, $this->stepGenerator->skeleton($steps, $existing, $foreign), $existing === '', 'write_steps');
+    }
+
+    /**
+     * The absolute features root the vocabulary scans.
+     */
+    private function featuresRoot(): string
+    {
+        return $this->absolute(trim($this->config->getFeaturesPath(), './'));
     }
 
     /**

--- a/src/PhpSpec/CodeGeneration/StepGenerator.php
+++ b/src/PhpSpec/CodeGeneration/StepGenerator.php
@@ -67,9 +67,10 @@ class StepGenerator
      *
      * @param array<int, array{keyword: string, text: string}> $steps steps with 'keyword' and 'text' keys
      * @param string $existing the current steps-file content, empty for a new file
+     * @param list<string> $definedElsewhere titles other steps files already define, never re-scaffolded
      * @return string the complete new steps-file content
      */
-    public function skeleton(array $steps, string $existing = ''): string
+    public function skeleton(array $steps, string $existing = '', array $definedElsewhere = []): string
     {
         $content = $existing === '' ? "<?php\n" : rtrim($existing) . "\n";
 
@@ -90,7 +91,7 @@ class StepGenerator
                 $keyword = $primary;
             }
             $pattern = $this->extractPattern($step['text']);
-            if (isset($emitted[$pattern]) || ($existing !== '' && $this->defines($existing, $pattern))) {
+            if (isset($emitted[$pattern]) || in_array($pattern, $definedElsewhere, true) || ($existing !== '' && $this->defines($existing, $pattern))) {
                 continue;
             }
             $emitted[$pattern] = true;

--- a/src/PhpSpec/CodeGeneration/StepGenerator.php
+++ b/src/PhpSpec/CodeGeneration/StepGenerator.php
@@ -77,6 +77,11 @@ class StepGenerator
         // an "And" under a When generates when(), under a Then generates then().
         $primary = 'given';
 
+        // One definition per title: a step used twice in a scenario (or an
+        // already-defined one, whichever quotes it uses) registers once, and a
+        // second definition would now be rejected at load.
+        $emitted = [];
+
         foreach ($steps as $step) {
             $keyword = strtolower($step['keyword']);
             if (in_array($keyword, ['given', 'when', 'then'], true)) {
@@ -85,9 +90,10 @@ class StepGenerator
                 $keyword = $primary;
             }
             $pattern = $this->extractPattern($step['text']);
-            if ($existing !== '' && str_contains($existing, '"' . $pattern . '"')) {
+            if (isset($emitted[$pattern]) || ($existing !== '' && $this->defines($existing, $pattern))) {
                 continue;
             }
+            $emitted[$pattern] = true;
             $params = $this->extractParams($pattern);
 
             $content .= "\n$keyword(\"$pattern\", function ($params) {\n";
@@ -96,6 +102,15 @@ class StepGenerator
         }
 
         return $content;
+    }
+
+    /**
+     * Whether a steps file's content already defines the given pattern, in
+     * either quoting style.
+     */
+    private function defines(string $content, string $pattern): bool
+    {
+        return str_contains($content, '"' . $pattern . '"') || str_contains($content, "'" . $pattern . "'");
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Pair/AiAssistant.php
+++ b/src/PhpSpec/Console/Command/Pair/AiAssistant.php
@@ -35,6 +35,8 @@ use PhpSpec\Console\Command\Run\SuiteSummary;
 use PhpSpec\Extensions\ExtensionLoader;
 use PhpSpec\Filesystem;
 use PhpSpec\RealFilesystem;
+use PhpSpec\StoryBDD\StepVocabulary;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -832,10 +834,20 @@ final class AiAssistant
     /**
      * A proposal for an absolute path and content, reading any existing file so
      * the diff shown is real. Tools only ever produce these; nothing writes
-     * except the gate below.
+     * except the gate below. Steps content is checked against the project's
+     * step vocabulary first: a title registers once across all steps files,
+     * so a duplicate is rejected here instead of erroring at the next load.
      */
     private function proposalFor(string $absPath, string $content, string $origin): Proposal
     {
+        if (str_ends_with($absPath, '.steps.php')) {
+            $root = getcwd() . '/' . trim($this->config->getFeaturesPath(), './');
+            $rejection = (new StepVocabulary($this->filesystem))->rejectionFor($content, $absPath, $root);
+            if ($rejection !== null) {
+                throw new RuntimeException($rejection);
+            }
+        }
+
         $exists = $this->filesystem->exists($absPath);
 
         return new Proposal(ProjectPath::relative($absPath), $exists ? $this->filesystem->read($absPath) : '', $content, !$exists, $origin);

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -186,7 +186,15 @@ final class Run extends Command
             return 1;
         }
 
-        $results = $this->runSuiteStreaming($input, $output);
+        try {
+            $results = $this->runSuiteStreaming($input, $output);
+        } catch (\RuntimeException $e) {
+            // A load-time contract violation (e.g. two step definitions
+            // sharing a title) is the user's to fix; report it, never a trace.
+            $output->writeln(sprintf('<fg=red>%s</>', $e->getMessage()));
+
+            return 1;
+        }
 
         $this->writeReportFiles($input, $output, $results);
         $this->printProfile($input, $output, $results);
@@ -345,6 +353,7 @@ final class Run extends Command
      * @return SuiteResult the aggregated suite results
      *
      * @throws RandomException
+     * @throws \RuntimeException when the loader rejects a duplicate step title
      */
     private function runSuiteStreaming(Input $input, Output $output): SuiteResult
     {

--- a/src/PhpSpec/Loader.php
+++ b/src/PhpSpec/Loader.php
@@ -51,6 +51,8 @@ final class Loader
      *
      * @param string|null $files directory or file path; defaults to ./spec
      * @param string|null $filter substring to match against spec file paths
+     *
+     * @throws \RuntimeException when a steps file registers a step title that is already defined
      */
     public function load(?string $files, ?string $filter = null): Suite
     {

--- a/src/PhpSpec/StoryBDD/StepRegistry.php
+++ b/src/PhpSpec/StoryBDD/StepRegistry.php
@@ -14,15 +14,23 @@
 
 namespace PhpSpec\StoryBDD;
 
+use RuntimeException;
+
 /**
  * @internal
  * Maps step patterns to closures for matching against Gherkin step text.
  * Patterns use {string}, {int}, {word}, and {*} placeholders that are converted to regex capture groups.
+ * A title registers once: matching is global and keyword-blind, so a second
+ * definition of the same title (even under another keyword) could only shadow
+ * or be shadowed silently, and is rejected instead.
  */
 final class StepRegistry
 {
     /** @var array<int, array{pattern: string, regex: string, callback: \Closure}> registered step definitions */
     private array $steps = [];
+
+    /** @var array<string, string> pattern => source location of its definition */
+    private array $definedAt = [];
 
     /**
      * Registers a step definition with a pattern and its implementing closure.
@@ -30,14 +38,42 @@ final class StepRegistry
      * @param string $pattern step pattern with optional {string}/{int}/{word}/{*} placeholders
      * @param \Closure $callback the closure to execute when the pattern matches
      * @return void
+     *
+     * @throws RuntimeException when the pattern is already registered
      */
     public function addStep(string $pattern, \Closure $callback): void
     {
+        if (isset($this->definedAt[$pattern])) {
+            throw new RuntimeException(sprintf(
+                'Step "%s" is already defined at %s; remove the duplicate at %s. Step titles must be unique across all steps files, whatever their keyword.',
+                $pattern,
+                $this->definedAt[$pattern],
+                self::locationOf($callback),
+            ));
+        }
+
+        $this->definedAt[$pattern] = self::locationOf($callback);
         $this->steps[] = [
             'pattern' => $pattern,
             'regex' => $this->patternToRegex($pattern),
             'callback' => $callback,
         ];
+    }
+
+    /**
+     * The file:line a step closure was written at, relative to the project when
+     * possible, so a duplicate error points straight at both definitions.
+     */
+    private static function locationOf(\Closure $callback): string
+    {
+        $reflection = new \ReflectionFunction($callback);
+        $file = $reflection->getFileName() ?: 'unknown';
+        $cwd = getcwd();
+        if (is_string($cwd) && str_starts_with($file, $cwd . DIRECTORY_SEPARATOR)) {
+            $file = substr($file, strlen($cwd) + 1);
+        }
+
+        return $file . ':' . ($reflection->getStartLine() ?: 0);
     }
 
     /**
@@ -66,6 +102,7 @@ final class StepRegistry
     public function clear(): void
     {
         $this->steps = [];
+        $this->definedAt = [];
     }
 
     /**

--- a/src/PhpSpec/StoryBDD/StepVocabulary.php
+++ b/src/PhpSpec/StoryBDD/StepVocabulary.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\StoryBDD;
+
+use PhpSpec\Filesystem;
+
+/**
+ * @internal
+ * The project's step vocabulary as written on disk: which titles the steps
+ * files define, without loading them. Writers consult it before proposing
+ * steps content, because a title registers once across all files and a
+ * duplicate errors at load.
+ */
+final class StepVocabulary
+{
+    private const DEFINITION = '~\b(?:given|when|then|step_and|step_but)\s*\(\s*(["\'])(.*?)\1~';
+
+    public function __construct(private readonly Filesystem $filesystem) {}
+
+    /**
+     * The definition titles a steps file's content declares, in order.
+     *
+     * @return list<string>
+     */
+    public function titlesIn(string $content): array
+    {
+        preg_match_all(self::DEFINITION, $content, $matches);
+
+        return $matches[2];
+    }
+
+    /**
+     * Every title defined under a features root, mapped to the file defining
+     * it (the first, when a legacy tree still holds duplicates).
+     *
+     * @param string $featuresRoot absolute path of the features directory
+     * @return array<string, string> title => absolute steps-file path
+     */
+    public function definedTitles(string $featuresRoot): array
+    {
+        $titles = [];
+        foreach ($this->stepsFilesUnder($featuresRoot) as $file) {
+            foreach ($this->titlesIn($this->filesystem->read($file)) as $title) {
+                $titles[$title] ??= $file;
+            }
+        }
+
+        return $titles;
+    }
+
+    /**
+     * Why proposed steps content must not be written, or null when it may: a
+     * title defined twice within it, or a title another steps file already
+     * owns. The target file's own titles are exempt, because writing the file
+     * replaces them.
+     *
+     * @param string $content the proposed steps-file content
+     * @param string $targetPath the file the content is destined for (any base)
+     * @param string $featuresRoot absolute path of the features directory
+     */
+    public function rejectionFor(string $content, string $targetPath, string $featuresRoot): ?string
+    {
+        $titles = $this->titlesIn($content);
+        $duplicate = $this->firstDuplicate($titles);
+        if ($duplicate !== null) {
+            return sprintf('The proposed steps define "%s" twice; a step title registers once, so define it once and reuse it.', $duplicate);
+        }
+
+        $target = basename($targetPath);
+        foreach ($this->definedTitles($featuresRoot) as $title => $file) {
+            if (basename($file) === $target) {
+                continue;
+            }
+
+            if (in_array($title, $titles, true)) {
+                return sprintf('Step "%s" is already defined in "%s"; reuse that step instead of redefining it.', $title, $file);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The first title appearing more than once, or null when all are unique.
+     *
+     * @param list<string> $titles
+     */
+    private function firstDuplicate(array $titles): ?string
+    {
+        $seen = [];
+        foreach ($titles as $title) {
+            if (isset($seen[$title])) {
+                return $title;
+            }
+
+            $seen[$title] = true;
+        }
+
+        return null;
+    }
+
+    /**
+     * Every *.steps.php file under a directory, recursively.
+     *
+     * @return list<string> absolute paths
+     */
+    private function stepsFilesUnder(string $dir): array
+    {
+        if (!$this->filesystem->isDir($dir)) {
+            return [];
+        }
+
+        $files = [];
+        foreach ($this->filesystem->scandir($dir) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            if ($this->filesystem->isDir($path)) {
+                $files = array_merge($files, $this->stepsFilesUnder($path));
+
+                continue;
+            }
+
+            if (str_ends_with($entry, '.steps.php')) {
+                $files[] = $path;
+            }
+        }
+
+        return $files;
+    }
+}


### PR DESCRIPTION
Dogfood bug: a scenario using the same step twice (\"Given I add a 'pending' task ... / And I add a 'completed' task ...\") got two identical pending stubs appended to its steps file. Deeper, duplicate step titles across files are a silent trap: runtime matching is global and keyword-blind, first definition wins, and a second definition against a different context property crashes confusingly far from the cause (seen live: \"Call to a member function add() on null\").

Two changes:

- StepRegistry rejects a second definition of a title it already holds, whatever the keyword, with a message naming both locations (file:line of each closure, via reflection): Step \"I filter the list\" is already defined at features/steps/a.steps.php:3; remove the duplicate at features/steps/b.steps.php:7. The run reports it red and exits 1; no stack trace.
- StepGenerator emits one definition per title: a step used twice in a scenario produces a single stub, and an existing definition is recognised in either quoting style.

Our own suite carried one duplicate (the file-should-contain assertion, defined in both assertions and extensions steps); the richer of the two bodies now lives once in assertions.steps.php. A new world assertion (file should contain exactly N times) locks the generator behaviour.

Verification: 1704 examples and 27 features / 220 scenarios / 1111 steps green on 8.2.30/8.3.16/8.4.4/8.5.3, coverage 92%, phpstan and cs-fixer clean.