### PR TITLE
Accept hyphenated ai config keys and name the missing one honestly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
  - A step whose code throws reports under Errors with its type, code excerpt, and location, and tallies as "N errored"; only a failed expectation reads as a Failure
  - PHP warnings raised inside a step land in the Warnings section with their location instead of leaking raw to the terminal
- - The ai config accepts hyphenated key spellings (api-key, max-tokens), and a present ai section missing its key is told exactly which key, never that the section does not exist
+ - The ai section is validated as documented: unknown or misspelled keys get a did-you-mean, hyphenated spellings are accepted, wrong-typed values are named instead of silently dropped, and a missing key is named precisely, never reported as a missing section
+ - Forgetting the ai provider names the installed papi package as the answer, instead of silently assuming openai and then blaming a missing composer package
+ - An ollama config works without api_key and its base_url reaches the provider; all six providers (google, anthropic, openai, grok, deepseek, ollama) are documented
 
 ## [9.0.0-beta.16](https://github.com/phpspec/phpspec/compare/9.0.0-beta.15...9.0.0-beta.16)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
  - A step whose code throws reports under Errors with its type, code excerpt, and location, and tallies as "N errored"; only a failed expectation reads as a Failure
  - PHP warnings raised inside a step land in the Warnings section with their location instead of leaking raw to the terminal
+ - The ai config accepts hyphenated key spellings (api-key, max-tokens), and a present ai section missing its key is told exactly which key, never that the section does not exist
 
 ## [9.0.0-beta.16](https://github.com/phpspec/phpspec/compare/9.0.0-beta.15...9.0.0-beta.16)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,13 +305,16 @@ ai:
 
 | Key | Required | Description |
 |---|---|---|
-| `provider` | Yes | LLM provider: `google`, `anthropic`, or `openai` |
+| `provider` | Yes | LLM provider: `google`, `anthropic`, `openai`, `grok`, `deepseek`, or `ollama` |
 | `model` | No | Model identifier; your setting always beats the shipped default |
 | `max_tokens` | No | Output-token ceiling per call; beats the per-command defaults |
 | `effort` | No | Reasoning effort passed to the provider (e.g. `low`, `medium`, `high`), applied once the provider supports it |
-| `api_key` | Yes | API key for the provider. Without this, AI features are disabled. |
+| `api_key` | Yes* | API key for the provider. Required for every provider except `ollama`. |
+| `base_url` | No | The local ollama endpoint (defaults to `http://localhost:11434`); only `ollama` reads it |
 
-Default models per provider: `gemini-3.1-pro-preview` (google), `claude-sonnet-5` (anthropic), `gpt-5.1` (openai).
+Default models per provider: `gemini-3.1-pro-preview` (google), `claude-sonnet-5` (anthropic), `gpt-5.1` (openai), `grok-4` (grok), `deepseek-chat` (deepseek), `llama3.1` (ollama).
+
+Key names are snake_case; hyphenated spellings (`api-key`) are accepted. A misspelled or unknown key, a missing required one, or a wrong-typed value is reported precisely, naming the key and the fix.
 
 ### Customising the prompts
 

--- a/features/scenarios/cli/next.feature
+++ b/features/scenarios/cli/next.feature
@@ -36,6 +36,18 @@ Feature: AI-powered next suggestion
     And the output should contain "The ai section is missing api_key"
     And the output should not contain "AI configuration required"
 
+  Scenario: Forgetting the provider points at the installed papi package
+    Given no phpspec.json config
+    And a phpspec.yaml config:
+      """
+      ai:
+        api_key: bogus-key
+      """
+    When I run phpspec next
+    Then the exit code should not be 0
+    And the output should contain "The ai section is missing provider"
+    And the output should contain "set provider: google"
+
   Scenario: Suggest next step for a project with specs but no features
     Given a phpspec.yaml config:
       """

--- a/features/scenarios/cli/next.feature
+++ b/features/scenarios/cli/next.feature
@@ -13,6 +13,29 @@ Feature: AI-powered next suggestion
     Then the exit code should not be 0
     And the output should contain "AI configuration required"
 
+  Scenario: A hyphenated api-key spelling is accepted
+    Given no phpspec.json config
+    And a phpspec.yaml config:
+      """
+      ai:
+        provider: google
+        api-key: bogus-key
+      """
+    When I run phpspec next
+    Then the output should not contain "AI configuration required"
+
+  Scenario: An ai section without its key is told which key is missing
+    Given no phpspec.json config
+    And a phpspec.yaml config:
+      """
+      ai:
+        provider: google
+      """
+    When I run phpspec next
+    Then the exit code should not be 0
+    And the output should contain "The ai section is missing api_key"
+    And the output should not contain "AI configuration required"
+
   Scenario: Suggest next step for a project with specs but no features
     Given a phpspec.yaml config:
       """

