### PR TITLE
Make the --format=agent contract total

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The agent document reports the coverage verdict, and a missed --coverage-min gate now counts as actionable
  - The agent summary carries one rerun command covering every failure
  - A failing Story BDD scenario carries its own spec location and rerun command, in parallel runs too
+ - The agent document reports a story run one entry per scenario, with the steps that did not pass inside it, and counts scenarios alongside steps
+ - Each row of a Scenario Outline is named by its values, so two rows are told apart wherever scenarios are reported
 
 ### Fixed
  - --format=agent keeps standard output to the document alone: the seed line, profile table, coverage lines and error text no longer break it
  - A run that cannot start, or that dies partway, still emits an agent document naming what stopped it
  - toHaveLength failures now say what length the subject actually has
- - Agent entries are named as a path (App\Basket > totals the prices), so two scenarios sharing a step title no longer share an id
+ - Agent entries are named as a path (App\Basket > totals the prices), and no two entries in a document share an id
  - An errored entry carries its message in the same field a failure does
  - Failure values keep a float's fraction and name an object by what it is (an enum case, a stringable's string, else its class) instead of by a per-run object id
  - A directory argument with a trailing slash no longer doubles the separator in reported paths

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - The agent document reports the coverage verdict, and a missed --coverage-min gate now counts as actionable
+ - The agent summary carries one rerun command covering every failure
+
 ### Fixed
+ - --format=agent keeps standard output to the document alone: the seed line, profile table, coverage lines and error text no longer break it
+ - A run that cannot start, or that dies partway, still emits an agent document naming what stopped it
+ - toHaveLength failures now say what length the subject actually has
  - Notes typed on any pair question now reach the assistant, not just the ones the AI asked
  - /next no longer overrides the pairing role's own prompt, so the navigator offers a change instead of asking permission to offer it
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - An errored entry carries its message in the same field a failure does
  - Failure values keep a float's fraction and name an object by what it is (an enum case, a stringable's string, else its class) instead of by a per-run object id
  - A directory argument with a trailing slash no longer doubles the separator in reported paths
+ - A suite configured without paths of its own reports the spec path instead of nothing
  - Notes typed on any pair question now reach the assistant, not just the ones the AI asked
  - /next no longer overrides the pairing role's own prompt, so the navigator offers a change instead of asking permission to offer it
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
  - The agent document reports the coverage verdict, and a missed --coverage-min gate now counts as actionable
  - The agent summary carries one rerun command covering every failure
+ - A failing Story BDD scenario carries its own spec location and rerun command, in parallel runs too
 
 ### Fixed
  - --format=agent keeps standard output to the document alone: the seed line, profile table, coverage lines and error text no longer break it
  - A run that cannot start, or that dies partway, still emits an agent document naming what stopped it
  - toHaveLength failures now say what length the subject actually has
