### PR TITLE
Present every AI command outcome as the agent document under --format=agent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - `--format=agent` on every command: `next` emits its suggestion with the exact command that acts on it, `generate` applies and emits receipts, `describe`/`exemplify` accept it as the canonical spelling of `--agent` (now a deprecated alias)
+
 ### Fixed
  - Two step definitions sharing a title now error at load, naming both locations; matching is keyword-blind, so the duplicate could only shadow silently
  - A step used twice in a scenario generates one definition, not two
  - AI-written steps respect the vocabulary too: content redefining a title another steps file owns is rejected with a pointer to reuse it, and scaffolds skip titles defined elsewhere
+ - The run agent document reports the real random seed and what was run, never `seed: null` and `suite: "default"` placeholders
 
 ## [9.0.0-beta.15](https://github.com/phpspec/phpspec/compare/9.0.0-beta.14...9.0.0-beta.15)
 

--- a/features/scenarios/cli/agent-commands.feature
+++ b/features/scenarios/cli/agent-commands.feature
@@ -27,3 +27,36 @@ Feature: Agent scaffolding commands
     And the output should contain "checkout"
     And a spec file "spec/App/Basket.spec.php" should be generated
     And the spec file should contain an example for "checkout"
+
+  Scenario: describe accepts --format=agent as the canonical spelling of --agent
+    When I run phpspec command "describe App/Cart --format=agent"
+    Then the output should be valid JSON
+    And the output should contain "describe"
+    And a spec file "spec/App/Cart.spec.php" should be generated
+
+  Scenario: exemplify accepts --format=agent too
+    When I run phpspec command "describe App/Cart --format=agent"
+    And I run phpspec command "exemplify App/Cart total --format=agent"
+    Then the output should be valid JSON
+    And the output should contain "total"
+
+  Scenario: generate emits the agent document with applied receipts under --format=agent
+    Given a phpspec.yaml config:
+      """
+      ai:
+        provider: google
+        api_key: test-key
+      """
+    And a feature file "features/adding_a_task.feature":
+      """
+      Feature: Adding a task
+        Scenario: Adding a task
+          Given I have a todo list
+          When I add the task "Buy milk"
+          Then I should have 1 task on my list
+      """
+    When I run phpspec command "generate the steps --format=agent"
+    Then the output should be valid JSON
+    And the output should contain "applied"
+    And the output should contain "features/steps/adding_a_task.steps.php"
+    And the file "features/steps/adding_a_task.steps.php" should contain "given("

