### PR TITLE
Prepare 9.0.0-beta.17

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [9.0.0-beta.17](https://github.com/phpspec/phpspec/compare/9.0.0-beta.16...9.0.0-beta.17)
 
 ### Changed
  - Pair's conversation runs through the one `Agent::chat()` pipeline: a persistent Transcript carries the history, the PairToolExecutor runs the tools live, and pair's own provider loop is deleted

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -24,4 +24,4 @@
 
     (new PhpSpec\Console\Application($version))->run();
 
-})('9.0.0-beta.16');
+})('9.0.0-beta.17');


### PR DESCRIPTION
Stamps the Unreleased section as 9.0.0-beta.17 and bumps the CLI version string.

beta.17 carries the pair-onto-pipeline rewire (persistent Transcript, PairToolExecutor, role manifests, session recording and the first replayable pair eval), the step error/warning classification, and the fully validated ai config contract.

Verified on 8.3.16: 1785 examples green, 228 scenarios / 1154 steps green.