+ - Agent entries are named as a path (App\Basket > totals the prices), so two scenarios sharing a step title no longer share an id
+ - An errored entry carries its message in the same field a failure does
+ - Failure values keep a float's fraction and name an object by what it is (an enum case, a stringable's string, else its class) instead of by a per-run object id
+ - A directory argument with a trailing slash no longer doubles the separator in reported paths
  - Notes typed on any pair question now reach the assistant, not just the ones the AI asked
  - /next no longer overrides the pairing role's own prompt, so the navigator offers a change instead of asking permission to offer it
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -34,7 +34,7 @@ class — produces:
 {
   "suite": {
     "v": 1, "event": "run_started", "suite": "default",
-    "examples": 3, "steps": 0, "seed": null
+    "examples": 3, "scenarios": 0, "steps": 0, "seed": null
   },
   "examples": [
     {
@@ -66,7 +66,7 @@ class — produces:
   ],
   "result": {
     "v": 1, "event": "summary",
-    "examples": 3, "steps": 0,
+    "examples": 3, "scenarios": 0, "steps": 0,
     "passing": 1, "failing": 1, "errors": 1, "pending": 0, "skipped": 0,
     "actionable": 2,
     "duration_ms": 4,
@@ -82,24 +82,33 @@ Every object carries `"v"` — the agent-protocol version (currently `1`).
 
 ### `suite` — the header
 
-`examples` and `steps` are the totals for the run (`steps` is non-zero only for
-Story BDD feature runs). `suite` is the suite name; `seed` is the random-order
-seed when one was used, else `null`.
+`examples`, `scenarios` and `steps` are the totals for the run (`scenarios` and
+`steps` are non-zero only for Story BDD feature runs). `suite` is the suite name;
+`seed` is the random-order seed when one was used, else `null`.
 
 ### `examples` — only what needs attention
 
-**Passing examples are omitted.** A green suite of thousands need not spend
+**Passing entries are omitted.** A green suite of thousands need not spend
 tokens on entries an agent will never act on — the summary still counts them.
 Each listed entry is one that failed, errored, or is pending/skipped.
+
+**One entry is one thing to fix.** A spec run reports examples; a Story BDD run
+reports **scenarios**, not steps, because a scenario is what fails, what re-runs,
+and what you act on. The steps that did not pass ride inside the entry, so one
+broken scenario is a single item naming the step that broke it, never a failure
+followed by a train of skipped siblings pointing at the same line. Each row of a
+Scenario Outline is its own entry, named by its values
+(`Adding > Adding numbers (1, 2)`).
 
 | Field | Meaning |
 |---|---|
 | `id` | A stable identifier for this example: a hash of its full name. It survives edits that move lines or change where a failure fires, so you can ask *"is THIS exact failure still here?"* across runs. Recomputable from `example`. |
-| `example` | The full name, as a path: `App\Basket > totals the prices` for a spec, `Counting > Counting up > Given a broken step` for a feature step. |
+| `example` | The full name, as a path: `App\Basket > totals the prices` for a spec, `Checkout > Paying for a basket` for a scenario. |
 | `state` | `failing`, `error`, `pending`, or `skipped` (`passing` entries are omitted). |
 | `message` | What went wrong, whatever the state. An `error` entry keeps `exception` too, for the class and the site. |
-| `spec` | The `file:line` of the failing assertion or the error, project-relative. For a feature step it is the scenario's own line. |
+| `spec` | The `file:line` of the failing assertion or the error, project-relative. For a scenario it is the line its `Scenario:` keyword sits on. |
 | `rerun` | The exact arguments to re-run **just this one example or scenario**: prepend your PhpSpec binary. No full-suite re-run needed to verify one fix. |
+| `steps` | Scenarios only: the steps that did not pass, each `{ title, state, message? }`, in the order they were declared. |
 
 **`failing`** entries also carry the expectation:
 
@@ -135,8 +144,10 @@ fraction, so `90.0` is never reported as the `90` it was compared against.
 ### `result` — the summary
 
 The counts (`passing`, `failing`, `errors`, `pending`, `skipped`) are for the
-whole run. The one number to branch on is **`actionable`** = failing + errors +
-pending, plus a coverage gate the run missed and anything that stopped it.
+whole run, in the units the entries are reported in: one per example, one per
+scenario. `steps` is a size, not a verdict. The one number to branch on is
+**`actionable`** = failing + errors + pending, plus a coverage gate the run
+missed and anything that stopped it.
 **Zero means there is nothing to do**, and it never disagrees with the exit code.
 `duration_ms` is the run's wall time; `offers` is the run-wide, de-duplicated
 list of code PhpSpec can generate.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -130,8 +130,42 @@ marker; objects render as `ClassName#id`) so the document never blows up.
 
 The counts (`passing`, `failing`, `errors`, `pending`, `skipped`) are for the
 whole run. The one number to branch on is **`actionable`** = failing + errors +
-pending. **Zero means there is nothing to do.** `duration_ms` is the run's wall
-time; `offers` is the run-wide, de-duplicated list of code PhpSpec can generate.
+pending, plus a coverage gate the run missed and anything that stopped it.
+**Zero means there is nothing to do**, and it never disagrees with the exit code.
+`duration_ms` is the run's wall time; `offers` is the run-wide, de-duplicated
+list of code PhpSpec can generate.
+
+| Field | Present when | Meaning |
+|---|---|---|
+| `rerun` | anything failed with a location | One command that re-runs every failing example at once, so a fix is checked against all of what it was meant to fix. |
+| `coverage` | a `--coverage*` option was given | `{ "percent", "required", "met" }`. `required` is `null` without `--coverage-min`, and `met` is then always `true`. A missed gate adds 1 to `actionable`. |
+
+### `fatal`: when the run could not finish
+
+A run that never started (a missing bootstrap, an unknown format) or that died
+partway (a parse error, a class that fails to compile) still answers with a
+document. It carries a top-level `fatal` of `{ "message", "at" }`, holds whatever
+the run did manage to collect, and counts 1 in `actionable`.
+
+```json
+{
+  "suite": { "v": 1, "event": "run_started", "suite": "default", "examples": 0, "steps": 0, "seed": null },
+  "examples": [],
+  "result": { "v": 1, "event": "summary", "examples": 0, "actionable": 1, "…": "…" },
+  "fatal": {
+    "message": "Class Mute contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Speaks::speak)",
+    "at": "spec/App/Broken.spec.php:8"
+  }
+}
+```
+
+### Standard output carries the document, and nothing else
+
+Under `--format=agent` the document is the only thing written to standard
+output: the randomised-order seed, the `--profile` table, coverage lines, report
+notes and error text all go elsewhere, and PHP's own fatal reports are sent to
+the error stream. Parse the whole of stdout as one JSON object; read stderr when
+you want the human text as well.
 
 ## Offers — code PhpSpec can generate for you
 
@@ -229,8 +263,11 @@ Always run PhpSpec with the machine-readable formatter and parse the JSON:
 
 Read the single JSON object it prints:
 
-- `result.actionable` is the number to act on. **0 means the suite is green —
-  stop.** Otherwise it's `failing + errors + pending`.
+- `result.actionable` is the number to act on. **0 means there is nothing left,
+  so stop.** It counts `failing + errors + pending`, plus a missed
+  `--coverage-min` gate and anything that stopped the run.
+- A run that could not finish carries a top-level `fatal` of `{ message, at }`.
+  Read it before anything else: the counts describe only what ran before it.
 - `examples[]` lists only what needs attention (passing examples are omitted).
   Each has a `state`:
   - `failing` — the code ran but behaviour is wrong. Look at `expected.value`
@@ -242,7 +279,8 @@ Read the single JSON object it prints:
   - `pending` — an unimplemented example; implement it.
 - To verify a single fix, re-run just that example: take its `rerun` value and
   prepend the binary — e.g. `bin/phpspec run spec/App/Basket.spec.php:6`. Don't
-  re-run the whole suite to check one change.
+  re-run the whole suite to check one change. `result.rerun` does the same for
+  every failure at once.
 - Track a specific failure across runs by its `id` (stable across edits that
   move lines). A failure is fixed when its `id` no longer appears.
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -40,7 +40,7 @@ class — produces:
     {
       "v": 1,
       "id": "6fd046add251",
-      "example": "Basket totals the prices of its products",
+      "example": "App\\Basket > totals the prices of its products",
       "state": "failing",
       "expected": { "matcher": "toBe", "value": 4000, "negated": false },
       "actual": 3500,
@@ -51,8 +51,9 @@ class — produces:
     {
       "v": 1,
       "id": "66b1647a77b6",
-      "example": "Basket applies a coupon",
+      "example": "App\\Basket > applies a coupon",
       "state": "error",
+      "message": "Class \"App\\Coupon\" not found",
       "exception": {
         "class": "Error",
         "message": "Class \"App\\Coupon\" not found",
@@ -93,11 +94,12 @@ Each listed entry is one that failed, errored, or is pending/skipped.
 
 | Field | Meaning |
 |---|---|
-| `id` | A stable identifier for this example — a hash of its full name (described subject + title). It survives edits that move lines or change where a failure fires, so you can ask *"is THIS exact failure still here?"* across runs. Recomputable from `example`. |
-| `example` | The full name: the described subject followed by the example title. |
+| `id` | A stable identifier for this example: a hash of its full name. It survives edits that move lines or change where a failure fires, so you can ask *"is THIS exact failure still here?"* across runs. Recomputable from `example`. |
+| `example` | The full name, as a path: `App\Basket > totals the prices` for a spec, `Counting > Counting up > Given a broken step` for a feature step. |
 | `state` | `failing`, `error`, `pending`, or `skipped` (`passing` entries are omitted). |
-| `spec` | The `file:line` of the failing assertion or the error, project-relative. |
-| `rerun` | The exact arguments to re-run **just this one example** — prepend your PhpSpec binary. No full-suite re-run needed to verify one fix. |
+| `message` | What went wrong, whatever the state. An `error` entry keeps `exception` too, for the class and the site. |
+| `spec` | The `file:line` of the failing assertion or the error, project-relative. For a feature step it is the scenario's own line. |
+| `rerun` | The exact arguments to re-run **just this one example or scenario**: prepend your PhpSpec binary. No full-suite re-run needed to verify one fix. |
 
 **`failing`** entries also carry the expectation:
 
@@ -111,7 +113,7 @@ Each listed entry is one that failed, errored, or is pending/skipped.
 > `expected.value` is what should have happened, `actual` is what did. (PhpSpec's
 > internal naming is the reverse — the formatter un-inverts it for you.)
 
-**`error`** entries carry `exception` (`class`, `message`, `at`) instead. When
+**`error`** entries carry `exception` (`class`, `message`, `at`) as well. When
 the error names something PhpSpec can generate — a missing class, interface, or
 method — the entry also carries a per-example `offer` (see below). A failing
 expectation carries **no** offer: the code exists and its behaviour is simply
@@ -124,7 +126,11 @@ Sometimes the deprecation is the actual clue behind a failure.
 
 Large or object values in `expected`/`actual` are exported compactly (long
 strings and arrays are truncated with a `{ "truncated": true, "length": N }`
-marker; objects render as `ClassName#id`) so the document never blows up.
+marker) so the document never blows up. Objects are named by what they are, not
+by which instance they were: an enum as `App\Status::Active`, anything that can
+describe itself as `App\Money("12.00 GBP")`, everything else as `App\Basket`.
+Two runs of the same failure therefore report the same value. Floats keep their
+fraction, so `90.0` is never reported as the `90` it was compared against.
 
 ### `result` — the summary
 
@@ -274,15 +280,17 @@ Read the single JSON object it prints:
     (what the spec wants), `actual` (what the code produced), and `message`.
     Fix the implementation; do not change the spec to match the code unless the
     spec is genuinely wrong.
-  - `error` — an exception was thrown (`exception.class`, `exception.message`).
-    If the entry has an `offer`, PhpSpec can generate the missing piece.
+  - `error`: an exception was thrown. `message` says what, `exception` adds the
+    class and the site. If the entry has an `offer`, PhpSpec can generate the
+    missing piece.
   - `pending` — an unimplemented example; implement it.
 - To verify a single fix, re-run just that example: take its `rerun` value and
   prepend the binary — e.g. `bin/phpspec run spec/App/Basket.spec.php:6`. Don't
   re-run the whole suite to check one change. `result.rerun` does the same for
   every failure at once.
 - Track a specific failure across runs by its `id` (stable across edits that
-  move lines). A failure is fixed when its `id` no longer appears.
+  move lines). A failure is fixed when its `id` no longer appears. A failing
+  Story BDD scenario has an `id` and a `rerun` of its own, just like an example.
 
 ## Generating code
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -204,11 +204,16 @@ bin/phpspec run --format=html > report.html
 Emits the whole run as a single machine-readable JSON document for coding agents
 — no ANSI, no prose. Each failing/erroring example carries the expectation, a
 stable `id`, a line-targeted `rerun` command, and any code-generation `offer`;
-the summary carries the counts and a run-wide `offers` list:
+the summary carries the counts, one `rerun` for every failure at once, the
+coverage verdict when coverage was collected, and a run-wide `offers` list:
 
 ```bash
 bin/phpspec run --format=agent
 ```
+
+The document is the only thing on standard output, whatever happens: the seed
+line, the `--profile` table, coverage lines and error text move aside, and a run
+that dies partway still ends with a document naming the `fatal` that stopped it.
 
 See [Coding Agents](agent.md) for the full contract, the `--accept-offers` /
 `--fake` apply flow, and a ready-made `CLAUDE.md` snippet.

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -107,6 +107,20 @@ Feature: Agent output format
     And the output should contain "required"
     And the exit code should be 1
 
+  Scenario: A run that cannot start still answers with a document
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () { expect(2)->toBe(2); });
+      });
+      """
+    When I run phpspec run with option "--format=agent --bootstrap=nope.php"
+    Then the output should be valid JSON
+    And the output should contain "fatal"
+    And the output should contain "Bootstrap file not found"
+    And the exit code should be 1
+
   Scenario: A fatal still leaves a document, naming what stopped the run
     Given a spec file "spec/App/Broken.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -107,6 +107,31 @@ Feature: Agent output format
     And the output should contain "required"
     And the exit code should be 1
 
+  Scenario: A length failure reports the length the subject actually has
+    Given a spec file "spec/App/Bag.spec.php":
+      """
+      <?php
+      describe('App\Bag', function () {
+          it('holds two', function () { expect([1])->toHaveLength(2); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "Expected [1] to have length 2, has 1"
+
+  Scenario: The summary carries one command that re-runs everything that failed
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds', function () { expect(1)->toBe(2); });
+          it('subtracts', function () { expect(3)->toBe(4); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "spec/App/Calc.spec.php:3 spec/App/Calc.spec.php:4"
+
   Scenario: A run that cannot start still answers with a document
     Given a spec file "spec/App/Calc.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -68,6 +68,45 @@ Feature: Agent output format
     When I run phpspec run with option "--format=agent --profile=3"
     Then the output should be valid JSON
 
+  Scenario: A failed coverage gate rides inside the document instead of printing after it
+    Given a PSR-4 project with "spec" and "src" directories
+    And a class "src/App/Calc.php":
+      """
+      <?php
+
+      namespace App;
+
+      class Calc
+      {
+          public function add(int $a, int $b): int
+          {
+              return $a + $b;
+          }
+
+          public function unused(): int
+          {
+              return 0;
+          }
+      }
+      """
+    And a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+
+      use App\Calc;
+
+      describe('Calc', function () {
+          it('adds two numbers', function () {
+              expect((new Calc())->add(1, 2))->toBe(3);
+          });
+      });
+      """
+    When I run phpspec run with coverage options "--format=agent --coverage-min=90"
+    Then the output should be valid JSON
+    And the output should contain "coverage"
+    And the output should contain "required"
+    And the exit code should be 1
+
   Scenario: A missing class surfaces as an offer, and --accept-offers generates it
     Given a spec file "spec/App/Basket.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -131,6 +131,80 @@ Feature: Agent output format
     And the failing entries should have distinct ids
     And the output should contain "run features/counting.feature:2 features/counting.feature:5"
 
+  Scenario: A broken scenario is one entry, naming the step that broke it
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/checkout.feature":
+      """
+      Feature: Checkout
+        Scenario: Paying for a basket
+          Given a basket with 2 items
+          When I pay
+          Then I get a receipt
+      """
+    And a step file "features/steps/checkout.steps.php":
+      """
+      <?php
+
+      given('a basket with {int} items', function (int $count) {
+          throw new RuntimeException('no basket yet');
+      });
+      """
+    When I run phpspec run with option "features/ --format=agent"
+    Then the output should be valid JSON
+    And the report should have 1 entry
+    And the output should contain "Checkout > Paying for a basket"
+    And the output should contain "no basket yet"
+    And the output should contain "run features/checkout.feature:2"
+
+  Scenario: The same step twice in one scenario is still one entry
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/twice.feature":
+      """
+      Feature: Twice
+        Scenario: The same step twice
+          Given a broken step
+          Given a broken step
+      """
+    And a step file "features/steps/twice.steps.php":
+      """
+      <?php
+
+      given('a broken step', function () {
+          throw new RuntimeException('this step is broken');
+      });
+      """
+    When I run phpspec run with option "features/ --format=agent"
+    Then the output should be valid JSON
+    And the report should have 1 entry
+
+  Scenario: Each row of a scenario outline is told apart by its values
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/adding.feature":
+      """
+      Feature: Adding
+        Scenario Outline: Adding numbers
+          Given I add <a> and <b>
+
+          Examples:
+            | a | b |
+            | 1 | 2 |
+            | 3 | 4 |
+      """
+    And a step file "features/steps/adding.steps.php":
+      """
+      <?php
+
+      given('I add {int} and {int}', function (int $a, int $b) {
+          throw new RuntimeException("cannot add $a and $b");
+      });
+      """
+    When I run phpspec run with option "features/ --format=agent"
+    Then the output should be valid JSON
+    And the report should have 2 entries
+    And the failing entries should have distinct ids
+    And the output should contain "Adding numbers (1, 2)"
+    And the output should contain "Adding numbers (3, 4)"
+
   Scenario: An errored example says what went wrong in the same field a failure does
     Given a spec file "spec/App/Calc.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -107,6 +107,30 @@ Feature: Agent output format
     And the output should contain "required"
     And the exit code should be 1
 
+  Scenario: Two scenarios failing the same step are told apart and re-run one by one
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/counting.feature":
+      """
+      Feature: Counting
+        Scenario: Counting up
+          Given a broken step
+
+        Scenario: Counting down
+          Given a broken step
+      """
+    And a step file "features/steps/counting.steps.php":
+      """
+      <?php
+
+      given('a broken step', function () {
+          throw new RuntimeException('this step is broken');
+      });
+      """
+    When I run phpspec run with option "features/ --format=agent"
+    Then the output should be valid JSON
+    And the failing entries should have distinct ids
+    And the output should contain "run features/counting.feature:2 features/counting.feature:5"
+
   Scenario: A length failure reports the length the subject actually has
     Given a spec file "spec/App/Bag.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -45,6 +45,29 @@ Feature: Agent output format
     And the output should contain "rerun"
     And the output should contain "run spec/App/Calc.spec.php:"
 
+  Scenario: A randomised run keeps the document the only thing on stdout
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () { expect(2)->toBe(2); });
+      });
+      """
+    When I run phpspec run with option "--format=agent --order=random"
+    Then the output should be valid JSON
+    And the output should contain "seed"
+
+  Scenario: A profiled run keeps the document the only thing on stdout
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () { expect(2)->toBe(2); });
+      });
+      """
+    When I run phpspec run with option "--format=agent --profile=3"
+    Then the output should be valid JSON
+
   Scenario: A missing class surfaces as an offer, and --accept-offers generates it
     Given a spec file "spec/App/Basket.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -156,6 +156,37 @@ Feature: Agent output format
     Then the output should be valid JSON
     And the output should contain "Expected 90.0 to be 90"
 
+  Scenario: An object in a failure is named, not numbered
+    Given a spec file "spec/App/Bag.spec.php":
+      """
+      <?php
+
+      enum Status
+      {
+          case Active;
+      }
+
+      class Money
+      {
+          public function __construct(private string $amount) {}
+
+          public function __toString(): string
+          {
+              return $this->amount;
+          }
+      }
+
+      describe('App\Bag', function () {
+          it('holds a status', function () { expect(Status::Active)->toBeNull(); });
+          it('holds an amount', function () { expect(new Money('12.00 GBP'))->toBeNull(); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "Status::Active"
+    And the output should contain "12.00 GBP"
+    And the output should not contain "Status#"
+
   Scenario: A length failure reports the length the subject actually has
     Given a spec file "spec/App/Bag.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -131,6 +131,31 @@ Feature: Agent output format
     And the failing entries should have distinct ids
     And the output should contain "run features/counting.feature:2 features/counting.feature:5"
 
+  Scenario: An errored example says what went wrong in the same field a failure does
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () { throw new RuntimeException('the adder exploded'); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And every reported entry should carry a message
+    And the output should contain "the adder exploded"
+
+  Scenario: A whole float is not reported as an integer
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () { expect(90.0)->toBe(90); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "Expected 90.0 to be 90"
+
   Scenario: A length failure reports the length the subject actually has
     Given a spec file "spec/App/Bag.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -107,6 +107,27 @@ Feature: Agent output format
     And the output should contain "required"
     And the exit code should be 1
 
+  Scenario: A fatal still leaves a document, naming what stopped the run
+    Given a spec file "spec/App/Broken.spec.php":
+      """
+      <?php
+
+      interface Speaks
+      {
+          public function speak(): string;
+      }
+
+      class Mute implements Speaks {}
+
+      describe('App\Broken', function () {
+          it('never runs', function () {});
+      });
+      """
+    When I run phpspec run in a fresh process with option "--format=agent"
+    Then the standard output should be valid JSON
+    And the output should contain "fatal"
+    And the output should contain "abstract method"
+
   Scenario: A missing class surfaces as an offer, and --accept-offers generates it
     Given a spec file "spec/App/Basket.spec.php":
       """

--- a/features/scenarios/cli/parallel-execution.feature
+++ b/features/scenarios/cli/parallel-execution.feature
@@ -41,6 +41,20 @@ Feature: Parallel execution
     When I run phpspec run with option "--parallel=2"
     Then all examples should pass
 
+  Scenario: A path given after --parallel is still the path to run
+    Given a spec file "spec/App/Swallowed.spec.php":
+      """
+      <?php
+      describe('Swallowed', function () {
+          it('runs', function () {
+              expect(true)->toBeTrue();
+          });
+      });
+      """
+    When I run phpspec run with option "--parallel spec/App/Swallowed.spec.php"
+    Then all examples should pass
+    And the output should contain "1 example"
+
   Scenario: Stop on failure with parallel execution
     Given a spec file "spec/App/Failing.spec.php":
       """

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -101,6 +101,16 @@ then('the output should be valid JSON', function () {
     }
 });
 
+// Every reported entry must be addressable on its own: an id that two entries
+// share cannot answer "is THIS failure still here?".
+then('the failing entries should have distinct ids', function () {
+    $document = json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
+    $ids = array_column($document['examples'] ?? [], 'id');
+
+    expect(count($ids))->toBeGreaterThan(1);
+    expect(array_unique($ids))->toHaveLength(count($ids));
+});
+
 // Standard output on its own, for the runs where the error stream carries text
 // of its own (PHP's fatal report) and the document must still stand alone.
 then('the standard output should be valid JSON', function () {

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -101,6 +101,20 @@ then('the output should be valid JSON', function () {
     }
 });
 
+// How many things the run says are worth acting on: one per example or scenario,
+// never one per step of the same broken scenario.
+then('the report should have {int} entries', function (int $count) {
+    $document = json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($document['examples'] ?? [])->toHaveLength($count);
+});
+
+then('the report should have {int} entry', function (int $count) {
+    $document = json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($document['examples'] ?? [])->toHaveLength($count);
+});
+
 // One field answers "what went wrong", whatever the entry's state: a consumer
 // should not have to know that an error hides its text somewhere else.
 then('every reported entry should carry a message', function () {

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -101,6 +101,18 @@ then('the output should be valid JSON', function () {
     }
 });
 
+// Standard output on its own, for the runs where the error stream carries text
+// of its own (PHP's fatal report) and the document must still stand alone.
+then('the standard output should be valid JSON', function () {
+    try {
+        json_decode(trim($this->stdout), true, 512, JSON_THROW_ON_ERROR);
+    } catch (\JsonException $e) {
+        throw new \RuntimeException(
+            "Expected valid JSON on standard output ({$e->getMessage()}).\nStandard output:\n{$this->stdout}",
+        );
+    }
+});
+
 // -- File existence (sets $this->lastFile for chained assertions) ------
 
 then('a spec file {string} should be generated', function (string $path) {

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -101,6 +101,19 @@ then('the output should be valid JSON', function () {
     }
 });
 
+// One field answers "what went wrong", whatever the entry's state: a consumer
+// should not have to know that an error hides its text somewhere else.
+then('every reported entry should carry a message', function () {
+    $document = json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
+    $entries = $document['examples'] ?? [];
+
+    expect($entries)->not()->toBe([]);
+
+    foreach ($entries as $entry) {
+        expect($entry)->toHaveKey('message');
+    }
+});
+
 // Every reported entry must be addressable on its own: an id that two entries
 // share cannot answer "is THIS failure still here?".
 then('the failing entries should have distinct ids', function () {

--- a/features/steps/runner.steps.php
+++ b/features/steps/runner.steps.php
@@ -54,6 +54,9 @@ if (!function_exists('_phpspec_exec')) {
 
         $world->exitCode = proc_close($process);
         $world->output = $stdout . $stderr;
+        // Kept apart as well: a machine-readable format owns standard output
+        // alone, and PHP's own error text belongs on the error stream.
+        $world->stdout = $stdout;
     }
 }
 
@@ -69,6 +72,12 @@ when('I run the spec', function () {
 
 when('I run phpspec run with option {string}', function (string $options) {
     _phpspec_exec($this, 'run ' . $options);
+});
+
+// A run expected to kill its process (a fatal in a spec file) must not take
+// this suite down with it, so it always gets a process of its own.
+when('I run phpspec run in a fresh process with option {string}', function (string $options) {
+    _phpspec_exec_subprocess($this, 'run ' . $options);
 });
 
 when('I run phpspec run {string}', function (string $path) {

--- a/spec/PhpSpec/Console/Command/Run/CoverageReporter.spec.php
+++ b/spec/PhpSpec/Console/Command/Run/CoverageReporter.spec.php
@@ -18,11 +18,11 @@ describe(CoverageReporter::class, function () {
             // whole-suite collection (xdebug coverage state is process-global).
             if (!CoverageCollector::isCollecting()) {
 
-                it('returns true when Xdebug coverage is available', function () {
+                it('starts with nothing to report when Xdebug coverage is available', function () {
                     $output = new BufferedOutput();
                     $reporter = new CoverageReporter();
 
-                    expect($reporter->start($output))->toBeTrue();
+                    expect($reporter->start())->toBeNull();
 
                     // Stop the collection so no state leaks into later examples
                     $reporter->report($output, new CoverageOptions(srcPath: 'src'));
@@ -36,7 +36,7 @@ describe(CoverageReporter::class, function () {
                 $reporter = new CoverageReporter();
 
                 try {
-                    expect($reporter->start($output, perExample: true))->toBeTrue();
+                    expect($reporter->start(perExample: true))->toBeNull();
                     expect(CoverageRegistry::collector())->toBeAnInstanceOf(PerExampleCollector::class);
                 } finally {
                     CoverageRegistry::reset();
@@ -45,23 +45,14 @@ describe(CoverageReporter::class, function () {
 
         } else {
 
-            it('returns false when Xdebug coverage is not available', function () {
-                $output = new BufferedOutput();
+            it('returns the reason when Xdebug coverage is not available', function () {
                 $reporter = new CoverageReporter();
-                expect($reporter->start($output))->toBeFalse();
+                expect($reporter->start())->toContain('Code coverage requires Xdebug');
             });
 
-            it('returns false in per-example mode when Xdebug coverage is not available', function () {
-                $output = new BufferedOutput();
+            it('returns the reason in per-example mode when Xdebug coverage is not available', function () {
                 $reporter = new CoverageReporter();
-                expect($reporter->start($output, perExample: true))->toBeFalse();
-            });
-
-            it('writes error message when Xdebug coverage is not available', function () {
-                $output = new BufferedOutput();
-                $reporter = new CoverageReporter();
-                $reporter->start($output);
-                expect($output->fetch())->toContain('Code coverage requires Xdebug');
+                expect($reporter->start(perExample: true))->toContain('Code coverage requires Xdebug');
             });
 
         }

--- a/spec/PhpSpec/Console/Command/Run/CoverageReporter.spec.php
+++ b/spec/PhpSpec/Console/Command/Run/CoverageReporter.spec.php
@@ -93,7 +93,7 @@ describe(CoverageReporter::class, function () {
             $reporter = new CoverageReporter();
 
             try {
-                $exitCode = $reporter->report($output, new CoverageOptions(
+                $verdict = $reporter->report($output, new CoverageOptions(
                     srcPath: dirname($fixture),
                     showText: true,
                     cloverPath: $dir . '/clover.xml',
@@ -102,7 +102,10 @@ describe(CoverageReporter::class, function () {
                     coverageMin: '100',
                 ));
 
-                expect($exitCode)->toBeNull();
+                expect($verdict->met())->toBeTrue();
+                expect($verdict->exitCode())->toBeNull();
+                expect($verdict->percent)->toBe(100.0);
+                expect($verdict->required)->toBe(100.0);
                 expect(file_exists($dir . '/clover.xml'))->toBeTrue();
                 expect(file_exists($dir . '/html/index.html'))->toBeTrue();
                 expect(file_exists($dir . '/coverage.json'))->toBeTrue();
@@ -119,7 +122,7 @@ describe(CoverageReporter::class, function () {
             }
         });
 
-        it('returns exit code 1 when coverage is below the minimum', function (CoverageDriver $driver) {
+        it('returns a verdict that demands exit code 1 when coverage is below the minimum', function (CoverageDriver $driver) {
             $fixture = (string) realpath(__DIR__ . '/../../../Coverage/Driver/fixtures/covered_probe.php');
             allow($driver->stop())->toReturn([$fixture => [3 => 1, 4 => -1]]);
             $collector = new PerExampleCollector($driver);
@@ -132,12 +135,14 @@ describe(CoverageReporter::class, function () {
             $reporter = new CoverageReporter();
 
             try {
-                $exitCode = $reporter->report($output, new CoverageOptions(
+                $verdict = $reporter->report($output, new CoverageOptions(
                     srcPath: dirname($fixture),
                     coverageMin: '90',
                 ));
 
-                expect($exitCode)->toBe(1);
+                expect($verdict->met())->toBeFalse();
+                expect($verdict->exitCode())->toBe(1);
+                expect($verdict->percent)->toBe(50.0);
                 expect($output->fetch())->toContain('below the required');
             } finally {
                 CoverageRegistry::reset();

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -2,6 +2,8 @@
 
 use PhpSpec\Coverage\CoverageVerdict;
 use PhpSpec\Report\Formatter\Agent;
+use PhpSpec\Report\Formatter\Agent\Fatal;
+use PhpSpec\Report\Formatter\Agent\ProcessEnd;
 use PhpSpec\Result\ExampleResult;
 use PhpSpec\Result\FeatureResult;
 use PhpSpec\Result\MatchResult;
@@ -11,6 +13,22 @@ use PhpSpec\Result\StepResult;
 use PhpSpec\Result\SuiteResult;
 use PhpSpec\Specification\ExampleError;
 use Symfony\Component\Console\Output\BufferedOutput;
+
+// A process end the spec fires by hand, in place of PHP's own shutdown.
+class AgentSpecProcessEnd implements ProcessEnd
+{
+    private ?Closure $ending = null;
+
+    public function atEnd(Closure $ending): void
+    {
+        $this->ending = $ending;
+    }
+
+    public function arrives(?Fatal $fatal = null): void
+    {
+        ($this->ending)($fatal);
+    }
+}
 
 describe(Agent::class, function () {
 
@@ -104,6 +122,61 @@ describe(Agent::class, function () {
 
         expect($doc['result']['coverage'])->toBe(['percent' => 72.5, 'required' => null, 'met' => true]);
         expect($doc['result']['actionable'])->toBe(0);
+    });
+
+    it('still publishes a document when a fatal ends the process, naming what stopped it', function () {
+        $output = new BufferedOutput();
+        $end = new AgentSpecProcessEnd();
+        $formatter = new Agent($output, null, $end);
+        $formatter->begin();
+        $formatter->printResult(new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]));
+
+        // No end(), no publish(): the process died loading the next spec file.
+        $end->arrives(new Fatal('Class Mute contains 1 abstract method', getcwd() . '/spec/App/Broken.spec.php', 8));
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+
+        expect($doc['fatal'])->toBe([
+            'message' => 'Class Mute contains 1 abstract method',
+            'at' => 'spec/App/Broken.spec.php:8',
+        ]);
+        expect($doc['result']['actionable'])->toBe(1);
+        expect($doc['result']['passing'])->toBe(1);
+    });
+
+    it('publishes what it has when the process ends with no fatal', function () {
+        $output = new BufferedOutput();
+        $end = new AgentSpecProcessEnd();
+        $formatter = new Agent($output, null, $end);
+        $formatter->begin();
+
+        $end->arrives();
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+
+        expect($doc)->not()->toHaveKey('fatal');
+        expect($doc['result']['actionable'])->toBe(0);
+    });
+
+    it('leaves the published document alone when the process ends after it', function () {
+        $output = new BufferedOutput();
+        $end = new AgentSpecProcessEnd();
+        $formatter = new Agent($output, null, $end);
+        $formatter->format(new SuiteResult([]));
+
+        $end->arrives(new Fatal('something later went wrong'));
+
+        expect(substr_count($output->fetch(), '"run_started"'))->toBe(1);
+    });
+
+    it('keeps the first thing that stopped the run', function () {
+        $output = new BufferedOutput();
+        $formatter = new Agent($output);
+        $formatter->stopped('Bootstrap file not found: vendor/autoload.php');
+        $formatter->stopped('and then everything else broke');
+        $formatter->publish();
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+
+        expect($doc['fatal']['message'])->toBe('Bootstrap file not found: vendor/autoload.php');
+        expect($doc['fatal']['at'])->toBeNull();
     });
 
     it('omits coverage from the result when none was collected', function () use ($render) {

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -44,6 +44,36 @@ describe(Agent::class, function () {
         expect($doc['suite']['suite'])->toBe('spec,features/');
     });
 
+    it('writes the document once, however often the command publishes it', function () {
+        $output = new BufferedOutput();
+        $formatter = new Agent($output);
+        $formatter->format(new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
+        ]));
+
+        $formatter->publish();
+        $formatter->publish();
+
+        expect(substr_count($output->fetch(), '"run_started"'))->toBe(1);
+    });
+
+    it('publishes what it collected even when the run never reached its end', function () {
+        $output = new BufferedOutput();
+        $formatter = new Agent($output);
+        $formatter->begin();
+        $formatter->printResult(new SpecificationResult('App\\Basket', [
+            new ExampleResult('holds products', [MatchResult::failed(1, 2, 'Expected 1 to be 2', getcwd() . '/spec/App/Basket.spec.php', 9, null, 'toBe')]),
+        ]));
+
+        // No end(): a fatal took the process before the last example.
+        $formatter->publish();
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+
+        expect($doc['result']['failing'])->toBe(1);
+        expect($doc['result']['duration_ms'])->toBe(0);
+        expect($doc['examples'][0]['example'])->toBe('App\\Basket holds products');
+    });
+
     it('omits passing examples from the entries but still counts them', function () use ($render) {
         $doc = $render(new SuiteResult([
             new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -53,7 +53,8 @@ describe(Agent::class, function () {
     it('reports the seed and suite it was told about, so a flaky order is reproducible', function () {
         $output = new BufferedOutput();
         $formatter = new Agent($output);
-        $formatter->describeRun(424242, 'spec,features/');
+        $formatter->targets('spec,features/');
+        $formatter->randomisedWith(424242);
         $formatter->format(new SuiteResult([
             new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
         ]));
@@ -79,6 +80,7 @@ describe(Agent::class, function () {
     it('publishes what it collected even when the run never reached its end', function () {
         $output = new BufferedOutput();
         $formatter = new Agent($output);
+        $formatter->targets('./spec');
         $formatter->begin();
         $formatter->printResult(new SpecificationResult('App\\Basket', [
             new ExampleResult('holds products', [MatchResult::failed(1, 2, 'Expected 1 to be 2', getcwd() . '/spec/App/Basket.spec.php', 9, null, 'toBe')]),
@@ -91,6 +93,9 @@ describe(Agent::class, function () {
         expect($doc['result']['failing'])->toBe(1);
         expect($doc['result']['duration_ms'])->toBe(0);
         expect($doc['examples'][0]['example'])->toBe('App\\Basket > holds products');
+        // What the run was trying to run is known before the run: a document cut
+        // short still says it.
+        expect($doc['suite']['suite'])->toBe('./spec');
     });
 
     it('carries a missed coverage gate in the result, and counts it as work left', function () {

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -90,7 +90,7 @@ describe(Agent::class, function () {
 
         expect($doc['result']['failing'])->toBe(1);
         expect($doc['result']['duration_ms'])->toBe(0);
-        expect($doc['examples'][0]['example'])->toBe('App\\Basket holds products');
+        expect($doc['examples'][0]['example'])->toBe('App\\Basket > holds products');
     });
 
     it('carries a missed coverage gate in the result, and counts it as work left', function () {
@@ -253,7 +253,7 @@ describe(Agent::class, function () {
             ]),
         ]))['examples'][0];
 
-        expect($example['id'])->toBe(substr(sha1('App\\Basket totals the prices'), 0, 12));
+        expect($example['id'])->toBe(substr(sha1('App\\Basket > totals the prices'), 0, 12));
     });
 
     it('keeps an example id stable when only its line moves', function () use ($render) {
@@ -360,6 +360,50 @@ describe(Agent::class, function () {
         expect($doc['examples'][0]['state'])->toBe('failing');
         expect($doc['examples'][0]['example'])->toContain('Given a basket');
         expect($doc['examples'][0]['id'])->toBe(substr(sha1($doc['examples'][0]['example']), 0, 12));
+    });
+
+    it('names a step by feature, scenario and step, so two scenarios never share an id', function () use ($render) {
+        $failing = function (string $title): StepResult {
+            $step = new StepResult($title, 'error');
+            $step->setError(new \PhpSpec\StoryBDD\StepError('this step is broken', new \RuntimeException('this step is broken')));
+
+            return $step;
+        };
+
+        $doc = $render(new SuiteResult([
+            new FeatureResult('Counting', [
+                new ScenarioResult('Counting up', [$failing('Given a broken step')], 2),
+                new ScenarioResult('Counting down', [$failing('Given a broken step')], 5),
+            ], 'features/counting.feature'),
+        ]));
+
+        expect($doc['examples'][0]['example'])->toBe('Counting > Counting up > Given a broken step');
+        expect($doc['examples'][1]['example'])->toBe('Counting > Counting down > Given a broken step');
+        expect($doc['examples'][0]['id'])->not()->toBe($doc['examples'][1]['id']);
+    });
+
+    it('addresses a failing scenario by the line that re-runs it', function () use ($render) {
+        $step = new StepResult('Given a broken step', 'error');
+        $step->setError(new \PhpSpec\StoryBDD\StepError('this step is broken', new \RuntimeException('this step is broken')));
+
+        $doc = $render(new SuiteResult([
+            new FeatureResult('Counting', [new ScenarioResult('Counting up', [$step], 5)], 'features/counting.feature'),
+        ]));
+
+        expect($doc['examples'][0]['spec'])->toBe('features/counting.feature:5');
+        expect($doc['examples'][0]['rerun'])->toBe('run features/counting.feature:5');
+        expect($doc['result']['rerun'])->toBe('run features/counting.feature:5');
+    });
+
+    it('leaves a passing scenario out, location and all', function () use ($render) {
+        $doc = $render(new SuiteResult([
+            new FeatureResult('Counting', [
+                new ScenarioResult('Counting up', [new StepResult('Given a good step', 'passed')], 2),
+            ], 'features/counting.feature'),
+        ]));
+
+        expect($doc['examples'])->toBe([]);
+        expect($doc['result'])->not()->toHaveKey('rerun');
     });
 
 });

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -179,6 +179,27 @@ describe(Agent::class, function () {
         expect($doc['fatal']['at'])->toBeNull();
     });
 
+    it('joins every failing target into one rerun command, without repeats', function () use ($render) {
+        $spec = getcwd() . '/spec/App/Basket.spec.php';
+        $doc = $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [
+                new ExampleResult('totals', [MatchResult::failed(1, 2, 'Expected 1 to be 2', $spec, 12, null, 'toBe')]),
+                new ExampleResult('counts', [MatchResult::failed(3, 4, 'Expected 3 to be 4', $spec, 20, null, 'toBe')]),
+                new ExampleResult('repeats', [MatchResult::failed(3, 4, 'Expected 3 to be 4', $spec, 20, null, 'toBe')]),
+            ]),
+        ]));
+
+        expect($doc['result']['rerun'])->toBe('run spec/App/Basket.spec.php:12 spec/App/Basket.spec.php:20');
+    });
+
+    it('offers no rerun command when nothing failed', function () use ($render) {
+        $doc = $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
+        ]));
+
+        expect($doc['result'])->not()->toHaveKey('rerun');
+    });
+
     it('omits coverage from the result when none was collected', function () use ($render) {
         $doc = $render(new SuiteResult([
             new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -400,6 +400,21 @@ describe(Agent::class, function () {
         expect($doc['result']['rerun'])->toBe('run features/counting.feature:5');
     });
 
+    it('reports a skipped step without addressing it, so the rerun stays about failures', function () use ($render) {
+        $broken = new StepResult('Given a broken step', 'error');
+        $broken->setError(new \PhpSpec\StoryBDD\StepError('this step is broken', new \RuntimeException('this step is broken')));
+
+        $doc = $render(new SuiteResult([
+            new FeatureResult('Counting', [
+                new ScenarioResult('Counting up', [$broken, new StepResult('Then it counts', 'skipped')], 2),
+            ], 'features/counting.feature'),
+        ]));
+
+        expect($doc['examples'][1]['state'])->toBe('skipped');
+        expect($doc['examples'][1])->not()->toHaveKey('rerun');
+        expect($doc['result']['rerun'])->toBe('run features/counting.feature:2');
+    });
+
     it('leaves a passing scenario out, location and all', function () use ($render) {
         $doc = $render(new SuiteResult([
             new FeatureResult('Counting', [

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -47,7 +47,7 @@ describe(Agent::class, function () {
         expect($doc)->toHaveKey('suite');
         expect($doc)->toHaveKey('examples');
         expect($doc)->toHaveKey('result');
-        expect($doc['suite'])->toBe(['v' => 1, 'event' => 'run_started', 'suite' => 'default', 'examples' => 1, 'steps' => 0, 'seed' => null]);
+        expect($doc['suite'])->toBe(['v' => 1, 'event' => 'run_started', 'suite' => 'default', 'examples' => 1, 'scenarios' => 0, 'steps' => 0, 'seed' => null]);
     });
 
     it('reports the seed and suite it was told about, so a flaky order is reproducible', function () {
@@ -352,22 +352,46 @@ describe(Agent::class, function () {
         expect($result['offers'])->toBe([['action' => 'create_class', 'target' => 'App\\Coupon']]);
     });
 
-    it('counts feature steps as steps, not examples, and emits the failing one', function () use ($render) {
+    it('counts a story run in scenarios and steps, never in examples', function () use ($render) {
         $step = new StepResult('Given a basket', 'failure');
         $step->setError(new \PhpSpec\StoryBDD\StepError('step went wrong', new \RuntimeException('step went wrong')));
-        $scenario = new ScenarioResult('Checkout', [$step]);
+        $scenario = new ScenarioResult('Checkout', [$step, new StepResult('When I pay', 'skipped')]);
         $feature = new FeatureResult('Shopping', [$scenario], '/features/shopping.feature');
 
         $doc = $render(new SuiteResult([$feature]));
 
-        expect($doc['result']['steps'])->toBe(1);
+        expect($doc['result']['steps'])->toBe(2);
+        expect($doc['result']['scenarios'])->toBe(1);
         expect($doc['result']['examples'])->toBe(0);
+        // One scenario is one thing to fix, however many steps it took with it.
+        expect($doc['result']['failing'])->toBe(1);
+        expect($doc['examples'])->toHaveLength(1);
         expect($doc['examples'][0]['state'])->toBe('failing');
-        expect($doc['examples'][0]['example'])->toContain('Given a basket');
+        expect($doc['examples'][0]['example'])->toBe('Shopping > Checkout');
+        expect($doc['examples'][0]['message'])->toBe('step went wrong');
         expect($doc['examples'][0]['id'])->toBe(substr(sha1($doc['examples'][0]['example']), 0, 12));
     });
 
-    it('names a step by feature, scenario and step, so two scenarios never share an id', function () use ($render) {
+    it('carries the steps that were not passing, so the broken one is named', function () use ($render) {
+        $step = new StepResult('Given a basket', 'failure');
+        $step->setError(new \PhpSpec\StoryBDD\StepError('step went wrong', new \RuntimeException('step went wrong')));
+        $feature = new FeatureResult('Shopping', [
+            new ScenarioResult('Checkout', [
+                new StepResult('Given a shop', 'passed'),
+                $step,
+                new StepResult('When I pay', 'skipped'),
+            ], 4),
+        ], 'features/shopping.feature');
+
+        $doc = $render(new SuiteResult([$feature]));
+
+        expect($doc['examples'][0]['steps'])->toBe([
+            ['title' => 'Given a basket', 'state' => 'failing', 'message' => 'step went wrong'],
+            ['title' => 'When I pay', 'state' => 'skipped'],
+        ]);
+    });
+
+    it('names a scenario by feature and scenario, so two never share an id', function () use ($render) {
         $failing = function (string $title): StepResult {
             $step = new StepResult($title, 'error');
             $step->setError(new \PhpSpec\StoryBDD\StepError('this step is broken', new \RuntimeException('this step is broken')));
@@ -377,14 +401,36 @@ describe(Agent::class, function () {
 
         $doc = $render(new SuiteResult([
             new FeatureResult('Counting', [
+                // The same step text in both, which is what used to collide.
                 new ScenarioResult('Counting up', [$failing('Given a broken step')], 2),
                 new ScenarioResult('Counting down', [$failing('Given a broken step')], 5),
             ], 'features/counting.feature'),
         ]));
 
-        expect($doc['examples'][0]['example'])->toBe('Counting > Counting up > Given a broken step');
-        expect($doc['examples'][1]['example'])->toBe('Counting > Counting down > Given a broken step');
+        expect($doc['examples'][0]['example'])->toBe('Counting > Counting up');
+        expect($doc['examples'][1]['example'])->toBe('Counting > Counting down');
         expect($doc['examples'][0]['id'])->not()->toBe($doc['examples'][1]['id']);
+    });
+
+    it('reports a scenario once however often a step title repeats inside it', function () use ($render) {
+        $failing = function (string $title, string $state = 'error'): StepResult {
+            $step = new StepResult($title, $state);
+            $step->setError(new \PhpSpec\StoryBDD\StepError('this step is broken', new \RuntimeException('this step is broken')));
+
+            return $step;
+        };
+
+        $doc = $render(new SuiteResult([
+            new FeatureResult('Twice', [
+                new ScenarioResult('The same step twice', [
+                    $failing('Given a broken step'),
+                    new StepResult('Given a broken step', 'skipped'),
+                ], 2),
+            ], 'features/twice.feature'),
+        ]));
+
+        expect($doc['examples'])->toHaveLength(1);
+        expect($doc['examples'][0]['example'])->toBe('Twice > The same step twice');
     });
 
     it('addresses a failing scenario by the line that re-runs it', function () use ($render) {
@@ -400,19 +446,16 @@ describe(Agent::class, function () {
         expect($doc['result']['rerun'])->toBe('run features/counting.feature:5');
     });
 
-    it('reports a skipped step without addressing it, so the rerun stays about failures', function () use ($render) {
-        $broken = new StepResult('Given a broken step', 'error');
-        $broken->setError(new \PhpSpec\StoryBDD\StepError('this step is broken', new \RuntimeException('this step is broken')));
-
+    it('leaves a scenario waiting on undefined steps unaddressed, so the rerun stays about failures', function () use ($render) {
         $doc = $render(new SuiteResult([
             new FeatureResult('Counting', [
-                new ScenarioResult('Counting up', [$broken, new StepResult('Then it counts', 'skipped')], 2),
+                new ScenarioResult('Counting up', [new StepResult('Given nothing yet', 'undefined')], 2),
             ], 'features/counting.feature'),
         ]));
 
-        expect($doc['examples'][1]['state'])->toBe('skipped');
-        expect($doc['examples'][1])->not()->toHaveKey('rerun');
-        expect($doc['result']['rerun'])->toBe('run features/counting.feature:2');
+        expect($doc['examples'][0]['state'])->toBe('pending');
+        expect($doc['examples'][0])->not()->toHaveKey('rerun');
+        expect($doc['result'])->not()->toHaveKey('rerun');
     });
 
     it('leaves a passing scenario out, location and all', function () use ($render) {

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -1,5 +1,6 @@
 <?php
 
+use PhpSpec\Coverage\CoverageVerdict;
 use PhpSpec\Report\Formatter\Agent;
 use PhpSpec\Result\ExampleResult;
 use PhpSpec\Result\FeatureResult;
@@ -72,6 +73,45 @@ describe(Agent::class, function () {
         expect($doc['result']['failing'])->toBe(1);
         expect($doc['result']['duration_ms'])->toBe(0);
         expect($doc['examples'][0]['example'])->toBe('App\\Basket holds products');
+    });
+
+    it('carries a missed coverage gate in the result, and counts it as work left', function () {
+        $output = new BufferedOutput();
+        $formatter = new Agent($output);
+        $formatter->begin();
+        $formatter->printResult(new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]));
+        $formatter->end(new SuiteResult([]));
+        $formatter->covered(new CoverageVerdict(24.34, 90.0));
+        $formatter->publish();
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+
+        // JSON has one number type, so 90.0 comes back as 90.
+        expect($doc['result']['coverage']['percent'])->toBe(24.3);
+        expect((float) $doc['result']['coverage']['required'])->toBe(90.0);
+        expect($doc['result']['coverage']['met'])->toBeFalse();
+        expect($doc['result']['failing'])->toBe(0);
+        expect($doc['result']['actionable'])->toBe(1);
+    });
+
+    it('reports coverage without a threshold as met, adding no work', function () {
+        $output = new BufferedOutput();
+        $formatter = new Agent($output);
+        $formatter->begin();
+        $formatter->end(new SuiteResult([]));
+        $formatter->covered(new CoverageVerdict(72.5));
+        $formatter->publish();
+        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+
+        expect($doc['result']['coverage'])->toBe(['percent' => 72.5, 'required' => null, 'met' => true]);
+        expect($doc['result']['actionable'])->toBe(0);
+    });
+
+    it('omits coverage from the result when none was collected', function () use ($render) {
+        $doc = $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
+        ]));
+
+        expect($doc['result'])->not()->toHaveKey('coverage');
     });
 
     it('omits passing examples from the entries but still counts them', function () use ($render) {

--- a/spec/PhpSpec/Report/Formatter/Agent/ValueExporter.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent/ValueExporter.spec.php
@@ -23,16 +23,16 @@ describe(ValueExporter::class, function () {
         expect(strlen($out['value']))->toBe(200);
     });
 
-    it('renders an object as ClassName#id without dumping its graph', function () {
-        expect(ValueExporter::export(new \RuntimeException('boom')))->toStartWith('RuntimeException#');
+    it('names an object without dumping its graph', function () {
+        expect(ValueExporter::export(new \RuntimeException('boom')))->toBe('RuntimeException("boom")');
     });
 
-    it('exports a small array recursively, hashing nested objects', function () {
+    it('exports a small array recursively, naming nested objects', function () {
         $out = ValueExporter::export([1, 'two', new \stdClass()]);
 
         expect($out[0])->toBe(1);
         expect($out[1])->toBe('two');
-        expect($out[2])->toStartWith('stdClass#');
+        expect($out[2])->toBe('stdClass');
     });
 
     it('truncates an array with more than 10 elements and says so', function () {

--- a/src/PhpSpec/Configuration.php
+++ b/src/PhpSpec/Configuration.php
@@ -298,14 +298,20 @@ final class Configuration
 
     /**
      * Returns all load paths combined from all suites, comma-separated.
+     *
+     * A suite that names no paths of its own means the project's spec path: the
+     * loader has always run it that way, and saying so here keeps the answer the
+     * same wherever it is asked, including the header of a report written before
+     * anything is loaded.
      */
     public function getAllLoadPaths(): string
     {
         $paths = [];
         foreach ($this->getSuites() as $suite) {
-            $paths = array_merge($paths, $suite['paths'] ?? []);
+            $paths = array_merge($paths, $suite['paths'] ?? [$this->getSpecPath()]);
         }
-        return implode(',', $paths);
+
+        return implode(',', array_unique($paths));
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -200,31 +200,29 @@ final class Run extends Command
      */
     private function perform(Input $input, Output $prose, Formatter $formatter): int
     {
-        if (!$this->loadBootstrap($input, $prose)) {
-            return 1;
+        $missingBootstrap = $this->loadBootstrap($input);
+
+        if ($missingBootstrap !== null) {
+            return $this->stopped($prose, $formatter, $missingBootstrap);
         }
         $this->registerAutoloader();
 
         $pathsFrom = $input->getOption('paths-from');
 
         if ($pathsFrom !== null && !is_file($pathsFrom)) {
-            $prose->writeln("<fg=red>Paths file not found: $pathsFrom</>");
-
-            return 1;
+            return $this->stopped($prose, $formatter, "Paths file not found: $pathsFrom");
         }
 
         $unknownFormats = $this->unknownFormats($input);
 
         if ($unknownFormats !== []) {
-            $prose->writeln('<fg=red>Unknown format: ' . implode(', ', $unknownFormats) . ' (available: pretty, dot, tap, junit, html, agent)</>');
-
-            return 1;
+            return $this->stopped($prose, $formatter, 'Unknown format: ' . implode(', ', $unknownFormats) . ' (available: pretty, dot, tap, junit, html, agent)');
         }
 
-        $coverageReporter = $this->startCoverage($input, $prose);
+        $coverageReporter = $this->startCoverage($input);
 
-        if ($coverageReporter === false) {
-            return 1;
+        if (is_string($coverageReporter)) {
+            return $this->stopped($prose, $formatter, $coverageReporter);
         }
 
         try {
@@ -232,9 +230,7 @@ final class Run extends Command
         } catch (\RuntimeException $e) {
             // A load-time contract violation (e.g. two step definitions
             // sharing a title) is the user's to fix; report it, never a trace.
-            $prose->writeln(sprintf('<fg=red>%s</>', $e->getMessage()));
-
-            return 1;
+            return $this->stopped($prose, $formatter, $e->getMessage());
         }
 
         $this->writeReportFiles($input, $prose, $results);
@@ -321,28 +317,47 @@ final class Run extends Command
     }
 
     /**
+     * Reports what stopped the run before it could produce results: red on the
+     * console for a human, and inside the document for an agent, so a run that
+     * returns nothing never leaves either of them guessing why.
+     *
+     * @param Output $prose the channel for the run's human-facing lines
+     * @param Formatter $formatter the console formatter for the run's results
+     * @param string $message what went wrong
+     * @return int the exit code the caller returns
+     */
+    private function stopped(Output $prose, Formatter $formatter, string $message): int
+    {
+        $prose->writeln(sprintf('<fg=red>%s</>', $message));
+
+        if ($formatter instanceof Agent) {
+            $formatter->stopped($message);
+        }
+
+        return 1;
+    }
+
+    /**
      * Resolves and requires the bootstrap file from --bootstrap, config, or vendor/autoload.php.
-     * Returns false if the specified file does not exist.
      *
      * @param Input $input the console input to read --bootstrap from
-     * @param Output $output the console output for error messages
-     * @return bool true if bootstrap loaded (or none needed), false if file not found
+     * @return string|null null once loaded (or when none is needed), or why it could not be
      */
-    private function loadBootstrap(Input $input, Output $output): bool
+    private function loadBootstrap(Input $input): ?string
     {
         $bootstrap = $input->getOption('bootstrap') ?? $this->config->getBootstrap();
         if ($bootstrap === null && file_exists('vendor/autoload.php')) {
             $bootstrap = 'vendor/autoload.php';
         }
         if ($bootstrap === null) {
-            return true;
+            return null;
         }
         if (!file_exists($bootstrap)) {
-            $output->writeln("<fg=red>Bootstrap file not found: $bootstrap</>");
-            return false;
+            return "Bootstrap file not found: $bootstrap";
         }
         require $bootstrap;
-        return true;
+
+        return null;
     }
 
     private function registerAutoloader(): void
@@ -354,10 +369,10 @@ final class Run extends Command
      * Starts code coverage collection if any --coverage* option was given.
      *
      * @param Input $input the console input to check coverage options
-     * @param Output $output the console output for error messages
-     * @return CoverageReporter|null|false reporter if started, null if not requested, false on error
+     * @return CoverageReporter|null|string the reporter once started, null when no
+     *                                      coverage was asked for, or why it could not start
      */
-    private function startCoverage(Input $input, Output $output): CoverageReporter|null|false
+    private function startCoverage(Input $input): CoverageReporter|null|string
     {
         if (!$this->wantsCoverage($input)) {
             return null;
@@ -371,11 +386,7 @@ final class Run extends Command
 
         $reporter = new CoverageReporter();
 
-        if (!$reporter->start($output, perExample: $perExample)) {
-            return false;
-        }
-
-        return $reporter;
+        return $reporter->start(perExample: $perExample) ?? $reporter;
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -22,6 +22,7 @@ use PhpSpec\Console\Command\Run\GenerationReport;
 use PhpSpec\Console\Command\Run\RunOutcome;
 use PhpSpec\Console\Command\Run\SuiteSummary;
 use PhpSpec\Coverage\CoverageOptions;
+use PhpSpec\Coverage\CoverageVerdict;
 use PhpSpec\Extensions\ExtensionLoader;
 use PhpSpec\Extensions\FormatterBridge;
 use PhpSpec\FilterRegistry;
@@ -231,10 +232,19 @@ final class Run extends Command
         $this->printProfile($input, $prose, $results);
 
         if ($coverageReporter) {
-            $exitCode = $this->reportCoverage($input, $prose, $coverageReporter);
+            $verdict = $this->reportCoverage($input, $prose, $coverageReporter);
 
-            if ($exitCode !== null) {
-                return $exitCode;
+            if ($verdict !== null) {
+                // The gate's verdict belongs in the document as much as in the
+                // exit code: an agent that reads one and not the other would
+                // otherwise call a failed run green.
+                if ($formatter instanceof Agent) {
+                    $formatter->covered($verdict);
+                }
+
+                if ($verdict->exitCode() !== null) {
+                    return $verdict->exitCode();
+                }
             }
         }
 
@@ -650,10 +660,10 @@ final class Run extends Command
      * @param Input $input the console input for coverage report options
      * @param Output $output the console output for report rendering
      * @param CoverageReporter $reporter the active coverage reporter
-     * @return int|null exit code if coverage below minimum, null otherwise
+     * @return CoverageVerdict|null what the run covered, or null when nothing was collected
      * @throws DOMException
      */
-    private function reportCoverage(Input $input, Output $output, CoverageReporter $reporter): ?int
+    private function reportCoverage(Input $input, Output $output, CoverageReporter $reporter): ?CoverageVerdict
     {
         if ($this->coveragePartials !== []) {
             $reporter->mergePartials($this->coveragePartials);

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -171,13 +171,19 @@ final class Run extends Command
         $document = $formatter instanceof Agent ? $formatter : null;
         $prose = $document !== null ? new BufferedOutput() : $output;
 
+        // Resolved once, here: it is what the run targets, and it recovers the
+        // positional path a "--parallel features" swallows, so asking twice
+        // would answer differently the second time.
+        $files = $this->suitePaths($input);
+        $document?->targets($files);
+
         // PHP prints a fatal to standard output as well as the error stream, and
         // standard output is the document's. Sending its own reports to the error
         // stream leaves the channel clean; the document names the fatal itself.
         $displayErrors = $document !== null ? (string) ini_set('display_errors', 'stderr') : null;
 
         try {
-            return $this->perform($input, $prose, $formatter);
+            return $this->perform($input, $prose, $formatter, $files);
         } finally {
             $document?->publish();
             if ($displayErrors !== null) {
@@ -193,12 +199,13 @@ final class Run extends Command
      * @param Input $input the console input (arguments and options)
      * @param Output $prose where human-facing lines go
      * @param Formatter $formatter the console formatter for the run's results
+     * @param string $files the paths this run targets, as the loader takes them
      * @return int exit code: 0 = success, 1 = failure/error or bootstrap missing, 2 = coverage below minimum
      *
      * @throws RandomException
      * @throws DOMException
      */
-    private function perform(Input $input, Output $prose, Formatter $formatter): int
+    private function perform(Input $input, Output $prose, Formatter $formatter, string $files): int
     {
         $missingBootstrap = $this->loadBootstrap($input);
 
@@ -226,7 +233,7 @@ final class Run extends Command
         }
 
         try {
-            $results = $this->runSuiteStreaming($input, $prose, $formatter);
+            $results = $this->runSuiteStreaming($input, $prose, $formatter, $files);
         } catch (\RuntimeException $e) {
             // A load-time contract violation (e.g. two step definitions
             // sharing a title) is the user's to fix; report it, never a trace.
@@ -390,6 +397,51 @@ final class Run extends Command
     }
 
     /**
+     * What this run targets, as the loader will be given it: the paths named on
+     * the command line (and any read from --paths-from), else the suite the
+     * flags ask for, else everything the config declares. Resolved before the
+     * suite is loaded, so a run that dies while loading can still say what it
+     * was trying to run.
+     *
+     * @param Input $input the console input for the file arguments and suite flags
+     * @return string the comma-separated paths
+     */
+    private function suitePaths(Input $input): string
+    {
+        $paths = $input->getArgument('files');
+
+        // VALUE_OPTIONAL may swallow the positional arg: --parallel features → parallel="features"
+        $parallel = $input->getOption('parallel');
+        if ($parallel !== false && is_string($parallel) && !ctype_digit($parallel)) {
+            $paths[] = $parallel;
+            $input->setOption('parallel', null);
+        }
+
+        $pathsFrom = $input->getOption('paths-from');
+
+        if ($pathsFrom !== null && is_file($pathsFrom)) {
+            $listed = file($pathsFrom, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            $paths = array_merge($paths, array_filter(array_map('trim', $listed ?: [])));
+        }
+
+        if (!empty($paths)) {
+            return implode(',', $paths);
+        }
+
+        if ($input->getOption('story')) {
+            return $this->config->getFeaturesPath();
+        }
+
+        if ($input->getOption('all')) {
+            $suitePaths = $this->config->getAllLoadPaths();
+
+            return str_contains($suitePaths, 'features') ? $suitePaths : $suitePaths . ',features/';
+        }
+
+        return $this->config->getAllLoadPaths();
+    }
+
+    /**
      * Checks whether any coverage option was given.
      *
      * @param Input $input the console input to check coverage options
@@ -412,39 +464,14 @@ final class Run extends Command
      * @param Input $input the console input for files, filter, order, and format options
      * @param Output $prose the channel for the run's human-facing lines
      * @param Formatter $formatter the console formatter the results stream through
+     * @param string $files the paths this run targets, as the loader takes them
      * @return SuiteResult the aggregated suite results
      *
      * @throws RandomException
      * @throws \RuntimeException when the loader rejects a duplicate step title
      */
-    private function runSuiteStreaming(Input $input, Output $prose, Formatter $formatter): SuiteResult
+    private function runSuiteStreaming(Input $input, Output $prose, Formatter $formatter, string $files): SuiteResult
     {
-        $paths = $input->getArgument('files');
-
-        // VALUE_OPTIONAL may swallow the positional arg: --parallel features → parallel="features"
-        $parallel = $input->getOption('parallel');
-        if ($parallel !== false && is_string($parallel) && !ctype_digit($parallel)) {
-            $paths[] = $parallel;
-            $input->setOption('parallel', null);
-        }
-
-        $pathsFrom = $input->getOption('paths-from');
-
-        if ($pathsFrom !== null) {
-            $listed = file($pathsFrom, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            $paths = array_merge($paths, array_filter(array_map('trim', $listed ?: [])));
-        }
-
-        if (!empty($paths)) {
-            $files = implode(',', $paths);
-        } elseif ($input->getOption('story')) {
-            $files = $this->config->getFeaturesPath();
-        } elseif ($input->getOption('all')) {
-            $suitePaths = $this->config->getAllLoadPaths();
-            $files = str_contains($suitePaths, 'features') ? $suitePaths : $suitePaths . ',features/';
-        } else {
-            $files = $this->config->getAllLoadPaths();
-        }
         $filter = $input->getOption('filter');
 
         if ($filter !== null) {
@@ -469,11 +496,12 @@ final class Run extends Command
         if ($input->getOption('order') === 'random') {
             $seed = $input->getOption('seed') !== null ? (int) $input->getOption('seed') : random_int(0, 999999);
             $prose->writeln("<fg=yellow>Randomised with seed $seed</>");
+
+            if ($formatter instanceof Agent) {
+                $formatter->randomisedWith($seed);
+            }
         }
 
-        if ($formatter instanceof Agent) {
-            $formatter->describeRun($seed, $files);
-        }
         $formatter->begin();
 
         $start = hrtime(true);

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -31,6 +31,7 @@ use PhpSpec\Loader;
 use PhpSpec\Parallel\ParallelRunner;
 use PhpSpec\Report\Formatter;
 use PhpSpec\Report\Formatter\Agent;
+use PhpSpec\Report\Formatter\Agent\ShutdownProcessEnd;
 use PhpSpec\Report\Formatter\Dot;
 use PhpSpec\Report\Formatter\Html;
 use PhpSpec\Report\Formatter\Junit;
@@ -170,10 +171,18 @@ final class Run extends Command
         $document = $formatter instanceof Agent ? $formatter : null;
         $prose = $document !== null ? new BufferedOutput() : $output;
 
+        // PHP prints a fatal to standard output as well as the error stream, and
+        // standard output is the document's. Sending its own reports to the error
+        // stream leaves the channel clean; the document names the fatal itself.
+        $displayErrors = $document !== null ? (string) ini_set('display_errors', 'stderr') : null;
+
         try {
             return $this->perform($input, $prose, $formatter);
         } finally {
             $document?->publish();
+            if ($displayErrors !== null) {
+                ini_set('display_errors', $displayErrors);
+            }
         }
     }
 
@@ -620,7 +629,11 @@ final class Run extends Command
             'tap' => new Tap($output),
             'junit' => new Junit($output),
             'html' => new Html($output),
-            'agent' => new Agent($output, fn(SuiteResult $results) => $this->codeGenerator(false)->scan($results)->toArray()),
+            'agent' => new Agent(
+                $output,
+                fn(SuiteResult $results) => $this->codeGenerator(false)->scan($results)->toArray(),
+                new ShutdownProcessEnd(),
+            ),
             default => new Pretty($output),
         };
     }

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -159,7 +159,38 @@ final class Run extends Command
      */
     protected function execute(Input $input, Output $output): int
     {
-        if (!$this->loadBootstrap($input, $output)) {
+        $format = $this->resolveFormat($input);
+        $formatter = $this->createFormatter($format, $output);
+        // The agent document IS the console under --format=agent, so every human
+        // line the command would otherwise print (the seed, the profile table, the
+        // coverage verdict, an error) is routed off the console: what an agent
+        // needs is told to the formatter instead and rides inside the document.
+        // For every other format the two are the same stream.
+        $document = $formatter instanceof Agent ? $formatter : null;
+        $prose = $document !== null ? new BufferedOutput() : $output;
+
+        try {
+            return $this->perform($input, $prose, $formatter);
+        } finally {
+            $document?->publish();
+        }
+    }
+
+    /**
+     * The run itself, writing every human line to the prose channel and results
+     * through the formatter.
+     *
+     * @param Input $input the console input (arguments and options)
+     * @param Output $prose where human-facing lines go
+     * @param Formatter $formatter the console formatter for the run's results
+     * @return int exit code: 0 = success, 1 = failure/error or bootstrap missing, 2 = coverage below minimum
+     *
+     * @throws RandomException
+     * @throws DOMException
+     */
+    private function perform(Input $input, Output $prose, Formatter $formatter): int
+    {
+        if (!$this->loadBootstrap($input, $prose)) {
             return 1;
         }
         $this->registerAutoloader();
@@ -167,7 +198,7 @@ final class Run extends Command
         $pathsFrom = $input->getOption('paths-from');
 
         if ($pathsFrom !== null && !is_file($pathsFrom)) {
-            $output->writeln("<fg=red>Paths file not found: $pathsFrom</>");
+            $prose->writeln("<fg=red>Paths file not found: $pathsFrom</>");
 
             return 1;
         }
@@ -175,32 +206,32 @@ final class Run extends Command
         $unknownFormats = $this->unknownFormats($input);
 
         if ($unknownFormats !== []) {
-            $output->writeln('<fg=red>Unknown format: ' . implode(', ', $unknownFormats) . ' (available: pretty, dot, tap, junit, html, agent)</>');
+            $prose->writeln('<fg=red>Unknown format: ' . implode(', ', $unknownFormats) . ' (available: pretty, dot, tap, junit, html, agent)</>');
 
             return 1;
         }
 
-        $coverageReporter = $this->startCoverage($input, $output);
+        $coverageReporter = $this->startCoverage($input, $prose);
 
         if ($coverageReporter === false) {
             return 1;
         }
 
         try {
-            $results = $this->runSuiteStreaming($input, $output);
+            $results = $this->runSuiteStreaming($input, $prose, $formatter);
         } catch (\RuntimeException $e) {
             // A load-time contract violation (e.g. two step definitions
             // sharing a title) is the user's to fix; report it, never a trace.
-            $output->writeln(sprintf('<fg=red>%s</>', $e->getMessage()));
+            $prose->writeln(sprintf('<fg=red>%s</>', $e->getMessage()));
 
             return 1;
         }
 
-        $this->writeReportFiles($input, $output, $results);
-        $this->printProfile($input, $output, $results);
+        $this->writeReportFiles($input, $prose, $results);
+        $this->printProfile($input, $prose, $results);
 
         if ($coverageReporter) {
-            $exitCode = $this->reportCoverage($input, $output, $coverageReporter);
+            $exitCode = $this->reportCoverage($input, $prose, $coverageReporter);
 
             if ($exitCode !== null) {
                 return $exitCode;
@@ -226,7 +257,7 @@ final class Run extends Command
                 SuiteSummary::fromSuiteResult($results),
             ));
         } elseif (!in_array($this->resolveFormat($input), ['junit', 'html', 'agent'], true)) {
-            $this->generateCode($output, $results, (bool) $input->getOption('fake'), $input->isInteractive());
+            $this->generateCode($prose, $results, (bool) $input->getOption('fake'), $input->isInteractive());
         }
 
         return $results->status();
@@ -349,13 +380,14 @@ final class Run extends Command
      * and returns the aggregated suite results.
      *
      * @param Input $input the console input for files, filter, order, and format options
-     * @param Output $output the console output for displaying results
+     * @param Output $prose the channel for the run's human-facing lines
+     * @param Formatter $formatter the console formatter the results stream through
      * @return SuiteResult the aggregated suite results
      *
      * @throws RandomException
      * @throws \RuntimeException when the loader rejects a duplicate step title
      */
-    private function runSuiteStreaming(Input $input, Output $output): SuiteResult
+    private function runSuiteStreaming(Input $input, Output $prose, Formatter $formatter): SuiteResult
     {
         $paths = $input->getArgument('files');
 
@@ -406,10 +438,9 @@ final class Run extends Command
         $seed = null;
         if ($input->getOption('order') === 'random') {
             $seed = $input->getOption('seed') !== null ? (int) $input->getOption('seed') : random_int(0, 999999);
-            $output->writeln("<fg=yellow>Randomised with seed $seed</>");
+            $prose->writeln("<fg=yellow>Randomised with seed $seed</>");
         }
 
-        $formatter = $this->createFormatter($this->resolveFormat($input), $output);
         if ($formatter instanceof Agent) {
             $formatter->describeRun($seed, $files);
         }

--- a/src/PhpSpec/Console/Command/Run/CoverageReporter.php
+++ b/src/PhpSpec/Console/Command/Run/CoverageReporter.php
@@ -19,6 +19,7 @@ use PhpSpec\Coverage\CloverReport;
 use PhpSpec\Coverage\CoverageCollector;
 use PhpSpec\Coverage\CoverageOptions;
 use PhpSpec\Coverage\CoverageRegistry;
+use PhpSpec\Coverage\CoverageVerdict;
 use PhpSpec\Coverage\Driver\XdebugDriver;
 use PhpSpec\Coverage\HtmlReport;
 use PhpSpec\Coverage\JsonReport;
@@ -80,10 +81,11 @@ final class CoverageReporter
      *
      * @param Output $output the console output
      * @param CoverageOptions $options the requested reports and their destinations
-     * @return int|null returns 1 if below minimum threshold, null otherwise
+     * @return CoverageVerdict|null what the run covered, or null when nothing was
+     *                              collected or the state was only dumped for a worker
      * @throws DOMException
      */
-    public function report(Output $output, CoverageOptions $options): ?int
+    public function report(Output $output, CoverageOptions $options): ?CoverageVerdict
     {
         $perExampleCollector = CoverageRegistry::collector();
 
@@ -185,16 +187,16 @@ final class CoverageReporter
     }
 
     /**
-     * Renders the text, Clover and HTML reports and enforces the minimum
-     * coverage threshold.
+     * Renders the text, Clover and HTML reports and measures the run against
+     * the minimum coverage threshold.
      *
      * @param Output $output the console output
      * @param array<string, array<int, int>> $covData filtered coverage data, relative file paths mapped to line hits
      * @param CoverageOptions $options the requested reports and their destinations
-     * @return int|null returns 1 if below minimum threshold, null otherwise
+     * @return CoverageVerdict what the run covered, and whether that was enough
      * @throws DOMException
      */
-    private function renderReports(Output $output, array $covData, CoverageOptions $options): ?int
+    private function renderReports(Output $output, array $covData, CoverageOptions $options): CoverageVerdict
     {
         if ($options->showText) {
             (new TextReport())->render($covData, $output);
@@ -210,32 +212,26 @@ final class CoverageReporter
             $output->writeln("  HTML report: {$options->htmlPath}/index.html");
         }
 
-        if ($options->coverageMin !== null) {
-            $totalCovered = 0;
-            $totalExecutable = 0;
+        $totalCovered = 0;
+        $totalExecutable = 0;
 
-            foreach ($covData as $lines) {
-                $counts = CoverageCollector::countLines($lines);
-                $totalCovered += $counts['covered'];
-                $totalExecutable += $counts['executable'];
-            }
-
-            $pct = $totalExecutable > 0 ? ($totalCovered / $totalExecutable) * 100 : 0;
-            $min = (float) $options->coverageMin;
-
-            if ($pct < $min) {
-                $output->writeln(sprintf(
-                    '<fg=red>Code coverage %.1f%% is below the required %.1f%%</>',
-                    $pct,
-                    $min,
-                ));
-
-                return 1;
-            }
-
-            $output->writeln(sprintf('<fg=green>Code coverage %.1f%% meets the required %.1f%%</>', $pct, $min));
+        foreach ($covData as $lines) {
+            $counts = CoverageCollector::countLines($lines);
+            $totalCovered += $counts['covered'];
+            $totalExecutable += $counts['executable'];
         }
 
-        return null;
+        $verdict = new CoverageVerdict(
+            $totalExecutable > 0 ? ($totalCovered / $totalExecutable) * 100 : 0.0,
+            $options->coverageMin !== null ? (float) $options->coverageMin : null,
+        );
+
+        if ($verdict->required !== null) {
+            $output->writeln($verdict->met()
+                ? sprintf('<fg=green>Code coverage %.1f%% meets the required %.1f%%</>', $verdict->percent, $verdict->required)
+                : sprintf('<fg=red>Code coverage %.1f%% is below the required %.1f%%</>', $verdict->percent, $verdict->required));
+        }
+
+        return $verdict;
     }
 }

--- a/src/PhpSpec/Console/Command/Run/CoverageReporter.php
+++ b/src/PhpSpec/Console/Command/Run/CoverageReporter.php
@@ -48,28 +48,25 @@ final class CoverageReporter
      * is activated in the CoverageRegistry and the runner cycles it around
      * each example.
      *
-     * @param Output $output the console output for error messages
      * @param bool $perExample whether to collect coverage per example
-     * @return bool true if collection started, false if unavailable
+     * @return string|null null once collection started, or why it could not
      */
-    public function start(Output $output, bool $perExample = false): bool
+    public function start(bool $perExample = false): ?string
     {
         if (!CoverageCollector::isAvailable()) {
-            $output->writeln('<fg=red>Code coverage requires Xdebug with coverage mode enabled</>');
-
-            return false;
+            return 'Code coverage requires Xdebug with coverage mode enabled';
         }
 
         if ($perExample) {
             CoverageRegistry::activate(new PerExampleCollector(new XdebugDriver()));
 
-            return true;
+            return null;
         }
 
         $this->collector = new CoverageCollector();
         $this->collector->start();
 
-        return true;
+        return null;
     }
 
     /**

--- a/src/PhpSpec/Coverage/CoverageVerdict.php
+++ b/src/PhpSpec/Coverage/CoverageVerdict.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Coverage;
+
+/**
+ * @internal
+ * What a coverage run concluded: how much of the source the specs executed, and
+ * the threshold it was asked to meet. A plain value, so the one place that
+ * measured it says it once and everything downstream (the console line, the exit
+ * code, the agent document) derives from the same statement.
+ */
+final readonly class CoverageVerdict
+{
+    /**
+     * @param float $percent executable source lines covered, as a percentage
+     * @param float|null $required the --coverage-min threshold, or null when none was asked for
+     */
+    public function __construct(
+        public float $percent,
+        public ?float $required = null,
+    ) {}
+
+    /**
+     * Whether the run met what was asked of it. A run with no threshold has
+     * nothing to fall short of.
+     */
+    public function met(): bool
+    {
+        return $this->required === null || $this->percent >= $this->required;
+    }
+
+    /**
+     * The exit code this verdict demands, or null when it demands none.
+     */
+    public function exitCode(): ?int
+    {
+        return $this->met() ? null : 1;
+    }
+}

--- a/src/PhpSpec/Loader.php
+++ b/src/PhpSpec/Loader.php
@@ -186,7 +186,7 @@ final class Loader
                 continue;
             }
 
-            $filePath = $directory . '/' . $file;
+            $filePath = self::join($directory, $file);
 
             if ($this->fs->isDir($filePath)) {
                 $subdirectoryFilePaths = $this->loadSuite($filePath);
@@ -315,7 +315,7 @@ final class Loader
                 continue;
             }
 
-            $filePath = $path . '/' . $file;
+            $filePath = self::join($path, $file);
 
             if ($this->fs->isDir($filePath)) {
                 if ($file === 'steps') {
@@ -327,6 +327,20 @@ final class Loader
                 $featureFiles[] = $filePath;
             }
         }
+    }
+
+    /**
+     * Joins a directory and one of its entries. A directory named on the command
+     * line usually carries a trailing slash ("features/"), and a doubled
+     * separator would travel from here into every path PhpSpec reports back,
+     * including the rerun commands an agent is meant to run verbatim.
+     *
+     * @param string $directory the containing directory, with or without a trailing separator
+     * @param string $entry the file or directory name inside it
+     */
+    private static function join(string $directory, string $entry): string
+    {
+        return rtrim($directory, '/\\') . '/' . $entry;
     }
 
     /**
@@ -362,7 +376,7 @@ final class Loader
             if ($file === '.' || $file === '..') {
                 continue;
             }
-            $filePath = $dir . '/' . $file;
+            $filePath = self::join($dir, $file);
             if ($this->fs->isDir($filePath)) {
                 $this->collectStepFiles($filePath, $stepFiles);
             } elseif ($this->fs->isFile($filePath) && str_ends_with($file, '.steps.php')) {

--- a/src/PhpSpec/ObjectName.php
+++ b/src/PhpSpec/ObjectName.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec;
+
+use Stringable;
+use Throwable;
+use UnitEnum;
+
+/**
+ * @internal
+ * How an object appears in a failure: by what it is, never by which instance it
+ * happens to be. An object id changes between runs, so a report that carries one
+ * cannot be compared with the same report from the run before it, and it tells
+ * the reader nothing they can act on either.
+ *
+ * One statement of the rule, for every place a value is shown: the failure
+ * message, the array it sits in, and the agent document.
+ */
+final class ObjectName
+{
+    private const STRING_MAX = 60;
+
+    /**
+     * The name to show for an object: an enum by its case, anything that can
+     * describe itself by that description, and everything else by its class.
+     */
+    public static function of(object $value): string
+    {
+        if ($value instanceof UnitEnum) {
+            return $value::class . '::' . $value->name;
+        }
+
+        // A throwable describes itself with its whole stack trace, which is a
+        // wall of absolute paths that shift with every edit. Its message is the
+        // part that identifies it.
+        if ($value instanceof Throwable) {
+            return $value::class . '("' . self::clip($value->getMessage()) . '")';
+        }
+
+        if ($value instanceof Stringable) {
+            return $value::class . '("' . self::clip(self::describe($value)) . '")';
+        }
+
+        return $value::class;
+    }
+
+    /**
+     * The object's own description, or an empty one when asking for it fails:
+     * a report about a failure must not become a failure of its own.
+     */
+    private static function describe(Stringable $value): string
+    {
+        try {
+            return (string) $value;
+        } catch (Throwable) {
+            return '';
+        }
+    }
+
+    /**
+     * The description as a name can carry it: one line, and short enough to sit
+     * inside a message.
+     */
+    private static function clip(string $description): string
+    {
+        $line = strtok(trim($description), "\n");
+        $excerpt = $line === false ? '' : $line;
+
+        return mb_strlen($excerpt) > self::STRING_MAX
+            ? mb_substr($excerpt, 0, self::STRING_MAX - 1) . '…'
+            : $excerpt;
+    }
+}

--- a/src/PhpSpec/Parallel/WorkerProcess.php
+++ b/src/PhpSpec/Parallel/WorkerProcess.php
@@ -308,10 +308,10 @@ final class WorkerProcess
                 }
             }
 
-            $scenarios[] = new ScenarioResult((string) $scenarioXml['name'], $steps);
+            $scenarios[] = new ScenarioResult((string) $scenarioXml['name'], $steps, (int) ($scenarioXml['line'] ?? 0));
         }
 
-        return new FeatureResult((string) $featureXml['name'], $scenarios);
+        return new FeatureResult((string) $featureXml['name'], $scenarios, (string) ($featureXml['file'] ?? ''));
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -16,7 +16,9 @@ namespace PhpSpec\Report\Formatter;
 
 use PhpSpec\Coverage\CoverageVerdict;
 use PhpSpec\Report\AbstractFormatter;
+use PhpSpec\Report\Formatter\Agent\Fatal;
 use PhpSpec\Report\Formatter\Agent\Offers;
+use PhpSpec\Report\Formatter\Agent\ProcessEnd;
 use PhpSpec\Report\Formatter\Agent\Schema;
 use PhpSpec\Report\Formatter\Agent\ValueExporter;
 use PhpSpec\Result\ExampleResult;
@@ -66,10 +68,20 @@ final class Agent extends AbstractFormatter
     /** What the run covered, when coverage was collected. */
     private ?CoverageVerdict $coverage = null;
 
-    public function __construct(OutputInterface $output, ?\Closure $resolveCandidates = null)
+    /** @var array{message: string, at: string|null}|null what stopped the run short, when something did */
+    private ?array $fatal = null;
+
+    /**
+     * @param OutputInterface $output the stream the document goes to
+     * @param \Closure(SuiteResult): mixed|null $resolveCandidates resolves the run's generation candidates
+     * @param ProcessEnd|null $processEnd the promise-keeper: given one, the document
+     *                                    still goes out when the process dies mid-run
+     */
+    public function __construct(OutputInterface $output, ?\Closure $resolveCandidates = null, ?ProcessEnd $processEnd = null)
     {
         parent::__construct($output);
         $this->resolveCandidates = $resolveCandidates;
+        $processEnd?->atEnd($this->ended(...));
     }
 
     /**
@@ -110,6 +122,32 @@ final class Agent extends AbstractFormatter
     public function covered(CoverageVerdict $verdict): void
     {
         $this->coverage = $verdict;
+    }
+
+    /**
+     * Takes what stopped the run: a missing bootstrap, a rejected option, an
+     * error that killed the process. The first one to arrive is the one that
+     * mattered, so it is not overwritten by whatever came apart afterwards.
+     *
+     * @param string $message what went wrong
+     * @param string|null $at where, as a project-relative file:line
+     */
+    public function stopped(string $message, ?string $at = null): void
+    {
+        $this->fatal ??= ['message' => $message, 'at' => $at];
+    }
+
+    /**
+     * The process is going. Whatever ended it becomes part of the document, and
+     * the document goes out with what the run managed to collect.
+     */
+    private function ended(?Fatal $fatal): void
+    {
+        if ($fatal !== null) {
+            $this->stopped($fatal->message, $this->location($fatal->file, $fatal->line));
+        }
+
+        $this->publish();
     }
 
     /**
@@ -155,6 +193,7 @@ final class Agent extends AbstractFormatter
         // example: the number an agent checks must not say "nothing to do" while
         // the exit code says otherwise.
         $shortfall = $this->coverage !== null && !$this->coverage->met() ? 1 : 0;
+        $stopped = $this->fatal !== null ? 1 : 0;
 
         $result = [
             'suite' => [
@@ -177,9 +216,9 @@ final class Agent extends AbstractFormatter
                 'pending' => $pending,
                 'skipped' => $this->counts['skipped'] ?? 0,
                 // The one number an agent checks: everything red or unfinished
-                // (failures + errors + pending) plus a missed coverage gate.
-                // Zero means nothing to do.
-                'actionable' => $failing + $errors + $pending + $shortfall,
+                // (failures + errors + pending), plus a missed coverage gate and
+                // anything that stopped the run. Zero means nothing to do.
+                'actionable' => $failing + $errors + $pending + $shortfall + $stopped,
                 'duration_ms' => (int) round(($this->results?->getDuration() ?? 0.0) * 1000),
                 'offers' => $this->results !== null ? $this->offers($this->results) : [],
             ],
@@ -191,6 +230,10 @@ final class Agent extends AbstractFormatter
                 'required' => $this->coverage->required,
                 'met' => $this->coverage->met(),
             ];
+        }
+
+        if ($this->fatal !== null) {
+            $result['fatal'] = $this->fatal;
         }
 
         return $result;

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -510,9 +510,11 @@ final class Agent extends AbstractFormatter
 
         // A scenario is addressed by the line its keyword sits on, which is what
         // "file.feature:LINE" already selects, so a failing scenario re-runs on
-        // its own instead of dragging the whole story suite with it.
+        // its own instead of dragging the whole story suite with it. Only a
+        // failure is addressed, as with examples: a skipped step is not work to
+        // re-run, and the summary's rerun would otherwise sweep it up.
         $location = $this->location($origin->path, $origin->line);
-        if ($state !== 'passing' && $location !== null) {
+        if ($state === 'failing' && $location !== null) {
             $entry['spec'] = $location;
             $this->addRerun($entry, $location);
         }

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -174,7 +174,9 @@ final class Agent extends AbstractFormatter
         }
 
         $this->published = true;
-        $json = json_encode($this->document(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+        // The zero fraction is kept: a float that lost it would read as the int
+        // it was compared against, turning a type failure into a tautology.
+        $json = json_encode($this->document(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION) ?: '{}';
 
         $this->output->write($json . "\n", false, OutputInterface::OUTPUT_RAW);
     }
@@ -380,6 +382,9 @@ final class Agent extends AbstractFormatter
                 'message' => $error?->getMessage(),
                 'at' => $this->location($error?->getFile(), $error?->getLine()),
             ];
+            // Mirrored, so one field answers "what went wrong" whatever the
+            // state: the exception adds the class and the site, not the text.
+            $entry['message'] = $error?->getMessage();
             $location = $this->location($error?->getFile(), $error?->getLine());
             $entry['spec'] = $location;
             $this->addRerun($entry, $location);

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -87,16 +87,24 @@ final class Agent extends AbstractFormatter
     }
 
     /**
-     * Tells the formatter about the run it is rendering, so the document
-     * carries the real seed (an agent reruns a flaky order with it) and what
-     * was run instead of placeholders.
+     * Tells the formatter what the run targets, so the header says what was
+     * asked for instead of a placeholder. Told before the suite is loaded, so a
+     * run that dies loading still reports it.
      */
-    public function describeRun(?int $seed, string $suite): void
+    public function targets(string $suite): void
     {
-        $this->seed = $seed;
         if ($suite !== '') {
             $this->suite = $suite;
         }
+    }
+
+    /**
+     * Tells the formatter the seed the run was shuffled with, so an agent can
+     * reproduce a flaky order.
+     */
+    public function randomisedWith(int $seed): void
+    {
+        $this->seed = $seed;
     }
 
     public function begin(): void {}

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -224,6 +224,11 @@ final class Agent extends AbstractFormatter
             ],
         ];
 
+        $rerun = $this->rerunEverything();
+        if ($rerun !== null) {
+            $result['result']['rerun'] = $rerun;
+        }
+
         if ($this->coverage !== null) {
             $result['result']['coverage'] = [
                 'percent' => round($this->coverage->percent, 1),
@@ -237,6 +242,27 @@ final class Agent extends AbstractFormatter
         }
 
         return $result;
+    }
+
+    /**
+     * The one command that re-runs everything this run reported, so a fix can be
+     * checked against the whole of what it was meant to fix instead of one
+     * example at a time. Null when nothing failed anywhere with a location.
+     */
+    private function rerunEverything(): ?string
+    {
+        $targets = [];
+
+        foreach ($this->examples as $entry) {
+            $rerun = $entry['rerun'] ?? null;
+            if (is_string($rerun)) {
+                $targets[] = substr($rerun, strlen('run '));
+            }
+        }
+
+        $targets = array_values(array_unique($targets));
+
+        return $targets !== [] ? 'run ' . implode(' ', $targets) : null;
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -52,6 +52,9 @@ final class Agent extends AbstractFormatter
     /** How many story (feature) steps ran. */
     private int $stepCount = 0;
 
+    /** How many story scenarios ran: the unit a story run is counted and reported in. */
+    private int $scenarioCount = 0;
+
     /** @var (\Closure(SuiteResult): mixed)|null resolves the run's generation candidates as a plain array */
     private readonly ?\Closure $resolveCandidates;
 
@@ -111,7 +114,15 @@ final class Agent extends AbstractFormatter
 
     public function printResult(Results $result): void
     {
-        $this->collect($result, $this->within(new Origin(), $result));
+        $origin = $this->within(new Origin(), $result);
+
+        if ($result instanceof ScenarioResult) {
+            $this->recordScenario($result, $origin);
+
+            return;
+        }
+
+        $this->collect($result, $origin);
     }
 
     /**
@@ -213,6 +224,7 @@ final class Agent extends AbstractFormatter
                 'event' => Schema::EVENT_RUN_STARTED,
                 'suite' => $this->suite,
                 'examples' => $this->exampleCount,
+                'scenarios' => $this->scenarioCount,
                 'steps' => $this->stepCount,
                 'seed' => $this->seed,
             ],
@@ -221,7 +233,10 @@ final class Agent extends AbstractFormatter
                 'v' => Schema::V,
                 'event' => Schema::EVENT_SUMMARY,
                 'examples' => $this->exampleCount,
+                'scenarios' => $this->scenarioCount,
                 'steps' => $this->stepCount,
+                // Counted in the units the entries are reported in: one per
+                // example, one per scenario. Steps are a size, not a verdict.
                 'passing' => $this->counts['passing'] ?? 0,
                 'failing' => $failing,
                 'errors' => $errors,
@@ -317,9 +332,14 @@ final class Agent extends AbstractFormatter
     {
         foreach ($results->getResults() as $child) {
             if ($child instanceof ExampleResult) {
-                $this->record($this->fromExample($child, $origin), 'example');
-            } elseif ($child instanceof StepResult) {
-                $this->record($this->fromStep($child, $origin), 'step');
+                $this->record($this->fromExample($child, $origin));
+            } elseif ($child instanceof ScenarioResult) {
+                // A scenario is the unit a story run reports: it is what fails,
+                // what re-runs, and what a reader acts on. Its steps ride inside
+                // it rather than becoming entries of their own, so one broken
+                // scenario is one thing to fix and not a failure plus a train of
+                // skipped siblings that address the same line.
+                $this->recordScenario($child, $this->within($origin, $child));
             } elseif ($child instanceof Results) {
                 $this->collect($child, $this->within($origin, $child));
             }
@@ -327,23 +347,17 @@ final class Agent extends AbstractFormatter
     }
 
     /**
-     * Counts an entry by state, and keeps it in the emitted list unless it
-     * passed — a green suite of thousands need not spend tokens on entries an
+     * Counts an example by state, and keeps it in the emitted list unless it
+     * passed: a green suite of thousands need not spend tokens on entries an
      * agent will never act on; the summary still counts them.
      *
      * @param array<string, mixed> $entry
-     * @param 'example'|'step' $kind
      */
-    private function record(array $entry, string $kind): void
+    private function record(array $entry): void
     {
         $state = is_string($entry['state'] ?? null) ? $entry['state'] : 'passing';
         $this->counts[$state] = ($this->counts[$state] ?? 0) + 1;
-
-        if ($kind === 'step') {
-            $this->stepCount++;
-        } else {
-            $this->exampleCount++;
-        }
+        $this->exampleCount++;
 
         if ($state !== 'passing') {
             $this->examples[] = $entry;
@@ -487,39 +501,97 @@ final class Agent extends AbstractFormatter
     /**
      * @return array<string, mixed>
      */
-    private function fromStep(StepResult $step, Origin $origin): array
+    /**
+     * Records one scenario: counted whatever it did, and emitted when it needs
+     * attention, carrying the steps that were not passing so the reader sees
+     * which one broke (or which are still undefined) without a second lookup.
+     */
+    private function recordScenario(ScenarioResult $scenario, Origin $origin): void
     {
-        $state = match (true) {
-            $step->isPending() || $step->isUndefined() => 'pending',
-            $step->isFailure() || $step->isError() => 'failing',
-            $step->isSkipped() => 'skipped',
-            default => 'passing',
-        };
+        $steps = [];
+        $state = 'passing';
+        $message = null;
 
-        $name = $origin->name($step->getTitle());
+        foreach ($scenario->getResults() as $step) {
+            if (!$step instanceof StepResult) {
+                continue;
+            }
+
+            $this->stepCount++;
+            $stepState = $this->stepState($step);
+
+            if ($stepState === 'passing') {
+                continue;
+            }
+
+            $reported = ['title' => $step->getTitle(), 'state' => $stepState];
+
+            if ($stepState === 'failing' && $step->getError() !== null) {
+                $reported['message'] = $step->getError()->getMessage();
+                $message ??= $step->getError()->getMessage();
+            }
+
+            $steps[] = $reported;
+            $state = self::worst($state, $stepState);
+        }
+
+        $this->scenarioCount++;
+        $this->counts[$state] = ($this->counts[$state] ?? 0) + 1;
+
+        if ($state === 'passing') {
+            return;
+        }
+
         $entry = [
             'v' => Schema::V,
-            'id' => $this->identify($name),
-            'example' => $name,
+            'id' => $this->identify($origin->name),
+            'example' => $origin->name,
             'state' => $state,
         ];
 
-        if ($state === 'failing' && $step->getError() !== null) {
-            $entry['message'] = $step->getError()->getMessage();
+        if ($message !== null) {
+            $entry['message'] = $message;
         }
+
+        $entry['steps'] = $steps;
 
         // A scenario is addressed by the line its keyword sits on, which is what
         // "file.feature:LINE" already selects, so a failing scenario re-runs on
         // its own instead of dragging the whole story suite with it. Only a
-        // failure is addressed, as with examples: a skipped step is not work to
-        // re-run, and the summary's rerun would otherwise sweep it up.
+        // failure is addressed, as with examples: a scenario waiting on undefined
+        // steps is work to write, not work to re-run.
         $location = $this->location($origin->path, $origin->line);
         if ($state === 'failing' && $location !== null) {
             $entry['spec'] = $location;
             $this->addRerun($entry, $location);
         }
 
-        return $entry;
+        $this->examples[] = $entry;
+    }
+
+    /**
+     * A step's state in the document's vocabulary.
+     */
+    private function stepState(StepResult $step): string
+    {
+        return match (true) {
+            $step->isPending() || $step->isUndefined() => 'pending',
+            $step->isFailure() || $step->isError() => 'failing',
+            $step->isSkipped() => 'skipped',
+            default => 'passing',
+        };
+    }
+
+    /**
+     * The state a scenario takes from its steps: the one that most needs
+     * attention wins, so a scenario whose first step failed reads as failing
+     * however many of its steps were skipped behind it.
+     */
+    private static function worst(string $state, string $candidate): string
+    {
+        $order = ['passing' => 0, 'skipped' => 1, 'pending' => 2, 'failing' => 3];
+
+        return $order[$candidate] > $order[$state] ? $candidate : $state;
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -18,12 +18,14 @@ use PhpSpec\Coverage\CoverageVerdict;
 use PhpSpec\Report\AbstractFormatter;
 use PhpSpec\Report\Formatter\Agent\Fatal;
 use PhpSpec\Report\Formatter\Agent\Offers;
+use PhpSpec\Report\Formatter\Agent\Origin;
 use PhpSpec\Report\Formatter\Agent\ProcessEnd;
 use PhpSpec\Report\Formatter\Agent\Schema;
 use PhpSpec\Report\Formatter\Agent\ValueExporter;
 use PhpSpec\Result\ExampleResult;
 use PhpSpec\Result\FeatureResult;
 use PhpSpec\Result\MatchResult;
+use PhpSpec\Result\ScenarioResult;
 use PhpSpec\Result\SpecificationResult;
 use PhpSpec\Result\StepResult;
 use PhpSpec\Result\SuiteResult;
@@ -101,7 +103,7 @@ final class Agent extends AbstractFormatter
 
     public function printResult(Results $result): void
     {
-        $this->collect($result, $this->subjectOf($result));
+        $this->collect($result, $this->within(new Origin(), $result));
     }
 
     /**
@@ -283,31 +285,33 @@ final class Agent extends AbstractFormatter
     }
 
     /**
-     * The subject a result names its children after — the described class for a
-     * spec, the title for a feature — or null when it carries none.
+     * The origin one level into a result: a spec or feature adds its title (and
+     * a feature the file it lives in), a scenario adds its title and the line
+     * that re-runs it. Anything else passes the origin through untouched.
      */
-    private function subjectOf(Results $result): ?string
+    private function within(Origin $origin, Results $result): Origin
     {
-        if ($result instanceof SpecificationResult || $result instanceof FeatureResult) {
-            return $result->getTitle();
-        }
-
-        return null;
+        return match (true) {
+            $result instanceof FeatureResult => $origin->within($result->getTitle(), $result->getPath()),
+            $result instanceof ScenarioResult => $origin->within($result->getTitle(), line: $result->getLine()),
+            $result instanceof SpecificationResult => $origin->within($result->getTitle()),
+            default => $origin,
+        };
     }
 
     /**
      * Walks the result tree, emitting one entry per example/step and threading
-     * the enclosing subject down so each entry is named in full.
+     * the origin down so each entry is named in full and knows where it lives.
      */
-    private function collect(Results $results, ?string $subject): void
+    private function collect(Results $results, Origin $origin): void
     {
         foreach ($results->getResults() as $child) {
             if ($child instanceof ExampleResult) {
-                $this->record($this->fromExample($child, $subject), 'example');
+                $this->record($this->fromExample($child, $origin), 'example');
             } elseif ($child instanceof StepResult) {
-                $this->record($this->fromStep($child, $subject), 'step');
+                $this->record($this->fromStep($child, $origin), 'step');
             } elseif ($child instanceof Results) {
-                $this->collect($child, $this->subjectOf($child) ?? $subject);
+                $this->collect($child, $this->within($origin, $child));
             }
         }
     }
@@ -339,10 +343,10 @@ final class Agent extends AbstractFormatter
     /**
      * @return array<string, mixed>
      */
-    private function fromExample(ExampleResult $example, ?string $subject): array
+    private function fromExample(ExampleResult $example, Origin $origin): array
     {
         $state = $this->exampleState($example);
-        $name = $this->name($subject, $example->getTitle());
+        $name = $origin->name($example->getTitle());
         $entry = [
             'v' => Schema::V,
             'id' => $this->identify($name),
@@ -470,7 +474,7 @@ final class Agent extends AbstractFormatter
     /**
      * @return array<string, mixed>
      */
-    private function fromStep(StepResult $step, ?string $subject): array
+    private function fromStep(StepResult $step, Origin $origin): array
     {
         $state = match (true) {
             $step->isPending() || $step->isUndefined() => 'pending',
@@ -479,7 +483,7 @@ final class Agent extends AbstractFormatter
             default => 'passing',
         };
 
-        $name = $this->name($subject, $step->getTitle());
+        $name = $origin->name($step->getTitle());
         $entry = [
             'v' => Schema::V,
             'id' => $this->identify($name),
@@ -491,15 +495,16 @@ final class Agent extends AbstractFormatter
             $entry['message'] = $step->getError()->getMessage();
         }
 
-        return $entry;
-    }
+        // A scenario is addressed by the line its keyword sits on, which is what
+        // "file.feature:LINE" already selects, so a failing scenario re-runs on
+        // its own instead of dragging the whole story suite with it.
+        $location = $this->location($origin->path, $origin->line);
+        if ($state !== 'passing' && $location !== null) {
+            $entry['spec'] = $location;
+            $this->addRerun($entry, $location);
+        }
 
-    /**
-     * Joins the subject and the title into the example's full name.
-     */
-    private function name(?string $subject, string $title): string
-    {
-        return $subject !== null && $subject !== '' ? $subject . ' ' . $title : $title;
+        return $entry;
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec\Report\Formatter;
 
+use PhpSpec\Coverage\CoverageVerdict;
 use PhpSpec\Report\AbstractFormatter;
 use PhpSpec\Report\Formatter\Agent\Offers;
 use PhpSpec\Report\Formatter\Agent\Schema;
@@ -62,6 +63,9 @@ final class Agent extends AbstractFormatter
     /** Whether the document has gone out, so it goes out exactly once. */
     private bool $published = false;
 
+    /** What the run covered, when coverage was collected. */
+    private ?CoverageVerdict $coverage = null;
+
     public function __construct(OutputInterface $output, ?\Closure $resolveCandidates = null)
     {
         parent::__construct($output);
@@ -97,6 +101,15 @@ final class Agent extends AbstractFormatter
     public function end(SuiteResult $results): void
     {
         $this->results = $results;
+    }
+
+    /**
+     * Takes what the coverage run concluded, so the document reports it rather
+     * than a line printed after the document could ever say.
+     */
+    public function covered(CoverageVerdict $verdict): void
+    {
+        $this->coverage = $verdict;
     }
 
     /**
@@ -138,8 +151,12 @@ final class Agent extends AbstractFormatter
         $failing = $this->counts['failing'] ?? 0;
         $errors = $this->counts['error'] ?? 0;
         $pending = $this->counts['pending'] ?? 0;
+        // A coverage gate the run missed is work left to do, exactly like a red
+        // example: the number an agent checks must not say "nothing to do" while
+        // the exit code says otherwise.
+        $shortfall = $this->coverage !== null && !$this->coverage->met() ? 1 : 0;
 
-        return [
+        $result = [
             'suite' => [
                 'v' => Schema::V,
                 'event' => Schema::EVENT_RUN_STARTED,
@@ -160,12 +177,23 @@ final class Agent extends AbstractFormatter
                 'pending' => $pending,
                 'skipped' => $this->counts['skipped'] ?? 0,
                 // The one number an agent checks: everything red or unfinished
-                // (failures + errors + pending). Zero means nothing to do.
-                'actionable' => $failing + $errors + $pending,
+                // (failures + errors + pending) plus a missed coverage gate.
+                // Zero means nothing to do.
+                'actionable' => $failing + $errors + $pending + $shortfall,
                 'duration_ms' => (int) round(($this->results?->getDuration() ?? 0.0) * 1000),
                 'offers' => $this->results !== null ? $this->offers($this->results) : [],
             ],
         ];
+
+        if ($this->coverage !== null) {
+            $result['result']['coverage'] = [
+                'percent' => round($this->coverage->percent, 1),
+                'required' => $this->coverage->required,
+                'met' => $this->coverage->met(),
+            ];
+        }
+
+        return $result;
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -56,6 +56,12 @@ final class Agent extends AbstractFormatter
     /** What was run, as the paths the loader was given. */
     private string $suite = 'default';
 
+    /** The run's results, once it reached the end; null while it is still going. */
+    private ?SuiteResult $results = null;
+
+    /** Whether the document has gone out, so it goes out exactly once. */
+    private bool $published = false;
+
     public function __construct(OutputInterface $output, ?\Closure $resolveCandidates = null)
     {
         parent::__construct($output);
@@ -82,13 +88,58 @@ final class Agent extends AbstractFormatter
         $this->collect($result, $this->subjectOf($result));
     }
 
+    /**
+     * Takes the run's results. The document is not written here: it is the whole
+     * command's artifact, not the suite runner's, so it waits for {@see publish()}
+     * and can still be told what the command learns after the last example (the
+     * coverage verdict).
+     */
     public function end(SuiteResult $results): void
+    {
+        $this->results = $results;
+    }
+
+    /**
+     * A whole-suite render is complete in itself (a report file, a spec), so it
+     * publishes as it ends.
+     */
+    public function format(SuiteResult $results): void
+    {
+        parent::format($results);
+        $this->publish();
+    }
+
+    /**
+     * Writes the document, once. Every path out of the command comes through
+     * here, so an agent reads exactly one JSON object whether the run finished,
+     * failed its coverage gate, or died: calling it twice is a no-op.
+     */
+    public function publish(): void
+    {
+        if ($this->published) {
+            return;
+        }
+
+        $this->published = true;
+        $json = json_encode($this->document(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+
+        $this->output->write($json . "\n", false, OutputInterface::OUTPUT_RAW);
+    }
+
+    /**
+     * The document as it stands: the header, every actionable entry, and the
+     * totals. Built from whatever has been collected, so a run cut short still
+     * reports what it managed to see.
+     *
+     * @return array<string, mixed>
+     */
+    private function document(): array
     {
         $failing = $this->counts['failing'] ?? 0;
         $errors = $this->counts['error'] ?? 0;
         $pending = $this->counts['pending'] ?? 0;
 
-        $document = [
+        return [
             'suite' => [
                 'v' => Schema::V,
                 'event' => Schema::EVENT_RUN_STARTED,
@@ -111,14 +162,10 @@ final class Agent extends AbstractFormatter
                 // The one number an agent checks: everything red or unfinished
                 // (failures + errors + pending). Zero means nothing to do.
                 'actionable' => $failing + $errors + $pending,
-                'duration_ms' => (int) round($results->getDuration() * 1000),
-                'offers' => $this->offers($results),
+                'duration_ms' => (int) round(($this->results?->getDuration() ?? 0.0) * 1000),
+                'offers' => $this->results !== null ? $this->offers($this->results) : [],
             ],
         ];
-
-        $json = json_encode($document, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
-
-        $this->output->write($json . "\n", false, OutputInterface::OUTPUT_RAW);
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent/Fatal.php
+++ b/src/PhpSpec/Report/Formatter/Agent/Fatal.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter\Agent;
+
+/**
+ * @internal
+ * The error that ended the process: a compile or parse error no catch block ever
+ * sees. A plain value, so the formatter never has to know how PHP reports one.
+ */
+final readonly class Fatal
+{
+    /**
+     * @param string $message PHP's own description of the error
+     * @param string|null $file the file it fired in, when known
+     * @param int|null $line the line it fired on, when known
+     */
+    public function __construct(
+        public string $message,
+        public ?string $file = null,
+        public ?int $line = null,
+    ) {}
+}

--- a/src/PhpSpec/Report/Formatter/Agent/Origin.php
+++ b/src/PhpSpec/Report/Formatter/Agent/Origin.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter\Agent;
+
+/**
+ * @internal
+ * Where an entry came from: the path of titles that leads to it, and the file
+ * and line that address it. Built up as the result tree is walked, so a step
+ * knows the scenario it belongs to and a scenario knows the line to re-run.
+ *
+ * The titles join the way the pretty and dot output already joins them, so one
+ * failure has one name whichever formatter reports it.
+ */
+final readonly class Origin
+{
+    /**
+     * @param string $name the titles leading here, joined
+     * @param string|null $path the file this came from, when it is addressable
+     * @param int|null $line the line within that file, when one is known
+     */
+    public function __construct(
+        public string $name = '',
+        public ?string $path = null,
+        public ?int $line = null,
+    ) {}
+
+    /**
+     * The origin one level in: the title joins the path, and a file or line
+     * given here addresses everything below it.
+     *
+     * @param string $title the title of the level being entered
+     * @param string|null $path the file it lives in, or null to keep the current one
+     * @param int|null $line the line it starts at, or null to keep the current one
+     */
+    public function within(string $title, ?string $path = null, ?int $line = null): self
+    {
+        return new self(
+            $this->name === '' ? $title : $this->name . ' > ' . $title,
+            $path ?? $this->path,
+            $line ?? $this->line,
+        );
+    }
+
+    /**
+     * The full name of an entry with this title: every title above it, then its
+     * own.
+     */
+    public function name(string $title): string
+    {
+        return $this->within($title)->name;
+    }
+}

--- a/src/PhpSpec/Report/Formatter/Agent/ProcessEnd.php
+++ b/src/PhpSpec/Report/Formatter/Agent/ProcessEnd.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter\Agent;
+
+use Closure;
+
+/**
+ * @internal
+ * The last word before the process goes: a way to be called back as PHP shuts
+ * down, told what killed it when something did. The agent document promises to
+ * be there whatever happens, and a compile error is not something a catch block
+ * can keep that promise through.
+ */
+interface ProcessEnd
+{
+    /**
+     * Registers the callback to run as the process ends. It receives the fatal
+     * error that ended it, or null when the process simply finished.
+     *
+     * @param Closure(Fatal|null): void $ending
+     */
+    public function atEnd(Closure $ending): void;
+}

--- a/src/PhpSpec/Report/Formatter/Agent/ShutdownProcessEnd.php
+++ b/src/PhpSpec/Report/Formatter/Agent/ShutdownProcessEnd.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Report\Formatter\Agent;
+
+use Closure;
+
+/**
+ * @internal
+ * The real process end: PHP's own shutdown, reading whatever error was last
+ * raised. Only the errors that end a process are reported; a warning the run
+ * survived is the example's business, not the document's.
+ */
+final class ShutdownProcessEnd implements ProcessEnd
+{
+    private const ENDS_THE_PROCESS = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR;
+
+    public function atEnd(Closure $ending): void
+    {
+        register_shutdown_function(static function () use ($ending): void {
+            $error = error_get_last();
+            $fatal = $error !== null && ($error['type'] & self::ENDS_THE_PROCESS) !== 0
+                ? new Fatal($error['message'], $error['file'], $error['line'])
+                : null;
+
+            $ending($fatal);
+        });
+    }
+}

--- a/src/PhpSpec/Report/Formatter/Agent/ValueExporter.php
+++ b/src/PhpSpec/Report/Formatter/Agent/ValueExporter.php
@@ -14,12 +14,14 @@
 
 namespace PhpSpec\Report\Formatter\Agent;
 
+use PhpSpec\ObjectName;
+
 /**
  * @internal
  * Exports an arbitrary value into a compact, JSON-encodable shape for the agent
  * formatter: scalars pass through, long strings and large arrays are truncated
- * with a marker of their real length, and objects become "ClassName#id" — never
- * a full object graph — so a single expectation cannot flood the model's context.
+ * with a marker of their real length, and objects are named rather than dumped,
+ * so a single expectation cannot flood the model's context.
  */
 final class ValueExporter
 {
@@ -35,7 +37,7 @@ final class ValueExporter
     public static function export(mixed $value, int $depth = 0): mixed
     {
         if (is_object($value)) {
-            return $value::class . '#' . spl_object_id($value);
+            return ObjectName::of($value);
         }
 
         if (is_string($value)) {

--- a/src/PhpSpec/Report/Formatter/Junit.php
+++ b/src/PhpSpec/Report/Formatter/Junit.php
@@ -147,6 +147,12 @@ final class Junit extends AbstractFormatter
         $featureSuite->setAttribute('name', $feature->getTitle());
         $featureSuite->setAttribute('type', 'feature');
 
+        // Where each scenario lives travels with the report, so a parallel run
+        // rebuilding results from a worker's XML can still say how to re-run one.
+        if ($feature->getPath() !== '') {
+            $featureSuite->setAttribute('file', $feature->getPath());
+        }
+
         foreach ($feature->getResults() as $scenario) {
             if (!$scenario instanceof ScenarioResult) {
                 continue;
@@ -154,6 +160,10 @@ final class Junit extends AbstractFormatter
             $scenarioSuite = $xml->createElement('testsuite');
             $scenarioSuite->setAttribute('name', $scenario->getTitle());
             $scenarioSuite->setAttribute('type', 'scenario');
+
+            if ($scenario->getLine() > 0) {
+                $scenarioSuite->setAttribute('line', (string) $scenario->getLine());
+            }
 
             foreach ($scenario->getResults() as $step) {
                 if (!$step instanceof StepResult) {

--- a/src/PhpSpec/Result/ScenarioResult.php
+++ b/src/PhpSpec/Result/ScenarioResult.php
@@ -25,11 +25,23 @@ final readonly class ScenarioResult implements Results
     /**
      * @param string $title the scenario description
      * @param array<StepResult> $stepResults child StepResult instances
+     * @param int $line the line its "Scenario:" keyword sits on, or the examples
+     *                  table row for an outline expansion; 0 when unknown
      */
     public function __construct(
         private string $title,
         private array $stepResults,
+        private int $line = 0,
     ) {}
+
+    /**
+     * The line that addresses this scenario in a "file.feature:LINE" run, or 0
+     * when the result was rebuilt without one.
+     */
+    public function getLine(): int
+    {
+        return $this->line;
+    }
 
     /**
      * Returns the scenario description.

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -819,10 +819,22 @@ class Expectation
                 'boolean' => self::replaceOne('%s', $value ? 'true' : 'false', $message),
                 'array' => self::replaceOne('%s', self::formatArray($value), $message),
                 'NULL' => self::replaceOne('%s', 'null', $message),
+                'double' => self::replaceOne('%s', self::formatFloat($value), $message),
                 default => self::replaceOne('%s', (string) $value, $message)
             };
         }
         return $message;
+    }
+
+    /**
+     * A float as a failure message must show it: keeping the fraction, so a
+     * strict comparison that failed on type alone does not read as a tautology
+     * ("Expected 90 to be 90"), and at full precision, so the one that failed on
+     * a rounding tail says so instead of tidying itself up to 0.3.
+     */
+    private static function formatFloat(float $value): string
+    {
+        return is_finite($value) ? var_export($value, true) : (string) $value;
     }
 
     /**
@@ -876,6 +888,7 @@ class Expectation
             'string' => '"' . $item . '"',
             'boolean' => $item ? 'true' : 'false',
             'NULL' => 'null',
+            'double' => self::formatFloat($item),
             default => (string) $item,
         }, $value);
 

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -17,6 +17,7 @@ namespace PhpSpec\Specification;
 use BadMethodCallException;
 use Closure;
 use PhpSpec\Browser\Response;
+use PhpSpec\ObjectName;
 
 /**
  * Fluent assertion API returned by expect(). Provides built-in matchers (toBe, toContain, etc.)
@@ -814,7 +815,7 @@ class Expectation
     {
         foreach ($values as $value) {
             $message = match (gettype($value)) {
-                'object' => self::replaceOne('%s', get_class($value) . '#' . spl_object_id($value), $message),
+                'object' => self::replaceOne('%s', ObjectName::of($value), $message),
                 'string' => self::replaceOne('%s', '"' . self::clip($value) . '"', $message),
                 'boolean' => self::replaceOne('%s', $value ? 'true' : 'false', $message),
                 'array' => self::replaceOne('%s', self::formatArray($value), $message),
@@ -883,7 +884,7 @@ class Expectation
     private static function formatArray(array $value): string
     {
         $parts = array_map(static fn(mixed $item): string => match (gettype($item)) {
-            'object' => get_class($item) . '#' . spl_object_id($item),
+            'object' => ObjectName::of($item),
             'array' => 'array(' . count($item) . ')',
             'string' => '"' . $item . '"',
             'boolean' => $item ? 'true' : 'false',

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -539,9 +539,13 @@ class Expectation
     {
         return $this->match(
             fn($expected) => is_string($expected) ? strlen($expected) === $length : count($expected) === $length,
-            'Expected %s to have length %s',
+            // The subject alone leaves the reader counting: an array of one array
+            // prints as "[array(2)]", which reads like a length of 2. The length
+            // asserted on is the one thing the message must state outright.
+            'Expected %s to have length %s, has %s',
             $this->subject,
             $length,
+            self::lengthOf($this->subject),
             ['__fake' => is_string($this->subject) ? "str_repeat('x', {$length})" : "array_fill(0, {$length}, null)"],
         );
     }
@@ -819,6 +823,20 @@ class Expectation
             };
         }
         return $message;
+    }
+
+    /**
+     * How long a subject is in the terms toHaveLength asserts on: characters for
+     * a string, elements for anything countable, and "no length" for a subject
+     * that has none (the matcher fails it either way, and the message says why).
+     */
+    private static function lengthOf(mixed $subject): int|string
+    {
+        return match (true) {
+            is_string($subject) => strlen($subject),
+            is_countable($subject) => count($subject),
+            default => 'no length',
+        };
     }
 
     /**

--- a/src/PhpSpec/StoryBDD/Feature.php
+++ b/src/PhpSpec/StoryBDD/Feature.php
@@ -173,7 +173,9 @@ final readonly class Feature implements SpecBlock
 
         DispatcherRegistry::dispatcher()->removeSubscriber($collector);
 
-        return new ScenarioResult($scenario->title, $stepResults);
+        // An outline expansion is addressed by its own examples-table row; every
+        // other scenario by its keyword line.
+        return new ScenarioResult($scenario->title, $stepResults, $scenario->exampleLine ?? $scenario->line);
     }
 
     /**

--- a/src/PhpSpec/StoryBDD/GherkinParser.php
+++ b/src/PhpSpec/StoryBDD/GherkinParser.php
@@ -82,10 +82,11 @@ final class GherkinParser
 
         $stepIndex = $this->buildStepIndex($document);
         $scenarioLines = $this->buildScenarioLineIndex($document);
+        $exampleRows = $this->buildExampleRowIndex($document);
         $featureTags = $this->mapTags($document->feature->tags);
 
         $scenarios = array_map(
-            fn(Pickle $pickle) => $this->mapPickle($pickle, $stepIndex, $scenarioLines, $featureTags),
+            fn(Pickle $pickle) => $this->mapPickle($pickle, $stepIndex, $scenarioLines, $exampleRows, $featureTags),
             $pickles,
         );
 
@@ -179,6 +180,56 @@ final class GherkinParser
     }
 
     /**
+     * Builds an index of AST examples-row IDs to the values in that row, for
+     * outlines whose title says nothing about the row. A row that never reaches
+     * the title is the only thing telling two expansions apart, so the name has
+     * to carry it.
+     *
+     * @return array<string, string> map of row ID to its values, comma-separated
+     */
+    private function buildExampleRowIndex(GherkinDocument $document): array
+    {
+        $index = [];
+
+        if ($document->feature === null) {
+            return $index;
+        }
+
+        foreach ($document->feature->children as $child) {
+            $scenarios = [];
+            if ($child->scenario !== null) {
+                $scenarios[] = $child->scenario;
+            }
+            if ($child->rule !== null) {
+                foreach ($child->rule->children as $ruleChild) {
+                    if ($ruleChild->scenario !== null) {
+                        $scenarios[] = $ruleChild->scenario;
+                    }
+                }
+            }
+
+            foreach ($scenarios as $scenario) {
+                // A title with placeholders is already row-specific once the
+                // pickle substitutes them; appending the values would say it twice.
+                if (str_contains($scenario->name, '<')) {
+                    continue;
+                }
+
+                foreach ($scenario->examples as $examples) {
+                    foreach ($examples->tableBody as $row) {
+                        $index[$row->id] = implode(', ', array_map(
+                            static fn(object $cell): string => $cell->value,
+                            $row->cells,
+                        ));
+                    }
+                }
+            }
+        }
+
+        return $index;
+    }
+
+    /**
      * Maps a Cucumber Pickle to a ScenarioNode.
      *
      * The scenario line is the AST keyword line, shared by every scenario a
@@ -188,9 +239,10 @@ final class GherkinParser
      * @param Pickle $pickle the pickle to map
      * @param array<string, string> $stepIndex AST step ID to keyword map
      * @param array<string, int> $scenarioLines AST scenario ID to keyword line map
+     * @param array<string, string> $exampleRows AST row ID to its values, for outlines whose title omits them
      * @param string[] $featureTags feature-level tags to exclude from scenario tags
      */
-    private function mapPickle(Pickle $pickle, array $stepIndex, array $scenarioLines, array $featureTags): ScenarioNode
+    private function mapPickle(Pickle $pickle, array $stepIndex, array $scenarioLines, array $exampleRows, array $featureTags): ScenarioNode
     {
         $steps = array_map(
             fn(PickleStep $step) => $this->mapPickleStep($step, $stepIndex),
@@ -209,7 +261,13 @@ final class GherkinParser
         $pickleLine = $pickle->location->line ?? 0;
         $exampleLine = $pickleLine !== 0 && $pickleLine !== $line ? $pickleLine : null;
 
-        return new ScenarioNode($pickle->name, $steps, $scenarioTags, $line, $exampleLine);
+        // Every expansion of an outline shares its title unless the title itself
+        // names the placeholders. Naming the row makes each expansion its own
+        // scenario to a reader, instead of the same one reported twice.
+        $row = $exampleRows[$pickle->astNodeIds[1] ?? ''] ?? null;
+        $name = $row !== null ? $pickle->name . ' (' . $row . ')' : $pickle->name;
+
+        return new ScenarioNode($name, $steps, $scenarioTags, $line, $exampleLine);
     }
 
     /**


### PR DESCRIPTION
- Standard output under `--format=agent` carries the document and nothing else: the seed line, the profile table, coverage lines, report notes and error text all move aside, and PHP's own error reports go to stderr.
- The document is the command's artifact, published exactly once from every exit path, including the ones that used to produce no JSON at all.
- A run that dies (a parse or compile error) or never starts (missing bootstrap, unknown format, coverage without Xdebug) still answers with a document naming what stopped it.
- The coverage verdict rides inside the document, and a missed `--coverage-min` gate counts as actionable, so the payload no longer disagrees with the exit code.
- A story run reports one entry per scenario, with the steps that did not pass inside it, so one broken scenario is one thing to fix with one rerun command instead of a failure plus a train of skipped siblings.
- Entries are named as a path (`App\Basket > totals the prices`), scenario-outline rows are named by their values, and no two entries in a document share an id.
- The summary carries one rerun command covering every failure, and a failing scenario is addressable by its own line, in parallel runs too.
- Failure values say what they mean: floats keep their fraction and precision, objects are named by what they are rather than by a per-run object id, `toHaveLength` reports the actual length, and an errored entry carries its message where a failure carries one.
- Fixed on the way: a directory argument with a trailing slash doubled the separator in every reported path, and a suite configured without paths of its own reported nothing.