--- a/spec/PhpSpec/Ai/Agent/OutcomePresenter.spec.php
+++ b/spec/PhpSpec/Ai/Agent/OutcomePresenter.spec.php
@@ -1,0 +1,63 @@
+<?php
+
+use PhpSpec\Ai\Agent\Outcome;
+use PhpSpec\Ai\Agent\OutcomePresenter;
+use PhpSpec\Ai\Agent\Phase;
+use PhpSpec\Ai\Agent\Proposal;
+use PhpSpec\Ai\Agent\Step;
+
+describe(OutcomePresenter::class, function () {
+
+    it('renders a next suggestion with the exact command that acts on it', function () {
+        $outcome = new Outcome(
+            new Step(Phase::Refactor, null, null, 'features are green: refactor, or grow the story'),
+            [],
+            '',
+            ['type' => 'feature', 'target' => 'deleting_a_task', 'reason' => 'The list only grows.'],
+        );
+
+        $document = (new OutcomePresenter())->document('next', $outcome, [], 'vendor/bin/phpspec generate "a feature for deleting_a_task"');
+
+        expect($document['command']['command'])->toBe('next');
+        expect($document['suggestion']['type'])->toBe('feature');
+        expect($document['suggestion']['target'])->toBe('deleting_a_task');
+        expect($document['suggestion']['run'])->toBe('vendor/bin/phpspec generate "a feature for deleting_a_task"');
+        expect($document['step']['phase'])->toBe('refactor');
+        expect($document['actionable'])->toBe(1);
+    });
+
+    it('renders generate proposals as path, action, and applied, never file content', function () {
+        $outcome = new Outcome(
+            new Step(Phase::WriteFeature, 'features/adding.feature', null, 'you named it'),
+            [
+                new Proposal('features/adding.feature', '', "Feature: Adding\n", true, 'write_feature'),
+                new Proposal('features/steps/adding.steps.php', 'old', 'new', false, 'write_steps'),
+            ],
+        );
+
+        $document = (new OutcomePresenter())->document('generate', $outcome, [true, false]);
+
+        expect($document['proposals'][0])->toBe(['path' => 'features/adding.feature', 'action' => 'create', 'applied' => true]);
+        expect($document['proposals'][1])->toBe(['path' => 'features/steps/adding.steps.php', 'action' => 'update', 'applied' => false]);
+        expect($document['actionable'])->toBe(1);
+        expect((string) json_encode($document))->not()->toContain('Feature: Adding');
+    });
+
+    it('carries the prose and reports nothing actionable when there is nothing to act on', function () {
+        $document = (new OutcomePresenter())->document('generate', new Outcome(null, [], 'The model returned no usable answer.'));
+
+        expect($document['prose'])->toBe('The model returned no usable answer.');
+        expect($document['actionable'])->toBe(0);
+        expect(array_key_exists('step', $document))->toBe(false);
+        expect(array_key_exists('suggestion', $document))->toBe(false);
+    });
+
+    it('emits one JSON line, raw and unescaped', function () {
+        $json = (new OutcomePresenter())->render('next', new Outcome(null, [], 'a/b stays a/b'));
+
+        expect($json)->toContain('"command":"next"');
+        expect($json)->toContain('a/b stays a/b');
+        expect($json)->not()->toContain('a\/b');
+    });
+
+});

--- a/spec/PhpSpec/Console/Command/Next.spec.php
+++ b/spec/PhpSpec/Console/Command/Next.spec.php
@@ -869,6 +869,64 @@ describe(Next::class, function () {
             expect($tester->getDisplay())->not()->toContain('Would you like me to create that for you?');
         });
 
