### PR TITLE
Ride papi-ai 0.15 so the configured effort reaches the model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+ - papi-ai 0.15 is pulled in, so a configured ai.effort now maps to each provider's native thinking controls (older papi installs keep working; effort stays inert there)
+
 ## [9.0.0-beta.17](https://github.com/phpspec/phpspec/compare/9.0.0-beta.16...9.0.0-beta.17)
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.75",
         "phpstan/phpstan": "^2.1",
-        "papi-ai/papi-core": "^0.13",
-        "papi-ai/google": "^0.13"
+        "papi-ai/papi-core": "^0.13 || ^0.14 || ^0.15",
+        "papi-ai/google": "^0.13 || ^0.14 || ^0.15"
     },
 
     "conflict": {


### PR DESCRIPTION
Widens the papi constraints to "^0.13 || ^0.14 || ^0.15" (resolving core 0.15.1 and google 0.15.4) and keeps the 0.13 floor for user installs, where effort stays harmlessly inert.

phpspec already sent ai.effort on every call; papi 0.15 now maps it onto each provider's native thinking controls, so the config key does real work.

Verified: both suites and phpstan green against 0.15, plus a live pair call in the dogfood sandbox with effort: high consumed end to end.