### PR TITLE
Prepare 9.0.0-beta.18

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [9.0.0-beta.18](https://github.com/phpspec/phpspec/compare/9.0.0-beta.17...9.0.0-beta.18)
 
 ### Added
  - The agent document reports the coverage verdict, and a missed --coverage-min gate now counts as actionable

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -24,4 +24,4 @@
 
     (new PhpSpec\Console\Application($version))->run();
 
-})('9.0.0-beta.17');
+})('9.0.0-beta.18');


### PR DESCRIPTION
- Stamps the `[Unreleased]` section as 9.0.0-beta.18 with its compare link
- Bumps the version in `bin/phpspec`