+        it('emits the agent document with the actuating command under --format=agent, never a prompt', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
+            allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: test-key\n" : '');
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'feature',
+                'target' => 'deleting_a_task',
+                'reason' => 'The list only grows.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $tester = new CommandTester($cmd);
+            $exitCode = $tester->execute(['--format' => 'agent']);
+
+            expect($exitCode)->toBe(0);
+            $document = json_decode(trim($tester->getDisplay()), true);
+            expect($document['command']['command'])->toBe('next');
+            expect($document['suggestion']['type'])->toBe('feature');
+            expect($document['suggestion']['run'])->toContain('generate "a feature for deleting_a_task"');
+            expect($tester->getDisplay())->not()->toContain('Would you like');
+            expect($tester->getDisplay())->not()->toContain('Analysing');
+        });
+
+        it('keeps the growth steer inside the agent document', function (Filesystem $fs) {
+            $yamlPath = './phpspec.yaml';
+            $cwd = getcwd();
+            $srcFile = $cwd . '/src/App/TodoList.php';
+            allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath || $p === $srcFile || str_contains($p, 'journal.jsonl'));
+            allow($fs->read())->toReturnUsing(function (string $p) use ($yamlPath): string {
+                if ($p === $yamlPath) {
+                    return "ai:\n  provider: google\n  api_key: test-key\n";
+                }
+                if (str_contains($p, 'journal.jsonl')) {
+                    return '{"at":1000,"command":"refactor","target":"App\\\\TodoList","technique":"Inline Method","description":"x"}' . "\n";
+                }
+                return '';
+            });
+            allow($fs->mtime())->toReturn(900);
+
+            $configWithAi = new Configuration('.', $fs);
+            $suggestFn = fn(array $aiConfig): array => [
+                'type' => 'refactor',
+                'target' => 'App\\TodoList',
+                'reason' => 'The suite is green.',
+            ];
+            $cmd = new Next($configWithAi, $fs, $suggestFn);
+
+            $tester = new CommandTester($cmd);
+            $exitCode = $tester->execute(['--format' => 'agent']);
+
+            expect($exitCode)->toBe(0);
+            $document = json_decode(trim($tester->getDisplay()), true);
+            expect($document['suggestion']['type'])->toBe('info');
+            expect($document['prose'] ?? $document['suggestion']['reason'])->toContain('already refactored');
+        });
+
         it('passes AI config to the suggest function', function (Filesystem $fs) {
             $yamlPath = './phpspec.yaml';
             allow($fs->exists())->toReturnUsing(function (string $path) use ($yamlPath): bool {

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -31,6 +31,19 @@ describe(Agent::class, function () {
         expect($doc['suite'])->toBe(['v' => 1, 'event' => 'run_started', 'suite' => 'default', 'examples' => 1, 'steps' => 0, 'seed' => null]);
     });
 
+    it('reports the seed and suite it was told about, so a flaky order is reproducible', function () {
+        $output = new BufferedOutput();
+        $formatter = new Agent($output);
+        $formatter->describeRun(424242, 'spec,features/');
+        $formatter->format(new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
+        ]));
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+
+        expect($doc['suite']['seed'])->toBe(424242);
+        expect($doc['suite']['suite'])->toBe('spec,features/');
+    });
+
     it('omits passing examples from the entries but still counts them', function () use ($render) {
         $doc = $render(new SuiteResult([
             new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),

--- a/src/PhpSpec/Ai/Agent/OutcomePresenter.php
+++ b/src/PhpSpec/Ai/Agent/OutcomePresenter.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Ai\Agent;
+
+use PhpSpec\Report\Formatter\Agent\Schema;
+
+/**
+ * @internal
+ * Renders an Outcome as the machine-readable agent document, the one presenter
+ * behind `--format=agent` for the AI commands: the resolved step, the
+ * suggestion with the exact command that acts on it, the proposals as
+ * path/action/applied receipts (never file content; the agent reads the file),
+ * the prose, and the one number an agent checks: what is left to act on.
+ */
+final class OutcomePresenter
+{
+    /**
+     * The document as an array.
+     *
+     * @param string $command the AI command that produced the outcome
+     * @param list<bool> $applied whether each proposal (by index) reached disk
+     * @param string|null $run the exact invocation that acts on the suggestion
+     * @return array<string, mixed>
+     */
+    public function document(string $command, Outcome $outcome, array $applied = [], ?string $run = null): array
+    {
+        $document = [
+            'command' => [
+                'v' => Schema::V,
+                'event' => 'command_result',
+                'command' => $command,
+            ],
+        ];
+
+        if ($outcome->step !== null) {
+            $document['step'] = [
+                'phase' => $outcome->step->phase->value,
+                'path' => $outcome->step->path,
+                'subject' => $outcome->step->subject,
+                'because' => $outcome->step->because,
+            ];
+        }
+
+        if ($outcome->data !== []) {
+            $document['suggestion'] = $outcome->data;
+            if ($run !== null) {
+                $document['suggestion']['run'] = $run;
+            }
+        }
+
+        $unapplied = 0;
+        if ($outcome->proposals !== []) {
+            $document['proposals'] = [];
+            foreach ($outcome->proposals as $index => $proposal) {
+                $wasApplied = $applied[$index] ?? false;
+                $document['proposals'][] = [
+                    'path' => $proposal->path,
+                    'action' => $proposal->isNew ? 'create' : 'update',
+                    'applied' => $wasApplied,
+                ];
+                $unapplied += $wasApplied ? 0 : 1;
+            }
+        }
+
+        if ($outcome->prose !== '') {
+            $document['prose'] = $outcome->prose;
+        }
+
+        $document['actionable'] = $unapplied + ($run !== null ? 1 : 0);
+
+        return $document;
+    }
+
+    /**
+     * The document as one raw JSON line.
+     *
+     * @param list<bool> $applied whether each proposal (by index) reached disk
+     */
+    public function render(string $command, Outcome $outcome, array $applied = [], ?string $run = null): string
+    {
+        return (json_encode($this->document($command, $outcome, $applied, $run), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}') . "\n";
+    }
+}

--- a/src/PhpSpec/Console/Command/Describe.php
+++ b/src/PhpSpec/Console/Command/Describe.php
@@ -56,7 +56,8 @@ final class Describe extends Command
             ])
             ->addOption('exemplify', 'e', Option::VALUE_REQUIRED, 'Add an example for a method')
             ->addOption('run', 'r', Option::VALUE_NONE, 'Run specs after generating')
-            ->addOption('agent', null, Option::VALUE_NONE, 'Emit a machine-readable JSON receipt instead of prose (for coding agents)')
+            ->addOption('agent', null, Option::VALUE_NONE, 'Deprecated alias of --format=agent')
+            ->addOption('format', 'f', Option::VALUE_REQUIRED, 'Output format: pretty, or agent (machine-readable JSON receipt for coding agents)', 'pretty')
             ->setDescription('Generate spec for a class');
     }
 
@@ -73,7 +74,7 @@ final class Describe extends Command
         $class = $input->getArgument('class');
         $spec = str_replace('\\', '/', $class);
 
-        if ($input->getOption('agent')) {
+        if ($input->getOption('agent') || $input->getOption('format') === 'agent') {
             return $this->describeForAgent($spec, $input, $output);
         }
 

--- a/src/PhpSpec/Console/Command/Exemplify.php
+++ b/src/PhpSpec/Console/Command/Exemplify.php
@@ -46,7 +46,8 @@ final class Exemplify extends Command
                 new Argument('class', Argument::REQUIRED, 'Class to add the example to'),
                 new Argument('method', Argument::REQUIRED, 'Method to exemplify'),
             ])
-            ->addOption('agent', null, Option::VALUE_NONE, 'Emit a machine-readable JSON receipt instead of prose (for coding agents)')
+            ->addOption('agent', null, Option::VALUE_NONE, 'Deprecated alias of --format=agent')
+            ->addOption('format', 'f', Option::VALUE_REQUIRED, 'Output format: pretty, or agent (machine-readable JSON receipt for coding agents)', 'pretty')
             ->setDescription('Add an example for a method to a spec file');
     }
 
@@ -59,7 +60,7 @@ final class Exemplify extends Command
         $this->generator->generate($spec);
         $added = $this->generator->addExample($spec, $method);
 
-        if ($input->getOption('agent')) {
+        if ($input->getOption('agent') || $input->getOption('format') === 'agent') {
             $receipt = [
                 'v' => Schema::V,
                 'action' => 'exemplify',

--- a/src/PhpSpec/Console/Command/Generate.php
+++ b/src/PhpSpec/Console/Command/Generate.php
@@ -16,6 +16,8 @@ namespace PhpSpec\Console\Command;
 
 use PhpSpec\Ai\Agent\Agent;
 use PhpSpec\Ai\Agent\CommandProfile;
+use PhpSpec\Ai\Agent\Outcome;
+use PhpSpec\Ai\Agent\OutcomePresenter;
 use PhpSpec\Ai\Agent\Proposal;
 use PhpSpec\Ai\Agent\Writer;
 use PhpSpec\Ai\Contracts\ProviderInterface;
@@ -27,6 +29,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument as Argument;
 use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Input\InputOption as Option;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -60,7 +63,8 @@ final class Generate extends Command
         $this
             ->setName('generate')
             ->setDescription('Generate a feature, steps, spec, or code from a natural-language instruction (requires AI)')
-            ->addArgument('instruction', Argument::IS_ARRAY, 'What to build, in plain English');
+            ->addArgument('instruction', Argument::IS_ARRAY, 'What to build, in plain English')
+            ->addOption('format', 'f', Option::VALUE_REQUIRED, 'Output format: pretty, or agent (machine-readable JSON; applies without prompting)', 'pretty');
     }
 
     protected function execute(Input $input, Output $output): int
@@ -80,14 +84,21 @@ final class Generate extends Command
             return 1;
         }
 
-        $output->writeln('');
-        $output->writeln('  <fg=gray>Generating...</>');
-        $output->writeln('');
+        $forAgent = $input->getOption('format') === 'agent';
+        if (!$forAgent) {
+            $output->writeln('');
+            $output->writeln('  <fg=gray>Generating...</>');
+            $output->writeln('');
+        }
 
         // The profile is shipped package code, so it always loads from the real
         // filesystem; the project filesystem seam only grounds and writes.
         $agent = new Agent($this->config, $this->filesystem, $this->provider);
         $outcome = $agent->do(CommandProfile::load('generate'), $instruction);
+
+        if ($forAgent) {
+            return $this->generateForAgent($output, $outcome);
+        }
 
         if ($outcome->proposals === []) {
             $reason = $outcome->prose !== '' ? $outcome->prose : 'Could not generate anything for that instruction. Try rephrasing.';
@@ -111,6 +122,25 @@ final class Generate extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * The agent path: a machine consumer is never prompted, so every proposal
+     * applies, and the one JSON document carries the receipts (path, action,
+     * applied), never file content: the agent reads the files it now owns.
+     */
+    private function generateForAgent(Output $output, Outcome $outcome): int
+    {
+        $writer = new Writer($this->filesystem);
+        $applied = [];
+        foreach ($outcome->proposals as $proposal) {
+            $writer->apply($proposal);
+            $applied[] = true;
+        }
+
+        $output->write((new OutcomePresenter())->render('generate', $outcome, $applied), false, Output::OUTPUT_RAW);
+
+        return $outcome->proposals === [] ? 1 : 0;
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -17,6 +17,8 @@ namespace PhpSpec\Console\Command;
 use PhpSpec\Ai\Agent\Agent;
 use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Ai\Agent\Grounding;
+use PhpSpec\Ai\Agent\Outcome;
+use PhpSpec\Ai\Agent\OutcomePresenter;
 use PhpSpec\Ai\Agent\Phase;
 use PhpSpec\Ai\Agent\ProjectPath;
 use PhpSpec\Ai\Agent\Request;
@@ -35,6 +37,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
@@ -80,11 +83,14 @@ final class Next extends Command
     {
         $this
             ->setName('next')
-            ->setDescription('AI suggests what to describe or specify next');
+            ->setDescription('AI suggests what to describe or specify next')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format: pretty, or agent (machine-readable JSON for coding agents)', 'pretty');
     }
 
     protected function execute(Input $input, Output $output): int
     {
+        $forAgent = $input->getOption('format') === 'agent';
+
         // 1. Check AI config
         $aiConfig = $this->config->getAiConfig();
         if ($aiConfig === null) {
@@ -99,14 +105,21 @@ final class Next extends Command
         }
 
         // 3. Scan project and get suggestion
-        $output->writeln('');
-        $output->writeln('  <fg=gray>Analysing project...</>');
-        $output->writeln('');
+        if (!$forAgent) {
+            $output->writeln('');
+            $output->writeln('  <fg=gray>Analysing project...</>');
+            $output->writeln('');
+        }
 
         $suggestion = $this->getSuggestion($aiConfig);
 
         // 4. Validate — if we got no target and no reason, the response was unusable
         if ($suggestion['target'] === '' && $suggestion['reason'] === '') {
+            if ($forAgent) {
+                $output->write((new OutcomePresenter())->render('next', new Outcome(null, [], 'Could not get a suggestion. Please try again.')), false, Output::OUTPUT_RAW);
+
+                return 1;
+            }
             $output->writeln('  <fg=yellow>Could not get a suggestion. Please try again.</>');
             $output->writeln('');
             return 1;
@@ -115,11 +128,11 @@ final class Next extends Command
         // 4b. If the suggested spec already exists, never re-describe it (that
         // just loops) — coach to run so the missing class is driven out instead.
         if ($suggestion['type'] === 'spec' && $this->specFileExists($suggestion['target'])) {
-            $output->writeln(sprintf('  A spec for <fg=bright-blue;options=bold>%s</> already exists.', $suggestion['target']));
-            $output->writeln('  <fg=gray>Run it to drive out the class:</> ' . self::invokedBinary() . ' run');
-            $output->writeln('');
-
-            return 0;
+            $suggestion = [
+                'type' => 'info',
+                'target' => '',
+                'reason' => sprintf('A spec for "%s" already exists. Run it to drive out the class.', $suggestion['target']),
+            ];
         }
 
         // 4c. Red, green, REFACTOR happens once: a refactor suggestion for a
@@ -127,39 +140,79 @@ final class Next extends Command
         // growth instead of polishing the same class forever.
         $suggestion = $this->steerAwayFromStaleRefactor($suggestion);
 
-        // 5. Display
-        $this->displaySuggestion($output, $suggestion);
+        $actuation = $this->actuationFor($suggestion);
 
-        // 6. Offer to create (only when we have a proper target)
-        if ($suggestion['target'] === '') {
+        // The agent document carries the suggestion and the exact command that
+        // acts on it; a machine consumer is never prompted.
+        if ($forAgent) {
+            $run = $actuation !== null ? self::invokedBinary() . ' ' . $actuation['display'] : null;
+            $outcome = new Outcome(null, [], '', $suggestion);
+            $output->write((new OutcomePresenter())->render('next', $outcome, [], $run), false, Output::OUTPUT_RAW);
+
             return 0;
         }
 
-        if ($suggestion['type'] === 'spec') {
-            return $this->offerDescribe($input, $output, $suggestion['target']);
+        // 5. Display
+        $this->displaySuggestion($output, $suggestion);
+
+        // 6. Offer to act (only when the suggestion determined an actuation)
+        if ($actuation === null) {
+            if ($suggestion['type'] === 'implement' && $suggestion['target'] !== '') {
+                $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . ' run');
+            }
+
+            return 0;
         }
 
-        if ($suggestion['type'] === 'feature') {
-            return $this->offerFeature($input, $output, $suggestion['target']);
+        return $this->offerToRun($input, $output, $actuation['display'], $actuation['command'], $actuation['args'], $actuation['ask']);
+    }
+
+    /**
+     * The command a suggestion actuates through, with its bound arguments and
+     * display line, shared by the interactive offer and the agent document so
+     * both always name the same invocation. Null when nothing actuates: an
+     * info suggestion, or a failing subject that is no class (its honest next
+     * move is a run, which shows the failure).
+     *
+     * @param array{type: string, target: string, reason: string} $suggestion
+     * @return array{command: string, args: array<string, mixed>, display: string, ask: string}|null
+     */
+    private function actuationFor(array $suggestion): ?array
+    {
+        $target = $suggestion['target'];
+        if ($target === '') {
+            return null;
         }
 
-        if ($suggestion['type'] === 'steps') {
-            return $this->offerSteps($input, $output, $suggestion['target']);
-        }
+        $create = 'Would you like me to create that for you?';
+        $generate = fn(string $instruction): array => [
+            'command' => 'generate',
+            'args' => ['instruction' => [$instruction]],
+            'display' => sprintf('generate "%s"', $instruction),
+            'ask' => $create,
+        ];
 
-        if ($suggestion['type'] === 'implement') {
-            return $this->offerImplement($input, $output, $suggestion['target'], $suggestion['reason']);
-        }
-
-        if ($suggestion['type'] === 'example') {
-            return $this->offerExemplify($input, $output, $suggestion['target'], $suggestion['reason']);
-        }
-
-        if ($suggestion['type'] === 'refactor') {
-            return $this->offerRefactor($input, $output, $suggestion['target']);
-        }
-
-        return 0;
+        return match ($suggestion['type']) {
+            'spec' => [
+                'command' => 'describe',
+                'args' => ['class' => str_replace('\\', '/', $target)],
+                'display' => 'describe ' . str_replace('\\', '/', $target),
+                'ask' => $create,
+            ],
+            'feature' => $generate('a feature for ' . $target),
+            'steps' => $generate('the steps for ' . $target),
+            'example' => $generate($this->taskInstruction('add a spec example for ' . $target, $suggestion['reason'])),
+            'implement' => preg_match('~^[A-Z][A-Za-z0-9]*(?:\\\\[A-Z][A-Za-z0-9]*)*$~', $target) === 1
+                ? $generate($this->taskInstruction('implement ' . $target, $suggestion['reason']))
+                : null,
+            'refactor' => [
+                'command' => 'refactor',
+                'args' => ['target' => str_replace('\\', '/', $target)],
+                'display' => 'refactor ' . str_replace('\\', '/', $target),
+                'ask' => 'Would you like me to run it now?',
+            ],
+            default => null,
+        };
     }
 
     /**
@@ -244,55 +297,6 @@ final class Next extends Command
         $output->writeln('');
     }
 
-    private function offerDescribe(Input $input, Output $output, string $target): int
-    {
-        $classArg = str_replace('\\', '/', $target);
-
-        return $this->offerToRun($input, $output, "describe $classArg", 'describe', ['class' => $classArg]);
-    }
-
-    /**
-     * A feature suggestion actuates through `generate`, which owns Gherkin,
-     * the features directory, and the scenario content; `describe` would turn
-     * the story name into a spec.
-     */
-    private function offerFeature(Input $input, Output $output, string $target): int
-    {
-        $instruction = 'a feature for ' . $target;
-
-        return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
-    }
-
-    /**
-     * A steps suggestion actuates through `generate`, whose step resolution
-     * writes the step definitions for the named feature deterministically.
-     */
-    private function offerSteps(Input $input, Output $output, string $target): int
-    {
-        $instruction = 'the steps for ' . $target;
-
-        return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
-    }
-
-    /**
-     * A failing class actuates through `generate`, whose "implement" wording
-     * routes to the write-code step with the class and its spec in context. A
-     * subject that is no class (a story slug, a bare string) has no one-shot
-     * actuator, so the hint is the run that shows the failure.
-     */
-    private function offerImplement(Input $input, Output $output, string $target, string $reason): int
-    {
-        if (preg_match('~^[A-Z][A-Za-z0-9]*(?:\\\\[A-Z][A-Za-z0-9]*)*$~', $target) !== 1) {
-            $output->writeln('  <fg=gray>Run:</> ' . self::invokedBinary() . ' run');
-
-            return 0;
-        }
-
-        $instruction = $this->taskInstruction('implement ' . $target, $reason);
-
-        return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
-    }
-
     /**
      * Offers to act on the suggestion: a printed hint when not interactive, a
      * [Y/n] confirmation and the command run when it is.
@@ -321,17 +325,6 @@ final class Next extends Command
         }
 
         return $application->find($command)->run(new ArrayInput($args), $output);
-    }
-
-    /**
-     * An example suggestion actuates through `generate`, whose spec wording
-     * routes to growing the existing spec (same phrasing the pair ghost uses).
-     */
-    private function offerExemplify(Input $input, Output $output, string $target, string $reason): int
-    {
-        $instruction = $this->taskInstruction('add a spec example for ' . $target, $reason);
-
-        return $this->offerToRun($input, $output, sprintf('generate "%s"', $instruction), 'generate', ['instruction' => [$instruction]]);
     }
 
     /**
@@ -373,17 +366,6 @@ final class Next extends Command
             'target' => '',
             'reason' => sprintf('"%s" was already refactored and has not changed since. Grow the story instead: add the next scenario or feature.', $suggestion['target']),
         ];
-    }
-
-    /**
-     * The green-suite step: offer to run the refactor command, which shows
-     * its baseline and asks its own consent before anything is applied.
-     */
-    private function offerRefactor(Input $input, Output $output, string $target): int
-    {
-        $classArg = str_replace('\\', '/', $target);
-
-        return $this->offerToRun($input, $output, "refactor $classArg", 'refactor', ['target' => $classArg], 'Would you like me to run it now?');
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -410,6 +410,9 @@ final class Run extends Command
         }
 
         $formatter = $this->createFormatter($this->resolveFormat($input), $output);
+        if ($formatter instanceof Agent) {
+            $formatter->describeRun($seed, $files);
+        }
         $formatter->begin();
 
         $start = hrtime(true);

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -50,10 +50,29 @@ final class Agent extends AbstractFormatter
     /** @var (\Closure(SuiteResult): mixed)|null resolves the run's generation candidates as a plain array */
     private readonly ?\Closure $resolveCandidates;
 
+    /** The randomisation seed of this run, when order is random. */
+    private ?int $seed = null;
+
+    /** What was run, as the paths the loader was given. */
+    private string $suite = 'default';
+
     public function __construct(OutputInterface $output, ?\Closure $resolveCandidates = null)
     {
         parent::__construct($output);
         $this->resolveCandidates = $resolveCandidates;
+    }
+
+    /**
+     * Tells the formatter about the run it is rendering, so the document
+     * carries the real seed (an agent reruns a flaky order with it) and what
+     * was run instead of placeholders.
+     */
+    public function describeRun(?int $seed, string $suite): void
+    {
+        $this->seed = $seed;
+        if ($suite !== '') {
+            $this->suite = $suite;
+        }
     }
 
     public function begin(): void {}
@@ -73,10 +92,10 @@ final class Agent extends AbstractFormatter
             'suite' => [
                 'v' => Schema::V,
                 'event' => Schema::EVENT_RUN_STARTED,
-                'suite' => 'default',
+                'suite' => $this->suite,
                 'examples' => $this->exampleCount,
                 'steps' => $this->stepCount,
-                'seed' => null,
+                'seed' => $this->seed,
             ],
             'examples' => $this->examples,
             'result' => [


### PR DESCRIPTION
The agent format grows from a run-only formatter into the one machine surface for every command, standardised on --format=agent as agreed (with --agent kept as a deprecated alias on describe/exemplify for one beta).

The heart is a new OutcomePresenter: since every AI command already returns the same Outcome value (step, proposals, prose, structured data), one presenter renders it as the agent JSON document. On top of it:

- next --format=agent emits the suggestion plus the exact invocation that acts on it (e.g. run: vendor/bin/phpspec generate \"a feature for deleting_a_task\"), never a prompt; the journal growth steer and existing-spec coaching land inside the document. The interactive offers and the document now share one actuationFor mapping, so both always name the same command; the six per-type offer arms collapsed into it.
- generate --format=agent applies its proposals without prompting (a machine consumer chose the format) and emits path/action/applied receipts, never file content: the agent reads the files it now owns.
- describe/exemplify accept --format=agent as the canonical spelling of their --agent flag.
- The run document reports the real seed under --order=random (an agent can rerun a flaky order) and the paths that were run, instead of the hardcoded seed: null and suite: \"default\".

Verification: 1721 examples and 27 features / 223 scenarios / 1129 steps green on 8.2.30/8.3.16/8.4.4/8.5.3, coverage 92.1, phpstan and cs-fixer clean.