### PR TITLE
Resolve prompts through project overrides and rename the pipeline verb to chat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - Any AI prompt can be overridden per project under .phpspec/prompts/; prose-only command overrides inherit the shipped tools and params, and the capture log marks overridden names
+
+### Changed
+ - The pipeline's one verb is `Agent::chat(command, instruction)`; commands pass a name and the agent resolves the manifest through its own prompt library
+
+## [Unreleased]
+
 ### Changed
  - End-of-run detail is grouped into Failures, Errors, Warnings, Deprecations, and Skipped sections, and the dot formatter tells the same detailed story as pretty
  - A failure reads as an aligned pair labeled by its matcher (expected / to contain), long multiline values capped head[...]tail with newlines escaped

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,4 +313,23 @@ ai:
 
 Default models per provider: `gemini-3.1-pro-preview` (google), `claude-sonnet-5` (anthropic), `gpt-5.1` (openai).
 
+### Customising the prompts
+
+Every prompt the AI commands use is a text file. The shipped ones live inside the package; a project overrides any of them by placing a file of the same name under `.phpspec/prompts/`, which is committable and survives composer updates. A project file fully replaces the shipped one.
+
+```
+.phpspec/prompts/
+  commands/next.txt            the next advisor's manifest and voice
+  commands/generate.txt        the generate command
+  commands/refactor.txt        the refactor rules
+  instructions/write-spec.txt  step guidance (also: write-feature, write-steps, write-code, refactor, tdd-cycle)
+  instructions/spec-syntax.txt syntax primers (also: steps-syntax, gherkin-syntax, pair-guidance)
+  tools/offer_change.txt       any tool description, by tool name
+  navigator.txt                the pair navigator role (also: driver.txt, next.txt)
+```
+
+Command files under `commands/` may start with YAML frontmatter (tools, answer channel, grounding, temperature, max_tokens). Overrides inherit the shipped frontmatter per key: a prose-only file keeps the shipped machine contract, and declaring only `temperature: 0.2` keeps the shipped tools. An `@include <name>` line inside any prompt resolves project-first.
+
+`.phpspec/ai/last-request.json` marks overridden prompts in `composed_from` (e.g. `"commands/next (project)"`), so you can always see whose words the model heard.
+
 See [Pair Programming & AI](pair.md) for full documentation on pair mode, the AI assistant, and the refactor command.

--- a/features/scenarios/cli/prompt-overrides.feature
+++ b/features/scenarios/cli/prompt-overrides.feature
@@ -1,0 +1,30 @@
+Feature: Project-level prompt overrides
+  As a team using phpspec's AI commands
+  I want to override the shipped prompts from my own project
+  So that tuning the AI's voice survives composer updates
+
+  Scenario: a project prompt file overrides the shipped one and the capture log says so
+    Given a phpspec.yaml config:
+      """
+      ai:
+        provider: google
+        api_key: test-key
+      """
+    And a file ".phpspec/prompts/commands/generate.txt":
+      """
+      You are OUR generator. House rule: never invent fixture domains.
+      """
+    When I run phpspec command "generate a spec for App/Basket that holds products"
+    Then the file ".phpspec/ai/last-request.json" should contain "commands/generate (project)"
+    And the file ".phpspec/ai/last-request.json" should contain "OUR generator"
+
+  Scenario: without an override the capture log names the shipped prompt plainly
+    Given a phpspec.yaml config:
+      """
+      ai:
+        provider: google
+        api_key: test-key
+      """
+    When I run phpspec command "generate a spec for App/Basket that holds products"
+    Then the file ".phpspec/ai/last-request.json" should contain "commands/generate"
+    And the file ".phpspec/ai/last-request.json" should not contain "(project)"

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -72,6 +72,15 @@ then('the output should contain {string} exactly {int} times', function (string 
     }
 });
 
+then('the file {string} should not contain {string}', function (string $path, string $text) {
+    $content = (string) file_get_contents($this->projectDir . '/' . $path);
+    if (str_contains($content, $text)) {
+        throw new \RuntimeException(
+            "Expected \"{$path}\" NOT to contain \"{$text}\".\nContent:\n{$content}",
+        );
+    }
+});
+
 then('the file {string} should contain {string} exactly {int} times', function (string $path, string $text, int $times) {
     $content = (string) file_get_contents($this->projectDir . '/' . $path);
     $found = substr_count($content, $text);

--- a/spec/PhpSpec/Ai/Agent/Agent.spec.php
+++ b/spec/PhpSpec/Ai/Agent/Agent.spec.php
@@ -40,15 +40,6 @@ describe(Agent::class, function () {
         });
     });
 