--- a/spec/PhpSpec/Configuration.spec.php
+++ b/spec/PhpSpec/Configuration.spec.php
@@ -272,6 +272,19 @@ describe(Configuration::class, function () {
         expect($config->aiConfigProblem())->toBe('The ai section is missing api_key. Add it to your phpspec config.');
     });
 
+    it('names the wrong type when api_key is present but not a string', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  provider: google\n  api_key: 12345\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->getAiConfig())->toBeNull();
+        expect($config->aiConfigProblem())->toBe('The ai section\'s api_key must be a string. Quote it in your phpspec config.');
+    });
+
     it('asks for the ai section when the config has none', function (Filesystem $fs) {
         allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
             '/app/phpspec.yaml' => true,

--- a/spec/PhpSpec/Configuration.spec.php
+++ b/spec/PhpSpec/Configuration.spec.php
@@ -243,6 +243,59 @@ describe(Configuration::class, function () {
         ]);
     });
 
+    it('accepts hyphenated spellings of the ai keys, api-key and max-tokens', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  provider: google\n  api-key: test-key-123\n  max-tokens: 32000\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->getAiConfig())->toBe([
+            'provider' => 'google',
+            'maxTokens' => 32000,
+            'api_key' => 'test-key-123',
+        ]);
+    });
+
+    it('names the missing key when the ai section exists without api_key', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  provider: google\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->getAiConfig())->toBeNull();
+        expect($config->aiConfigProblem())->toBe('The ai section is missing api_key. Add it to your phpspec config.');
+    });
+
+    it('asks for the ai section when the config has none', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("spec_path: spec\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->aiConfigProblem())->toBe('AI configuration required. Add an "ai" section to your phpspec config.');
+    });
+
+    it('reports no ai config problem when the section is usable', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  provider: google\n  api_key: test-key-123\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->aiConfigProblem())->toBeNull();
+    });
+
     it('exposes a configured max_tokens as an int', function (Filesystem $fs) {
         allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
             '/app/phpspec.yaml' => true,

--- a/spec/PhpSpec/Configuration.spec.php
+++ b/spec/PhpSpec/Configuration.spec.php
@@ -272,6 +272,74 @@ describe(Configuration::class, function () {
         expect($config->aiConfigProblem())->toBe('The ai section is missing api_key. Add it to your phpspec config.');
     });
 
+    it('requires provider, and names the installed papi package as the answer', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  api_key: test-key-123\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->getAiConfig())->toBeNull();
+        expect($config->aiConfigProblem())->toBe('The ai section is missing provider. papi-ai/google is installed, so set provider: google.');
+    });
+
+    it('rejects an unknown provider, listing the known ones', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  provider: googel\n  api_key: test-key-123\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->getAiConfig())->toBeNull();
+        expect($config->aiConfigProblem())->toBe('Unknown ai provider "googel". The known providers are google, anthropic, openai, grok, deepseek, and ollama.');
+    });
+
+    it('accepts an ollama section without api_key, passing its base_url through', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  provider: ollama\n  base_url: http://localhost:11434\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->aiConfigProblem())->toBeNull();
+        expect($config->getAiConfig())->toBe([
+            'provider' => 'ollama',
+            'base_url' => 'http://localhost:11434',
+        ]);
+    });
+
+    it('catches a misspelled ai key with a suggestion', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  provider: google\n  api_keys: test-key-123\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->getAiConfig())->toBeNull();
+        expect($config->aiConfigProblem())->toBe('Unknown ai key "api_keys". Did you mean "api_key"?');
+    });
+
+    it('names a wrong-typed optional key instead of silently dropping it', function (Filesystem $fs) {
+        allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
+            '/app/phpspec.yaml' => true,
+            default => false,
+        });
+        allow($fs->read())->toReturn("ai:\n  provider: google\n  api_key: test-key-123\n  max_tokens: plenty\n");
+
+        $config = new Configuration('/app', $fs);
+
+        expect($config->getAiConfig())->toBeNull();
+        expect($config->aiConfigProblem())->toBe('The ai section\'s max_tokens must be a positive number.');
+    });
+
     it('names the wrong type when api_key is present but not a string', function (Filesystem $fs) {
         allow($fs->exists())->toReturnUsing(fn(string $path) => match ($path) {
             '/app/phpspec.yaml' => true,
@@ -340,12 +408,12 @@ describe(Configuration::class, function () {
             'api_key' => 'test-key-123',
         ]);
 
+        // A wrong-typed effort is named, never silently dropped.
         allow($fs->read())->toReturn("ai:\n  provider: google\n  api_key: test-key-123\n  effort: 12\n");
+        $config = new Configuration('/app', $fs);
 
-        expect((new Configuration('/app', $fs))->getAiConfig())->toBe([
-            'provider' => 'google',
-            'api_key' => 'test-key-123',
-        ]);
+        expect($config->getAiConfig())->toBeNull();
+        expect($config->aiConfigProblem())->toBe('The ai section\'s effort must be a non-empty string.');
     });
 
     it('returns null for ai config when not configured', function (Filesystem $fs) {

--- a/src/PhpSpec/Ai/Agent/Agent.php
+++ b/src/PhpSpec/Ai/Agent/Agent.php
@@ -438,7 +438,7 @@ final class Agent
         }
 
         if ($aiConfig === null) {
-            throw new RuntimeException('AI configuration required. Add an "ai" section to your phpspec config.');
+            throw new RuntimeException($this->config->aiConfigProblem() ?? 'AI configuration required. Add an "ai" section to your phpspec config.');
         }
 
         return ProviderFactory::create($aiConfig);

--- a/src/PhpSpec/Ai/Agent/Agent.php
+++ b/src/PhpSpec/Ai/Agent/Agent.php
@@ -136,7 +136,7 @@ final class Agent
      * answers in prose), executes the tool calls into proposals, and captures
      * the exchange.
      *
-     * @param array{provider: string, model?: string, api_key: string, maxTokens?: int, effort?: string}|null $aiConfig
+     * @param array{provider: string, model?: string, api_key?: string, maxTokens?: int, effort?: string}|null $aiConfig
      */
     private function ask(CommandProfile $profile, ?Step $step, Grounding $grounding, string $instruction, ?array $aiConfig): Outcome
     {
@@ -429,7 +429,7 @@ final class Agent
      * The provider to talk to: the injected seam, or one built from the ai
      * config; a missing config is reported like any other provider failure.
      *
-     * @param array{provider: string, model?: string, api_key: string, maxTokens?: int, effort?: string}|null $aiConfig
+     * @param array{provider: string, model?: string, api_key?: string, maxTokens?: int, effort?: string}|null $aiConfig
      */
     private function providerFor(?array $aiConfig): ProviderInterface
     {

--- a/src/PhpSpec/Ai/ProviderFactory.php
+++ b/src/PhpSpec/Ai/ProviderFactory.php
@@ -29,13 +29,46 @@ final class ProviderFactory
         'openai' => ['class' => 'PapiAI\OpenAI\OpenAIProvider', 'model' => 'gpt-5.1'],
         'grok' => ['class' => 'PapiAI\Grok\GrokProvider', 'model' => 'grok-4'],
         'deepseek' => ['class' => 'PapiAI\DeepSeek\DeepSeekProvider', 'model' => 'deepseek-chat'],
-        'ollama' => ['class' => 'PapiAI\Ollama\OllamaProvider', 'model' => 'llama3.1'],
+        'ollama' => ['class' => 'PapiAI\Ollama\OllamaProvider', 'model' => 'llama3.1', 'needs_key' => false],
     ];
+
+    /**
+     * Every provider name this factory can construct.
+     *
+     * @return list<string>
+     */
+    public static function providers(): array
+    {
+        return array_keys(self::DEFAULTS);
+    }
+
+    /**
+     * The providers whose papi package is actually installed, so a config
+     * message can point at the one the project already has.
+     *
+     * @return list<string>
+     */
+    public static function installed(): array
+    {
+        return array_values(array_filter(
+            array_keys(self::DEFAULTS),
+            static fn(string $provider): bool => class_exists(self::DEFAULTS[$provider]['class']),
+        ));
+    }
+
+    /**
+     * Whether a provider authenticates with an api_key (a local ollama does
+     * not; it connects to a base_url instead).
+     */
+    public static function needsApiKey(string $provider): bool
+    {
+        return self::DEFAULTS[$provider]['needs_key'] ?? true;
+    }
 
     /**
      * Creates an AI provider instance from the given configuration.
      *
-     * @param array{provider?: string, api_key: string, model?: string, base_url?: string} $aiConfig
+     * @param array{provider?: string, api_key?: string, model?: string, base_url?: string} $aiConfig
      *
      * @return ProviderInterface
      *
@@ -68,9 +101,9 @@ final class ProviderFactory
             );
         }
 
-        $papiProvider = $provider === 'ollama'
-            ? new $class($aiConfig['base_url'] ?? 'http://localhost:11434')
-            : new $class($aiConfig['api_key']);
+        $papiProvider = self::needsApiKey($provider)
+            ? new $class($aiConfig['api_key'] ?? throw new InvalidArgumentException(sprintf('Provider "%s" needs an api_key.', $provider)))
+            : new $class($aiConfig['base_url'] ?? 'http://localhost:11434');
 
         return new PapiProvider($papiProvider);
     }

--- a/src/PhpSpec/Configuration.php
+++ b/src/PhpSpec/Configuration.php
@@ -342,7 +342,7 @@ final class Configuration
     public function getAiConfig(): ?array
     {
         $ai = $this->normalisedAiSection();
-        if ($ai === null || !isset($ai['api_key']) || !is_string($ai['api_key'])) {
+        if ($ai === null || $this->aiSectionGap($ai) !== null) {
             return null;
         }
         $result = [
@@ -405,20 +405,39 @@ final class Configuration
 
     /**
      * What stands between the user and a working AI config, or null when the
-     * config is usable: a present-but-keyless section is told which key is
-     * missing, never that the section does not exist.
+     * config is usable: a present-but-unusable section is told exactly what
+     * the gap is, never that the section does not exist. The message comes
+     * from the same check that makes {@see getAiConfig()} return null, so the
+     * two can never disagree.
      */
     public function aiConfigProblem(): ?string
     {
-        if ($this->getAiConfig() !== null) {
-            return null;
+        $ai = $this->normalisedAiSection();
+        if ($ai === null) {
+            return 'AI configuration required. Add an "ai" section to your phpspec config.';
         }
 
-        if ($this->normalisedAiSection() !== null) {
+        return $this->aiSectionGap($ai);
+    }
+
+    /**
+     * The first unmet requirement of the ai section as a user-facing message,
+     * or null when the section is usable. The one statement of what a usable
+     * ai config requires: the reader and the diagnosis both derive from it.
+     *
+     * @param array<string, mixed> $ai the normalised ai section
+     */
+    private function aiSectionGap(array $ai): ?string
+    {
+        if (!isset($ai['api_key'])) {
             return 'The ai section is missing api_key. Add it to your phpspec config.';
         }
 
-        return 'AI configuration required. Add an "ai" section to your phpspec config.';
+        if (!is_string($ai['api_key'])) {
+            return 'The ai section\'s api_key must be a string. Quote it in your phpspec config.';
+        }
+
+        return null;
     }
 
     /**

--- a/src/PhpSpec/Configuration.php
+++ b/src/PhpSpec/Configuration.php
@@ -341,8 +341,8 @@ final class Configuration
      */
     public function getAiConfig(): ?array
     {
-        $ai = $this->get('ai');
-        if (!is_array($ai) || !isset($ai['api_key']) || !is_string($ai['api_key'])) {
+        $ai = $this->normalisedAiSection();
+        if ($ai === null || !isset($ai['api_key']) || !is_string($ai['api_key'])) {
             return null;
         }
         $result = [
@@ -401,5 +401,47 @@ final class Configuration
     public function toArray(): array
     {
         return $this->config;
+    }
+
+    /**
+     * What stands between the user and a working AI config, or null when the
+     * config is usable: a present-but-keyless section is told which key is
+     * missing, never that the section does not exist.
+     */
+    public function aiConfigProblem(): ?string
+    {
+        if ($this->getAiConfig() !== null) {
+            return null;
+        }
+
+        if ($this->normalisedAiSection() !== null) {
+            return 'The ai section is missing api_key. Add it to your phpspec config.';
+        }
+
+        return 'AI configuration required. Add an "ai" section to your phpspec config.';
+    }
+
+    /**
+     * The raw ai section with hyphenated spellings of its keys folded onto the
+     * canonical snake_case names (api-key reads as api_key), or null when the
+     * config has no ai section. Snake case stays the documented spelling; the
+     * common YAML hyphen habit simply keeps working.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function normalisedAiSection(): ?array
+    {
+        $ai = $this->get('ai');
+        if (!is_array($ai)) {
+            return null;
+        }
+
+        foreach (['api-key' => 'api_key', 'max-tokens' => 'max_tokens'] as $hyphenated => $canonical) {
+            if (isset($ai[$hyphenated]) && !isset($ai[$canonical])) {
+                $ai[$canonical] = $ai[$hyphenated];
+            }
+        }
+
+        return $ai;
     }
 }

--- a/src/PhpSpec/Configuration.php
+++ b/src/PhpSpec/Configuration.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec;
 
+use PhpSpec\Ai\ProviderFactory;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -335,9 +336,17 @@ final class Configuration
     }
 
     /**
-     * Returns the AI configuration block, or null if not configured.
+     * The keys a valid ai section may hold, in their canonical snake_case
+     * spellings; the documented contract in one place.
+     */
+    private const AI_KEYS = ['provider', 'model', 'max_tokens', 'effort', 'api_key', 'base_url'];
+
+    /**
+     * Returns the AI configuration block, or null when it is absent or
+     * unusable ({@see aiConfigProblem()} says why). api_key is present for
+     * every provider that authenticates with one; a local ollama has none.
      *
-     * @return array{provider: string, model?: string, maxTokens?: int, effort?: string, api_key: string}|null
+     * @return array{provider: string, model?: string, maxTokens?: int, effort?: string, base_url?: string, api_key?: string}|null
      */
     public function getAiConfig(): ?array
     {
@@ -345,19 +354,26 @@ final class Configuration
         if ($ai === null || $this->aiSectionGap($ai) !== null) {
             return null;
         }
-        $result = [
-            'provider' => isset($ai['provider']) && is_string($ai['provider']) ? $ai['provider'] : 'openai',
-        ];
-        if (isset($ai['model']) && is_string($ai['model'])) {
+
+        // The gap check above vouched for every key and type, so the values
+        // read straight through; nothing here is silently defaulted or dropped.
+        $result = ['provider' => $ai['provider']];
+        if (isset($ai['model'])) {
             $result['model'] = $ai['model'];
         }
-        if (isset($ai['max_tokens']) && is_numeric($ai['max_tokens']) && (int) $ai['max_tokens'] > 0) {
+        if (isset($ai['max_tokens'])) {
             $result['maxTokens'] = (int) $ai['max_tokens'];
         }
-        if (isset($ai['effort']) && is_string($ai['effort']) && $ai['effort'] !== '') {
+        if (isset($ai['effort'])) {
             $result['effort'] = $ai['effort'];
         }
-        $result['api_key'] = $ai['api_key'];
+        if (isset($ai['base_url'])) {
+            $result['base_url'] = $ai['base_url'];
+        }
+        if (isset($ai['api_key'])) {
+            $result['api_key'] = $ai['api_key'];
+        }
+
         return $result;
     }
 
@@ -421,30 +437,129 @@ final class Configuration
     }
 
     /**
+     * Whether the config declares an ai section at all, usable or not.
+     */
+    public function hasAiSection(): bool
+    {
+        return is_array($this->get('ai'));
+    }
+
+    /**
      * The first unmet requirement of the ai section as a user-facing message,
      * or null when the section is usable. The one statement of what a usable
-     * ai config requires: the reader and the diagnosis both derive from it.
+     * ai config requires: the reader and the diagnosis both derive from it,
+     * and the provider knowledge comes from the factory that constructs them,
+     * so neither the message nor the acceptance can drift from reality.
      *
      * @param array<string, mixed> $ai the normalised ai section
      */
     private function aiSectionGap(array $ai): ?string
     {
-        if (!isset($ai['api_key'])) {
-            return 'The ai section is missing api_key. Add it to your phpspec config.';
+        foreach (array_keys($ai) as $key) {
+            if (!in_array($key, self::AI_KEYS, true)) {
+                return $this->unknownAiKey((string) $key);
+            }
         }
 
-        if (!is_string($ai['api_key'])) {
-            return 'The ai section\'s api_key must be a string. Quote it in your phpspec config.';
+        if (!isset($ai['provider'])) {
+            return $this->missingProvider();
+        }
+
+        if (!is_string($ai['provider']) || !in_array($ai['provider'], ProviderFactory::providers(), true)) {
+            return sprintf(
+                'Unknown ai provider "%s". The known providers are %s.',
+                is_scalar($ai['provider']) ? (string) $ai['provider'] : get_debug_type($ai['provider']),
+                self::naturalList(ProviderFactory::providers()),
+            );
+        }
+
+        if (ProviderFactory::needsApiKey($ai['provider'])) {
+            if (!isset($ai['api_key'])) {
+                return 'The ai section is missing api_key. Add it to your phpspec config.';
+            }
+
+            if (!is_string($ai['api_key'])) {
+                return 'The ai section\'s api_key must be a string. Quote it in your phpspec config.';
+            }
+        }
+
+        if (isset($ai['model']) && !is_string($ai['model'])) {
+            return 'The ai section\'s model must be a string.';
+        }
+
+        if (isset($ai['max_tokens']) && (!is_numeric($ai['max_tokens']) || (int) $ai['max_tokens'] <= 0)) {
+            return 'The ai section\'s max_tokens must be a positive number.';
+        }
+
+        if (isset($ai['effort']) && (!is_string($ai['effort']) || $ai['effort'] === '')) {
+            return 'The ai section\'s effort must be a non-empty string.';
+        }
+
+        if (isset($ai['base_url']) && !is_string($ai['base_url'])) {
+            return 'The ai section\'s base_url must be a string.';
         }
 
         return null;
     }
 
     /**
+     * The message for an unrecognised ai key: the nearest known key when the
+     * spelling is close (a typo), the full list otherwise.
+     */
+    private function unknownAiKey(string $key): string
+    {
+        $closest = null;
+        $best = 4;
+        foreach (self::AI_KEYS as $known) {
+            $distance = levenshtein($key, $known);
+            if ($distance < $best) {
+                $best = $distance;
+                $closest = $known;
+            }
+        }
+
+        if ($closest !== null) {
+            return sprintf('Unknown ai key "%s". Did you mean "%s"?', $key, $closest);
+        }
+
+        return sprintf('Unknown ai key "%s". The known keys are %s.', $key, self::naturalList(self::AI_KEYS));
+    }
+
+    /**
+     * The missing-provider message: when exactly one papi provider package is
+     * installed, the error names it as the answer.
+     */
+    private function missingProvider(): string
+    {
+        $installed = ProviderFactory::installed();
+        if (count($installed) === 1) {
+            return sprintf('The ai section is missing provider. papi-ai/%s is installed, so set provider: %s.', $installed[0], $installed[0]);
+        }
+
+        return sprintf('The ai section is missing provider. Set it to %s.', self::naturalList(ProviderFactory::providers()));
+    }
+
+    /**
+     * Joins words as prose: "google, anthropic, and openai".
+     *
+     * @param list<string> $items
+     */
+    private static function naturalList(array $items): string
+    {
+        if (count($items) <= 1) {
+            return implode('', $items);
+        }
+
+        $last = array_pop($items);
+
+        return implode(', ', $items) . ', and ' . $last;
+    }
+
+    /**
      * The raw ai section with hyphenated spellings of its keys folded onto the
-     * canonical snake_case names (api-key reads as api_key), or null when the
-     * config has no ai section. Snake case stays the documented spelling; the
-     * common YAML hyphen habit simply keeps working.
+     * canonical snake_case names (api-key reads as api_key, for every known
+     * key), or null when the config has no ai section. Snake case stays the
+     * documented spelling; the common YAML hyphen habit simply keeps working.
      *
      * @return array<string, mixed>|null
      */
@@ -455,9 +570,11 @@ final class Configuration
             return null;
         }
 
-        foreach (['api-key' => 'api_key', 'max-tokens' => 'max_tokens'] as $hyphenated => $canonical) {
-            if (isset($ai[$hyphenated]) && !isset($ai[$canonical])) {
-                $ai[$canonical] = $ai[$hyphenated];
+        foreach (array_keys($ai) as $key) {
+            $canonical = str_replace('-', '_', (string) $key);
+            if ($canonical !== $key && in_array($canonical, self::AI_KEYS, true) && !isset($ai[$canonical])) {
+                $ai[$canonical] = $ai[$key];
+                unset($ai[$key]);
             }
         }
 

--- a/src/PhpSpec/Console/Command/Generate.php
+++ b/src/PhpSpec/Console/Command/Generate.php
@@ -70,7 +70,7 @@ final class Generate extends Command
     {
         $aiConfig = $this->config->getAiConfig();
         if ($aiConfig === null) {
-            $output->writeln('<fg=red>AI configuration required. Add an "ai" section to your phpspec config.</>');
+            $output->writeln('<fg=red>' . $this->config->aiConfigProblem() . '</>');
 
             return 1;
         }

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -55,13 +55,13 @@ final class Next extends Command
 
     private readonly SpecRunner $specRunner;
 
-    /** @var (callable(array{provider: string, model?: string, api_key: string}, string): array{type: string, target: string, reason: string})|null */
+    /** @var (callable(array{provider: string, model?: string, api_key?: string}, string): array{type: string, target: string, reason: string})|null */
     private $suggestFn;
 
     /**
      * @param Configuration $config
      * @param Filesystem|null $filesystem
-     * @param (callable(array{provider: string, model?: string, api_key: string}, string): array{type: string, target: string, reason: string})|null $suggestFn injectable display seam; receives the AI config and the rendered situation
+     * @param (callable(array{provider: string, model?: string, api_key?: string}, string): array{type: string, target: string, reason: string})|null $suggestFn injectable display seam; receives the AI config and the rendered situation
      * @param SpecRunner|null $specRunner runs the suite for feature grounding; defaults to a subprocess
      * @param ProviderInterface|null $provider injectable AI seam for the agent pipeline
      */
@@ -233,7 +233,7 @@ final class Next extends Command
      * deterministically, and the model answers with a suggest_next tool call
      * (never JSON-in-prose to parse).
      *
-     * @param array{provider: string, model?: string, api_key: string} $aiConfig
+     * @param array{provider: string, model?: string, api_key?: string} $aiConfig
      * @return array{type: string, target: string, reason: string}
      */
     private function getSuggestion(array $aiConfig): array

--- a/src/PhpSpec/Console/Command/Next.php
+++ b/src/PhpSpec/Console/Command/Next.php
@@ -93,7 +93,7 @@ final class Next extends Command
         // 1. Check AI config
         $aiConfig = $this->config->getAiConfig();
         if ($aiConfig === null) {
-            $output->writeln('<fg=red>AI configuration required. Add an "ai" section to your phpspec config.</>');
+            $output->writeln('<fg=red>' . $this->config->aiConfigProblem() . '</>');
             return 1;
         }
 

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -120,15 +120,24 @@ final class CommandDispatcher
         }
 
         $aiConfig = $this->config->getAiConfig();
-        if ($aiConfig !== null) {
-            try {
-                $provider = ProviderFactory::create($aiConfig);
-                $this->ai = new AiAssistant($provider, $this->config, $this->output, $this->filesystem, $this->interactive, $this->extensionLoader, $this->chooser, $this->roleState);
-            } catch (Exception $e) {
-                // Any provider failure — an unknown name, a missing package, a bad
-                // key — leaves AI unavailable rather than crashing the session.
-                $this->aiUnavailableReason = $e->getMessage();
+        if ($aiConfig === null) {
+            // A present-but-unusable ai section is a reason worth showing (the
+            // config diagnosis names the exact gap); a wholly absent section
+            // stays quiet, keeping pair usable without AI.
+            if ($this->config->hasAiSection()) {
+                $this->aiUnavailableReason = $this->config->aiConfigProblem();
             }
+
+            return;
+        }
+
+        try {
+            $provider = ProviderFactory::create($aiConfig);
+            $this->ai = new AiAssistant($provider, $this->config, $this->output, $this->filesystem, $this->interactive, $this->extensionLoader, $this->chooser, $this->roleState);
+        } catch (Exception $e) {
+            // Any provider failure — a missing package, a bad key — leaves AI
+            // unavailable rather than crashing the session.
+            $this->aiUnavailableReason = $e->getMessage();
         }
     }
 

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -639,7 +639,7 @@ final class CommandDispatcher
 
         $aiConfig = $this->config->getAiConfig();
         if ($aiConfig === null) {
-            $this->output->error('AI configuration required for /generate: add an "ai" section to phpspec.yaml.');
+            $this->output->error('/generate needs AI. ' . $this->config->aiConfigProblem());
 
             return self::CONTINUE;
         }
@@ -825,7 +825,7 @@ final class CommandDispatcher
 
         $this->output->error(
             "No AI provider is configured, so I can't use natural language.\n"
-            . '  Add an "ai" section to phpspec.yaml, or type /help for the available commands.',
+            . '  ' . $this->config->aiConfigProblem() . ' Or type /help for the available commands.',
         );
 
         return self::CONTINUE;

--- a/src/PhpSpec/Console/Command/Refactor.php
+++ b/src/PhpSpec/Console/Command/Refactor.php
@@ -248,7 +248,7 @@ final class Refactor extends Command
     /**
      * Performs the refactoring via injected callable or RefactorAgent.
      *
-     * @param array{provider: string, model?: string, api_key: string, effort?: string} $aiConfig
+     * @param array{provider: string, model?: string, api_key?: string, effort?: string} $aiConfig
      * @param callable(string, string, string): bool $confirm asked with (technique, description, diff) before the write
      */
     private function performRefactoring(array $aiConfig, string $srcPath, string $specPath, ?string $method, callable $confirm): RefactorResult

--- a/src/PhpSpec/Console/Command/Refactor.php
+++ b/src/PhpSpec/Console/Command/Refactor.php
@@ -81,7 +81,7 @@ final class Refactor extends Command
         // 1. Check AI config
         $aiConfig = $this->config->getAiConfig();
         if ($aiConfig === null) {
-            $output->writeln('<fg=red>AI configuration required. Add an "ai" section to your phpspec config.</>');
+            $output->writeln('<fg=red>' . $this->config->aiConfigProblem() . '</>');
             return 1;
         }
 


### PR DESCRIPTION
Dogfood report: a phpspec.yml with an ai section spelled api-key was answered with "AI configuration required. Add an ai section to your phpspec config.", claiming the section does not exist.

Two fixes. The ai section now accepts the common YAML hyphen habit: api-key and max-tokens read as api_key and max_tokens (snake_case stays the documented spelling). And when the section genuinely lacks its key, the message says exactly that: "The ai section is missing api_key. Add it to your phpspec config." All six message sites (the standalone commands, the pipeline, and pair's two contextual hints) speak through the one Configuration::aiConfigProblem() answer, so the wording can never diverge again.

Verified on 8.2.30/8.3.16/8.4.4/8.5.3, both suites, phpstan and cs-fixer clean, with feature scenarios locking both the hyphenated spelling and the honest missing-key message.