-    let('profile', fn() => new CommandProfile(
-        name: 'generate',
-        body: 'THE-BODY',
-        tools: ['write_feature', 'write_steps', 'propose_edit'],
-        answer: 'tool_call',
-        grounding: ['recency', 'tree', 'named_files'],
-        temperature: 0.2,
-    ));
-
     let('config', fn(Filesystem $fs) => new Configuration('.', $fs));
 
     it('consults the model for a named new feature and keeps the derived path over its content', function (Filesystem $fs) {
@@ -57,7 +48,7 @@ describe(Agent::class, function () {
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $outcome = $agent->do($this->profile, 'a simple scenario in features/user_adds_tasks.feature');
+        $outcome = $agent->chat('generate', 'a simple scenario in features/user_adds_tasks.feature');
 
         expect($replay->requests)->toHaveLength(1);
         expect($outcome->step->phase)->toBe(Phase::WriteFeature);
@@ -71,7 +62,7 @@ describe(Agent::class, function () {
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $outcome = $agent->do($this->profile, 'a spec for a Coupon that reduces a total');
+        $outcome = $agent->chat('generate', 'a spec for a Coupon that reduces a total');
 
         expect($outcome->proposals[0]->path)->toBe('spec/Coupon.spec.php');
         expect($replay->requests)->toHaveLength(1);
@@ -86,19 +77,18 @@ describe(Agent::class, function () {
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $agent->do($this->profile, 'a spec for a Coupon');
+        $agent->chat('generate', 'a spec for a Coupon');
 
         expect($replay->requests[0]['options']['toolChoice'])->toBe('required');
     });
 
     it('forces the one declared tool by name when the manifest declares exactly one', function (Filesystem $fs) {
-        $profile = new CommandProfile(name: 'next', body: 'ADVISE', tools: ['suggest_next'], answer: 'tool_call');
         $replay = new ReplayProvider([
             new Response('', [new ToolCall('1', 'suggest_next', ['type' => 'spec', 'target' => 'App\\Coupon', 'reason' => 'ok'])]),
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $agent->do($profile, '');
+        $agent->chat('next', '');
 
         expect($replay->requests[0]['options']['toolChoice'])->toBe(['name' => 'suggest_next']);
     });
@@ -107,13 +97,12 @@ describe(Agent::class, function () {
         $yamlPath = './phpspec.yaml';
         allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $yamlPath);
         allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $yamlPath ? "ai:\n  provider: google\n  api_key: k\n  max_tokens: 9999\n" : '');
-        $profile = new CommandProfile(name: 'generate', body: '', tools: ['propose_edit'], answer: 'tool_call', maxTokens: 4096);
         $replay = new ReplayProvider([
             new Response('', [new ToolCall('1', 'propose_edit', ['path' => 'spec/Coupon.spec.php', 'content' => "<?php\ndescribe('Coupon', fn() => null);"])]),
         ]);
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
 
-        $agent->do($profile, 'a spec for a Coupon');
+        $agent->chat('generate', 'a spec for a Coupon');
 
         expect($replay->requests[0]['options']['maxTokens'])->toBe(9999);
     });
@@ -127,37 +116,64 @@ describe(Agent::class, function () {
         ]);
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
 
-        $agent->do($this->profile, 'a spec for a Coupon');
+        $agent->chat('generate', 'a spec for a Coupon');
 
         expect($replay->requests[0]['options']['effort'])->toBe('high');
     });
 
     it('falls back from the manifest max_tokens to it before any code default', function (Filesystem $fs) {
-        $profile = new CommandProfile(name: 'generate', body: '', tools: ['propose_edit'], answer: 'tool_call', maxTokens: 4096);
         $replay = new ReplayProvider([
             new Response('', [new ToolCall('1', 'propose_edit', ['path' => 'spec/Coupon.spec.php', 'content' => "<?php\ndescribe('Coupon', fn() => null);"])]),
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $agent->do($profile, 'a spec for a Coupon');
+        $agent->chat('generate', 'a spec for a Coupon');
 
-        expect($replay->requests[0]['options']['maxTokens'])->toBe(4096);
+        expect($replay->requests[0]['options']['maxTokens'])->toBe(16384);   // the shipped generate manifest
     });
 
-    it('sends no toolChoice for a prose command', function (Filesystem $fs) {
-        $profile = new CommandProfile(name: 'chat', body: 'TALK', tools: [], answer: 'prose');
+    it('sends no toolChoice for a prose command, resolved from a project prompt', function (Filesystem $fs) {
+        $override = getcwd() . '/.phpspec/prompts/commands/advice.txt';
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $override);
+        allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $override ? 'TALK to the human.' : '');
         $replay = new ReplayProvider([new Response('some advice')]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $agent->do($profile, 'what next?');
+        $agent->chat('advice', 'what next?');
 
         expect($replay->requests[0]['options'])->not()->toHaveKey('toolChoice');
+        expect($replay->requests[0]['messages'][0]->content)->toContain('TALK to the human.');
+    });
+
+    it('folds a project override over the shipped manifest per key', function (Filesystem $fs) {
+        $override = getcwd() . '/.phpspec/prompts/commands/generate.txt';
+        allow($fs->exists())->toReturnUsing(fn(string $p): bool => $p === $override);
+        allow($fs->read())->toReturnUsing(fn(string $p): string => $p === $override ? "---\ntemperature: 0.9\n---\nOUR house rules." : '');
+        $replay = new ReplayProvider([
+            new Response('', [new ToolCall('1', 'propose_edit', ['path' => 'spec/Coupon.spec.php', 'content' => "<?php\ndescribe('Coupon', fn() => null);"])]),
+        ]);
+        $agent = new Agent($this->config, $fs, $replay);
+
+        $agent->chat('generate', 'a spec for a Coupon');
+
+        expect($replay->requests[0]['options']['temperature'])->toBe(0.9);        // the project's key
+        expect($replay->requests[0]['options']['tools'])->toHaveLength(3);        // the shipped tools survive
+        expect($replay->requests[0]['messages'][0]->content)->toContain('OUR house rules.');
+    });
+
+    it('reports an unknown command as prose instead of crashing', function (Filesystem $fs) {
+        $agent = new Agent($this->config, $fs, new ReplayProvider());
+
+        $outcome = $agent->chat('nonsense', 'anything');
+
+        expect($outcome->proposals)->toBe([]);
+        expect($outcome->prose)->toContain('Unknown AI command "nonsense"');
     });
 
     it('surfaces a provider failure as prose instead of crashing the command', function (Filesystem $fs) {
         $agent = new Agent($this->config, $fs, new AgentSpecThrowingProvider());
 
-        $outcome = $agent->do($this->profile, 'a spec for a Coupon');
+        $outcome = $agent->chat('generate', 'a spec for a Coupon');
 
         expect($outcome->proposals)->toBe([]);
         expect($outcome->prose)->toContain('API key not valid');
@@ -166,7 +182,7 @@ describe(Agent::class, function () {
     it('stands in with the feature skeleton when the provider fails on a write-feature ask', function (Filesystem $fs) {
         $agent = new Agent($this->config, $fs, new AgentSpecThrowingProvider());
 
-        $outcome = $agent->do($this->profile, 'a feature for completing_a_task.feature');
+        $outcome = $agent->chat('generate', 'a feature for completing_a_task.feature');
 
         expect($outcome->proposals[0]->path)->toBe('features/completing_a_task.feature');
         expect($outcome->proposals[0]->new)->toContain('Feature:');
@@ -180,7 +196,7 @@ describe(Agent::class, function () {
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $outcome = $agent->do($this->profile, 'a spec for a Coupon');
+        $outcome = $agent->chat('generate', 'a spec for a Coupon');
 
         expect($replay->requests)->toHaveLength(2);
         expect($outcome->proposals[0]->path)->toBe('spec/Coupon.spec.php');
@@ -190,7 +206,7 @@ describe(Agent::class, function () {
         $replay = new ReplayProvider([new Response('prose'), new Response('more prose')]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $outcome = $agent->do($this->profile, 'a spec for a Coupon');
+        $outcome = $agent->chat('generate', 'a spec for a Coupon');
 
         expect($outcome->proposals)->toBe([]);
         expect($outcome->prose)->not()->toBe('');
@@ -203,7 +219,7 @@ describe(Agent::class, function () {
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $outcome = $agent->do($this->profile, 'a spec for a Calc');
+        $outcome = $agent->chat('generate', 'a spec for a Calc');
 
         expect($outcome->proposals)->toBe([]);
         expect($outcome->prose)->toContain('ObjectBehavior');
@@ -212,7 +228,7 @@ describe(Agent::class, function () {
     it('surfaces a deterministic refusal as the outcome prose', function (Filesystem $fs) {
         $agent = new Agent($this->config, $fs, new ReplayProvider());
 
-        $outcome = $agent->do($this->profile, 'the steps for features/missing.feature');
+        $outcome = $agent->chat('generate', 'the steps for features/missing.feature');
 
         expect($outcome->proposals)->toBe([]);
         expect($outcome->prose)->toContain('features/missing.feature');
@@ -228,7 +244,7 @@ describe(Agent::class, function () {
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $agent->do($this->profile, 'change Calc to do something');
+        $agent->chat('generate', 'change Calc to do something');
 
         $context = $replay->requests[0]['messages'][1]->content;
         expect($context)->toContain('Calc.php');            // the tree
@@ -242,7 +258,7 @@ describe(Agent::class, function () {
         ]);
         $agent = new Agent($this->config, $fs, $replay);
 
-        $agent->do($this->profile, 'a spec for a Coupon');
+        $agent->chat('generate', 'a spec for a Coupon');
 
         $captures = array_filter(array_keys($this->written), fn(string $path) => str_ends_with($path, '.phpspec/ai/last-request.json'));
 

--- a/spec/PhpSpec/Ai/Agent/CommandProfile.spec.php
+++ b/spec/PhpSpec/Ai/Agent/CommandProfile.spec.php
@@ -1,27 +1,27 @@
 <?php
 
 use PhpSpec\Ai\Agent\CommandProfile;
-use PhpSpec\Filesystem;
+use PhpSpec\Ai\Prompt;
 
 // Commands are data: everything the pipeline needs to know about a command is
 // declared in its prompt file's frontmatter (tools, answer channel, grounding
-// sections, model params), so tuning a command is a text edit, never code.
+// sections, model params). A project override folds over the shipped manifest
+// per key, so prose-only overrides keep the shipped machine contract.
 describe(CommandProfile::class, function () {
 
-    it('parses the manifest frontmatter and keeps the prose body', function (Filesystem $fs) {
-        allow($fs->exists())->toReturn(true);
-        allow($fs->read())->toReturn(<<<'TXT'
-        ---
-        tools: [write_feature, write_steps]
-        answer: tool_call
-        grounding: [recency, tree]
-        temperature: 0.2
-        max_tokens: 4096
-        ---
-        You turn one instruction into ONE artifact.
-        TXT);
+    $manifest = <<<'TXT'
+    ---
+    tools: [write_feature, write_steps]
+    answer: tool_call
+    grounding: [recency, tree]
+    temperature: 0.2
+    max_tokens: 4096
+    ---
+    You turn one instruction into ONE artifact.
+    TXT;
 
-        $profile = CommandProfile::load('generate', $fs);
+    it('parses the manifest frontmatter and keeps the prose body', function () use ($manifest) {
+        $profile = CommandProfile::compose('generate', new Prompt('commands/generate', $manifest, Prompt::SHIPPED));
 
         expect($profile->name)->toBe('generate');
         expect($profile->tools)->toBe(['write_feature', 'write_steps']);
@@ -31,13 +31,11 @@ describe(CommandProfile::class, function () {
         expect($profile->maxTokens)->toBe(4096);
         expect($profile->body)->toContain('ONE artifact');
         expect($profile->body)->not()->toContain('tools:');
+        expect($profile->origin)->toBe(Prompt::SHIPPED);
     });
 
-    it('treats a file without frontmatter as pure prose with defaults', function (Filesystem $fs) {
-        allow($fs->exists())->toReturn(true);
-        allow($fs->read())->toReturn("Just the prose.\n");
-
-        $profile = CommandProfile::load('generate', $fs);
+    it('treats a file without frontmatter as pure prose with defaults', function () {
+        $profile = CommandProfile::compose('generate', new Prompt('commands/generate', "Just the prose.\n", Prompt::SHIPPED));
 
         expect($profile->body)->toBe('Just the prose.');
         expect($profile->tools)->toBe([]);
@@ -45,18 +43,43 @@ describe(CommandProfile::class, function () {
         expect($profile->temperature)->toBeNull();
     });
 
-    it('refuses to load a command with no prompt file', function (Filesystem $fs) {
-        allow($fs->exists())->toReturn(false);
+    it('lets a prose-only project override keep the whole shipped manifest', function () use ($manifest) {
+        $profile = CommandProfile::compose(
+            'generate',
+            new Prompt('commands/generate', 'OUR house rules.', Prompt::PROJECT),
+            new Prompt('commands/generate', $manifest, Prompt::SHIPPED),
+        );
 
-        expect(fn() => CommandProfile::load('nope', $fs))
+        expect($profile->body)->toBe('OUR house rules.');
+        expect($profile->tools)->toBe(['write_feature', 'write_steps']);
+        expect($profile->answer)->toBe('tool_call');
+        expect($profile->grounding)->toBe(['recency', 'tree']);
+        expect($profile->temperature)->toBe(0.2);
+        expect($profile->maxTokens)->toBe(4096);
+        expect($profile->origin)->toBe(Prompt::PROJECT);
+    });
+
+    it('folds override frontmatter per key: a temperature-only override keeps the shipped tools', function () use ($manifest) {
+        $profile = CommandProfile::compose(
+            'generate',
+            new Prompt('commands/generate', "---\ntemperature: 0.9\n---\nOUR prose.", Prompt::PROJECT),
+            new Prompt('commands/generate', $manifest, Prompt::SHIPPED),
+        );
+
+        expect($profile->temperature)->toBe(0.9);
+        expect($profile->tools)->toBe(['write_feature', 'write_steps']);
+        expect($profile->answer)->toBe('tool_call');
+        expect($profile->body)->toBe('OUR prose.');
+    });
+
+    it('refuses to compose a command with no prompt layers', function () {
+        expect(fn() => CommandProfile::compose('nope'))
             ->toThrow(RuntimeException::class, 'Unknown AI command "nope": no "commands/nope.txt" prompt found.');
     });
 
-    it('rejects an unknown answer channel instead of silently ignoring the typo', function (Filesystem $fs) {
-        allow($fs->exists())->toReturn(true);
-        allow($fs->read())->toReturn("---\nanswer: tool-call\n---\nBody.");
-
-        expect(fn() => CommandProfile::load('generate', $fs))->toThrow(RuntimeException::class);
+    it('rejects an unknown answer channel instead of silently ignoring the typo', function () {
+        expect(fn() => CommandProfile::compose('generate', new Prompt('commands/generate', "---\nanswer: tool-call\n---\nBody.", Prompt::SHIPPED)))
+            ->toThrow(RuntimeException::class);
     });
 
 });

--- a/spec/PhpSpec/Ai/Agent/Request.spec.php
+++ b/spec/PhpSpec/Ai/Agent/Request.spec.php
@@ -28,7 +28,7 @@ describe(Request::class, function () {
     it('composes system as body, then the shared cycle, then the step instruction', function (Filesystem $fs) {
         $step = new Step(Phase::WriteSteps, null, 'features/adding.feature', 'steps are undefined');
 
-        $request = Request::compose($this->profile, $step, Grounding::empty(), 'the steps', new PromptLibrary($fs));
+        $request = Request::compose($this->profile, $step, Grounding::empty(), 'the steps', new PromptLibrary(null, $fs));
 
         expect($request->system)->toMatch('~THE-BODY.*THE-CYCLE.*STEPS-GUIDE~s');
         expect($request->composedFrom)->toBe(['commands/generate', 'instructions/tdd-cycle', 'instructions/write-steps']);
@@ -37,14 +37,14 @@ describe(Request::class, function () {
     it('names the current step and its because, so the model knows where we are', function (Filesystem $fs) {
         $step = new Step(Phase::WriteSteps, null, null, 'steps are undefined');
 
-        $request = Request::compose($this->profile, $step, Grounding::empty(), 'the steps', new PromptLibrary($fs));
+        $request = Request::compose($this->profile, $step, Grounding::empty(), 'the steps', new PromptLibrary(null, $fs));
 
         expect($request->system)->toContain('write-steps');
         expect($request->system)->toContain('steps are undefined');
     });
 
     it('composes without a step section when no step resolved', function (Filesystem $fs) {
-        $request = Request::compose($this->profile, null, Grounding::empty(), 'help me', new PromptLibrary($fs));
+        $request = Request::compose($this->profile, null, Grounding::empty(), 'help me', new PromptLibrary(null, $fs));
 
         expect($request->system)->toMatch('~THE-BODY.*THE-CYCLE~s');
         expect($request->system)->not()->toContain('STEPS-GUIDE');
@@ -57,22 +57,36 @@ describe(Request::class, function () {
             namedFiles: ['src/TodoList.php' => '<?php class TodoList {}'],
         );
 
-        $request = Request::compose($this->profile, null, $grounding, 'the steps', new PromptLibrary($fs));
+        $request = Request::compose($this->profile, null, $grounding, 'the steps', new PromptLibrary(null, $fs));
 
         expect($request->context)->toMatch('~# Project files.*# src/TodoList\.php.*# Instruction\nthe steps~s');
         expect($request->context)->toContain('class TodoList');
     });
 
     it('keeps the context to just the instruction when the grounding is empty', function (Filesystem $fs) {
-        $request = Request::compose($this->profile, null, Grounding::empty(), 'the steps', new PromptLibrary($fs));
+        $request = Request::compose($this->profile, null, Grounding::empty(), 'the steps', new PromptLibrary(null, $fs));
 
         expect($request->context)->toBe("# Instruction\nthe steps");
+    });
+
+    it('marks overridden prompt names in composedFrom so the capture shows whose words the model heard', function (Filesystem $project, Filesystem $fs) {
+        allow($project->exists())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '.phpspec/prompts/instructions/tdd-cycle.txt'));
+        allow($project->read())->toReturn('OUR-CYCLE');
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturnUsing(fn(string $p): string => str_contains($p, 'write-steps') ? 'STEPS-GUIDE' : '');
+        $profile = new CommandProfile(name: 'generate', body: 'THE-BODY', origin: PhpSpec\Ai\Prompt::PROJECT);
+        $step = new Step(Phase::WriteSteps, null, 'features/adding.feature', 'steps are undefined');
+
+        $request = Request::compose($profile, $step, Grounding::empty(), 'the steps', new PromptLibrary($project, $fs));
+
+        expect($request->system)->toContain('OUR-CYCLE');
+        expect($request->composedFrom)->toBe(['commands/generate (project)', 'instructions/tdd-cycle (project)', 'instructions/write-steps']);
     });
 
     it('renders the journal grounding so polish already done is visible to the model', function (Filesystem $fs) {
         $grounding = new Grounding(polished: ['App\\TodoList', 'App\\TaskQueue']);
 
-        $request = Request::compose($this->profile, null, $grounding, '', new PromptLibrary($fs));
+        $request = Request::compose($this->profile, null, $grounding, '', new PromptLibrary(null, $fs));
 
         expect($request->context)->toContain('# Refactoring journal');
         expect($request->context)->toContain('Already refactored and unchanged since: App\\TodoList, App\\TaskQueue.');
@@ -89,7 +103,7 @@ describe(Request::class, function () {
         );
         $grounding = new Grounding(suite: $suite, recentFeature: 'features/adding.feature');
 
-        $request = Request::compose($this->profile, null, $grounding, '', new PromptLibrary($fs));
+        $request = Request::compose($this->profile, null, $grounding, '', new PromptLibrary(null, $fs));
 
         expect($request->context)->toMatch('~# Suite state.*# Instruction~s');
         expect($request->context)->toContain('FEATURES: 1 features, 1 scenarios, 3 steps (0 failing, 3 undefined)');

--- a/spec/PhpSpec/Ai/Eval/GenerateCodeByIntent.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateCodeByIntent.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
 
@@ -26,7 +25,7 @@ describe('E4 generate: code by intent', function () {
         $replay = ReplayProvider::fromRecording($rec);
 
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
-        $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
+        $outcome = $agent->chat('generate', $rec['instruction']);
 
         expect($outcome->proposals[0]->path)->toMatch('~^src/.*\.php$~');        // under src/
         expect($outcome->proposals[0]->path)->not()->toEndWith('.spec.php');     // not a spec

--- a/spec/PhpSpec/Ai/Eval/GenerateFeatureByIntent.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateFeatureByIntent.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
 
@@ -29,7 +28,7 @@ describe('E2 generate: feature by intent', function () {
         $replay = ReplayProvider::fromRecording($rec);
 
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
-        $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
+        $outcome = $agent->chat('generate', $rec['instruction']);
 
         // Assert on the value (not a boolean derived from it) so a failure carries
         // the actual path into --format=agent, keeping the JSON actionable.

--- a/spec/PhpSpec/Ai/Eval/GenerateFeatureExplicitPath.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateFeatureExplicitPath.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
 
@@ -29,7 +28,7 @@ describe('E1 generate: feature at an explicit path', function () {
         $replay = ReplayProvider::fromRecording($rec);
 
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
-        $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
+        $outcome = $agent->chat('generate', $rec['instruction']);
 
         expect($replay->requests)->toHaveLength(2);                                // consulted, then re-asked once
         expect($outcome->proposals[0]->path)->toBe('features/user_adds_tasks.feature');

--- a/spec/PhpSpec/Ai/Eval/GenerateNoExampleEcho.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateNoExampleEcho.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
 
@@ -28,7 +27,7 @@ describe('E7 generate: the prompt example never leaks into the path', function (
         $replay = ReplayProvider::fromRecording($rec);
 
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
-        $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
+        $outcome = $agent->chat('generate', $rec['instruction']);
 
         expect($outcome->proposals[0]->path)->toContain('Coupon');               // the instruction's subject
         expect($outcome->proposals[0]->path)->not()->toContain('Calculator');    // not the prompt example

--- a/spec/PhpSpec/Ai/Eval/GenerateResolvesSubjectFromTree.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateResolvesSubjectFromTree.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
 
@@ -42,7 +41,7 @@ describe('E12 generate: a bare subject resolves against the project tree', funct
         $replay = ReplayProvider::fromRecording($rec);
 
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
-        $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
+        $outcome = $agent->chat('generate', $rec['instruction']);
 
         $context = $replay->requests[0]['messages'][1]->content;
         expect($context)->toContain('should add');                                // the REAL current spec reached the model

--- a/spec/PhpSpec/Ai/Eval/GenerateRespectsProjectLayout.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateRespectsProjectLayout.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Ai\Response;
 use PhpSpec\Ai\ToolCall;
 use PhpSpec\Configuration;
@@ -37,7 +36,7 @@ describe('E10 generate: inferred paths respect the project layout', function () 
     it('places inferred code under the configured src_path with the PSR-4 prefix stripped', function (Filesystem $fs) use ($agentFor, $editCall) {
         $agent = $agentFor($fs, "src_path: lib\npsr4_prefix: App\nai:\n  provider: google\n  api_key: x\n", $editCall('src/App/Coupon.php', '<?php // impl'));
 
-        $outcome = $agent->do(CommandProfile::load('generate'), 'implement the apply method on App\\Coupon');
+        $outcome = $agent->chat('generate', 'implement the apply method on App\\Coupon');
 
         expect($outcome->proposals[0]->path)->toBe('lib/Coupon.php');
     });
@@ -45,7 +44,7 @@ describe('E10 generate: inferred paths respect the project layout', function () 
     it('places an inferred spec under the configured spec_path, mirroring the namespace', function (Filesystem $fs) use ($agentFor, $editCall) {
         $agent = $agentFor($fs, "spec_path: test/spec\nai:\n  provider: google\n  api_key: x\n", $editCall('spec/Whatever.spec.php', "<?php\ndescribe('Coupon', fn() => null);"));
 
-        $outcome = $agent->do(CommandProfile::load('generate'), 'a spec for App\\Coupon');
+        $outcome = $agent->chat('generate', 'a spec for App\\Coupon');
 
         expect($outcome->proposals[0]->path)->toBe('test/spec/App/Coupon.spec.php');
     });
@@ -56,7 +55,7 @@ describe('E10 generate: inferred paths respect the project layout', function () 
         ]);
         $agent = $agentFor($fs, "features_path: test/features\nai:\n  provider: google\n  api_key: x\n", $replay);
 
-        $outcome = $agent->do(CommandProfile::load('generate'), 'a feature for adding a task');
+        $outcome = $agent->chat('generate', 'a feature for adding a task');
 
         expect($replay->requests)->toHaveLength(1);
         expect($outcome->proposals[0]->path)->toMatch('~^test/features/.+\.feature$~');

--- a/spec/PhpSpec/Ai/Eval/GenerateSpecByIntent.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateSpecByIntent.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
 
@@ -28,7 +27,7 @@ describe('E3 generate: spec by intent', function () {
         $replay = ReplayProvider::fromRecording($rec);
 
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
-        $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
+        $outcome = $agent->chat('generate', $rec['instruction']);
 
         expect($outcome->proposals[0]->path)->toMatch('~^spec/.*\.spec\.php$~'); // a spec, at a spec path
         expect($outcome->proposals[0]->path)->toContain('Coupon');               // the class from the instruction

--- a/spec/PhpSpec/Ai/Eval/GenerateSpecModernDsl.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateSpecModernDsl.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
 
@@ -30,7 +29,7 @@ describe('E5/E6 generate: reject ObjectBehavior spec syntax', function () {
             $replay = ReplayProvider::fromRecording($rec);
 
             $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
-            $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
+            $outcome = $agent->chat('generate', $rec['instruction']);
 
             expect($outcome->proposals)->toBe([]);
             expect($outcome->prose)->toContain('ObjectBehavior');

--- a/spec/PhpSpec/Ai/Eval/GenerateStepsBodies.spec.php
+++ b/spec/PhpSpec/Ai/Eval/GenerateStepsBodies.spec.php
@@ -1,7 +1,6 @@
 <?php
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Configuration;
 use PhpSpec\Filesystem;
 
@@ -42,7 +41,7 @@ describe('E13 generate: step bodies come from the model when the scaffold is com
         $replay = ReplayProvider::fromRecording($rec);
 
         $agent = new Agent(new Configuration('.', $fs), $fs, $replay);
-        $outcome = $agent->do(CommandProfile::load('generate'), $rec['instruction']);
+        $outcome = $agent->chat('generate', $rec['instruction']);
 
         $context = $replay->requests[0]['messages'][1]->content;
         expect($context)->toContain('pending()');                 // the current steps file reached the model

--- a/spec/PhpSpec/Ai/PromptLibrary.spec.php
+++ b/spec/PhpSpec/Ai/PromptLibrary.spec.php
@@ -1,26 +1,78 @@
 <?php
 
+use PhpSpec\Ai\Prompt;
 use PhpSpec\Ai\PromptLibrary;
 use PhpSpec\Filesystem;
 
+// The library resolves a prompt name through two layers: the project's
+// .phpspec/prompts directory first (the team's voice, committable), then the
+// shipped Prompts directory (package code). One resolution seam serves every
+// consumer.
 describe(PromptLibrary::class, function () {
 
-    it('reads a prompt artifact by name from the Prompts directory', function (Filesystem $fs) {
+    $shippedOnly = fn(Filesystem $shipped) => new PromptLibrary(null, $shipped, '/project');
+
+    it('reads a shipped prompt artifact by name from the Prompts directory', function (Filesystem $fs) use ($shippedOnly) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturnUsing(fn(string $p): string => str_ends_with($p, '/Prompts/next.txt') ? 'OUTSIDE-IN coaching' : '');
-        $library = new PromptLibrary($fs);
 
-        expect($library->read('next'))->toBe('OUTSIDE-IN coaching');
+        expect($shippedOnly($fs)->read('next'))->toBe('OUTSIDE-IN coaching');
     });
 
-    it('returns an empty string when the artifact is absent', function (Filesystem $fs) {
+    it('returns an empty string when the artifact is absent everywhere', function (Filesystem $fs) use ($shippedOnly) {
         allow($fs->exists())->toReturn(false);
-        $library = new PromptLibrary($fs);
 
-        expect($library->read('missing'))->toBe('');
+        expect($shippedOnly($fs)->read('missing'))->toBe('');
     });
 
-    it('expands an @include line with the named prompt, in place', function (Filesystem $fs) {
+    it('prefers a project override over the shipped prompt', function (Filesystem $project, Filesystem $shipped) {
+        allow($project->exists())->toReturnUsing(fn(string $p): bool => $p === '/project/.phpspec/prompts/commands/next.txt');
+        allow($project->read())->toReturn('OUR coaching');
+        allow($shipped->exists())->toReturn(true);
+        allow($shipped->read())->toReturn('SHIPPED coaching');
+
+        $library = new PromptLibrary($project, $shipped, '/project');
+
+        expect($library->read('commands/next'))->toBe('OUR coaching');
+    });
+
+    it('falls back to the shipped prompt when the project has no override', function (Filesystem $project, Filesystem $shipped) {
+        allow($project->exists())->toReturn(false);
+        allow($shipped->exists())->toReturn(true);
+        allow($shipped->read())->toReturn('SHIPPED coaching');
+
+        $library = new PromptLibrary($project, $shipped, '/project');
+
+        expect($library->read('commands/next'))->toBe('SHIPPED coaching');
+    });
+
+    it('stacks every existing layer, project first, each naming its origin', function (Filesystem $project, Filesystem $shipped) {
+        allow($project->exists())->toReturnUsing(fn(string $p): bool => str_contains($p, '.phpspec/prompts/'));
+        allow($project->read())->toReturn('OURS');
+        allow($shipped->exists())->toReturn(true);
+        allow($shipped->read())->toReturn('THEIRS');
+
+        $stack = (new PromptLibrary($project, $shipped, '/project'))->stack('commands/generate');
+
+        expect($stack)->toHaveCount(2);
+        expect($stack[0]->origin)->toBe(Prompt::PROJECT);
+        expect($stack[0]->text)->toBe('OURS');
+        expect($stack[1]->origin)->toBe(Prompt::SHIPPED);
+        expect($stack[1]->text)->toBe('THEIRS');
+    });
+
+    it('stacks a single shipped layer when no override exists', function (Filesystem $project, Filesystem $shipped) {
+        allow($project->exists())->toReturn(false);
+        allow($shipped->exists())->toReturn(true);
+        allow($shipped->read())->toReturn('THEIRS');
+
+        $stack = (new PromptLibrary($project, $shipped, '/project'))->stack('commands/generate');
+
+        expect($stack)->toHaveCount(1);
+        expect($stack[0]->origin)->toBe(Prompt::SHIPPED);
+    });
+
+    it('expands an @include line with the named prompt, in place', function (Filesystem $fs) use ($shippedOnly) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturnUsing(fn(string $p): string => match (true) {
             str_ends_with($p, '/Prompts/commands/generate.txt') => "Head.\n\n@include instructions/spec-syntax\n\nTail.",
@@ -28,10 +80,23 @@ describe(PromptLibrary::class, function () {
             default => '',
         });
 
-        expect((new PromptLibrary($fs))->read('commands/generate'))->toBe("Head.\n\nTHE-SYNTAX\n\nTail.");
+        expect($shippedOnly($fs)->read('commands/generate'))->toBe("Head.\n\nTHE-SYNTAX\n\nTail.");
     });
 
-    it('expands includes inside included prompts', function (Filesystem $fs) {
+    it('resolves an @include inside a shipped prompt project-first', function (Filesystem $project, Filesystem $shipped) {
+        allow($project->exists())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '.phpspec/prompts/instructions/spec-syntax.txt'));
+        allow($project->read())->toReturn('OUR-SYNTAX');
+        allow($shipped->exists())->toReturn(true);
+        allow($shipped->read())->toReturnUsing(fn(string $p): string => str_ends_with($p, '/Prompts/commands/generate.txt')
+            ? "@include instructions/spec-syntax"
+            : 'SHIPPED-SYNTAX');
+
+        $library = new PromptLibrary($project, $shipped, '/project');
+
+        expect($library->read('commands/generate'))->toBe('OUR-SYNTAX');
+    });
+
+    it('expands includes inside included prompts', function (Filesystem $fs) use ($shippedOnly) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturnUsing(fn(string $p): string => match (true) {
             str_ends_with($p, '/Prompts/a.txt') => "@include b",
@@ -40,17 +105,17 @@ describe(PromptLibrary::class, function () {
             default => '',
         });
 
-        expect((new PromptLibrary($fs))->read('a'))->toBe("B says:\nC");
+        expect($shippedOnly($fs)->read('a'))->toBe("B says:\nC");
     });
 
-    it('resolves an include of a missing prompt to nothing', function (Filesystem $fs) {
+    it('resolves an include of a missing prompt to nothing', function (Filesystem $fs) use ($shippedOnly) {
         allow($fs->exists())->toReturnUsing(fn(string $p): bool => str_ends_with($p, '/Prompts/a.txt'));
         allow($fs->read())->toReturnUsing(fn(string $p): string => str_ends_with($p, '/Prompts/a.txt') ? "Head.\n@include gone\nTail." : '');
 
-        expect((new PromptLibrary($fs))->read('a'))->toBe("Head.\n\nTail.");
+        expect($shippedOnly($fs)->read('a'))->toBe("Head.\n\nTail.");
     });
 
-    it('throws on an include cycle instead of looping', function (Filesystem $fs) {
+    it('throws on an include cycle instead of looping', function (Filesystem $fs) use ($shippedOnly) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturnUsing(fn(string $p): string => match (true) {
             str_ends_with($p, '/Prompts/a.txt') => '@include b',
@@ -58,17 +123,27 @@ describe(PromptLibrary::class, function () {
             default => '',
         });
 
-        expect(fn() => (new PromptLibrary($fs))->read('a'))
+        expect(fn() => $shippedOnly($fs)->read('a'))
             ->toThrow(RuntimeException::class, 'Prompt include cycle: "a" is included while already being resolved (a > b).');
     });
 
-    it('leaves a mid-line @include mention alone: only a full directive line expands', function (Filesystem $fs) {
+    it('makes a self-including override a clear cycle error, not a silent loop', function (Filesystem $project, Filesystem $shipped) {
+        allow($project->exists())->toReturnUsing(fn(string $p): bool => str_contains($p, '.phpspec/prompts/commands/next.txt'));
+        allow($project->read())->toReturn('@include commands/next');
+        allow($shipped->exists())->toReturn(true);
+        allow($shipped->read())->toReturn('SHIPPED');
+
+        expect(fn() => (new PromptLibrary($project, $shipped, '/project'))->read('commands/next'))
+            ->toThrow(RuntimeException::class);
+    });
+
+    it('leaves a mid-line @include mention alone: only a full directive line expands', function (Filesystem $fs) use ($shippedOnly) {
         allow($fs->exists())->toReturn(true);
         allow($fs->read())->toReturnUsing(fn(string $p): string => str_ends_with($p, '/Prompts/a.txt')
             ? 'Use @include name on its own line.'
             : 'SHOULD-NOT-APPEAR');
 
-        expect((new PromptLibrary($fs))->read('a'))->toBe('Use @include name on its own line.');
+        expect($shippedOnly($fs)->read('a'))->toBe('Use @include name on its own line.');
     });
 
 });

--- a/src/PhpSpec/Ai/Agent/Agent.php
+++ b/src/PhpSpec/Ai/Agent/Agent.php
@@ -31,7 +31,7 @@ use Throwable;
 
 /**
  * @internal
- * The one verb every AI command calls. One `do()` grounds the command per its
+ * The one verb every AI command calls. One `chat()` resolves the command per its
  * manifest, resolves the current TDD step (the user's words first, the suite
  * state second), acts deterministically when the step fully determines the
  * artifact, and otherwise asks the model on the command's declared answer
@@ -76,20 +76,27 @@ final class Agent
         ?PromptLibrary $prompts = null,
     ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
-        $this->registry = $registry ?? new ToolRegistry($config, $this->filesystem);
-        $this->recorder = $recorder ?? new Recorder($this->filesystem);
         $this->prompts = $prompts ?? new PromptLibrary($this->filesystem);
+        $this->registry = $registry ?? new ToolRegistry($config, $this->filesystem, $this->prompts);
+        $this->recorder = $recorder ?? new Recorder($this->filesystem);
         $this->layout = new FeatureLayout();
     }
 
     /**
-     * Runs one turn of the pipeline for a command and an instruction. A caller
-     * that already knows part of its world (a suite it just ran, the recency it
-     * scanned) passes a seed grounding; the manifest's remaining sections are
-     * filled in around it.
+     * Runs one turn of the pipeline for a named command and an instruction:
+     * the command's profile resolves through the prompt library (project
+     * overrides first). A caller that already knows part of its world (a suite
+     * it just ran, the recency it scanned) passes a seed grounding; the
+     * manifest's remaining sections are filled in around it.
      */
-    public function do(CommandProfile $profile, string $instruction, ?Grounding $seed = null): Outcome
+    public function chat(string $command, string $instruction, ?Grounding $seed = null): Outcome
     {
+        try {
+            $profile = CommandProfile::compose($command, ...$this->prompts->stack('commands/' . $command));
+        } catch (RuntimeException $e) {
+            return new Outcome(null, [], $e->getMessage());
+        }
+
         $grounding = $this->ground($profile, $instruction, $seed);
         $step = $this->refineSubject(Step::resolve($instruction, $grounding));
         $aiConfig = $this->config->getAiConfig();

--- a/src/PhpSpec/Ai/Agent/CommandProfile.php
+++ b/src/PhpSpec/Ai/Agent/CommandProfile.php
@@ -14,8 +14,7 @@
 
 namespace PhpSpec\Ai\Agent;
 
-use PhpSpec\Ai\PromptLibrary;
-use PhpSpec\Filesystem;
+use PhpSpec\Ai\Prompt;
 use RuntimeException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -38,6 +37,7 @@ final readonly class CommandProfile
      * @param list<string> $grounding the grounding sections to build (e.g. recency, tree)
      * @param float|null $temperature sampling temperature, when the command pins one
      * @param int|null $maxTokens per-call output-token ceiling, when pinned
+     * @param string $origin where the winning prompt layer came from (Prompt::PROJECT or Prompt::SHIPPED)
      */
     public function __construct(
         public string $name,
@@ -47,22 +47,28 @@ final readonly class CommandProfile
         public array $grounding = [],
         public ?float $temperature = null,
         public ?int $maxTokens = null,
+        public string $origin = Prompt::SHIPPED,
     ) {}
 
     /**
-     * Loads a command's profile from its prompt file, parsing the optional YAML
-     * frontmatter into the manifest fields.
+     * Composes a command's profile from its prompt layers, nearest first: the
+     * body is the first layer's prose, and each manifest key comes from the
+     * first layer whose frontmatter declares it, so a prose-only project
+     * override keeps the shipped machine contract.
      *
-     * @throws RuntimeException when the file is missing or the manifest is invalid
+     * @throws RuntimeException when no layer exists or the manifest is invalid
      */
-    public static function load(string $name, ?Filesystem $filesystem = null): self
+    public static function compose(string $name, Prompt ...$layers): self
     {
-        $text = (new PromptLibrary($filesystem))->read('commands/' . $name);
-        if (trim($text) === '') {
+        if ($layers === []) {
             throw new RuntimeException(sprintf('Unknown AI command "%s": no "commands/%s.txt" prompt found.', $name, $name));
         }
 
-        [$meta, $body] = self::split($text, $name);
+        [$meta, $body] = self::split($layers[0]->text, $name);
+        foreach (array_slice($layers, 1) as $layer) {
+            [$layerMeta] = self::split($layer->text, $name);
+            $meta += $layerMeta;
+        }
 
         $answer = $meta['answer'] ?? 'prose';
         if (!in_array($answer, ['tool_call', 'prose'], true)) {
@@ -77,6 +83,7 @@ final readonly class CommandProfile
             self::names($meta['grounding'] ?? []),
             isset($meta['temperature']) ? (float) $meta['temperature'] : null,
             isset($meta['max_tokens']) ? (int) $meta['max_tokens'] : null,
+            $layers[0]->origin,
         );
     }
 

--- a/src/PhpSpec/Ai/Agent/Outcome.php
+++ b/src/PhpSpec/Ai/Agent/Outcome.php
@@ -16,7 +16,7 @@ namespace PhpSpec\Ai\Agent;
 
 /**
  * @internal
- * What one `do()` call produced: the step it resolved, the proposals to
+ * What one `chat()` call produced: the step it resolved, the proposals to
  * confirm, and any prose for the human. Presenters render this and nothing
  * else, so every command surface (interactive diff, plain advice, agent JSON)
  * is a rendering of the same value.

--- a/src/PhpSpec/Ai/Agent/Recorder.php
+++ b/src/PhpSpec/Ai/Agent/Recorder.php
@@ -43,7 +43,7 @@ final class Recorder
     }
 
     /**
-     * Writes the capture document for one `do()` call. A deterministic run has
+     * Writes the capture document for one `chat()` call. A deterministic run has
      * a null request and response; the step and proposals still tell the story.
      *
      * @param array{provider?: string, model?: string, api_key?: string, effort?: string} $aiConfig

--- a/src/PhpSpec/Ai/Agent/Request.php
+++ b/src/PhpSpec/Ai/Agent/Request.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec\Ai\Agent;
 
+use PhpSpec\Ai\Prompt;
 use PhpSpec\Ai\PromptLibrary;
 
 /**
@@ -46,25 +47,47 @@ final readonly class Request
      */
     public static function compose(CommandProfile $profile, ?Step $step, Grounding $grounding, string $instruction, PromptLibrary $prompts): self
     {
-        $composedFrom = ['commands/' . $profile->name];
+        $composedFrom = [self::mark('commands/' . $profile->name, $profile->origin)];
         $sections = [$profile->body];
 
-        $cycle = trim($prompts->read('instructions/tdd-cycle'));
-        if ($cycle !== '') {
-            $sections[] = $cycle;
-            $composedFrom[] = 'instructions/tdd-cycle';
+        $cycle = self::layer($prompts, 'instructions/tdd-cycle');
+        if ($cycle !== null) {
+            $sections[] = trim($cycle->text);
+            $composedFrom[] = self::mark($cycle->name, $cycle->origin);
         }
 
         if ($step !== null) {
             $header = sprintf('Current step: %s (%s).', $step->phase->value, $step->because);
-            $guide = trim($prompts->read('instructions/' . $step->phase->value));
-            $sections[] = $guide !== '' ? $header . "\n\n" . $guide : $header;
-            if ($guide !== '') {
-                $composedFrom[] = 'instructions/' . $step->phase->value;
+            $guide = self::layer($prompts, 'instructions/' . $step->phase->value);
+            $sections[] = $guide !== null ? $header . "\n\n" . trim($guide->text) : $header;
+            if ($guide !== null) {
+                $composedFrom[] = self::mark($guide->name, $guide->origin);
             }
         }
 
         return new self(implode("\n\n", $sections), self::context($grounding, $instruction), $composedFrom);
+    }
+
+    /**
+     * The winning layer for a name, or null when nothing non-empty resolves.
+     */
+    private static function layer(PromptLibrary $prompts, string $name): ?Prompt
+    {
+        $stack = $prompts->stack($name);
+        if ($stack === [] || trim($stack[0]->text) === '') {
+            return null;
+        }
+
+        return $stack[0];
+    }
+
+    /**
+     * A composedFrom entry: the prompt name, marked when the project spoke, so
+     * the capture log shows whose words the model heard.
+     */
+    private static function mark(string $name, string $origin): string
+    {
+        return $origin === Prompt::PROJECT ? $name . ' (project)' : $name;
     }
 
     /**

--- a/src/PhpSpec/Ai/Prompt.php
+++ b/src/PhpSpec/Ai/Prompt.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Ai;
+
+/**
+ * @internal
+ * One resolved prompt layer: its name, its include-expanded text, and where it
+ * came from. Data only; the library builds these, consumers fold or render.
+ */
+final readonly class Prompt
+{
+    public const PROJECT = 'project';
+
+    public const SHIPPED = 'shipped';
+
+    /**
+     * @param string $name the prompt name (e.g. "commands/generate")
+     * @param string $text the include-expanded prompt text
+     * @param string $origin one of the PROJECT/SHIPPED constants
+     */
+    public function __construct(
+        public string $name,
+        public string $text,
+        public string $origin,
+    ) {}
+}

--- a/src/PhpSpec/Ai/PromptLibrary.php
+++ b/src/PhpSpec/Ai/PromptLibrary.php
@@ -20,30 +20,42 @@ use RuntimeException;
 
 /**
  * @internal
- * Loads a named prompt artifact from the Ai/Prompts directory, so the coaching
- * text lives in an editable `.txt` file rather than inline in a command. Returns
- * an empty string when the artifact is missing, letting callers fall back.
+ * Resolves a named prompt through two layers: the project's `.phpspec/prompts`
+ * directory first (the team's voice, committable, surviving composer updates),
+ * then the shipped `Ai/Prompts` directory (package code). A project file fully
+ * replaces the shipped one of the same name. Returns an empty string when the
+ * artifact is missing everywhere, letting callers fall back.
  *
  * One composition directive keeps shared prose single-sourced: a line of the
- * form `@include <name>` is replaced with that artifact's resolved contents.
- * Only a full line is a directive; a missing target resolves to nothing (like
- * any missing artifact); a cycle is an authoring error and throws.
+ * form `@include <name>` is replaced with that artifact's resolved contents,
+ * looked up project-first like any other name. Only a full line is a
+ * directive; a missing target resolves to nothing (like any missing
+ * artifact); a cycle is an authoring error and throws.
  */
 final class PromptLibrary
 {
-    private readonly Filesystem $filesystem;
+    private readonly Filesystem $projectFilesystem;
+
+    private readonly Filesystem $shippedFilesystem;
+
+    private readonly string $projectDir;
 
     /**
-     * @param Filesystem|null $filesystem filesystem abstraction for testability
+     * @param Filesystem|null $projectFilesystem reads the project's override files; the project seam
+     * @param Filesystem|null $shippedFilesystem reads the shipped prompt files, which are package code
+     * @param string|null $projectDir the project root holding .phpspec/prompts; the working directory by default
      */
-    public function __construct(?Filesystem $filesystem = null)
+    public function __construct(?Filesystem $projectFilesystem = null, ?Filesystem $shippedFilesystem = null, ?string $projectDir = null)
     {
-        $this->filesystem = $filesystem ?? new RealFilesystem();
+        $this->projectFilesystem = $projectFilesystem ?? new RealFilesystem();
+        $this->shippedFilesystem = $shippedFilesystem ?? new RealFilesystem();
+        $this->projectDir = $projectDir ?? (getcwd() ?: '.');
     }
 
     /**
-     * Returns the contents of the named prompt artifact (`<name>.txt`) with its
-     * `@include` directives expanded, or an empty string when it cannot be read.
+     * Returns the contents of the named prompt (`<name>.txt`), project layer
+     * first, with its `@include` directives expanded; an empty string when it
+     * cannot be read anywhere.
      */
     public function read(string $name): string
     {
@@ -51,9 +63,33 @@ final class PromptLibrary
     }
 
     /**
-     * Reads one artifact and expands its include directives, tracking the chain
-     * of names currently being resolved so a cycle fails loudly instead of
-     * looping.
+     * Every layer the name resolves to, project first, each include-expanded
+     * and naming its origin. The one richer question consumers need: the
+     * manifest fold and the capture marker both come from it.
+     *
+     * @return list<Prompt>
+     */
+    public function stack(string $name): array
+    {
+        $layers = [];
+
+        $project = $this->projectText($name);
+        if ($project !== null) {
+            $layers[] = new Prompt($name, $this->expand($project, [$name]), Prompt::PROJECT);
+        }
+
+        $shipped = $this->shippedText($name);
+        if ($shipped !== null) {
+            $layers[] = new Prompt($name, $this->expand($shipped, [$name]), Prompt::SHIPPED);
+        }
+
+        return $layers;
+    }
+
+    /**
+     * Resolves one name to its first existing layer and expands its includes,
+     * tracking the chain of names currently being resolved so a cycle fails
+     * loudly instead of looping.
      *
      * @param list<string> $resolving the include chain, outermost first
      */
@@ -63,15 +99,44 @@ final class PromptLibrary
             throw new RuntimeException(sprintf('Prompt include cycle: "%s" is included while already being resolved (%s).', $name, implode(' > ', $resolving)));
         }
 
-        $path = __DIR__ . '/Prompts/' . $name . '.txt';
-        $text = $this->filesystem->exists($path) ? $this->filesystem->read($path) : '';
-
+        $text = $this->projectText($name) ?? $this->shippedText($name) ?? '';
         $resolving[] = $name;
 
+        return $this->expand($text, $resolving);
+    }
+
+    /**
+     * Expands every full-line `@include <name>` directive in the given text,
+     * each target resolved project-first.
+     *
+     * @param list<string> $resolving the include chain, outermost first
+     */
+    private function expand(string $text, array $resolving): string
+    {
         return (string) preg_replace_callback(
             '~^@include[ \t]+([A-Za-z0-9/_.-]+)[ \t\r]*$~m',
             fn(array $matches): string => trim($this->resolve($matches[1], $resolving)),
             $text,
         );
+    }
+
+    /**
+     * The raw project override for a name, or null when the project has none.
+     */
+    private function projectText(string $name): ?string
+    {
+        $path = $this->projectDir . '/.phpspec/prompts/' . $name . '.txt';
+
+        return $this->projectFilesystem->exists($path) ? $this->projectFilesystem->read($path) : null;
+    }
+
+    /**
+     * The raw shipped text for a name, or null when the package has none.
+     */
+    private function shippedText(string $name): ?string
+    {
+        $path = __DIR__ . '/Prompts/' . $name . '.txt';
+
+        return $this->shippedFilesystem->exists($path) ? $this->shippedFilesystem->read($path) : null;
     }
 }

--- a/src/PhpSpec/Console/Command/Generate.php
+++ b/src/PhpSpec/Console/Command/Generate.php
@@ -15,7 +15,6 @@
 namespace PhpSpec\Console\Command;
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Ai\Agent\Outcome;
 use PhpSpec\Ai\Agent\OutcomePresenter;
 use PhpSpec\Ai\Agent\Proposal;
@@ -91,10 +90,8 @@ final class Generate extends Command
             $output->writeln('');
         }
 
-        // The profile is shipped package code, so it always loads from the real
-        // filesystem; the project filesystem seam only grounds and writes.
         $agent = new Agent($this->config, $this->filesystem, $this->provider);
-        $outcome = $agent->do(CommandProfile::load('generate'), $instruction);
+        $outcome = $agent->chat('generate', $instruction);
 
         if ($forAgent) {
             return $this->generateForAgent($output, $outcome);

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -15,7 +15,6 @@
 namespace PhpSpec\Console\Command;
 
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Ai\Agent\Grounding;
 use PhpSpec\Ai\Agent\Outcome;
 use PhpSpec\Ai\Agent\OutcomePresenter;
@@ -257,7 +256,7 @@ final class Next extends Command
         }
 
         $agent = new Agent($this->config, $this->filesystem, $this->provider);
-        $outcome = $agent->do(CommandProfile::load('next'), '', $grounding);
+        $outcome = $agent->chat('next', '', $grounding);
 
         $reason = (string) ($outcome->data['reason'] ?? '');
 

--- a/src/PhpSpec/Console/Command/Pair/AiAssistant.php
+++ b/src/PhpSpec/Console/Command/Pair/AiAssistant.php
@@ -77,6 +77,9 @@ final class AiAssistant
 
     private readonly Chooser $chooser;
 
+    /** Resolves prompt files, project overrides first. */
+    private readonly PromptLibrary $prompts;
+
     private readonly RoleState $roleState;
 
     /** Runs specs and returns structured red/green, for run_specs and auto-verify. */
@@ -151,6 +154,7 @@ final class AiAssistant
         ?SpecRunner $specRunner = null,
     ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
+        $this->prompts = new PromptLibrary($this->filesystem);
         $this->chooser = $chooser ?? new Chooser($output, $interactive);
         $this->roleState = $roleState ?? new RoleState();
         $this->specRunner = $specRunner ?? new SubprocessRunner();
@@ -614,7 +618,7 @@ final class AiAssistant
      */
     private function loadRoleArtifact(PairRole $role): string
     {
-        $text = (new PromptLibrary())->read($role->promptArtifact());
+        $text = $this->prompts->read($role->promptArtifact());
 
         if (trim($text) === '') {
             return $role->aiIsNavigator()
@@ -826,9 +830,9 @@ final class AiAssistant
      * from the real filesystem). Tuning what a tool tells the model is a text
      * edit.
      */
-    private static function toolDescription(string $name): string
+    private function toolDescription(string $name): string
     {
-        return trim((new PromptLibrary())->read('tools/' . $name));
+        return trim($this->prompts->read('tools/' . $name));
     }
 
     /**
@@ -879,7 +883,7 @@ final class AiAssistant
 
         return Tool::make(
             name: 'describe',
-            description: self::toolDescription('describe'),
+            description: $this->toolDescription('describe'),
             parameters: [
                 'class_name' => [
                     'type' => 'string',
@@ -921,7 +925,7 @@ final class AiAssistant
 
         return Tool::make(
             name: 'add_example',
-            description: self::toolDescription('add_example'),
+            description: $this->toolDescription('add_example'),
             parameters: [
                 'class_name' => [
                     'type' => 'string',
@@ -977,7 +981,7 @@ final class AiAssistant
 
         return Tool::make(
             name: 'generate_feature',
-            description: self::toolDescription('generate_feature'),
+            description: $this->toolDescription('generate_feature'),
             parameters: [
                 'feature_name' => [
                     'type' => 'string',
@@ -1007,7 +1011,7 @@ final class AiAssistant
 
         return Tool::make(
             name: 'generate_steps',
-            description: self::toolDescription('generate_steps'),
+            description: $this->toolDescription('generate_steps'),
             parameters: [
                 'feature_name' => [
                     'type' => 'string',
@@ -1037,7 +1041,7 @@ final class AiAssistant
 
         return Tool::make(
             name: 'write_file',
-            description: self::toolDescription('write_file'),
+            description: $this->toolDescription('write_file'),
             parameters: [
                 'path' => [
                     'type' => 'string',
@@ -1078,7 +1082,7 @@ final class AiAssistant
 
         return Tool::make(
             name: 'update_file',
-            description: self::toolDescription('update_file'),
+            description: $this->toolDescription('update_file'),
             parameters: [
                 'path' => [
                     'type' => 'string',
@@ -1124,7 +1128,7 @@ final class AiAssistant
 
         return Tool::make(
             name: 'offer_change',
-            description: self::toolDescription('offer_change'),
+            description: $this->toolDescription('offer_change'),
             parameters: [
                 'path' => [
                     'type' => 'string',
@@ -1225,7 +1229,7 @@ final class AiAssistant
     {
         return Tool::make(
             name: 'suggest_next',
-            description: self::toolDescription('suggest_next'),
+            description: $this->toolDescription('suggest_next'),
             parameters: [
                 'type' => [
                     'type' => 'string',
@@ -1316,7 +1320,7 @@ final class AiAssistant
         // The role-neutral guidance is an editable prompt file (shipped package
         // code, so it loads from the real filesystem); only the project layout
         // is interpolated. Editing the pairing behaviour is a text edit.
-        $guidance = (new PromptLibrary())->read('instructions/pair-guidance');
+        $guidance = $this->prompts->read('instructions/pair-guidance');
         if (trim($guidance) !== '') {
             return strtr($guidance, [
                 '%spec_path%' => ltrim($this->config->getSpecPath(), './'),

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -16,7 +16,6 @@ namespace PhpSpec\Console\Command\Pair;
 
 use Exception;
 use PhpSpec\Ai\Agent\Agent;
-use PhpSpec\Ai\Agent\CommandProfile;
 use PhpSpec\Ai\Agent\Writer;
 use PhpSpec\Ai\PromptLibrary;
 use PhpSpec\Ai\ProviderFactory;
@@ -53,6 +52,9 @@ final class CommandDispatcher
     private readonly SpecRunner $specRunner;
     private readonly RoleState $roleState;
     private readonly Agent $agent;
+
+    /** Resolves prompt files, project overrides first. */
+    private readonly PromptLibrary $prompts;
     private ?AiAssistant $ai = null;
 
     /**
@@ -104,6 +106,7 @@ final class CommandDispatcher
     ) {
         $this->parser = new InputParser();
         $this->filesystem = $filesystem ?? new RealFilesystem();
+        $this->prompts = new PromptLibrary($this->filesystem);
         $this->chooser = $chooser ?? new Chooser($output, $interactive);
         $this->specRunner = $specRunner ?? new SubprocessRunner();
         $this->roleState = $roleState ?? new RoleState();
@@ -234,7 +237,7 @@ final class CommandDispatcher
      */
     private function nextInstruction(): string
     {
-        $coaching = (new PromptLibrary($this->filesystem))->read('next');
+        $coaching = $this->prompts->read('next');
         if (trim($coaching) === '') {
             $coaching = 'Follow outside-in, feature-first TDD — favour feature (story) tests, always a baby step.';
         }
@@ -642,8 +645,7 @@ final class CommandDispatcher
         $original = $instruction;
 
         for ($round = 0; $round < 3; $round++) {
-            // The profile is shipped package code, loaded from the real filesystem.
-            $outcome = $this->agent->do(CommandProfile::load('generate'), $instruction);
+            $outcome = $this->agent->chat('generate', $instruction);
             if ($outcome->proposals === []) {
                 $reason = $outcome->prose !== '' ? $outcome->prose : 'Could not generate anything for that instruction. Try rephrasing.';
                 if ($this->ai !== null) {

--- a/src/PhpSpec/Console/Command/Refactor/RefactorAgent.php
+++ b/src/PhpSpec/Console/Command/Refactor/RefactorAgent.php
@@ -19,6 +19,7 @@ use PhpSpec\Ai\AiTools;
 use PhpSpec\Ai\Contracts\ProviderInterface;
 use PhpSpec\Ai\Contracts\ToolInterface;
 use PhpSpec\Ai\Message;
+use PhpSpec\Ai\PromptLibrary;
 use PhpSpec\Ai\ProviderFactory;
 use PhpSpec\Ai\SpecSubprocess;
 use PhpSpec\Ai\Tool;
@@ -63,6 +64,8 @@ final class RefactorAgent
     /** @var (callable(string, string, string): bool)|null */
     private $confirm;
 
+    private readonly PromptLibrary $prompts;
+
     /**
      * @param callable(string): array{0: int, 1: string}|null $specRunner runs the spec file; defaults to a subprocess
      * @param (callable(string, string, string): bool)|null $confirm asked with (technique, description, diff) before the write; null applies without asking
@@ -74,10 +77,12 @@ final class RefactorAgent
         private readonly ?string $effort = null,
         ?callable $specRunner = null,
         ?callable $confirm = null,
+        ?PromptLibrary $prompts = null,
     ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
         $this->specRunner = $specRunner ?? SpecSubprocess::run(...);
         $this->confirm = $confirm;
+        $this->prompts = $prompts ?? new PromptLibrary($this->filesystem);
     }
 
     /**
@@ -307,14 +312,13 @@ final class RefactorAgent
     }
 
     /**
-     * The refactor command's manifest, or null when its prompt file cannot be
-     * loaded (prompts are shipped package code, so they load from the real
-     * filesystem).
+     * The refactor command's manifest resolved through the prompt library
+     * (project overrides first), or null when no prompt file exists.
      */
     private function profile(): ?CommandProfile
     {
         try {
-            return CommandProfile::load('refactor');
+            return CommandProfile::compose('refactor', ...$this->prompts->stack('commands/refactor'));
         } catch (RuntimeException) {
             return null;
         }


### PR DESCRIPTION
Since beta.10 every AI prompt is an editable text file, but they ship inside the package: a user's edit dies on the next composer update. This makes the promise real. A project overrides any shipped prompt by placing a file of the same name under .phpspec/prompts/ (mirroring commands/, instructions/, tools/, and the top-level role files), committable and team-shared. A project file fully replaces the shipped one; @include lines inside any prompt resolve project-first, and a self-including override is a clear cycle error.

Command manifests inherit per key: a prose-only override of commands/next.txt keeps the shipped tools, answer channel, grounding, and params; declaring only temperature changes only temperature. The capture log marks overridden names (commands/generate (project)) so you can always see whose words the model heard.

The design work rode the seams instead of adding query methods. A small Prompt value (name, text, origin) and one richer library question, stack(), replace what would have been a source()/readShipped() interrogation trio. The hidden-dependency statics went with it: CommandProfile::load() (a static constructing its own library, called from four sites) became the pure named constructor CommandProfile::compose(name, ...layers), and the pipeline verb was renamed as requested: commands now call Agent::chat("generate", instruction) and the agent resolves the manifest through its own prompt library, one instance flowing down into the ToolRegistry. AiAssistant and CommandDispatcher hold their library as a field (toolDescription became an instance method); RefactorAgent takes the library as a defaulted dependency. Shipped prompts read through their own filesystem (they are package code); project prompts read through the injected project seam.

Dogfooded live in the todo sandbox with a real provider: a steps-syntax override declaring the project's step-world property flowed through the @include into the composed request, and a prose-only commands/generate.txt override showed the (project) marker while inheriting the shipped tool-call contract end to end.

Verification: 1746 examples and 28 features / 225 scenarios / 1138 steps green on 8.2.30/8.3.16/8.4.4/8.5.3 (two new story scenarios lock the override and the marker offline via the capture log), coverage 92.1, phpstan and cs-fixer clean. Docs: a Customising the prompts section in configuration.md.