### PR TITLE
Agent format: JSON Lines, step expectations, printed output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - describe and exemplify refuse a name PHP could not parse instead of writing a spec that breaks the suite, and describe says what it needs when given nothing
+
 ## [9.0.0-beta.18](https://github.com/phpspec/phpspec/compare/9.0.0-beta.17...9.0.0-beta.18)
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
  - Every offer PhpSpec makes carries an id, and `phpspec accept <id>` applies exactly what was reported, refusing an offer whose file has since changed
+ - A failing story step reports the values it expected and got, on the step and on the entry, instead of only the sentence about them
+ - What a spec or step printed is captured and reported as the entry's output, in the agent stream and under the failure in the human formatters
 
 ### Changed
+ - `--format=agent` answers in JSON Lines (protocol v2): one event per line as it happens, so a failure arrives before the suite ends
+ - The agent summary omits offers when the run found nothing to generate, as it already did for rerun and coverage
  - generate no longer writes when there is nobody to ask: it offers the change under an id, and `run --accept-offers` stays as the bulk shortcut for a run's own offers
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - Every offer PhpSpec makes carries an id, and `phpspec accept <id>` applies exactly what was reported, refusing an offer whose file has since changed
+
+### Changed
+ - generate no longer writes when there is nobody to ask: it offers the change under an id, and `run --accept-offers` stays as the bulk shortcut for a run's own offers
+
 ### Fixed
  - describe and exemplify refuse a name PHP could not parse instead of writing a spec that breaks the suite, and describe says what it needs when given nothing
+ - accept resolves paths through the configuration the run was given, so `-c` is honoured
 
 ## [9.0.0-beta.18](https://github.com/phpspec/phpspec/compare/9.0.0-beta.17...9.0.0-beta.18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - generate no longer writes when there is nobody to ask: it offers the change under an id, and `run --accept-offers` stays as the bulk shortcut for a run's own offers
 
 ### Fixed
+ - A parallel run no longer reports `run :0` as an entry's rerun, nor a comparison of nothing with nothing: a failure that came back without its site now reports its message alone
  - describe and exemplify refuse a name PHP could not parse instead of writing a spec that breaks the suite, and describe says what it needs when given nothing
  - accept resolves paths through the configuration the run was given, so `-c` is honoured
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -2,9 +2,10 @@
 
 PhpSpec speaks a machine-readable dialect designed for coding agents (Claude
 Code, Cursor, or any script that shells out and parses output). Instead of the
-ANSI-decorated prose the human formatters produce, `--format=agent` emits a
-single JSON document where **the failure itself is the payload** — everything an
-agent needs to decide its next move, without re-reading the project.
+ANSI-decorated prose the human formatters produce, `--format=agent` emits **JSON
+Lines**: one self-contained event per line, written as it happens, where **the
+failure itself is the payload** — everything an agent needs to decide its next
+move, without re-reading the project.
 
 The same idea runs through the scaffolding commands: `describe --agent` and
 `exemplify --agent` return JSON receipts instead of prose, and `--accept-offers`
@@ -21,72 +22,43 @@ output and never hand-editing what PhpSpec can generate.
 bin/phpspec run --format=agent
 ```
 
-One JSON object is written to stdout, with no ANSI and no prose. It is
-`--parallel`-safe: the whole document is emitted once, at the end of the run,
-when the parent process holds the complete result.
+Standard output carries one JSON object per line, with no ANSI and no prose.
+Decode a line, act on it, decode the next: on a long suite the first failure
+reaches you while the rest is still running. It is `--parallel`-safe; entries
+then arrive in completion order rather than file order.
 
-## The document
+## The stream
 
 A run of three examples — one passing, one failing, one erroring on a missing
-class — produces:
+class — produces four lines:
 
 ```json
-{
-  "suite": {
-    "v": 1, "event": "run_started", "suite": "default",
-    "examples": 3, "scenarios": 0, "steps": 0, "seed": null
-  },
-  "examples": [
-    {
-      "v": 1,
-      "id": "6fd046add251",
-      "example": "App\\Basket > totals the prices of its products",
-      "state": "failing",
-      "expected": { "matcher": "toBe", "value": 4000, "negated": false },
-      "actual": 3500,
-      "message": "Expected 3500 to be 4000",
-      "spec": "spec/App/Basket.spec.php:6",
-      "rerun": "run spec/App/Basket.spec.php:6"
-    },
-    {
-      "v": 1,
-      "id": "66b1647a77b6",
-      "example": "App\\Basket > applies a coupon",
-      "state": "error",
-      "message": "Class \"App\\Coupon\" not found",
-      "exception": {
-        "class": "Error",
-        "message": "Class \"App\\Coupon\" not found",
-        "at": "spec/App/Basket.spec.php:8"
-      },
-      "spec": "spec/App/Basket.spec.php:8",
-      "rerun": "run spec/App/Basket.spec.php:8",
-      "offer": { "action": "create_class", "target": "App\\Coupon" }
-    }
-  ],
-  "result": {
-    "v": 1, "event": "summary",
-    "examples": 3, "scenarios": 0, "steps": 0,
-    "passing": 1, "failing": 1, "errors": 1, "pending": 0, "skipped": 0,
-    "actionable": 2,
-    "duration_ms": 4,
-    "offers": [
-      { "action": "create_class", "target": "App\\Coupon" },
-      { "action": "fake_method", "target": "App\\Basket::total", "value": "4000" }
-    ]
-  }
-}
+{"v":2,"event":"run_started","suite":"default","seed":null}
+{"v":2,"event":"example","id":"6fd046add251","example":"App\\Basket > totals the prices of its products","state":"failing","expected":{"matcher":"toBe","value":4000,"negated":false},"actual":3500,"message":"Expected 3500 to be 4000","spec":"spec/App/Basket.spec.php:6","rerun":"run spec/App/Basket.spec.php:6"}
+{"v":2,"event":"example","id":"66b1647a77b6","example":"App\\Basket > applies a coupon","state":"error","message":"Class \"App\\Coupon\" not found","exception":{"class":"Error","message":"Class \"App\\Coupon\" not found","at":"spec/App/Basket.spec.php:8"},"spec":"spec/App/Basket.spec.php:8","rerun":"run spec/App/Basket.spec.php:8","offer":{"action":"create_class","target":"App\\Coupon"}}
+{"v":2,"event":"summary","examples":3,"scenarios":0,"steps":0,"passing":1,"failing":1,"errors":1,"pending":0,"skipped":0,"actionable":2,"duration_ms":4,"offers":[{"action":"create_class","target":"App\\Coupon"},{"action":"fake_method","target":"App\\Basket::total","value":"4000"}]}
 ```
 
-Every object carries `"v"` — the agent-protocol version (currently `1`).
+Every line carries `"v"` — the agent-protocol version (currently `2`; version
+`1` was a single JSON object) — and an `"event"` naming its kind:
 
-### `suite` — the header
+| `event` | When | Meaning |
+|---|---|---|
+| `run_started` | always, first | The run began: what it targets and the seed it was shuffled with. |
+| `example` | per entry | One example or scenario that needs attention, the moment it is known. |
+| `fatal` | when the run died | What stopped it; the counts describe only what ran before it. |
+| `summary` | always, last | The totals, and the one number to branch on. |
 
-`examples`, `scenarios` and `steps` are the totals for the run (`scenarios` and
-`steps` are non-zero only for Story BDD feature runs). `suite` is the suite name;
-`seed` is the random-order seed when one was used, else `null`.
+The order is guaranteed: `run_started` first, `summary` last, whatever happened
+in between. A run that never started still emits both.
 
-### `examples` — only what needs attention
+### `run_started` — the header
+
+`suite` is what the run targets, as the paths were given; `seed` is the
+random-order seed when one was used, else `null`. The totals are not here: at
+this point nothing has run yet, and the `summary` carries them.
+
+### `example` — only what needs attention
 
 **Passing entries are omitted.** A green suite of thousands need not spend
 tokens on entries an agent will never act on — the summary still counts them.
@@ -108,7 +80,8 @@ Scenario Outline is its own entry, named by its values
 | `message` | What went wrong, whatever the state. An `error` entry keeps `exception` too, for the class and the site. |
 | `spec` | The `file:line` of the failing assertion or the error, project-relative. For a scenario it is the line its `Scenario:` keyword sits on. |
 | `rerun` | The exact arguments to re-run **just this one example or scenario**: prepend your PhpSpec binary. No full-suite re-run needed to verify one fix. |
-| `steps` | Scenarios only: the steps that did not pass, each `{ title, state, message? }`, in the order they were declared. |
+| `output` | What the code printed while this entry ran, present only when it printed something. See [Printed output](#printed-output). |
+| `steps` | Scenarios only: the steps that did not pass, each `{ title, state, message?, expected?, actual?, at? }`, in the order they were declared. |
 
 **`failing`** entries also carry the expectation:
 
@@ -121,6 +94,12 @@ Scenario Outline is its own entry, named by its values
 > **Note on `expected` vs `actual`.** These follow the universal convention:
 > `expected.value` is what should have happened, `actual` is what did. (PhpSpec's
 > internal naming is the reverse — the formatter un-inverts it for you.)
+
+A **story step** that failed an expectation reports the same pair, on the step
+inside `steps` (with `at`, the `file:line` of the expectation in your step file)
+and hoisted onto the entry next to `message`, so acting on the entry never means
+going a level deeper. A step whose code *threw* has a `message` and no
+expectation: there was none to report.
 
 **`error`** entries carry `exception` (`class`, `message`, `at`) as well. When
 the error names something PhpSpec can generate — a missing class, interface, or
@@ -135,13 +114,27 @@ Sometimes the deprecation is the actual clue behind a failure.
 
 Large or object values in `expected`/`actual` are exported compactly (long
 strings and arrays are truncated with a `{ "truncated": true, "length": N }`
-marker) so the document never blows up. Objects are named by what they are, not
-by which instance they were: an enum as `App\Status::Active`, anything that can
-describe itself as `App\Money("12.00 GBP")`, everything else as `App\Basket`.
+marker) so one entry can never flood a context window. Objects are named by what
+they are, not by which instance they were: an enum as `App\Status::Active`,
+anything that can describe itself as `App\Money("12.00 GBP")`, everything else
+as `App\Basket`.
 Two runs of the same failure therefore report the same value. Floats keep their
 fraction, so `90.0` is never reported as the `90` it was compared against.
 
-### `result` — the summary
+### Printed output
+
+Anything your code prints while an entry runs — an `echo` left in a spec, a
+`var_dump`, the output of a process a step shelled out to and echoed — is
+captured and reported as that entry's `output`, rather than landing in the
+middle of the stream and breaking it. For a scenario it is everything its steps
+printed, in order, **including the steps that passed**: a scenario usually runs
+the process in one step and reads the result in another.
+
+`output` is a string, or `{ "truncated": true, "length": N, "value": "…" }` when
+there was more than 4000 characters of it. The key is absent when nothing was
+printed.
+
+### `summary`
 
 The counts (`passing`, `failing`, `errors`, `pending`, `skipped`) are for the
 whole run, in the units the entries are reported in: one per example, one per
@@ -149,40 +142,34 @@ scenario. `steps` is a size, not a verdict. The one number to branch on is
 **`actionable`** = failing + errors + pending, plus a coverage gate the run
 missed and anything that stopped it.
 **Zero means there is nothing to do**, and it never disagrees with the exit code.
-`duration_ms` is the run's wall time; `offers` is the run-wide, de-duplicated
-list of code PhpSpec can generate.
+`duration_ms` is the run's wall time.
 
 | Field | Present when | Meaning |
 |---|---|---|
 | `rerun` | anything failed with a location | One command that re-runs every failing example at once, so a fix is checked against all of what it was meant to fix. |
 | `coverage` | a `--coverage*` option was given | `{ "percent", "required", "met" }`. `required` is `null` without `--coverage-min`, and `met` is then always `true`. A missed gate adds 1 to `actionable`. |
+| `offers` | the run found code it can generate | The run-wide, de-duplicated list. Absent when there is nothing to take. |
 
 ### `fatal`: when the run could not finish
 
 A run that never started (a missing bootstrap, an unknown format) or that died
-partway (a parse error, a class that fails to compile) still answers with a
-document. It carries a top-level `fatal` of `{ "message", "at" }`, holds whatever
-the run did manage to collect, and counts 1 in `actionable`.
+partway (a parse error, a class that fails to compile) still answers. It emits a
+`fatal` line of `{ "message", "at" }`, keeps whatever it managed to collect, and
+counts 1 in `actionable`:
 
 ```json
-{
-  "suite": { "v": 1, "event": "run_started", "suite": "default", "examples": 0, "steps": 0, "seed": null },
-  "examples": [],
-  "result": { "v": 1, "event": "summary", "examples": 0, "actionable": 1, "…": "…" },
-  "fatal": {
-    "message": "Class Mute contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Speaks::speak)",
-    "at": "spec/App/Broken.spec.php:8"
-  }
-}
+{"v":2,"event":"run_started","suite":"default","seed":null}
+{"v":2,"event":"fatal","message":"Class Mute contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Speaks::speak)","at":"spec/App/Broken.spec.php:8"}
+{"v":2,"event":"summary","examples":0,"actionable":1,"…":"…"}
 ```
 
-### Standard output carries the document, and nothing else
+### Standard output carries the stream, and nothing else
 
-Under `--format=agent` the document is the only thing written to standard
+Under `--format=agent` those lines are the only thing written to standard
 output: the randomised-order seed, the `--profile` table, coverage lines, report
-notes and error text all go elsewhere, and PHP's own fatal reports are sent to
-the error stream. Parse the whole of stdout as one JSON object; read stderr when
-you want the human text as well.
+notes, error text and anything your own code printed all go elsewhere, and PHP's
+own fatal reports are sent to the error stream. Parse stdout a line at a time;
+read stderr when you want the human text as well.
 
 ## Offers — code PhpSpec can generate for you
 
@@ -198,8 +185,8 @@ turned into flat data:
 | `create_steps` | `features/checkout.feature` | A feature has undefined steps. |
 | `fake_method` | `App\Basket::total` | An existing **empty** method that a spec pins to a value; `value` is the return expression `--fake` would insert (e.g. `"4000"`, `"'hello'"`, `"true"`). |
 
-Offers appear in two places: run-wide in `result.offers`, and per-example on the
-`offer` field of an `error` entry that maps to a concrete generation.
+Offers appear in two places: run-wide on the summary's `offers`, and per-example
+on the `offer` field of an `error` entry that maps to a concrete generation.
 
 ### Acting on offers
 
@@ -244,7 +231,7 @@ content is returned; the agent reads the file itself.
 bin/phpspec describe App/Basket --agent
 ```
 ```json
-{"v":1,"action":"describe","class":"App\\Basket","spec":"spec/App/Basket.spec.php","created":true}
+{"v":2,"action":"describe","class":"App\\Basket","spec":"spec/App/Basket.spec.php","created":true}
 ```
 
 `created` is `false` when the spec already existed (both commands are
@@ -254,7 +241,7 @@ idempotent). Combine `describe --agent` with `-e` to also add a method example:
 bin/phpspec describe App/Basket --agent -e checkout
 ```
 ```json
-{"v":1,"action":"describe","class":"App\\Basket","spec":"spec/App/Basket.spec.php","created":false,"example":{"method":"checkout","added":true}}
+{"v":2,"action":"describe","class":"App\\Basket","spec":"spec/App/Basket.spec.php","created":false,"example":{"method":"checkout","added":true}}
 ```
 
 `exemplify --agent` adds a single method example to a spec (creating the spec
@@ -264,7 +251,7 @@ first if needed):
 bin/phpspec exemplify App/Basket checkout --agent
 ```
 ```json
-{"v":1,"action":"exemplify","class":"App\\Basket","method":"checkout","spec":"spec/App/Basket.spec.php","added":true}
+{"v":2,"action":"exemplify","class":"App\\Basket","method":"checkout","spec":"spec/App/Basket.spec.php","added":true}
 ```
 
 `added` is `false` when an example for that method is already present.
@@ -275,7 +262,8 @@ Putting it together, an agent drives the full cycle through the CLI:
 
 1. **Scaffold** — `describe App/Basket --agent` (and `exemplify … --agent` per
    method) to lay down specs.
-2. **Read** — `run --format=agent`; branch on `result.actionable`.
+2. **Read** — `run --format=agent`; act on each `example` line as it arrives,
+   and branch on the `summary` line's `actionable`.
 3. **Generate** — for `create_*` offers, either write the code or run
    `run --accept-offers`; for `fake_method` offers, `run --accept-offers --fake`
    to get a first green.
@@ -296,14 +284,15 @@ Always run PhpSpec with the machine-readable formatter and parse the JSON:
 
     bin/phpspec run --format=agent
 
-Read the single JSON object it prints:
+It prints JSON Lines: one JSON object per line. Decode each line and branch on
+its `event`:
 
-- `result.actionable` is the number to act on. **0 means there is nothing left,
-  so stop.** It counts `failing + errors + pending`, plus a missed
-  `--coverage-min` gate and anything that stopped the run.
-- A run that could not finish carries a top-level `fatal` of `{ message, at }`.
-  Read it before anything else: the counts describe only what ran before it.
-- `examples[]` lists only what needs attention (passing examples are omitted).
+- `summary` is the last line. Its `actionable` is the number to act on. **0 means
+  there is nothing left, so stop.** It counts `failing + errors + pending`, plus
+  a missed `--coverage-min` gate and anything that stopped the run.
+- A `fatal` line means the run could not finish. Read it before anything else:
+  the counts describe only what ran before it.
+- `example` lines are what needs attention (passing examples are not reported).
   Each has a `state`:
   - `failing` — the code ran but behaviour is wrong. Look at `expected.value`
     (what the spec wants), `actual` (what the code produced), and `message`.
@@ -313,10 +302,12 @@ Read the single JSON object it prints:
     class and the site. If the entry has an `offer`, PhpSpec can generate the
     missing piece.
   - `pending` — an unimplemented example; implement it.
+- `output` on an entry is what the code printed while it ran: read it, it is
+  often the whole diagnosis for a scenario that drove a process of its own.
 - To verify a single fix, re-run just that example: take its `rerun` value and
   prepend the binary — e.g. `bin/phpspec run spec/App/Basket.spec.php:6`. Don't
-  re-run the whole suite to check one change. `result.rerun` does the same for
-  every failure at once.
+  re-run the whole suite to check one change. The `summary`'s `rerun` does the
+  same for every failure at once.
 - Track a specific failure across runs by its `id` (stable across edits that
   move lines). A failure is fixed when its `id` no longer appears. A failing
   Story BDD scenario has an `id` and a `rerun` of its own, just like an example.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -27,9 +27,11 @@ Decode a line, act on it, decode the next: on a long suite the first failure
 reaches you while the rest is still running.
 
 It is `--parallel`-safe, with one caveat: workers report back through JUnit,
-which carries the outcome and the message and nothing else, so entries from a
-parallel run arrive in completion order and without `expected`, `actual`,
-`spec`, `rerun` or `output`. Run without `--parallel` when you want the detail.
+which carries the outcome, the message and a scenario's line, and nothing else.
+Entries from a parallel run therefore arrive in completion order and without
+`expected`, `actual` or `output`; a failing spec example also arrives without
+`spec` and `rerun`, which JUnit has no room for. Run without `--parallel` when
+you want the whole of the detail.
 
 ## The stream
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -24,8 +24,12 @@ bin/phpspec run --format=agent
 
 Standard output carries one JSON object per line, with no ANSI and no prose.
 Decode a line, act on it, decode the next: on a long suite the first failure
-reaches you while the rest is still running. It is `--parallel`-safe; entries
-then arrive in completion order rather than file order.
+reaches you while the rest is still running.
+
+It is `--parallel`-safe, with one caveat: workers report back through JUnit,
+which carries the outcome and the message and nothing else, so entries from a
+parallel run arrive in completion order and without `expected`, `actual`,
+`spec`, `rerun` or `output`. Run without `--parallel` when you want the detail.
 
 ## The stream
 
@@ -78,8 +82,8 @@ Scenario Outline is its own entry, named by its values
 | `example` | The full name, as a path: `App\Basket > totals the prices` for a spec, `Checkout > Paying for a basket` for a scenario. |
 | `state` | `failing`, `error`, `pending`, or `skipped` (`passing` entries are omitted). |
 | `message` | What went wrong, whatever the state. An `error` entry keeps `exception` too, for the class and the site. |
-| `spec` | The `file:line` of the failing assertion or the error, project-relative. For a scenario it is the line its `Scenario:` keyword sits on. |
-| `rerun` | The exact arguments to re-run **just this one example or scenario**: prepend your PhpSpec binary. No full-suite re-run needed to verify one fix. |
+| `spec` | The `file:line` of the failing assertion or the error, project-relative. For a scenario it is the line its `Scenario:` keyword sits on. Absent when the site is not known. |
+| `rerun` | The exact arguments to re-run **just this one example or scenario**: prepend your PhpSpec binary. No full-suite re-run needed to verify one fix. Absent with `spec`. |
 | `output` | What the code printed while this entry ran, present only when it printed something. See [Printed output](#printed-output). |
 | `steps` | Scenarios only: the steps that did not pass, each `{ title, state, message?, expected?, actual?, at? }`, in the order they were declared. |
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -203,18 +203,36 @@ Offers appear in two places: run-wide in `result.offers`, and per-example on the
 
 ### Acting on offers
 
-Rather than write the boilerplate itself, an agent can have PhpSpec apply every
-pending offer in one non-interactive pass:
+**PhpSpec never applies a change because nobody was there to say no.** Every
+offer carries an `id` and waits under it, so you accept what you have actually
+read, in a second command:
+
+```bash
+bin/phpspec accept o_7f3a1c2d               # apply exactly that offer
+bin/phpspec accept o_7f3a1c2d o_91b0e4aa    # several at once, all or nothing
+```
+
+An id is derived from what the offer would do, so the same offer keeps it
+between runs and a new one is visibly new. `accept` refuses an id it has never
+seen, and refuses an offer whose file has changed since it was made: at that
+point the decision was taken about something else. Nothing is applied unless
+every named offer can be.
+
+For the common case of taking everything a run found, the bulk shortcut remains:
 
 ```bash
 bin/phpspec run --accept-offers            # create missing classes/interfaces/methods/steps
 bin/phpspec run --accept-offers --fake     # ...and fill empty methods with their spec'd return values
 ```
 
-`--accept-offers` runs the suite, applies all offers (no prompts), and exits `0`.
-Add `--fake` to also fill empty method bodies with the hardcoded returns their
-specs expect (the `fake_method` offers) — a fast way to a first green before you
-replace the fakes with real logic.
+`--accept-offers` runs the suite, applies all of that run's offers (no prompts),
+and exits `0`. Add `--fake` to also fill empty method bodies with the hardcoded
+returns their specs expect (the `fake_method` offers), a fast way to a first
+green before you replace the fakes with real logic.
+
+`generate` proposes rather than writes: its receipt carries an `id` per
+proposal with `applied: false`, and `accept` writes exactly the content that was
+reported.
 
 ## Scaffolding with JSON receipts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -186,7 +186,7 @@ The `Report` interface delegates to a `Formatter`. Available formatters:
 | `Tap` | TAP (Test Anything Protocol) format |
 | `Junit` | JUnit XML for CI integration |
 | `Html` | Self-contained HTML report |
-| `Agent` | Single machine-readable JSON document for coding agents (see [Coding Agents](agent.md)) |
+| `Agent` | Machine-readable JSON Lines for coding agents, one event per line (see [Coding Agents](agent.md)) |
 
 ### Pretty Formatter
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -220,19 +220,22 @@ bin/phpspec run --format=html > report.html
 
 #### Agent Formatter
 
-Emits the whole run as a single machine-readable JSON document for coding agents
-— no ANSI, no prose. Each failing/erroring example carries the expectation, a
-stable `id`, a line-targeted `rerun` command, and any code-generation `offer`;
-the summary carries the counts, one `rerun` for every failure at once, the
-coverage verdict when coverage was collected, and a run-wide `offers` list:
+Speaks the run to a coding agent in JSON Lines, one event per line as it
+happens: no ANSI, no prose, and no waiting for a long suite to end. Each
+failing/erroring example arrives as its own line carrying the expectation, what
+the code printed, a stable `id`, a line-targeted `rerun` command and any
+code-generation `offer`; the closing `summary` line carries the counts, one
+`rerun` for every failure at once, the coverage verdict when coverage was
+collected, and a run-wide `offers` list:
 
 ```bash
 bin/phpspec run --format=agent
 ```
 
-The document is the only thing on standard output, whatever happens: the seed
-line, the `--profile` table, coverage lines and error text move aside, and a run
-that dies partway still ends with a document naming the `fatal` that stopped it.
+Those lines are the only thing on standard output, whatever happens: the seed
+line, the `--profile` table, coverage lines, error text and anything the subject
+itself printed all move aside, and a run that dies partway still ends with a
+`fatal` line naming what stopped it and a `summary` after it.
 
 See [Coding Agents](agent.md) for the full contract, the `--accept-offers` /
 `--fake` apply flow, and a ready-made `CLAUDE.md` snippet.
@@ -350,8 +353,9 @@ bin/phpspec run --parallel=4      # four workers
 Each worker runs a slice of the spec files in its own process and reports back
 via JUnit; the parent merges the results before rendering. Coverage
 (`--coverage*`) composes with `--parallel` -- workers collect per-example
-coverage and the parent merges it. `--format=agent` is parallel-safe too, since
-its single document is emitted once the parent holds the complete result.
+coverage and the parent merges it. `--format=agent` is parallel-safe too: the
+parent emits each event as a worker reports it, so entries arrive in completion
+order rather than file order.
 
 ### Code Generation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,7 +66,9 @@ wording), and fully determined artifacts are generated without any model call: a
 feature request becomes a Gherkin skeleton, and `generate the steps` writes the
 step definitions for the last-touched feature by parsing it. Everything else is
 authored by the AI. Each proposal is shown as a diff and written after a `[Y/n]`
-confirmation. Requires an AI provider (see [Configuration](configuration.md#ai)).
+confirmation. With no terminal to ask, nothing is written: the change is offered
+under an id for [`accept`](#accept) to apply. Requires an AI provider (see
+[Configuration](configuration.md#ai)).
 
 ```bash
 bin/phpspec generate a feature for adding a task    # Gherkin under features/, no model call
@@ -80,6 +82,23 @@ and the artifact type follows its extension. Every exchange is captured to
 `.phpspec/ai/last-request.json`: the resolved step and its reason, the composed
 prompt files, and the model's reply, so a surprising result is debuggable at a
 glance. Also available in pair mode as `/generate <instruction>`.
+
+### `accept`
+
+Applies an offer PhpSpec made earlier, by its id. A run reports what it could
+generate, and `generate` reports what it would write; both wait under an id
+rather than changing anything on their own, so the decision is taken by whoever
+read them.
+
+```bash
+bin/phpspec accept o_7f3a1c2d               # apply exactly that offer
+bin/phpspec accept o_7f3a1c2d o_91b0e4aa    # several at once, all or nothing
+```
+
+The id is derived from the offer itself, so it is stable while the offer stands.
+An unknown id is refused, and so is an offer whose file has changed since it was
+made. `--format=agent` returns the receipt as JSON. Offers live in
+`.phpspec/offers.json`; the fifty most recent stay on the table.
 
 ### `describe`
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -57,7 +57,7 @@ English:
 bin/phpspec describe App/Calculator --agent
 ```
 ```json
-{"v":1,"action":"describe","class":"App\\Calculator","spec":"spec/App/Calculator.spec.php","created":true}
+{"v":2,"action":"describe","class":"App\\Calculator","spec":"spec/App/Calculator.spec.php","created":true}
 ```
 
 `created` (and `exemplify`'s `added`) report whether anything changed. See

--- a/features/scenarios/cli/agent-commands.feature
+++ b/features/scenarios/cli/agent-commands.feature
@@ -59,4 +59,6 @@ Feature: Agent scaffolding commands
     Then the output should be valid JSON
     And the output should contain "applied"
     And the output should contain "features/steps/adding_a_task.steps.php"
-    And the file "features/steps/adding_a_task.steps.php" should contain "given("
+    And no file "features/steps/adding_a_task.steps.php" should be generated
+    When I accept the offers phpspec made
+    Then the file "features/steps/adding_a_task.steps.php" should contain "given("

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -47,6 +47,47 @@ Feature: Agent output format
     And the output should contain "4000"
     And the output should contain "3500"
 
+  Scenario: What a failing example printed rides with it, off the document's stream
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds two numbers', function () {
+              echo "the subject said this";
+              expect(3500)->toBe(4000);
+          });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the reported entry should have printed "the subject said this"
+
+  Scenario: What a scenario printed rides with it, whichever step printed it
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/counting.feature":
+      """
+      Feature: Counting
+        Scenario: Counting up
+          Given I run the counter
+          Then it should have counted 3
+      """
+    And a step file "features/steps/counting.steps.php":
+      """
+      <?php
+
+      given('I run the counter', function () {
+          echo "the counter said 2";
+          $this->count = 2;
+      });
+
+      then('it should have counted {int}', function (int $expected) {
+          expect($this->count)->toBe($expected);
+      });
+      """
+    When I run phpspec run with option "features/ --format=agent"
+    Then the output should be valid JSON
+    And the reported entry should have printed "the counter said 2"
+
   Scenario: A failing example carries a line-targeted rerun command
     Given a spec file "spec/App/Calc.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -321,6 +321,23 @@ Feature: Agent output format
     And the output should contain "fatal"
     And the output should contain "abstract method"
 
+  Scenario: An offer can be taken on its own, by the id the run reported
+    Given a spec file "spec/App/Basket.spec.php":
+      """
+      <?php
+      describe('App\Basket', function () {
+          it('applies a coupon', function () {
+              expect(new App\Coupon())->toBeAnInstanceOf(App\Coupon::class);
+          });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should contain "create_class"
+    And no file "src/App/Coupon.php" should be generated
+    When I accept the offers phpspec made
+    Then a class file "src/App/Coupon.php" should be generated
+
   Scenario: A missing class surfaces as an offer, and --accept-offers generates it
     Given a spec file "spec/App/Basket.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -1,7 +1,22 @@
 Feature: Agent output format
   As a coding agent
-  I want phpspec results as a single machine-readable JSON document
-  So that I can decide my next action without parsing prose
+  I want phpspec results as machine-readable JSON events, one per line
+  So that I can act on a failure while the rest of the suite is still running
+
+  Scenario: The run answers in JSON Lines, one event per line
+    Given a spec file "spec/App/Calc.spec.php":
+      """
+      <?php
+      describe('App\Calc', function () {
+          it('adds', function () { expect(1)->toBe(2); });
+          it('subtracts', function () { expect(3)->toBe(4); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the output should have 4 events
+    And the first event should be "run_started"
+    And the last event should be "summary"
 
   Scenario: A passing run emits a valid JSON document with run_started and summary
     Given a spec file "spec/App/Calc.spec.php":
@@ -298,6 +313,8 @@ Feature: Agent output format
     Then the output should be valid JSON
     And the output should contain "fatal"
     And the output should contain "Bootstrap file not found"
+    And the first event should be "run_started"
+    And the last event should be "summary"
     And the exit code should be 1
 
   Scenario: A fatal still leaves a document, naming what stopped the run

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -171,6 +171,27 @@ Feature: Agent output format
     And the output should contain "no basket yet"
     And the output should contain "run features/checkout.feature:2"
 
+  Scenario: A failing step carries the expectation, not only the English of it
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/counting.feature":
+      """
+      Feature: Counting
+        Scenario: Counting up
+          Given I count 2 items
+      """
+    And a step file "features/steps/counting.steps.php":
+      """
+      <?php
+
+      given('I count {int} items', function (int $count) {
+          expect($count)->toBe(3);
+      });
+      """
+    When I run phpspec run with option "features/ --format=agent"
+    Then the output should be valid JSON
+    And the report should have 1 entry
+    And the failing step should report expected 3 and actual 2
+
   Scenario: The same step twice in one scenario is still one entry
     Given a PSR-4 project with "spec", "src", and "features" directories
     And a feature file "features/twice.feature":

--- a/features/scenarios/cli/code-generation.feature
+++ b/features/scenarios/cli/code-generation.feature
@@ -54,6 +54,30 @@ Feature: Code generation
     Then a spec file "spec/App/Formatter.spec.php" should be generated
     And the spec file should contain an example for "render"
 
+  Scenario: Describe refuses a name that is not a class
+    When I run phpspec describe "1"
+    Then the exit code should be 1
+    And the output should contain "not a valid class name"
+    And no file "spec/1.spec.php" should be generated
+
+  Scenario: Describe refuses a name that is not an identifier
+    When I run phpspec describe "Foo-Bar"
+    Then the exit code should be 1
+    And the output should contain "not a valid class name"
+    And no file "spec/Foo-Bar.spec.php" should be generated
+
+  Scenario: Describe asks for the class it should describe
+    When I run phpspec describe ""
+    Then the exit code should be 1
+    And the output should contain "Describe what?"
+    And no file "spec/.spec.php" should be generated
+
+  Scenario: Exemplify refuses a method that is not an identifier
+    When I run phpspec exemplify "App\Printer" "2print"
+    Then the exit code should be 1
+    And the output should contain "not a valid method name"
+    And no file "spec/App/Printer.spec.php" should be generated
+
   Scenario: Exemplify command adds an example to an existing spec
     When I run phpspec describe "App\Converter"
     And I run phpspec exemplify "App\Converter" "convert"

--- a/features/scenarios/cli/generate.feature
+++ b/features/scenarios/cli/generate.feature
@@ -65,9 +65,10 @@ Feature: Generate code from a natural-language instruction
         api_key: test-key
       """
     When I run phpspec command "generate a feature for completing_a_task.feature"
+    Then the output should contain "features/completing_a_task.feature"
+    When I accept the offers phpspec made
     Then a file "features/completing_a_task.feature" should be generated
     And the file "features/completing_a_task.feature" should contain "Feature:"
-    And the output should contain "features/completing_a_task.feature"
 
   Scenario: generate writes step definitions for the last-touched feature deterministically
     Given a phpspec.yaml config:
@@ -86,4 +87,6 @@ Feature: Generate code from a natural-language instruction
       """
     When I run phpspec command "generate the steps"
     Then the output should contain "features/steps/adding_a_task.steps.php"
-    And the file "features/steps/adding_a_task.steps.php" should contain "given("
+    And the output should contain "phpspec accept o_"
+    When I accept the offers phpspec made
+    Then the file "features/steps/adding_a_task.steps.php" should contain "given("

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -175,6 +175,15 @@ then('the failing step should report expected {int} and actual {int}', function 
     expect($failing[0]['actual'])->toBe($actual);
 });
 
+// What the subject printed is a diagnosis about the entry it printed under, and
+// it reaches the reader as data instead of landing in the middle of the report.
+then('the reported entry should have printed {string}', function (string $text) use ($events, $entries) {
+    $entry = $entries($events($this->output))[0] ?? [];
+    $printed = $entry['output'] ?? null;
+
+    expect(is_array($printed) ? ($printed['value'] ?? '') : (string) $printed)->toContain($text);
+});
+
 // Every reported entry must be addressable on its own: an id that two entries
 // share cannot answer "is THIS failure still here?".
 then('the failing entries should have distinct ids', function () use ($events, $entries) {

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -91,48 +91,83 @@ then('the file {string} should contain {string} exactly {int} times', function (
     }
 });
 
-then('the output should be valid JSON', function () {
-    try {
-        json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
-    } catch (\JsonException $e) {
-        throw new \RuntimeException(
-            "Expected valid JSON output ({$e->getMessage()}).\nOutput:\n{$this->output}",
-        );
+// PhpSpec answers an agent in JSON Lines: one self-contained event per line, as
+// it happens. Decoding line by line is the whole of what a consumer does, so the
+// harness reads the output exactly the way the contract asks it to be read.
+$events = static function (string $output): array {
+    $events = [];
+
+    foreach (explode("\n", trim($output)) as $line) {
+        $line = trim($line);
+        if ($line === '') {
+            continue;
+        }
+
+        try {
+            $events[] = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(
+                "Expected every line of the output to be a JSON event ({$e->getMessage()}).\nLine:\n{$line}",
+            );
+        }
     }
+
+    return $events;
+};
+
+// The entries a run reports: one per example or scenario that needs attention.
+$entries = static function (array $events): array {
+    return array_values(array_filter($events, fn(array $event) => ($event['event'] ?? null) === 'example'));
+};
+
+then('the output should be valid JSON', function () use ($events) {
+    $events($this->output);
+});
+
+then('the output should have {int} events', function (int $count) use ($events) {
+    expect($events($this->output))->toHaveLength($count);
+});
+
+// The stream's shape: an agent knows where the run starts and that the summary
+// is the last word, whatever happened in between.
+then('the first event should be {string}', function (string $name) use ($events) {
+    $stream = $events($this->output);
+
+    expect($stream[0]['event'] ?? null)->toBe($name);
+});
+
+then('the last event should be {string}', function (string $name) use ($events) {
+    $stream = $events($this->output);
+
+    expect(end($stream)['event'] ?? null)->toBe($name);
 });
 
 // How many things the run says are worth acting on: one per example or scenario,
 // never one per step of the same broken scenario.
-then('the report should have {int} entries', function (int $count) {
-    $document = json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
-
-    expect($document['examples'] ?? [])->toHaveLength($count);
+then('the report should have {int} entries', function (int $count) use ($events, $entries) {
+    expect($entries($events($this->output)))->toHaveLength($count);
 });
 
-then('the report should have {int} entry', function (int $count) {
-    $document = json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
-
-    expect($document['examples'] ?? [])->toHaveLength($count);
+then('the report should have {int} entry', function (int $count) use ($events, $entries) {
+    expect($entries($events($this->output)))->toHaveLength($count);
 });
 
 // One field answers "what went wrong", whatever the entry's state: a consumer
 // should not have to know that an error hides its text somewhere else.
-then('every reported entry should carry a message', function () {
-    $document = json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
-    $entries = $document['examples'] ?? [];
+then('every reported entry should carry a message', function () use ($events, $entries) {
+    $reported = $entries($events($this->output));
 
-    expect($entries)->not()->toBe([]);
+    expect($reported)->not()->toBe([]);
 
-    foreach ($entries as $entry) {
+    foreach ($reported as $entry) {
         expect($entry)->toHaveKey('message');
     }
 });
 
 // Every reported entry must be addressable on its own: an id that two entries
 // share cannot answer "is THIS failure still here?".
-then('the failing entries should have distinct ids', function () {
-    $document = json_decode(trim($this->output), true, 512, JSON_THROW_ON_ERROR);
-    $ids = array_column($document['examples'] ?? [], 'id');
+then('the failing entries should have distinct ids', function () use ($events, $entries) {
+    $ids = array_column($entries($events($this->output)), 'id');
 
     expect(count($ids))->toBeGreaterThan(1);
     expect(array_unique($ids))->toHaveLength(count($ids));
@@ -140,14 +175,8 @@ then('the failing entries should have distinct ids', function () {
 
 // Standard output on its own, for the runs where the error stream carries text
 // of its own (PHP's fatal report) and the document must still stand alone.
-then('the standard output should be valid JSON', function () {
-    try {
-        json_decode(trim($this->stdout), true, 512, JSON_THROW_ON_ERROR);
-    } catch (\JsonException $e) {
-        throw new \RuntimeException(
-            "Expected valid JSON on standard output ({$e->getMessage()}).\nStandard output:\n{$this->stdout}",
-        );
-    }
+then('the standard output should be valid JSON', function () use ($events) {
+    $events($this->stdout);
 });
 
 // -- File existence (sets $this->lastFile for chained assertions) ------

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -164,6 +164,17 @@ then('every reported entry should carry a message', function () use ($events, $e
     }
 });
 
+// A step's failure is data, not a sentence to parse back: the values that did
+// not match ride on the step that did not pass.
+then('the failing step should report expected {int} and actual {int}', function (int $expected, int $actual) use ($events, $entries) {
+    $entry = $entries($events($this->output))[0] ?? [];
+    $failing = array_values(array_filter($entry['steps'] ?? [], fn(array $step) => $step['state'] === 'failing'));
+
+    expect($failing)->not()->toBe([]);
+    expect($failing[0]['expected']['value'])->toBe($expected);
+    expect($failing[0]['actual'])->toBe($actual);
+});
+
 // Every reported entry must be addressable on its own: an id that two entries
 // share cannot answer "is THIS failure still here?".
 then('the failing entries should have distinct ids', function () use ($events, $entries) {

--- a/features/steps/runner.steps.php
+++ b/features/steps/runner.steps.php
@@ -74,6 +74,24 @@ when('I run phpspec run with option {string}', function (string $options) {
     _phpspec_exec($this, 'run ' . $options);
 });
 
+// Taking what PhpSpec last offered, the way a reader does: by the ids on the
+// table, in a second command, after the offers have been seen.
+when('I accept the offers phpspec made', function () {
+    $book = $this->projectDir . '/.phpspec/offers.json';
+
+    if (!file_exists($book)) {
+        throw new \RuntimeException("No offers were made: $book does not exist.");
+    }
+
+    $ids = array_column(json_decode((string) file_get_contents($book), true)['offers'] ?? [], 'id');
+
+    if ($ids === []) {
+        throw new \RuntimeException('The offer book is empty.');
+    }
+
+    _phpspec_exec($this, 'accept ' . implode(' ', $ids));
+});
+
 // A run expected to kill its process (a fatal in a spec file) must not take
 // this suite down with it, so it always gets a process of its own.
 when('I run phpspec run in a fresh process with option {string}', function (string $options) {

--- a/spec/PhpSpec/CapturedOutput.spec.php
+++ b/spec/PhpSpec/CapturedOutput.spec.php
@@ -1,0 +1,85 @@
+<?php
+
+use PhpSpec\CapturedOutput;
+
+describe(CapturedOutput::class, function () {
+
+    it('keeps what the body printed instead of letting it out', function () {
+        $captured = new CapturedOutput();
+
+        ob_start();
+        $captured->around(function () {
+            echo "printed by the subject\n";
+        });
+        $leaked = ob_get_clean();
+
+        expect($captured->text())->toBe("printed by the subject\n");
+        expect($leaked)->toBe('');
+    });
+
+    it('has nothing to show for a body that printed nothing', function () {
+        $captured = new CapturedOutput();
+        $captured->around(function () {});
+
+        expect($captured->text())->toBe('');
+    });
+
+    it('keeps what a throwing body printed, and lets the throw through', function () {
+        $captured = new CapturedOutput();
+
+        $thrown = null;
+
+        try {
+            $captured->around(function () {
+                echo 'as far as it got';
+
+                throw new RuntimeException('boom');
+            });
+        } catch (RuntimeException $e) {
+            $thrown = $e;
+        }
+
+        expect($thrown?->getMessage())->toBe('boom');
+        expect($captured->text())->toBe('as far as it got');
+    });
+
+    it('takes back a buffer the body opened and forgot to close', function () {
+        $captured = new CapturedOutput();
+        $depth = ob_get_level();
+
+        $captured->around(function () {
+            echo 'before';
+            ob_start();
+            echo 'inside a buffer of its own';
+        });
+
+        expect($captured->text())->toBe('beforeinside a buffer of its own');
+        expect(ob_get_level())->toBe($depth);
+    });
+
+    it('survives a body that closed one buffer too many', function () {
+        $captured = new CapturedOutput();
+
+        ob_start();
+        $captured->around(function () {
+            echo 'gone with the buffer';
+            ob_end_clean();
+        });
+        ob_end_clean();
+
+        expect($captured->text())->toBe('');
+    });
+
+    it('adds up what every body it ran printed', function () {
+        $captured = new CapturedOutput();
+        $captured->around(function () {
+            echo 'one ';
+        });
+        $captured->around(function () {
+            echo 'two';
+        });
+
+        expect($captured->text())->toBe('one two');
+    });
+
+});

--- a/spec/PhpSpec/CodeGeneration/PhpName.spec.php
+++ b/spec/PhpSpec/CodeGeneration/PhpName.spec.php
@@ -1,0 +1,57 @@
+<?php
+
+use PhpSpec\CodeGeneration\PhpName;
+
+describe(PhpName::class, function () {
+
+    context('class names', function () {
+        it('accepts a plain class', function () {
+            expect(PhpName::classProblem('Basket'))->toBeNull();
+        });
+
+        it('accepts a namespaced class, written either way round', function () {
+            expect(PhpName::classProblem('App\\Domain\\Basket'))->toBeNull();
+            expect(PhpName::classProblem('App/Domain/Basket'))->toBeNull();
+        });
+
+        it('accepts underscores and digits after the first character', function () {
+            expect(PhpName::classProblem('_Legacy\\Order2'))->toBeNull();
+        });
+
+        it('refuses a name that starts with a digit', function () {
+            expect(PhpName::classProblem('1'))->toBe('"1" is not a valid class name.');
+        });
+
+        it('refuses punctuation PHP could not parse', function () {
+            expect(PhpName::classProblem('Foo-Bar'))->toBe('"Foo-Bar" is not a valid class name.');
+            expect(PhpName::classProblem('my class'))->toBe('"my class" is not a valid class name.');
+        });
+
+        it('refuses a namespace with an empty segment', function () {
+            expect(PhpName::classProblem('App\\\\Basket'))->toBe('"App\\\\Basket" is not a valid class name.');
+        });
+
+        it('says plainly when nothing was given', function () {
+            expect(PhpName::classProblem(''))->toBe('No class name was given.');
+            expect(PhpName::classProblem('   '))->toBe('No class name was given.');
+        });
+    });
+
+    context('method names', function () {
+        it('accepts an identifier', function () {
+            expect(PhpName::methodProblem('addTask'))->toBeNull();
+        });
+
+        it('refuses a name that starts with a digit', function () {
+            expect(PhpName::methodProblem('2print'))->toBe('"2print" is not a valid method name.');
+        });
+
+        it('refuses a qualified name: a method is one identifier', function () {
+            expect(PhpName::methodProblem('App\\Basket::total'))->toBe('"App\\Basket::total" is not a valid method name.');
+        });
+
+        it('says plainly when nothing was given', function () {
+            expect(PhpName::methodProblem(''))->toBe('No method name was given.');
+        });
+    });
+});

--- a/spec/PhpSpec/Console/Command/Accept.spec.php
+++ b/spec/PhpSpec/Console/Command/Accept.spec.php
@@ -1,0 +1,108 @@
+<?php
+
+use PhpSpec\Console\Command\Accept;
+use PhpSpec\Filesystem;
+use PhpSpec\Offers\Offer;
+use PhpSpec\Offers\OfferBook;
+use Symfony\Component\Console\Tester\CommandTester;
+
+describe(Accept::class, function () {
+
+    beforeEach(function (Filesystem $fs) {
+        $this->files = [];
+        $this->written = [];
+        allow($fs->exists())->toReturnUsing(fn(string $path): bool => isset($this->files[$path]));
+        allow($fs->read())->toReturnUsing(fn(string $path): string => $this->files[$path] ?? '');
+        allow($fs->mkdir())->toReturn(null);
+        // The book keeps itself on disk, so a write to .phpspec is bookkeeping
+        // rather than a change to the project: assert on the project's files.
+        allow($fs->write())->toReturnUsing(function (string $path, string $content) {
+            $this->files[$path] = $content;
+            if (!str_contains($path, '/.phpspec/')) {
+                $this->written[$path] = $content;
+            }
+        });
+
+        $this->book = new OfferBook($fs, '/project');
+        $this->tester = fn(): CommandTester => new CommandTester(new Accept($fs, $this->book, '/project'));
+    });
+
+    it('takes an offer that is still on the table', function () {
+        $offer = Offer::write('src/App/Basket.php', "<?php\nclass Basket {}", true, '');
+        $this->book->record($offer);
+
+        $tester = ($this->tester)();
+        $tester->execute(['offer' => [$offer->id]], ['interactive' => false]);
+
+        expect($tester->getStatusCode())->toBe(0);
+        expect($tester->getDisplay())->toContain('Created src/App/Basket.php');
+        expect($this->written['/project/src/App/Basket.php'] ?? '')->toContain('class Basket');
+    });
+
+    it('takes several offers at once', function () {
+        $first = Offer::write('src/App/Basket.php', '<?php', true, '');
+        $second = Offer::write('src/App/Cart.php', '<?php', true, '');
+        $this->book->record($first, $second);
+
+        $tester = ($this->tester)();
+        $tester->execute(['offer' => [$first->id, $second->id]], ['interactive' => false]);
+
+        expect($tester->getStatusCode())->toBe(0);
+        expect(array_keys($this->written))->toBe(['/project/src/App/Basket.php', '/project/src/App/Cart.php']);
+    });
+
+    it('refuses an id it has never heard of, and says how offers are made', function () {
+        $tester = ($this->tester)();
+        $tester->execute(['offer' => ['o_nothing']], ['interactive' => false]);
+
+        expect($tester->getStatusCode())->toBe(1);
+        expect($tester->getDisplay())->toContain('o_nothing');
+        expect($this->written)->toBe([]);
+    });
+
+    it('refuses an offer the code has moved past', function () {
+        $offer = Offer::write('src/App/Basket.php', '<?php the proposal', false, 'the content when offered');
+        $this->book->record($offer);
+        $this->files['/project/src/App/Basket.php'] = 'someone edited it since';
+
+        $tester = ($this->tester)();
+        $tester->execute(['offer' => [$offer->id]], ['interactive' => false]);
+
+        expect($tester->getStatusCode())->toBe(1);
+        expect($tester->getDisplay())->toContain('changed since');
+        expect($this->written)->toBe([]);
+    });
+
+    it('applies nothing at all when one of several offers is refused', function () {
+        $good = Offer::write('src/App/Basket.php', '<?php', true, '');
+        $this->book->record($good);
+
+        $tester = ($this->tester)();
+        $tester->execute(['offer' => [$good->id, 'o_nothing']], ['interactive' => false]);
+
+        expect($tester->getStatusCode())->toBe(1);
+        expect($this->written)->toBe([]);
+    });
+
+    it('answers an agent on its own channel', function () {
+        $offer = Offer::write('src/App/Basket.php', '<?php', true, '');
+        $this->book->record($offer);
+
+        $tester = ($this->tester)();
+        $tester->execute(['offer' => [$offer->id], '--format' => 'agent'], ['interactive' => false]);
+
+        $document = json_decode(trim($tester->getDisplay()), true, flags: JSON_THROW_ON_ERROR);
+        expect($document['action'])->toBe('accept');
+        expect($document['accepted'][0]['id'])->toBe($offer->id);
+        expect($document['accepted'][0]['path'])->toBe('src/App/Basket.php');
+        expect($document['accepted'][0]['applied'])->toBeTrue();
+    });
+
+    it('tells an agent why it refused, on the same channel', function () {
+        $tester = ($this->tester)();
+        $tester->execute(['offer' => ['o_nothing'], '--format' => 'agent'], ['interactive' => false]);
+
+        $document = json_decode(trim($tester->getDisplay()), true, flags: JSON_THROW_ON_ERROR);
+        expect($document['error'])->toContain('o_nothing');
+    });
+});

--- a/spec/PhpSpec/Console/Command/Describe.spec.php
+++ b/spec/PhpSpec/Console/Command/Describe.spec.php
@@ -59,7 +59,7 @@ describe(Describe::class, function() {
 
         $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
         expect($doc)->toBe([
-            'v' => 1,
+            'v' => 2,
             'action' => 'describe',
             'class' => 'App\\Basket',
             'spec' => 'spec/App/Basket.spec.php',

--- a/spec/PhpSpec/Console/Command/Exemplify.spec.php
+++ b/spec/PhpSpec/Console/Command/Exemplify.spec.php
@@ -57,7 +57,7 @@ describe(Exemplify::class, function () {
 
         $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
         expect($doc)->toBe([
-            'v' => 1,
+            'v' => 2,
             'action' => 'exemplify',
             'class' => 'Acme\\Calculator',
             'method' => 'add',

--- a/spec/PhpSpec/Console/Command/Generate.spec.php
+++ b/spec/PhpSpec/Console/Command/Generate.spec.php
@@ -101,8 +101,8 @@ describe(Generate::class, function () {
         $tester->execute(['instruction' => ['a', 'Calc', 'class'], '--format' => 'agent'], ['interactive' => false]);
 
         $book = json_decode($stored[getcwd() . '/.phpspec/offers.json'] ?? '{}', true);
-        expect($book['offers'][0]['path'])->toBe('src/App/Calc.php');
-        expect($book['offers'][0]['content'])->toContain('class Calc');
+        expect($book['offers'][0]['target'])->toBe('src/App/Calc.php');
+        expect($book['offers'][0]['data']['content'])->toContain('class Calc');
     });
 
     it('reports when nothing could be generated', function (Filesystem $fs) use ($withAi) {

--- a/spec/PhpSpec/Console/Command/Generate.spec.php
+++ b/spec/PhpSpec/Console/Command/Generate.spec.php
@@ -37,26 +37,72 @@ describe(Generate::class, function () {
         expect($tester->getDisplay())->toContain('AI configuration required');
     });
 
-    it('shows a NEW FILE diff and writes the proposal non-interactively', function (Filesystem $fs) use ($withAi) {
+    $proposing = fn(): ReplayProvider => new ReplayProvider([
+        new Response('', [new ToolCall('1', 'propose_edit', ['path' => 'src/App/Calc.php', 'content' => "<?php\nclass Calc {}"])]),
+    ]);
+
+    // The offer book keeps itself on disk; a write to .phpspec is bookkeeping,
+    // not a change to the project.
+    $projectWrites = fn(array $written): array => array_filter(
+        $written,
+        fn(string $path): bool => !str_contains($path, '/.phpspec/'),
+        ARRAY_FILTER_USE_KEY,
+    );
+
+    it('shows a NEW FILE diff and offers the change rather than writing it', function (Filesystem $fs) use ($withAi, $proposing, $projectWrites) {
         $withAi($fs);
         $written = [];
         allow($fs->write())->toReturnUsing(function (string $p, string $c) use (&$written) {
             $written[$p] = $c;
         });
 
-        $provider = new ReplayProvider([
-            new Response('', [new ToolCall('1', 'propose_edit', ['path' => 'src/App/Calc.php', 'content' => "<?php\nclass Calc {}"])]),
-        ]);
-        $cmd = new Generate(new Configuration('.', $fs), $fs, $provider);
+        $cmd = new Generate(new Configuration('.', $fs), $fs, $proposing());
         $tester = new CommandTester($cmd);
 
+        // Nobody to ask is not the same as a yes.
         $tester->execute(['instruction' => ['a', 'Calc', 'class']], ['interactive' => false]);
 
         $out = $tester->getDisplay();
         expect($out)->toContain('[NEW FILE]');
         expect($out)->toContain('src/App/Calc.php');
-        expect($out)->toContain('Created');
-        expect($written[getcwd() . '/src/App/Calc.php'] ?? '')->toContain('class Calc');
+        expect($out)->toContain('phpspec accept o_');
+        expect($projectWrites($written))->toBe([]);
+    });
+
+    it('gives an agent an id for each proposal, unapplied', function (Filesystem $fs) use ($withAi, $proposing, $projectWrites) {
+        $withAi($fs);
+        $written = [];
+        allow($fs->write())->toReturnUsing(function (string $p, string $c) use (&$written) {
+            $written[$p] = $c;
+        });
+
+        $cmd = new Generate(new Configuration('.', $fs), $fs, $proposing());
+        $tester = new CommandTester($cmd);
+
+        $tester->execute(['instruction' => ['a', 'Calc', 'class'], '--format' => 'agent'], ['interactive' => false]);
+
+        $document = json_decode(trim($tester->getDisplay()), true, flags: JSON_THROW_ON_ERROR);
+        expect($document['proposals'][0]['path'])->toBe('src/App/Calc.php');
+        expect($document['proposals'][0]['applied'])->toBeFalse();
+        expect($document['proposals'][0]['id'])->toStartWith('o_');
+        expect($projectWrites($written))->toBe([]);
+    });
+
+    it('puts the proposal on the table, so accept can take exactly what was read', function (Filesystem $fs) use ($withAi, $proposing) {
+        $withAi($fs);
+        $stored = [];
+        allow($fs->write())->toReturnUsing(function (string $p, string $c) use (&$stored) {
+            $stored[$p] = $c;
+        });
+
+        $cmd = new Generate(new Configuration('.', $fs), $fs, $proposing());
+        $tester = new CommandTester($cmd);
+
+        $tester->execute(['instruction' => ['a', 'Calc', 'class'], '--format' => 'agent'], ['interactive' => false]);
+
+        $book = json_decode($stored[getcwd() . '/.phpspec/offers.json'] ?? '{}', true);
+        expect($book['offers'][0]['path'])->toBe('src/App/Calc.php');
+        expect($book['offers'][0]['content'])->toContain('class Calc');
     });
 
     it('reports when nothing could be generated', function (Filesystem $fs) use ($withAi) {

--- a/spec/PhpSpec/Offers/Offer.spec.php
+++ b/spec/PhpSpec/Offers/Offer.spec.php
@@ -1,0 +1,66 @@
+<?php
+
+use PhpSpec\Offers\Offer;
+
+describe(Offer::class, function () {
+
+    it('identifies itself from what it would do, so the same offer keeps its id', function () {
+        $one = Offer::write('src/App/Basket.php', "<?php\nclass Basket {}", true, '');
+        $again = Offer::write('src/App/Basket.php', "<?php\nclass Basket {}", true, '');
+
+        expect($one->id)->toBe($again->id);
+        expect($one->id)->toStartWith('o_');
+    });
+
+    it('is a different offer when the content differs', function () {
+        $one = Offer::write('src/App/Basket.php', "<?php\nclass Basket {}", true, '');
+        $other = Offer::write('src/App/Basket.php', "<?php\nfinal class Basket {}", true, '');
+
+        expect($one->id)->not()->toBe($other->id);
+    });
+
+    it('is a different offer when the path differs', function () {
+        $one = Offer::write('src/App/Basket.php', '<?php', true, '');
+        $other = Offer::write('src/App/Cart.php', '<?php', true, '');
+
+        expect($one->id)->not()->toBe($other->id);
+    });
+
+    it('says what it would do to the file', function () {
+        expect(Offer::write('src/App/Basket.php', '<?php', true, '')->action)->toBe('create');
+        expect(Offer::write('src/App/Basket.php', '<?php', false, 'old')->action)->toBe('update');
+    });
+
+    it('survives a round trip through storage', function () {
+        $offer = Offer::write('src/App/Basket.php', "<?php\nclass Basket {}", false, 'the old content');
+
+        expect(Offer::fromArray($offer->toArray())->toArray())->toBe($offer->toArray());
+    });
+
+    context('staleness', function () {
+        it('stands while the file is as it was when offered', function () {
+            $offer = Offer::write('src/App/Basket.php', '<?php new', false, 'the old content');
+
+            expect($offer->staleAgainst('the old content'))->toBeFalse();
+        });
+
+        it('is stale once the file has moved on', function () {
+            $offer = Offer::write('src/App/Basket.php', '<?php new', false, 'the old content');
+
+            expect($offer->staleAgainst('someone edited it'))->toBeTrue();
+        });
+
+        it('is stale when what it would create is already there', function () {
+            $offer = Offer::write('src/App/Basket.php', '<?php new', true, '');
+
+            expect($offer->staleAgainst('something exists now'))->toBeTrue();
+            expect($offer->staleAgainst(null))->toBeFalse();
+        });
+
+        it('is stale when what it would update has gone', function () {
+            $offer = Offer::write('src/App/Basket.php', '<?php new', false, 'the old content');
+
+            expect($offer->staleAgainst(null))->toBeTrue();
+        });
+    });
+});

--- a/spec/PhpSpec/Offers/OfferBook.spec.php
+++ b/spec/PhpSpec/Offers/OfferBook.spec.php
@@ -1,0 +1,78 @@
+<?php
+
+use PhpSpec\Filesystem;
+use PhpSpec\Offers\Offer;
+use PhpSpec\Offers\OfferBook;
+
+describe(OfferBook::class, function () {
+
+    beforeEach(function (Filesystem $fs) {
+        $this->stored = null;
+        allow($fs->exists())->toReturn(false);
+        allow($fs->read())->toReturnUsing(fn(): string => $this->stored ?? '');
+        allow($fs->mkdir())->toReturn(null);
+        allow($fs->write())->toReturnUsing(function (string $path, string $content) {
+            $this->stored = $content;
+            allow($this->fs->exists())->toReturn(true);
+        });
+        $this->fs = $fs;
+    });
+
+    it('hands back an offer it recorded', function (Filesystem $fs) {
+        $book = new OfferBook($fs);
+        $offer = Offer::write('src/App/Basket.php', '<?php', true, '');
+
+        $book->record($offer);
+
+        expect((new OfferBook($fs))->find($offer->id)?->path)->toBe('src/App/Basket.php');
+    });
+
+    it('knows nothing of an id it never recorded', function (Filesystem $fs) {
+        expect((new OfferBook($fs))->find('o_nothing'))->toBeNull();
+    });
+
+    it('keeps offers from earlier runs, so a reader can still accept one', function (Filesystem $fs) {
+        $book = new OfferBook($fs);
+        $first = Offer::write('src/App/Basket.php', '<?php', true, '');
+        $second = Offer::write('src/App/Cart.php', '<?php', true, '');
+
+        $book->record($first);
+        (new OfferBook($fs))->record($second);
+
+        $book = new OfferBook($fs);
+        expect($book->find($first->id))->not()->toBeNull();
+        expect($book->find($second->id))->not()->toBeNull();
+    });
+
+    it('records the same offer once, however often it is offered', function (Filesystem $fs) {
+        $offer = Offer::write('src/App/Basket.php', '<?php', true, '');
+
+        (new OfferBook($fs))->record($offer);
+        (new OfferBook($fs))->record($offer);
+
+        expect(json_decode($this->stored, true)['offers'])->toHaveLength(1);
+    });
+
+    it('forgets the oldest once the book is full, so it cannot grow without end', function (Filesystem $fs) {
+        $book = new OfferBook($fs);
+        $offers = [];
+        for ($i = 0; $i < OfferBook::KEPT + 5; $i++) {
+            $offers[] = Offer::write("src/App/Class$i.php", '<?php', true, '');
+        }
+
+        foreach ($offers as $offer) {
+            (new OfferBook($fs))->record($offer);
+        }
+
+        $book = new OfferBook($fs);
+        expect($book->find($offers[0]->id))->toBeNull();
+        expect($book->find($offers[count($offers) - 1]->id))->not()->toBeNull();
+    });
+
+    it('survives a book that was damaged on disk', function (Filesystem $fs) {
+        allow($fs->exists())->toReturn(true);
+        allow($fs->read())->toReturn('not json at all');
+
+        expect((new OfferBook($fs))->find('o_anything'))->toBeNull();
+    });
+});

--- a/spec/PhpSpec/Offers/OfferBook.spec.php
+++ b/spec/PhpSpec/Offers/OfferBook.spec.php
@@ -24,7 +24,7 @@ describe(OfferBook::class, function () {
 
         $book->record($offer);
 
-        expect((new OfferBook($fs))->find($offer->id)?->path)->toBe('src/App/Basket.php');
+        expect((new OfferBook($fs))->find($offer->id)?->target)->toBe('src/App/Basket.php');
     });
 
     it('knows nothing of an id it never recorded', function (Filesystem $fs) {

--- a/spec/PhpSpec/Offers/OfferBook.spec.php
+++ b/spec/PhpSpec/Offers/OfferBook.spec.php
@@ -56,7 +56,8 @@ describe(OfferBook::class, function () {
     it('forgets the oldest once the book is full, so it cannot grow without end', function (Filesystem $fs) {
         $book = new OfferBook($fs);
         $offers = [];
-        for ($i = 0; $i < OfferBook::KEPT + 5; $i++) {
+        // More than the book keeps, so the oldest must fall off the table.
+        for ($i = 0; $i < 60; $i++) {
             $offers[] = Offer::write("src/App/Class$i.php", '<?php', true, '');
         }
 

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -302,6 +302,38 @@ describe(Agent::class, function () {
         expect($example)->not()->toHaveKey('offer');
     });
 
+    it('keeps a null value an anonymous matcher failed on, having a site to prove it real', function () use ($render) {
+        // A custom or predicate matcher reaches phpspec through __call and stays
+        // nameless: null everywhere except the site. "Your code produced null"
+        // is exactly what the reader needs.
+        $match = MatchResult::failed(null, null, 'Expected the greeter to have greeted', getcwd() . '/spec/App/X.spec.php', 7);
+
+        $example = $render(new SuiteResult([
+            new SpecificationResult('App\\X', [new ExampleResult('greets', [$match])]),
+        ]))['examples'][0];
+
+        expect($example['expected'])->toBe(['matcher' => null, 'value' => null, 'negated' => false]);
+        expect($example)->toHaveKey('actual');
+        expect($example['actual'])->toBeNull();
+    });
+
+    it('reports only the message when a failure came back without its site', function () use ($render) {
+        // What a parallel worker's JUnit report can carry: the message, and a
+        // stand-in expectation comparing nothing with nothing.
+        $match = MatchResult::failed(null, null, 'Expected 3500 to be 4000', '', 0);
+
+        $example = $render(new SuiteResult([
+            new SpecificationResult('App\\Basket', [new ExampleResult('totals', [$match])]),
+        ]))['examples'][0];
+
+        expect($example['message'])->toBe('Expected 3500 to be 4000');
+        expect($example)->not()->toHaveKey('expected');
+        expect($example)->not()->toHaveKey('actual');
+        // And no location invented from the parts it does not have.
+        expect($example)->not()->toHaveKey('spec');
+        expect($example)->not()->toHaveKey('rerun');
+    });
+
     it('flags a negated matcher on the expected block', function () use ($render) {
         $match = MatchResult::failed(5, 5, 'Expected 5 not to be 5', getcwd() . '/spec/App/X.spec.php', 1, null, 'toBe', true);
         $example = $render(new SuiteResult([

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -315,7 +315,9 @@ describe(Agent::class, function () {
 
         $example = $render(new SuiteResult([new SpecificationResult('App\\Basket', [$errored])]))['examples'][0];
 
-        expect($example['offer'])->toBe(['action' => 'create_class', 'target' => 'App\\Coupon']);
+        expect($example['offer']['action'])->toBe('create_class');
+        expect($example['offer']['target'])->toBe('App\\Coupon');
+        expect($example['offer']['id'])->toStartWith('o_');
     });
 
     it('summarises totals and duration, offers empty for now', function () use ($render) {
@@ -349,7 +351,9 @@ describe(Agent::class, function () {
         $agent->format($suite);
 
         $result = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR)['result'];
-        expect($result['offers'])->toBe([['action' => 'create_class', 'target' => 'App\\Coupon']]);
+        expect($result['offers'][0]['action'])->toBe('create_class');
+        expect($result['offers'][0]['target'])->toBe('App\\Coupon');
+        expect($result['offers'][0]['id'])->toStartWith('o_');
     });
 
     it('counts a story run in scenarios and steps, never in examples', function () use ($render) {

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -32,25 +32,83 @@ class AgentSpecProcessEnd implements ProcessEnd
 
 describe(Agent::class, function () {
 
-    $render = function (SuiteResult $suite): array {
+    // The run answers in JSON Lines. Decoding a line at a time and filing each
+    // event by its kind is the whole of what a reader does, so the spec reads
+    // the output the same way: the header, the entries as they arrived, and the
+    // summary that closed the stream.
+    $stream = function (string $output): array {
+        $document = ['suite' => null, 'examples' => [], 'result' => null];
+
+        foreach (explode("\n", trim($output)) as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+
+            $event = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
+
+            match ($event['event']) {
+                'run_started' => $document['suite'] = $event,
+                'example' => $document['examples'][] = $event,
+                'fatal' => $document['fatal'] = $event,
+                'summary' => $document['result'] = $event,
+            };
+        }
+
+        return $document;
+    };
+
+    $render = function (SuiteResult $suite) use ($stream): array {
         $output = new BufferedOutput();
         (new Agent($output))->format($suite);
 
-        return json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        return $stream($output->fetch());
     };
 
-    it('emits one JSON object with suite, examples and result sections', function () use ($render) {
+    it('answers in JSON Lines, one self-contained event per line', function () {
+        $output = new BufferedOutput();
+        (new Agent($output))->format(new SuiteResult([
+            new SpecificationResult('App\\Basket', [
+                new ExampleResult('totals', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/X.spec.php', 3)]),
+            ]),
+        ]));
+
+        $lines = explode("\n", trim($output->fetch()));
+
+        expect($lines)->toHaveLength(3);
+        foreach ($lines as $line) {
+            expect(json_decode($line, true, flags: JSON_THROW_ON_ERROR)['v'])->toBe(2);
+        }
+        expect(json_decode($lines[0], true)['event'])->toBe('run_started');
+        expect(json_decode($lines[1], true)['event'])->toBe('example');
+        expect(json_decode($lines[2], true)['event'])->toBe('summary');
+    });
+
+    it('reports a failure while the run is still going, before any summary', function () {
+        $output = new BufferedOutput();
+        $formatter = new Agent($output);
+        $formatter->begin();
+        $formatter->printResult(new SpecificationResult('App\\Basket', [
+            new ExampleResult('totals', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/X.spec.php', 3)]),
+        ]));
+
+        // Nothing has ended the run: the entry is out all the same.
+        $written = $output->fetch();
+
+        expect($written)->toContain('"event":"example"');
+        expect($written)->not()->toContain('"event":"summary"');
+    });
+
+    it('emits a header, entries and a summary', function () use ($render) {
         $doc = $render(new SuiteResult([
             new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
         ]));
 
-        expect($doc)->toHaveKey('suite');
-        expect($doc)->toHaveKey('examples');
-        expect($doc)->toHaveKey('result');
-        expect($doc['suite'])->toBe(['v' => 1, 'event' => 'run_started', 'suite' => 'default', 'examples' => 1, 'scenarios' => 0, 'steps' => 0, 'seed' => null]);
+        expect($doc['suite'])->toBe(['v' => 2, 'event' => 'run_started', 'suite' => 'default', 'seed' => null]);
+        expect($doc['examples'])->toBe([]);
+        expect($doc['result']['event'])->toBe('summary');
     });
 
-    it('reports the seed and suite it was told about, so a flaky order is reproducible', function () {
+    it('reports the seed and suite it was told about, so a flaky order is reproducible', function () use ($stream) {
         $output = new BufferedOutput();
         $formatter = new Agent($output);
         $formatter->targets('spec,features/');
@@ -58,13 +116,13 @@ describe(Agent::class, function () {
         $formatter->format(new SuiteResult([
             new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
         ]));
-        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        $doc = $stream($output->fetch());
 
         expect($doc['suite']['seed'])->toBe(424242);
         expect($doc['suite']['suite'])->toBe('spec,features/');
     });
 
-    it('writes the document once, however often the command publishes it', function () {
+    it('closes the stream once, however often the command publishes it', function () {
         $output = new BufferedOutput();
         $formatter = new Agent($output);
         $formatter->format(new SuiteResult([
@@ -74,10 +132,12 @@ describe(Agent::class, function () {
         $formatter->publish();
         $formatter->publish();
 
-        expect(substr_count($output->fetch(), '"run_started"'))->toBe(1);
+        $written = $output->fetch();
+        expect(substr_count($written, '"run_started"'))->toBe(1);
+        expect(substr_count($written, '"summary"'))->toBe(1);
     });
 
-    it('publishes what it collected even when the run never reached its end', function () {
+    it('publishes what it collected even when the run never reached its end', function () use ($stream) {
         $output = new BufferedOutput();
         $formatter = new Agent($output);
         $formatter->targets('./spec');
@@ -88,17 +148,17 @@ describe(Agent::class, function () {
 
         // No end(): a fatal took the process before the last example.
         $formatter->publish();
-        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        $doc = $stream($output->fetch());
 
         expect($doc['result']['failing'])->toBe(1);
         expect($doc['result']['duration_ms'])->toBe(0);
         expect($doc['examples'][0]['example'])->toBe('App\\Basket > holds products');
-        // What the run was trying to run is known before the run: a document cut
+        // What the run was trying to run is known before the run: a stream cut
         // short still says it.
         expect($doc['suite']['suite'])->toBe('./spec');
     });
 
-    it('carries a missed coverage gate in the result, and counts it as work left', function () {
+    it('carries a missed coverage gate in the summary, and counts it as work left', function () use ($stream) {
         $output = new BufferedOutput();
         $formatter = new Agent($output);
         $formatter->begin();
@@ -106,7 +166,7 @@ describe(Agent::class, function () {
         $formatter->end(new SuiteResult([]));
         $formatter->covered(new CoverageVerdict(24.34, 90.0));
         $formatter->publish();
-        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        $doc = $stream($output->fetch());
 
         // JSON has one number type, so 90.0 comes back as 90.
         expect($doc['result']['coverage']['percent'])->toBe(24.3);
@@ -116,20 +176,20 @@ describe(Agent::class, function () {
         expect($doc['result']['actionable'])->toBe(1);
     });
 
-    it('reports coverage without a threshold as met, adding no work', function () {
+    it('reports coverage without a threshold as met, adding no work', function () use ($stream) {
         $output = new BufferedOutput();
         $formatter = new Agent($output);
         $formatter->begin();
         $formatter->end(new SuiteResult([]));
         $formatter->covered(new CoverageVerdict(72.5));
         $formatter->publish();
-        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        $doc = $stream($output->fetch());
 
         expect($doc['result']['coverage'])->toBe(['percent' => 72.5, 'required' => null, 'met' => true]);
         expect($doc['result']['actionable'])->toBe(0);
     });
 
-    it('still publishes a document when a fatal ends the process, naming what stopped it', function () {
+    it('still closes the stream when a fatal ends the process, naming what stopped it', function () use ($stream) {
         $output = new BufferedOutput();
         $end = new AgentSpecProcessEnd();
         $formatter = new Agent($output, null, $end);
@@ -138,30 +198,28 @@ describe(Agent::class, function () {
 
         // No end(), no publish(): the process died loading the next spec file.
         $end->arrives(new Fatal('Class Mute contains 1 abstract method', getcwd() . '/spec/App/Broken.spec.php', 8));
-        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        $doc = $stream($output->fetch());
 
-        expect($doc['fatal'])->toBe([
-            'message' => 'Class Mute contains 1 abstract method',
-            'at' => 'spec/App/Broken.spec.php:8',
-        ]);
+        expect($doc['fatal']['message'])->toBe('Class Mute contains 1 abstract method');
+        expect($doc['fatal']['at'])->toBe('spec/App/Broken.spec.php:8');
         expect($doc['result']['actionable'])->toBe(1);
         expect($doc['result']['passing'])->toBe(1);
     });
 
-    it('publishes what it has when the process ends with no fatal', function () {
+    it('publishes what it has when the process ends with no fatal', function () use ($stream) {
         $output = new BufferedOutput();
         $end = new AgentSpecProcessEnd();
         $formatter = new Agent($output, null, $end);
         $formatter->begin();
 
         $end->arrives();
-        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        $doc = $stream($output->fetch());
 
         expect($doc)->not()->toHaveKey('fatal');
         expect($doc['result']['actionable'])->toBe(0);
     });
 
-    it('leaves the published document alone when the process ends after it', function () {
+    it('leaves the closed stream alone when the process ends after it', function () {
         $output = new BufferedOutput();
         $end = new AgentSpecProcessEnd();
         $formatter = new Agent($output, null, $end);
@@ -172,16 +230,18 @@ describe(Agent::class, function () {
         expect(substr_count($output->fetch(), '"run_started"'))->toBe(1);
     });
 
-    it('keeps the first thing that stopped the run', function () {
+    it('keeps the first thing that stopped the run', function () use ($stream) {
         $output = new BufferedOutput();
         $formatter = new Agent($output);
         $formatter->stopped('Bootstrap file not found: vendor/autoload.php');
         $formatter->stopped('and then everything else broke');
         $formatter->publish();
-        $doc = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+        $doc = $stream($output->fetch());
 
         expect($doc['fatal']['message'])->toBe('Bootstrap file not found: vendor/autoload.php');
         expect($doc['fatal']['at'])->toBeNull();
+        // The header still leads, even for a run that never began.
+        expect($doc['suite']['event'])->toBe('run_started');
     });
 
     it('joins every failing target into one rerun command, without repeats', function () use ($render) {
@@ -205,7 +265,7 @@ describe(Agent::class, function () {
         expect($doc['result'])->not()->toHaveKey('rerun');
     });
 
-    it('omits coverage from the result when none was collected', function () use ($render) {
+    it('omits coverage from the summary when none was collected', function () use ($render) {
         $doc = $render(new SuiteResult([
             new SpecificationResult('App\\Basket', [new ExampleResult('holds products', [MatchResult::passed()])]),
         ]));
@@ -320,7 +380,7 @@ describe(Agent::class, function () {
         expect($example['offer']['id'])->toStartWith('o_');
     });
 
-    it('summarises totals and duration, offers empty for now', function () use ($render) {
+    it('summarises totals and duration, and says nothing about offers when there are none', function () use ($render) {
         $suite = new SuiteResult([
             new SpecificationResult('App\\Basket', [
                 new ExampleResult('holds products', [MatchResult::passed()]),
@@ -338,10 +398,10 @@ describe(Agent::class, function () {
         expect($result['errors'])->toBe(0);
         expect($result['actionable'])->toBe(1);
         expect($result['duration_ms'])->toBe(74);
-        expect($result['offers'])->toBe([]);
+        expect($result)->not()->toHaveKey('offers');
     });
 
-    it('lists code-generation offers in the summary from the candidate resolver', function () {
+    it('lists code-generation offers in the summary from the candidate resolver', function () use ($stream) {
         $output = new BufferedOutput();
         $suite = new SuiteResult([
             new SpecificationResult('App\\Basket', [new ExampleResult('needs a coupon', [], true)]),
@@ -350,7 +410,7 @@ describe(Agent::class, function () {
         $agent = new Agent($output, fn() => ['missingSpecClasses' => ['App\\Coupon']]);
         $agent->format($suite);
 
-        $result = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR)['result'];
+        $result = $stream($output->fetch())['result'];
         expect($result['offers'][0]['action'])->toBe('create_class');
         expect($result['offers'][0]['target'])->toBe('App\\Coupon');
         expect($result['offers'][0]['id'])->toStartWith('o_');

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -455,6 +455,36 @@ describe(Agent::class, function () {
         ]);
     });
 
+    it('hands over the values a step did not match, on the step and on the entry', function () use ($render) {
+        $step = new StepResult('Given I count 2 items', 'failure');
+        $step->setError(new \PhpSpec\StoryBDD\StepError('Expected 2 to be 3', new \RuntimeException('Expected 2 to be 3')));
+        $step->setMatch(MatchResult::failed(2, 3, 'Expected 2 to be 3', getcwd() . '/features/steps/counting.steps.php', 4, null, 'toBe'));
+
+        $entry = $render(new SuiteResult([
+            new FeatureResult('Counting', [new ScenarioResult('Counting up', [$step], 2)], 'features/counting.feature'),
+        ]))['examples'][0];
+
+        // Hoisted onto the entry, next to the message it already hoists.
+        expect($entry['expected'])->toBe(['matcher' => 'toBe', 'value' => 3, 'negated' => false]);
+        expect($entry['actual'])->toBe(2);
+        // And on the step that made it, with the line the expectation lives on.
+        expect($entry['steps'][0]['expected']['value'])->toBe(3);
+        expect($entry['steps'][0]['actual'])->toBe(2);
+        expect($entry['steps'][0]['at'])->toBe('features/steps/counting.steps.php:4');
+    });
+
+    it('leaves a thrown step to its message, having no expectation to report', function () use ($render) {
+        $step = new StepResult('Given a broken step', 'error');
+        $step->setError(new \PhpSpec\StoryBDD\StepError('this step is broken', new \RuntimeException('this step is broken')));
+
+        $entry = $render(new SuiteResult([
+            new FeatureResult('Counting', [new ScenarioResult('Counting up', [$step], 2)], 'features/counting.feature'),
+        ]))['examples'][0];
+
+        expect($entry)->not()->toHaveKey('expected');
+        expect($entry['steps'][0])->not()->toHaveKey('actual');
+    });
+
     it('names a scenario by feature and scenario, so two never share an id', function () use ($render) {
         $failing = function (string $title): StepResult {
             $step = new StepResult($title, 'error');

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -355,6 +355,50 @@ describe(Agent::class, function () {
         expect($entry)->not()->toHaveKey('notices');
     });
 
+    it('carries what an example printed, so the dump explaining it is not lost', function () use ($render) {
+        $example = new ExampleResult('totals', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/App/X.spec.php', 3)]);
+        $example->setOutput("the subject said this\n");
+
+        $entry = $render(new SuiteResult([new SpecificationResult('App\\X', [$example])]))['examples'][0];
+
+        expect($entry['output'])->toBe("the subject said this\n");
+    });
+
+    it('says nothing about output when nothing was printed', function () use ($render) {
+        $entry = $render(new SuiteResult([
+            new SpecificationResult('App\\X', [
+                new ExampleResult('totals', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/App/X.spec.php', 3)]),
+            ]),
+        ]))['examples'][0];
+
+        expect($entry)->not()->toHaveKey('output');
+    });
+
+    it('caps a flood of printed output, marking how much there was', function () use ($render) {
+        $example = new ExampleResult('totals', [MatchResult::failed(1, 2, 'no', getcwd() . '/spec/App/X.spec.php', 3)]);
+        $example->setOutput(str_repeat('x', 5000));
+
+        $entry = $render(new SuiteResult([new SpecificationResult('App\\X', [$example])]))['examples'][0];
+
+        expect($entry['output']['truncated'])->toBeTrue();
+        expect($entry['output']['length'])->toBe(5000);
+        expect(strlen($entry['output']['value']))->toBe(4000);
+    });
+
+    it('carries what a scenario printed, whichever of its steps did the printing', function () use ($render) {
+        $ran = new StepResult('Given I run the counter', 'passed');
+        $ran->setOutput('the counter said 2');
+        $checked = new StepResult('Then it should have counted 3', 'failure');
+        $checked->setError(new \PhpSpec\StoryBDD\StepError('Expected 2 to be 3', new \RuntimeException('Expected 2 to be 3')));
+
+        $entry = $render(new SuiteResult([
+            new FeatureResult('Counting', [new ScenarioResult('Counting up', [$ran, $checked], 2)], 'features/counting.feature'),
+        ]))['examples'][0];
+
+        // The step that printed it passed; the entry is what a reader acts on.
+        expect($entry['output'])->toBe('the counter said 2');
+    });
+
     it('reports an error example with the exception class, message and location', function () use ($render) {
         $errored = new ExampleResult('blows up', [], true);
         $errored->setError(new ExampleError('boom', new \RuntimeException('boom')));

--- a/spec/PhpSpec/Report/Formatter/Agent/Offers.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent/Offers.spec.php
@@ -5,13 +5,17 @@ use PhpSpec\Report\Formatter\Agent\Offers;
 describe(Offers::class, function () {
 
     it('maps a missing spec class to create_class', function () {
-        expect(Offers::fromCandidates(['missingSpecClasses' => ['App\\Coupon']]))
-            ->toBe([['action' => 'create_class', 'target' => 'App\\Coupon']]);
+        $offers = Offers::fromCandidates(['missingSpecClasses' => ['App\\Coupon']]);
+
+        expect($offers[0]['action'])->toBe('create_class');
+        expect($offers[0]['target'])->toBe('App\\Coupon');
     });
 
     it('maps a missing mock type to create_interface', function () {
-        expect(Offers::fromCandidates(['missingMockTypes' => ['App\\Repository']]))
-            ->toBe([['action' => 'create_interface', 'target' => 'App\\Repository']]);
+        $offers = Offers::fromCandidates(['missingMockTypes' => ['App\\Repository']]);
+
+        expect($offers[0]['action'])->toBe('create_interface');
+        expect($offers[0]['target'])->toBe('App\\Repository');
     });
 
     it('maps an undefined class method to create_method with a Class::method target', function () {
@@ -19,8 +23,10 @@ describe(Offers::class, function () {
             ['className' => 'App\\Basket', 'methodName' => 'checkout', 'file' => 'x', 'line' => 1],
         ]];
 
-        expect(Offers::fromCandidates($candidates))
-            ->toBe([['action' => 'create_method', 'target' => 'App\\Basket::checkout']]);
+        $offers = Offers::fromCandidates($candidates);
+
+        expect($offers[0]['action'])->toBe('create_method');
+        expect($offers[0]['target'])->toBe('App\\Basket::checkout');
     });
 
     it('maps a fakeable method to fake_method carrying its return expression as value', function () {
@@ -28,8 +34,11 @@ describe(Offers::class, function () {
             ['className' => 'App\\Calc', 'methodName' => 'add', 'fakeExpression' => 'return 3', 'file' => 'x', 'line' => 1],
         ]];
 
-        expect(Offers::fromCandidates($candidates))
-            ->toBe([['action' => 'fake_method', 'target' => 'App\\Calc::add', 'value' => 'return 3']]);
+        $offers = Offers::fromCandidates($candidates);
+
+        expect($offers[0]['action'])->toBe('fake_method');
+        expect($offers[0]['target'])->toBe('App\\Calc::add');
+        expect($offers[0]['value'])->toBe('return 3');
     });
 
     it('maps undefined steps to create_steps keyed by feature path', function () {
@@ -37,15 +46,19 @@ describe(Offers::class, function () {
             'features/checkout.feature' => [['keyword' => 'Given', 'text' => 'a basket']],
         ]];
 
-        expect(Offers::fromCandidates($candidates))
-            ->toBe([['action' => 'create_steps', 'target' => 'features/checkout.feature']]);
+        $offers = Offers::fromCandidates($candidates);
+
+        expect($offers[0]['action'])->toBe('create_steps');
+        expect($offers[0]['target'])->toBe('features/checkout.feature');
     });
 
     it('deduplicates the same action and target', function () {
         $candidates = ['missingSpecClasses' => ['App\\Coupon'], 'missingStepClasses' => ['App\\Coupon']];
 
-        expect(Offers::fromCandidates($candidates))
-            ->toBe([['action' => 'create_class', 'target' => 'App\\Coupon']]);
+        $offers = Offers::fromCandidates($candidates);
+
+        expect($offers)->toHaveLength(1);
+        expect($offers[0]['target'])->toBe('App\\Coupon');
     });
 
     it('returns an empty list when there is nothing to generate', function () {
@@ -53,18 +66,26 @@ describe(Offers::class, function () {
     });
 
     it('derives a create_class offer from a "Class not found" error', function () {
-        expect(Offers::forError('Class "App\\Coupon" not found'))
-            ->toBe(['action' => 'create_class', 'target' => 'App\\Coupon']);
+        $offer = Offers::forError('Class "App\\Coupon" not found');
+
+        expect($offer['action'])->toBe('create_class');
+        expect($offer['target'])->toBe('App\\Coupon');
+        // The same id the run-wide offer carries: both are derived from the same thing.
+        expect($offer['id'])->toBe(Offers::fromCandidates(['missingSpecClasses' => ['App\\Coupon']])[0]['id']);
     });
 
     it('derives a create_interface offer from a mock-creation error', function () {
-        expect(Offers::forError("Cannot create mock: class or interface 'App\\Repo' does not exist"))
-            ->toBe(['action' => 'create_interface', 'target' => 'App\\Repo']);
+        $offer = Offers::forError("Cannot create mock: class or interface 'App\\Repo' does not exist");
+
+        expect($offer['action'])->toBe('create_interface');
+        expect($offer['target'])->toBe('App\\Repo');
     });
 
     it('derives a create_method offer from an undefined-method error', function () {
-        expect(Offers::forError('Call to undefined method App\\Basket::checkout()'))
-            ->toBe(['action' => 'create_method', 'target' => 'App\\Basket::checkout']);
+        $offer = Offers::forError('Call to undefined method App\\Basket::checkout()');
+
+        expect($offer['action'])->toBe('create_method');
+        expect($offer['target'])->toBe('App\\Basket::checkout');
     });
 
     it('returns null for an error a generator cannot resolve', function () {

--- a/spec/PhpSpec/StoryBDD/Feature.spec.php
+++ b/spec/PhpSpec/StoryBDD/Feature.spec.php
@@ -112,6 +112,30 @@ describe(Feature::class, function () {
         expect($steps[1]->isSkipped())->toBeTrue();
     });
 
+    // The expectation a step fails on is kept on its result: specified end to
+    // end in features/scenarios/cli/agent-format.feature, because an expectation
+    // that fails inside a nested feature run is also collected by the example
+    // running it, which would fail this spec for the wrong reason.
+    it("leaves a thrown step without an expectation, since none was made", function () {
+        $registry = new StepRegistry();
+        $registry->addStep("a throwing step", function () {
+            throw new \RuntimeException("boom");
+        });
+
+        $feature = new Feature('test.feature', new FeatureNode(
+            'Throwing',
+            '',
+            null,
+            [new ScenarioNode('Throws', [
+                new StepNode('Given', 'a throwing step'),
+            ])]
+        ), $registry, new HookRegistry());
+
+        $result = $feature->run();
+
+        expect($result->getResults()[0]->getResults()[0]->getMatch())->toBeNull();
+    });
+
     it("captures PHP warnings raised inside a step instead of leaking them", function () {
         $registry = new StepRegistry();
         $registry->addStep("a noisy step", function () {

--- a/src/PhpSpec/CapturedOutput.php
+++ b/src/PhpSpec/CapturedOutput.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec;
+
+/**
+ * @internal
+ * Runs a piece of a run with a hand over the output stream, keeping what it
+ * printed rather than letting it land wherever it fell. What the subject prints
+ * is a diagnostic belonging to the example or step that provoked it, and under
+ * a machine-readable format standard output belongs to the report alone.
+ */
+final class CapturedOutput
+{
+    private string $text = '';
+
+    /**
+     * Runs the body, keeping everything it printed. Whatever the body does,
+     * including throwing, the stream is handed back as it was found.
+     *
+     * @param \Closure(): mixed $body the piece of the run to listen to
+     */
+    public function around(\Closure $body): void
+    {
+        $depth = ob_get_level();
+        ob_start();
+
+        try {
+            $body();
+        } finally {
+            // A body that opened a buffer of its own and never closed it does
+            // not get to swallow what it printed: unwind back down to ours.
+            while (ob_get_level() > $depth + 1) {
+                ob_end_flush();
+            }
+
+            // Unless it closed ours as well, in which case there is nothing
+            // left to take and the text stands at what came before.
+            if (ob_get_level() > $depth) {
+                $this->text .= (string) ob_get_clean();
+            }
+        }
+    }
+
+    /**
+     * Everything the bodies run so far have printed.
+     */
+    public function text(): string
+    {
+        return $this->text;
+    }
+}

--- a/src/PhpSpec/CodeGeneration/PhpName.php
+++ b/src/PhpSpec/CodeGeneration/PhpName.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\CodeGeneration;
+
+/**
+ * @internal
+ * What PhpSpec will accept as the name of something it is about to write.
+ *
+ * A generated file names its subject in code: `describe(App\Basket::class, ...)`.
+ * A name PHP cannot parse therefore does not produce a bad spec, it produces a
+ * file that stops the suite from loading at all, so the refusal has to happen
+ * before anything is written. One statement of the rule, so every writer refuses
+ * the same names and every caller can report the same reason.
+ */
+final class PhpName
+{
+    /** A single PHP identifier: a letter or underscore, then letters, digits or underscores. */
+    private const IDENTIFIER = '/^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$/';
+
+    /**
+     * Why this cannot name a class, or null when it can. Namespace separators
+     * are accepted either way round, since the commands take "App\Basket" and
+     * the generators pass "App/Basket".
+     *
+     * @param string $name the class name as it was given
+     */
+    public static function classProblem(string $name): ?string
+    {
+        if (trim($name) === '') {
+            return 'No class name was given.';
+        }
+
+        foreach (preg_split('~[\\\\/]~', $name) ?: [] as $segment) {
+            if (preg_match(self::IDENTIFIER, $segment) !== 1) {
+                return sprintf('"%s" is not a valid class name.', $name);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Why this cannot name a method, or null when it can. A method is one
+     * identifier: no namespace, no separators.
+     *
+     * @param string $name the method name as it was given
+     */
+    public static function methodProblem(string $name): ?string
+    {
+        if (trim($name) === '') {
+            return 'No method name was given.';
+        }
+
+        if (preg_match(self::IDENTIFIER, $name) !== 1) {
+            return sprintf('"%s" is not a valid method name.', $name);
+        }
+
+        return null;
+    }
+}

--- a/src/PhpSpec/CodeGeneration/SpecGenerator.php
+++ b/src/PhpSpec/CodeGeneration/SpecGenerator.php
@@ -16,6 +16,7 @@ namespace PhpSpec\CodeGeneration;
 
 use PhpSpec\Filesystem;
 use PhpSpec\RealFilesystem;
+use RuntimeException;
 
 /**
  * @internal
@@ -86,9 +87,18 @@ final class SpecGenerator
      * example.
      *
      * @param string $spec the class path using forward slashes
+     * @throws RuntimeException when the name cannot name a class in PHP
      */
     public function skeleton(string $spec): string
     {
+        // Every writer comes through here, so a name PHP could not parse is
+        // refused once, before it reaches a file that would break the suite.
+        $problem = PhpName::classProblem($spec);
+
+        if ($problem !== null) {
+            throw new RuntimeException($problem);
+        }
+
         $pieces = explode('/', $spec);
         $use = '';
         if (count($pieces) > 1) {
@@ -116,9 +126,16 @@ final class SpecGenerator
      * @param string $content the current spec content
      * @param string $spec the class path using forward slashes
      * @param string $method the method name to exemplify
+     * @throws RuntimeException when the name cannot name a method in PHP
      */
     public function withExample(string $content, string $spec, string $method): ?string
     {
+        $problem = PhpName::methodProblem($method);
+
+        if ($problem !== null) {
+            throw new RuntimeException($problem);
+        }
+
         // Already exemplified: don't append an identical example again.
         if (str_contains($content, "it(\"should $method\",")) {
             return null;

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -112,7 +112,7 @@ final class Application extends BaseApplication
         $defaultCommands[] = new Refactor($config);
         $defaultCommands[] = new Next($config);
         $defaultCommands[] = new Generate($config);
-        $defaultCommands[] = new Accept();
+        $defaultCommands[] = new Accept(config: $config);
 
         foreach ($extensionLoader->getCommands() as $cmd) {
             $defaultCommands[] = $cmd;

--- a/src/PhpSpec/Console/Application.php
+++ b/src/PhpSpec/Console/Application.php
@@ -17,6 +17,7 @@ namespace PhpSpec\Console;
 use PhpSpec\CodeGeneration\ClassGenerator;
 use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Accept;
 use PhpSpec\Console\Command\Describe;
 use PhpSpec\Console\Command\Exemplify;
 use PhpSpec\Console\Command\Generate;
@@ -111,6 +112,7 @@ final class Application extends BaseApplication
         $defaultCommands[] = new Refactor($config);
         $defaultCommands[] = new Next($config);
         $defaultCommands[] = new Generate($config);
+        $defaultCommands[] = new Accept();
 
         foreach ($extensionLoader->getCommands() as $cmd) {
             $defaultCommands[] = $cmd;

--- a/src/PhpSpec/Console/Command/Accept.php
+++ b/src/PhpSpec/Console/Command/Accept.php
@@ -16,6 +16,9 @@ namespace PhpSpec\Console\Command;
 
 use PhpSpec\Ai\Agent\Proposal;
 use PhpSpec\Ai\Agent\Writer;
+use PhpSpec\Configuration;
+use PhpSpec\Console\Command\Run\CodeGenerator;
+use PhpSpec\Console\Command\Run\GenerationCandidates;
 use PhpSpec\Filesystem;
 use PhpSpec\Offers\Offer;
 use PhpSpec\Offers\OfferBook;
@@ -25,6 +28,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument as Argument;
 use Symfony\Component\Console\Input\InputInterface as Input;
 use Symfony\Component\Console\Input\InputOption as Option;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 
 /**
@@ -42,10 +46,17 @@ final class Accept extends Command
 
     private readonly OfferBook $book;
 
-    public function __construct(?Filesystem $filesystem = null, ?OfferBook $book = null, private readonly ?string $baseDir = null)
-    {
+    private readonly Configuration $config;
+
+    public function __construct(
+        ?Filesystem $filesystem = null,
+        ?OfferBook $book = null,
+        private readonly ?string $baseDir = null,
+        ?Configuration $config = null,
+    ) {
         $this->filesystem = $filesystem ?? new RealFilesystem();
         $this->book = $book ?? new OfferBook($this->filesystem, $baseDir);
+        $this->config = $config ?? new Configuration($baseDir ?? '.', $this->filesystem);
 
         parent::__construct();
     }
@@ -80,9 +91,9 @@ final class Accept extends Command
                 );
             }
 
-            if ($offer->staleAgainst($this->contentOf($offer->path))) {
+            if ($offer->staleAgainst($this->contentOf($offer->target))) {
                 return $this->refuse(
-                    sprintf('Offer "%s" no longer fits %s, which changed since the offer was made.', $id, $offer->path),
+                    sprintf('Offer "%s" no longer fits %s, which changed since the offer was made.', $id, $offer->target),
                     $forAgent,
                     $output,
                 );
@@ -101,26 +112,21 @@ final class Accept extends Command
      */
     private function take(array $offers, bool $forAgent, Output $output): int
     {
-        $writer = new Writer($this->filesystem, $this->baseDir);
         $receipts = [];
+        $notes = $forAgent ? new BufferedOutput() : $output;
 
         foreach ($offers as $offer) {
-            $writer->apply(new Proposal($offer->path, $offer->was, $offer->content, $offer->action === 'create', 'accept'));
+            match ($offer->kind) {
+                Offer::GENERATE => $this->generate($offer, $notes),
+                default => $this->write($offer, $notes),
+            };
 
             $receipts[] = [
                 'id' => $offer->id,
-                'path' => $offer->path,
+                'path' => $offer->target,
                 'action' => $offer->action,
                 'applied' => true,
             ];
-
-            if (!$forAgent) {
-                $output->writeln(sprintf(
-                    '  <fg=green>%s %s</>',
-                    $offer->action === 'create' ? 'Created' : 'Updated',
-                    $offer->path,
-                ));
-            }
         }
 
         if ($forAgent) {
@@ -128,6 +134,42 @@ final class Accept extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * Applies a change that was proposed in full: the content travelled with
+     * the offer, so what lands is what was read.
+     */
+    private function write(Offer $offer, Output $output): void
+    {
+        (new Writer($this->filesystem, $this->baseDir))
+            ->apply(new Proposal($offer->target, $offer->was(), $offer->content(), $offer->action === 'create', 'accept'));
+
+        $output->writeln(sprintf(
+            '  <fg=green>%s %s</>',
+            $offer->action === 'create' ? 'Created' : 'Updated',
+            $offer->target,
+        ));
+    }
+
+    /**
+     * Generates the one thing this offer named, through the same generator the
+     * interactive runner uses. The generators never overwrite, so an offer
+     * whose subject now exists quietly does nothing rather than clobbering it.
+     */
+    private function generate(Offer $offer, Output $output): void
+    {
+        $candidates = is_array($offer->data['candidates'] ?? null) ? $offer->data['candidates'] : [];
+
+        $generator = new CodeGenerator(
+            ltrim($this->config->getSrcPath(), './'),
+            ltrim($this->config->getSpecPath(), './'),
+            false,
+            $this->config->getSpecSuffix(),
+            $this->config->getPsr4Prefix(),
+        );
+
+        $generator->apply($output, GenerationCandidates::fromArray($candidates), $offer->action === 'fake_method');
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Accept.php
+++ b/src/PhpSpec/Console/Command/Accept.php
@@ -28,7 +28,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument as Argument;
 use Symfony\Component\Console\Input\InputInterface as Input;
 use Symfony\Component\Console\Input\InputOption as Option;
-use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 
 /**
@@ -91,7 +91,7 @@ final class Accept extends Command
                 );
             }
 
-            if ($offer->staleAgainst($this->contentOf($offer->target))) {
+            if ($offer->kind === Offer::WRITE && $offer->staleAgainst($this->contentOf($offer->target))) {
                 return $this->refuse(
                     sprintf('Offer "%s" no longer fits %s, which changed since the offer was made.', $id, $offer->target),
                     $forAgent,
@@ -113,7 +113,7 @@ final class Accept extends Command
     private function take(array $offers, bool $forAgent, Output $output): int
     {
         $receipts = [];
-        $notes = $forAgent ? new BufferedOutput() : $output;
+        $notes = $forAgent ? new NullOutput() : $output;
 
         foreach ($offers as $offer) {
             match ($offer->kind) {

--- a/src/PhpSpec/Console/Command/Accept.php
+++ b/src/PhpSpec/Console/Command/Accept.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Command;
+
+use PhpSpec\Ai\Agent\Proposal;
+use PhpSpec\Ai\Agent\Writer;
+use PhpSpec\Filesystem;
+use PhpSpec\Offers\Offer;
+use PhpSpec\Offers\OfferBook;
+use PhpSpec\RealFilesystem;
+use PhpSpec\Report\Formatter\Agent\Schema;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument as Argument;
+use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Input\InputOption as Option;
+use Symfony\Component\Console\Output\OutputInterface as Output;
+
+/**
+ * @internal
+ * Takes an offer PhpSpec made earlier, by its id.
+ *
+ * Deciding requires seeing, and seeing happened in an earlier command, so this
+ * is where a decision is carried out: it applies exactly what was shown, or
+ * refuses, and never something else. Nothing is applied unless every named
+ * offer can be, so a batch cannot leave the project half changed.
+ */
+final class Accept extends Command
+{
+    private readonly Filesystem $filesystem;
+
+    private readonly OfferBook $book;
+
+    public function __construct(?Filesystem $filesystem = null, ?OfferBook $book = null, private readonly ?string $baseDir = null)
+    {
+        $this->filesystem = $filesystem ?? new RealFilesystem();
+        $this->book = $book ?? new OfferBook($this->filesystem, $baseDir);
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('accept')
+            ->setDescription('Apply an offer PhpSpec made, by its id')
+            ->setDefinition([
+                new Argument('offer', Argument::REQUIRED | Argument::IS_ARRAY, 'The id of an offer to apply'),
+            ])
+            ->addOption('format', 'f', Option::VALUE_REQUIRED, 'Output format: pretty, or agent (machine-readable JSON receipt for coding agents)', 'pretty');
+    }
+
+    protected function execute(Input $input, Output $output): int
+    {
+        $forAgent = $input->getOption('format') === 'agent';
+        /** @var list<string> $ids */
+        $ids = (array) $input->getArgument('offer');
+
+        $taking = [];
+
+        foreach ($ids as $id) {
+            $offer = $this->book->find($id);
+
+            if ($offer === null) {
+                return $this->refuse(
+                    sprintf('No offer "%s" is on the table. Offers are made by the command that proposes the change; run it again to get a fresh one.', $id),
+                    $forAgent,
+                    $output,
+                );
+            }
+
+            if ($offer->staleAgainst($this->contentOf($offer->path))) {
+                return $this->refuse(
+                    sprintf('Offer "%s" no longer fits %s, which changed since the offer was made.', $id, $offer->path),
+                    $forAgent,
+                    $output,
+                );
+            }
+
+            $taking[] = $offer;
+        }
+
+        return $this->take($taking, $forAgent, $output);
+    }
+
+    /**
+     * Applies the offers, all of which were checked first.
+     *
+     * @param list<Offer> $offers
+     */
+    private function take(array $offers, bool $forAgent, Output $output): int
+    {
+        $writer = new Writer($this->filesystem, $this->baseDir);
+        $receipts = [];
+
+        foreach ($offers as $offer) {
+            $writer->apply(new Proposal($offer->path, $offer->was, $offer->content, $offer->action === 'create', 'accept'));
+
+            $receipts[] = [
+                'id' => $offer->id,
+                'path' => $offer->path,
+                'action' => $offer->action,
+                'applied' => true,
+            ];
+
+            if (!$forAgent) {
+                $output->writeln(sprintf(
+                    '  <fg=green>%s %s</>',
+                    $offer->action === 'create' ? 'Created' : 'Updated',
+                    $offer->path,
+                ));
+            }
+        }
+
+        if ($forAgent) {
+            $this->emit(['v' => Schema::V, 'action' => 'accept', 'accepted' => $receipts], $output);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Reports why nothing was applied, on whichever channel the caller reads.
+     */
+    private function refuse(string $problem, bool $forAgent, Output $output): int
+    {
+        if ($forAgent) {
+            $this->emit(['v' => Schema::V, 'action' => 'accept', 'accepted' => [], 'error' => $problem], $output);
+
+            return 1;
+        }
+
+        $output->writeln(sprintf('<fg=red>%s</>', $problem));
+
+        return 1;
+    }
+
+    /**
+     * The file's content now, or null when it is not there.
+     */
+    private function contentOf(string $path): ?string
+    {
+        $file = ($this->baseDir ?? (getcwd() ?: '.')) . '/' . $path;
+
+        return $this->filesystem->exists($file) ? $this->filesystem->read($file) : null;
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     */
+    private function emit(array $document, Output $output): void
+    {
+        $json = json_encode($document, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+
+        $output->write($json . "\n", false, Output::OUTPUT_RAW);
+    }
+}

--- a/src/PhpSpec/Console/Command/Describe.php
+++ b/src/PhpSpec/Console/Command/Describe.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec\Console\Command;
 
+use PhpSpec\CodeGeneration\PhpName;
 use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Report\Formatter\Agent\Schema;
 use Symfony\Component\Console\Command\Command;
@@ -71,10 +72,24 @@ final class Describe extends Command
      */
     protected function execute(Input $input, Output $output): int
     {
-        $class = $input->getArgument('class');
+        $class = (string) $input->getArgument('class');
+        $method = (string) $input->getOption('exemplify');
+        $forAgent = $input->getOption('agent') || $input->getOption('format') === 'agent';
+
+        // Refused before anything is written: a spec named after something PHP
+        // cannot parse is not a bad spec, it is a file that stops the suite
+        // from loading.
+        $problem = trim($class) === ''
+            ? 'Describe what? Name the class, for example: describe App\\Basket'
+            : PhpName::classProblem($class) ?? ($method !== '' ? PhpName::methodProblem($method) : null);
+
+        if ($problem !== null) {
+            return $this->refuse($problem, $forAgent, $output);
+        }
+
         $spec = str_replace('\\', '/', $class);
 
-        if ($input->getOption('agent') || $input->getOption('format') === 'agent') {
+        if ($forAgent) {
             return $this->describeForAgent($spec, $input, $output);
         }
 
@@ -103,6 +118,33 @@ final class Describe extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * Reports a name the command will not write, on whichever channel the
+     * caller reads: a machine consumer gets the refusal as its receipt rather
+     * than as prose it cannot parse.
+     *
+     * @param string $problem why the name was refused
+     * @param bool $forAgent whether the caller asked for the machine-readable receipt
+     * @param Output $output the console output
+     * @return int the exit code (always 1)
+     */
+    private function refuse(string $problem, bool $forAgent, Output $output): int
+    {
+        if ($forAgent) {
+            $json = json_encode(
+                ['v' => Schema::V, 'action' => 'describe', 'error' => $problem],
+                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ) ?: '{}';
+            $output->write($json . "\n", false, Output::OUTPUT_RAW);
+
+            return 1;
+        }
+
+        $output->writeln(sprintf('<fg=red>%s</>', $problem));
+
+        return 1;
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Exemplify.php
+++ b/src/PhpSpec/Console/Command/Exemplify.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec\Console\Command;
 
+use PhpSpec\CodeGeneration\PhpName;
 use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Report\Formatter\Agent\Schema;
 use Symfony\Component\Console\Command\Command;
@@ -53,14 +54,36 @@ final class Exemplify extends Command
 
     protected function execute(Input $input, Output $output): int
     {
-        $class = $input->getArgument('class');
-        $method = $input->getArgument('method');
+        $class = (string) $input->getArgument('class');
+        $method = (string) $input->getArgument('method');
+        $forAgent = $input->getOption('agent') || $input->getOption('format') === 'agent';
+
+        // Both names are judged before either is written: an invalid method must
+        // not leave a spec file behind as a souvenir of a refused command.
+        $problem = PhpName::classProblem($class) ?? PhpName::methodProblem($method);
+
+        if ($problem !== null) {
+            if ($forAgent) {
+                $json = json_encode(
+                    ['v' => Schema::V, 'action' => 'exemplify', 'error' => $problem],
+                    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+                ) ?: '{}';
+                $output->write($json . "\n", false, Output::OUTPUT_RAW);
+
+                return 1;
+            }
+
+            $output->writeln(sprintf('<fg=red>%s</>', $problem));
+
+            return 1;
+        }
+
         $spec = str_replace('\\', '/', $class);
 
         $this->generator->generate($spec);
         $added = $this->generator->addExample($spec, $method);
 
-        if ($input->getOption('agent') || $input->getOption('format') === 'agent') {
+        if ($forAgent) {
             $receipt = [
                 'v' => Schema::V,
                 'action' => 'exemplify',

--- a/src/PhpSpec/Console/Command/Generate.php
+++ b/src/PhpSpec/Console/Command/Generate.php
@@ -156,7 +156,7 @@ final class Generate extends Command
         }
 
         $presenter = new OutcomePresenter();
-        $document = $presenter->document('generate', $outcome, array_fill(0, count($offers), false));
+        $document = $presenter->document('generate', $outcome);
 
         foreach ($offers as $index => $offer) {
             $document['proposals'][$index]['id'] = $offer->id;

--- a/src/PhpSpec/Console/Command/Generate.php
+++ b/src/PhpSpec/Console/Command/Generate.php
@@ -23,6 +23,8 @@ use PhpSpec\Ai\Contracts\ProviderInterface;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Refactor\Diff;
 use PhpSpec\Filesystem;
+use PhpSpec\Offers\Offer;
+use PhpSpec\Offers\OfferBook;
 use PhpSpec\RealFilesystem;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -63,7 +65,7 @@ final class Generate extends Command
             ->setName('generate')
             ->setDescription('Generate a feature, steps, spec, or code from a natural-language instruction (requires AI)')
             ->addArgument('instruction', Argument::IS_ARRAY, 'What to build, in plain English')
-            ->addOption('format', 'f', Option::VALUE_REQUIRED, 'Output format: pretty, or agent (machine-readable JSON; applies without prompting)', 'pretty');
+            ->addOption('format', 'f', Option::VALUE_REQUIRED, 'Output format: pretty, or agent (machine-readable JSON receipt for coding agents)', 'pretty');
     }
 
     protected function execute(Input $input, Output $output): int
@@ -105,39 +107,79 @@ final class Generate extends Command
         }
 
         $writer = new Writer($this->filesystem);
+        $offered = [];
+
         foreach ($outcome->proposals as $proposal) {
             $this->showDiff($output, $proposal);
 
-            if ($input->isInteractive() && !$this->confirm($input, $output)) {
-                $output->writeln('  <fg=gray>Left unchanged.</>');
+            if ($input->isInteractive()) {
+                if (!$this->confirm($input, $output)) {
+                    $output->writeln('  <fg=gray>Left unchanged.</>');
+
+                    continue;
+                }
+
+                $writer->apply($proposal);
+                $output->writeln(sprintf('  <fg=green>%s %s</>', $proposal->isNew ? 'Created' : 'Updated', $proposal->path));
 
                 continue;
             }
 
-            $writer->apply($proposal);
-            $output->writeln(sprintf('  <fg=green>%s %s</>', $proposal->isNew ? 'Created' : 'Updated', $proposal->path));
+            // Nobody to ask is not the same as a yes. The change waits on the
+            // table under an id, for whoever reads this to accept.
+            $offered[] = $this->offer($proposal);
+        }
+
+        if ($offered !== []) {
+            $this->book()->record(...$offered);
+            $output->writeln('');
+            foreach ($offered as $offer) {
+                $output->writeln(sprintf('  <fg=yellow>Offered %s</> <fg=gray>%s</>', $offer->id, $offer->path));
+            }
+            $output->writeln(sprintf('  <fg=gray>Apply with:</> phpspec accept %s', implode(' ', array_map(static fn(Offer $offer): string => $offer->id, $offered))));
         }
 
         return 0;
     }
 
     /**
-     * The agent path: a machine consumer is never prompted, so every proposal
-     * applies, and the one JSON document carries the receipts (path, action,
-     * applied), never file content: the agent reads the files it now owns.
+     * The agent path: nothing is applied here either. Each proposal goes on the
+     * table with an id, and the receipt names it, so the reader accepts what it
+     * has actually read rather than whatever a second call would produce.
      */
     private function generateForAgent(Output $output, Outcome $outcome): int
     {
-        $writer = new Writer($this->filesystem);
-        $applied = [];
-        foreach ($outcome->proposals as $proposal) {
-            $writer->apply($proposal);
-            $applied[] = true;
+        $offers = array_map(fn(Proposal $proposal): Offer => $this->offer($proposal), $outcome->proposals);
+
+        if ($offers !== []) {
+            $this->book()->record(...$offers);
         }
 
-        $output->write((new OutcomePresenter())->render('generate', $outcome, $applied), false, Output::OUTPUT_RAW);
+        $presenter = new OutcomePresenter();
+        $document = $presenter->document('generate', $outcome, array_fill(0, count($offers), false));
+
+        foreach ($offers as $index => $offer) {
+            $document['proposals'][$index]['id'] = $offer->id;
+        }
+
+        $json = json_encode($document, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+        $output->write($json . "\n", false, Output::OUTPUT_RAW);
 
         return $outcome->proposals === [] ? 1 : 0;
+    }
+
+    /**
+     * The proposal as an offer that can be accepted later, remembering the file
+     * as it stands now so a stale acceptance is refused.
+     */
+    private function offer(Proposal $proposal): Offer
+    {
+        return Offer::write($proposal->path, $proposal->new, $proposal->isNew, $proposal->old);
+    }
+
+    private function book(): OfferBook
+    {
+        return new OfferBook($this->filesystem);
     }
 
     /**

--- a/src/PhpSpec/Console/Command/Generate.php
+++ b/src/PhpSpec/Console/Command/Generate.php
@@ -134,7 +134,7 @@ final class Generate extends Command
             $this->book()->record(...$offered);
             $output->writeln('');
             foreach ($offered as $offer) {
-                $output->writeln(sprintf('  <fg=yellow>Offered %s</> <fg=gray>%s</>', $offer->id, $offer->path));
+                $output->writeln(sprintf('  <fg=yellow>Offered %s</> <fg=gray>%s</>', $offer->id, $offer->target));
             }
             $output->writeln(sprintf('  <fg=gray>Apply with:</> phpspec accept %s', implode(' ', array_map(static fn(Offer $offer): string => $offer->id, $offered))));
         }

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -28,9 +28,12 @@ use PhpSpec\Extensions\FormatterBridge;
 use PhpSpec\FilterRegistry;
 use PhpSpec\LineTargetRegistry;
 use PhpSpec\Loader;
+use PhpSpec\Offers\Offer;
+use PhpSpec\Offers\OfferBook;
 use PhpSpec\Parallel\ParallelRunner;
 use PhpSpec\Report\Formatter;
 use PhpSpec\Report\Formatter\Agent;
+use PhpSpec\Report\Formatter\Agent\Offers;
 use PhpSpec\Report\Formatter\Agent\ShutdownProcessEnd;
 use PhpSpec\Report\Formatter\Dot;
 use PhpSpec\Report\Formatter\Html;
@@ -280,6 +283,12 @@ final class Run extends Command
             ));
         } elseif (!in_array($this->resolveFormat($input), ['junit', 'html', 'agent'], true)) {
             $this->generateCode($prose, $results, (bool) $input->getOption('fake'), $input->isInteractive());
+        }
+
+        if ($formatter instanceof Agent) {
+            // A reader that was told about an offer can take it later by id,
+            // so what was reported has to still be there when they do.
+            $this->recordOffers($results);
         }
 
         return $results->status();
@@ -752,6 +761,30 @@ final class Run extends Command
      * @param bool $interactive whether generation should prompt (false = auto-accept)
      * @return CodeGenerator
      */
+    /**
+     * Puts this run's generation offers on the table under the same ids the
+     * document reports, so `phpspec accept <id>` generates exactly the one that
+     * was read. Both sides derive the id from the offer itself, so neither has
+     * to tell the other what it chose.
+     */
+    private function recordOffers(SuiteResult $results): void
+    {
+        $candidates = $this->codeGenerator(false)->scan($results)->toArray();
+        $offers = [];
+
+        foreach (Offers::fromCandidates($candidates) as $offer) {
+            $offers[] = Offer::generate(
+                $offer['action'],
+                $offer['target'],
+                Offers::candidateFor($candidates, $offer['action'], $offer['target']),
+            );
+        }
+
+        if ($offers !== []) {
+            (new OfferBook())->record(...$offers);
+        }
+    }
+
     private function codeGenerator(bool $interactive): CodeGenerator
     {
         return new CodeGenerator(

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -18,6 +18,7 @@ use DOMException;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Run\CodeGenerator;
 use PhpSpec\Console\Command\Run\CoverageReporter;
+use PhpSpec\Console\Command\Run\GenerationCandidates;
 use PhpSpec\Console\Command\Run\GenerationReport;
 use PhpSpec\Console\Command\Run\RunOutcome;
 use PhpSpec\Console\Command\Run\SuiteSummary;
@@ -66,6 +67,11 @@ final class Run extends Command
     /** @var array<int, string> partial coverage state files written by parallel workers */
     private array $coveragePartials = [];
 
+    /** What this run could generate, scanned once and shared by everything that reports it. */
+    private ?GenerationCandidates $candidates = null;
+
+    private readonly OfferBook $offers;
+
     /**
      * @param Loader $loader the spec/feature file loader
      * @param Runner $runner the spec runner
@@ -76,7 +82,10 @@ final class Run extends Command
         private readonly Runner $runner,
         private readonly Configuration $config = new Configuration('.'),
         private readonly ?ExtensionLoader $extensionLoader = null,
+        ?OfferBook $offers = null,
     ) {
+        $this->offers = $offers ?? new OfferBook();
+
         parent::__construct();
     }
 
@@ -679,7 +688,7 @@ final class Run extends Command
             'html' => new Html($output),
             'agent' => new Agent(
                 $output,
-                fn(SuiteResult $results) => $this->codeGenerator(false)->scan($results)->toArray(),
+                fn(SuiteResult $results) => $this->candidates($results)->toArray(),
                 new ShutdownProcessEnd(),
             ),
             default => new Pretty($output),
@@ -769,20 +778,30 @@ final class Run extends Command
      */
     private function recordOffers(SuiteResult $results): void
     {
-        $candidates = $this->codeGenerator(false)->scan($results)->toArray();
+        $candidates = $this->candidates($results);
         $offers = [];
 
-        foreach (Offers::fromCandidates($candidates) as $offer) {
+        foreach (Offers::fromCandidates($candidates->toArray()) as $offer) {
             $offers[] = Offer::generate(
                 $offer['action'],
                 $offer['target'],
-                Offers::candidateFor($candidates, $offer['action'], $offer['target']),
+                $this->candidates($results)->only($offer['action'], $offer['target'])->toArray(),
             );
         }
 
         if ($offers !== []) {
-            (new OfferBook())->record(...$offers);
+            $this->offers->record(...$offers);
         }
+    }
+
+    /**
+     * What this run could generate, scanned once: the document reports it and
+     * the offer book records it, and walking every result twice to say the same
+     * thing would be work for nothing.
+     */
+    private function candidates(SuiteResult $results): GenerationCandidates
+    {
+        return $this->candidates ??= $this->codeGenerator(false)->scan($results);
     }
 
     private function codeGenerator(bool $interactive): CodeGenerator

--- a/src/PhpSpec/Console/Command/Run/GenerationCandidates.php
+++ b/src/PhpSpec/Console/Command/Run/GenerationCandidates.php
@@ -46,6 +46,39 @@ final readonly class GenerationCandidates
     ) {}
 
     /**
+     * The candidates behind one offer alone, so accepting it generates that and
+     * nothing else. The action names live here, beside the lists they select,
+     * rather than in whatever happens to be reporting them.
+     *
+     * @param string $action the offer's action, e.g. create_class
+     * @param string $target what that offer would generate
+     */
+    public function only(string $action, string $target): self
+    {
+        $named = static fn(array $method): string => (string) ($method['className'] ?? '') . '::' . (string) ($method['methodName'] ?? '');
+        $matching = static fn(array $methods): array => array_values(array_filter(
+            $methods,
+            static fn(array $method): bool => $named($method) === $target,
+        ));
+        $named_ = static fn(array $fqcns): array => array_values(array_filter($fqcns, static fn(string $fqcn): bool => $fqcn === $target));
+
+        return match ($action) {
+            'create_class' => new self(
+                missingSpecClasses: $named_($this->missingSpecClasses),
+                missingStepClasses: $named_($this->missingStepClasses),
+            ),
+            'create_interface' => new self(missingMockTypes: $named_($this->missingMockTypes)),
+            'create_method' => new self(
+                undefinedMockInterfaceMethods: $matching($this->undefinedMockInterfaceMethods),
+                undefinedClassMethods: $matching($this->undefinedClassMethods),
+            ),
+            'fake_method' => new self(fakeableMethods: $matching($this->fakeableMethods)),
+            'create_steps' => new self(undefinedSteps: array_intersect_key($this->undefinedSteps, [$target => true])),
+            default => new self(),
+        };
+    }
+
+    /**
      * Returns whether there is nothing to generate.
      *
      * @return bool true when every candidate list is empty

--- a/src/PhpSpec/InProcessRunner.php
+++ b/src/PhpSpec/InProcessRunner.php
@@ -219,6 +219,11 @@ final class InProcessRunner
                         $result['instruction'] = [];
                     }
                     $result['instruction'][] = $part;
+                } elseif ($command === 'accept') {
+                    if (!isset($result['offer']) || !is_array($result['offer'])) {
+                        $result['offer'] = [];
+                    }
+                    $result['offer'][] = $part;
                 }
             }
         }

--- a/src/PhpSpec/Offers/Offer.php
+++ b/src/PhpSpec/Offers/Offer.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Offers;
+
+/**
+ * @internal
+ * Something PhpSpec will do if you say yes, kept where you can say yes to it
+ * later.
+ *
+ * A reader has to see an offer before accepting it, and what a model proposes
+ * cannot be rediscovered by asking again, so an offer carries an identity and
+ * everything needed to carry it out. It also remembers the file as it was when
+ * it was made: accepting an offer that no longer fits the code would apply a
+ * decision to something the reader never saw.
+ */
+final readonly class Offer
+{
+    /**
+     * @param string $id how to refer to this offer
+     * @param string $kind what sort of thing accepting it does
+     * @param string $action what it does to the target: create or update
+     * @param string $path the project-relative file it targets
+     * @param string $content the complete content it would write
+     * @param string $was the file's content when the offer was made, empty for a new file
+     */
+    private function __construct(
+        public string $id,
+        public string $kind,
+        public string $action,
+        public string $path,
+        public string $content,
+        public string $was,
+    ) {}
+
+    /**
+     * An offer to write a file.
+     *
+     * @param string $path the project-relative path
+     * @param string $content the complete proposed content
+     * @param bool $isNew whether the file does not exist yet
+     * @param string $was the current content, empty for a new file
+     */
+    public static function write(string $path, string $content, bool $isNew, string $was = ''): self
+    {
+        return new self(
+            self::identify($path, $content),
+            'write',
+            $isNew ? 'create' : 'update',
+            $path,
+            $content,
+            $was,
+        );
+    }
+
+    /**
+     * Whether the code has moved on since the offer was made, in which case
+     * accepting it would apply a decision taken about something else.
+     *
+     * @param string|null $current the file's content now, or null when it is not there
+     */
+    public function staleAgainst(?string $current): bool
+    {
+        if ($this->action === 'create') {
+            return $current !== null;
+        }
+
+        return $current === null || $current !== $this->was;
+    }
+
+    /**
+     * @return array<string, string> the offer as it is stored
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'kind' => $this->kind,
+            'action' => $this->action,
+            'path' => $this->path,
+            'content' => $this->content,
+            'was' => $this->was,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $stored one offer as it was stored
+     */
+    public static function fromArray(array $stored): self
+    {
+        return new self(
+            (string) ($stored['id'] ?? ''),
+            (string) ($stored['kind'] ?? 'write'),
+            (string) ($stored['action'] ?? 'update'),
+            (string) ($stored['path'] ?? ''),
+            (string) ($stored['content'] ?? ''),
+            (string) ($stored['was'] ?? ''),
+        );
+    }
+
+    /**
+     * The identity of an offer, derived from what it would do rather than
+     * invented, so an offer that is still on the table keeps the same id from
+     * one run to the next and a reader can tell it apart from a new one.
+     */
+    private static function identify(string $path, string $content): string
+    {
+        return 'o_' . substr(sha1($path . "\0" . $content), 0, 8);
+    }
+}

--- a/src/PhpSpec/Offers/Offer.php
+++ b/src/PhpSpec/Offers/Offer.php
@@ -35,7 +35,7 @@ final readonly class Offer
 
     /**
      * @param string $id how to refer to this offer
-     * @param string $kind write, generate, or command
+     * @param string $kind write or generate
      * @param string $action what accepting does, in the reader's terms
      * @param string $target what it affects: a file path, a class, or an invocation
      * @param array<string, mixed> $data everything else the kind needs to be carried out

--- a/src/PhpSpec/Offers/Offer.php
+++ b/src/PhpSpec/Offers/Offer.php
@@ -19,33 +19,38 @@ namespace PhpSpec\Offers;
  * Something PhpSpec will do if you say yes, kept where you can say yes to it
  * later.
  *
- * A reader has to see an offer before accepting it, and what a model proposes
- * cannot be rediscovered by asking again, so an offer carries an identity and
- * everything needed to carry it out. It also remembers the file as it was when
- * it was made: accepting an offer that no longer fits the code would apply a
- * decision to something the reader never saw.
+ * Deciding requires seeing, and seeing happens in an earlier command than
+ * accepting, so an offer carries an identity and everything needed to carry it
+ * out. The identity is derived from what the offer would do rather than
+ * invented, so an offer still on the table keeps its id from one run to the
+ * next and two commands can name the same offer without agreeing in advance.
+ *
+ * Two kinds, one shape: a change to write, whose content travels with it, and a
+ * piece of code to generate, whose recipe does.
  */
 final readonly class Offer
 {
+    public const WRITE = 'write';
+    public const GENERATE = 'generate';
+
     /**
      * @param string $id how to refer to this offer
-     * @param string $kind what sort of thing accepting it does
-     * @param string $action what it does to the target: create or update
-     * @param string $path the project-relative file it targets
-     * @param string $content the complete content it would write
-     * @param string $was the file's content when the offer was made, empty for a new file
+     * @param string $kind write, generate, or command
+     * @param string $action what accepting does, in the reader's terms
+     * @param string $target what it affects: a file path, a class, or an invocation
+     * @param array<string, mixed> $data everything else the kind needs to be carried out
      */
     private function __construct(
         public string $id,
         public string $kind,
         public string $action,
-        public string $path,
-        public string $content,
-        public string $was,
+        public string $target,
+        public array $data = [],
     ) {}
 
     /**
-     * An offer to write a file.
+     * An offer to write a file, remembering the file as it stands so a stale
+     * acceptance can be refused.
      *
      * @param string $path the project-relative path
      * @param string $content the complete proposed content
@@ -55,32 +60,72 @@ final readonly class Offer
     public static function write(string $path, string $content, bool $isNew, string $was = ''): self
     {
         return new self(
-            self::identify($path, $content),
-            'write',
+            self::identify(self::WRITE, $path, $content),
+            self::WRITE,
             $isNew ? 'create' : 'update',
             $path,
-            $content,
-            $was,
+            ['content' => $content, 'was' => $was],
         );
     }
 
     /**
-     * Whether the code has moved on since the offer was made, in which case
-     * accepting it would apply a decision taken about something else.
+     * An offer to generate code PhpSpec knows how to write: a missing class, an
+     * interface, a method, step definitions. The candidate travels with the
+     * offer, so accepting generates exactly what was reported.
+     *
+     * @param string $action the generation action, e.g. create_class
+     * @param string $target what would be generated
+     * @param array<string, mixed> $candidates the serialised GenerationCandidates holding only this one
+     */
+    public static function generate(string $action, string $target, array $candidates): self
+    {
+        return new self(
+            self::identify(self::GENERATE, $action, $target),
+            self::GENERATE,
+            $action,
+            $target,
+            ['candidates' => $candidates],
+        );
+    }
+
+    /**
+     * The complete content a write offer would put in the file.
+     */
+    public function content(): string
+    {
+        return is_string($this->data['content'] ?? null) ? $this->data['content'] : '';
+    }
+
+    /**
+     * The file's content when a write offer was made, empty for a new file.
+     */
+    public function was(): string
+    {
+        return is_string($this->data['was'] ?? null) ? $this->data['was'] : '';
+    }
+
+    /**
+     * Whether the code has moved on since a write offer was made, in which case
+     * accepting it would apply a decision taken about something else. Only a
+     * write can go stale: the generators never overwrite.
      *
      * @param string|null $current the file's content now, or null when it is not there
      */
     public function staleAgainst(?string $current): bool
     {
+        if ($this->kind !== self::WRITE) {
+            return false;
+        }
+
         if ($this->action === 'create') {
             return $current !== null;
         }
 
-        return $current === null || $current !== $this->was;
+        return $current === null || $current !== $this->was();
     }
 
     /**
-     * @return array<string, string> the offer as it is stored
+     * @return array<string, mixed> the offer as it is stored
      */
     public function toArray(): array
     {
@@ -88,9 +133,8 @@ final readonly class Offer
             'id' => $this->id,
             'kind' => $this->kind,
             'action' => $this->action,
-            'path' => $this->path,
-            'content' => $this->content,
-            'was' => $this->was,
+            'target' => $this->target,
+            'data' => $this->data,
         ];
     }
 
@@ -101,21 +145,18 @@ final readonly class Offer
     {
         return new self(
             (string) ($stored['id'] ?? ''),
-            (string) ($stored['kind'] ?? 'write'),
+            (string) ($stored['kind'] ?? self::WRITE),
             (string) ($stored['action'] ?? 'update'),
-            (string) ($stored['path'] ?? ''),
-            (string) ($stored['content'] ?? ''),
-            (string) ($stored['was'] ?? ''),
+            (string) ($stored['target'] ?? ''),
+            is_array($stored['data'] ?? null) ? $stored['data'] : [],
         );
     }
 
     /**
-     * The identity of an offer, derived from what it would do rather than
-     * invented, so an offer that is still on the table keeps the same id from
-     * one run to the next and a reader can tell it apart from a new one.
+     * The identity of an offer, derived from what it would do.
      */
-    private static function identify(string $path, string $content): string
+    private static function identify(string $kind, string $first, string $second): string
     {
-        return 'o_' . substr(sha1($path . "\0" . $content), 0, 8);
+        return 'o_' . substr(sha1($kind . "\0" . $first . "\0" . $second), 0, 8);
     }
 }

--- a/src/PhpSpec/Offers/OfferBook.php
+++ b/src/PhpSpec/Offers/OfferBook.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Offers;
+
+use PhpSpec\Filesystem;
+use PhpSpec\RealFilesystem;
+
+/**
+ * @internal
+ * Where offers wait between being made and being taken.
+ *
+ * A reader accepts an offer in a later command than the one that made it, so
+ * the offer has to outlive its own process. The book keeps the most recent ones
+ * and nothing else: it is a place to look something up by id, not a history.
+ */
+final class OfferBook
+{
+    /** How many offers stay on the table. Older ones are forgotten. */
+    public const KEPT = 50;
+
+    private const PATH = '.phpspec/offers.json';
+
+    private readonly Filesystem $filesystem;
+
+    public function __construct(?Filesystem $filesystem = null, private readonly ?string $baseDir = null)
+    {
+        $this->filesystem = $filesystem ?? new RealFilesystem();
+    }
+
+    /**
+     * Puts offers on the table, newest last, without recording the same offer
+     * twice: an offer that is made again is the one that was already there.
+     */
+    public function record(Offer ...$offers): void
+    {
+        if ($offers === []) {
+            return;
+        }
+
+        $book = $this->all();
+
+        foreach ($offers as $offer) {
+            unset($book[$offer->id]);
+            $book[$offer->id] = $offer;
+        }
+
+        $this->store(array_slice($book, -self::KEPT, null, true));
+    }
+
+    /**
+     * The offer with this id, or null when the table never held it or has since
+     * forgotten it.
+     */
+    public function find(string $id): ?Offer
+    {
+        return $this->all()[$id] ?? null;
+    }
+
+    /**
+     * Every offer still on the table, oldest first, keyed by id.
+     *
+     * @return array<string, Offer>
+     */
+    public function all(): array
+    {
+        $path = $this->file();
+
+        if (!$this->filesystem->exists($path)) {
+            return [];
+        }
+
+        $stored = json_decode($this->filesystem->read($path), true);
+
+        if (!is_array($stored) || !is_array($stored['offers'] ?? null)) {
+            return [];
+        }
+
+        $offers = [];
+
+        foreach ($stored['offers'] as $one) {
+            if (is_array($one)) {
+                $offer = Offer::fromArray($one);
+                $offers[$offer->id] = $offer;
+            }
+        }
+
+        return $offers;
+    }
+
+    /**
+     * @param array<string, Offer> $offers
+     */
+    private function store(array $offers): void
+    {
+        $path = $this->file();
+        $dir = dirname($path);
+
+        if (!$this->filesystem->exists($dir)) {
+            $this->filesystem->mkdir($dir);
+        }
+
+        $document = [
+            'v' => 1,
+            'offers' => array_values(array_map(static fn(Offer $offer): array => $offer->toArray(), $offers)),
+        ];
+
+        $this->filesystem->write($path, (string) json_encode($document, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+    }
+
+    private function file(): string
+    {
+        return ($this->baseDir ?? (getcwd() ?: '.')) . '/' . self::PATH;
+    }
+}

--- a/src/PhpSpec/Offers/OfferBook.php
+++ b/src/PhpSpec/Offers/OfferBook.php
@@ -28,7 +28,7 @@ use PhpSpec\RealFilesystem;
 final class OfferBook
 {
     /** How many offers stay on the table. Older ones are forgotten. */
-    public const KEPT = 50;
+    private const KEPT = 50;
 
     private const PATH = '.phpspec/offers.json';
 
@@ -73,7 +73,7 @@ final class OfferBook
      *
      * @return array<string, Offer>
      */
-    public function all(): array
+    private function all(): array
     {
         $path = $this->file();
 

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -34,14 +34,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
- * Emits the whole run as a single machine-readable JSON document for a coding
- * agent: a run_started header, one entry per example (and feature step), and a
- * summary with totals. No ANSI, no prose — the failure itself is the payload.
+ * Speaks the run to a coding agent in JSON Lines: a run_started header, one
+ * event per example or scenario that needs attention as it happens, and a
+ * summary with the totals. No ANSI, no prose, and no waiting for the end of a
+ * long suite — the failure itself is the payload, delivered while the rest is
+ * still running.
  */
 final class Agent extends AbstractFormatter
 {
-    /** @var list<array<string, mixed>> the actionable entries (passing ones are omitted) */
-    private array $examples = [];
+    /** @var list<string> what each reported entry re-runs, for the summary's one command */
+    private array $rerunTargets = [];
 
     /** @var array<string, int> tally of every unit by state, including passing */
     private array $counts = [];
@@ -67,7 +69,10 @@ final class Agent extends AbstractFormatter
     /** The run's results, once it reached the end; null while it is still going. */
     private ?SuiteResult $results = null;
 
-    /** Whether the document has gone out, so it goes out exactly once. */
+    /** Whether the header has gone out, so it leads the stream exactly once. */
+    private bool $started = false;
+
+    /** Whether the summary has gone out, so it closes the stream exactly once. */
     private bool $published = false;
 
     /** What the run covered, when coverage was collected. */
@@ -110,7 +115,30 @@ final class Agent extends AbstractFormatter
         $this->seed = $seed;
     }
 
-    public function begin(): void {}
+    public function begin(): void
+    {
+        $this->start();
+    }
+
+    /**
+     * Opens the stream with the header, once. Every event goes through a caller
+     * that has started it first, so the header leads the output even when the
+     * run died before it ever began.
+     */
+    private function start(): void
+    {
+        if ($this->started) {
+            return;
+        }
+
+        $this->started = true;
+        $this->emit([
+            'v' => Schema::V,
+            'event' => Schema::EVENT_RUN_STARTED,
+            'suite' => $this->suite,
+            'seed' => $this->seed,
+        ]);
+    }
 
     public function printResult(Results $result): void
     {
@@ -182,9 +210,10 @@ final class Agent extends AbstractFormatter
     }
 
     /**
-     * Writes the document, once. Every path out of the command comes through
-     * here, so an agent reads exactly one JSON object whether the run finished,
-     * failed its coverage gate, or died: calling it twice is a no-op.
+     * Closes the stream, once. Every path out of the command comes through
+     * here, so the last line an agent reads is always the summary whether the
+     * run finished, failed its coverage gate, or died: calling it twice is a
+     * no-op.
      */
     public function publish(): void
     {
@@ -193,21 +222,44 @@ final class Agent extends AbstractFormatter
         }
 
         $this->published = true;
+        $this->start();
+
+        if ($this->fatal !== null) {
+            $this->emit([
+                'v' => Schema::V,
+                'event' => Schema::EVENT_FATAL,
+                'message' => $this->fatal['message'],
+                'at' => $this->fatal['at'],
+            ]);
+        }
+
+        $this->emit($this->summary());
+    }
+
+    /**
+     * Writes one event on a line of its own, which is the whole of the wire
+     * format: a reader decodes a line and acts on it, without waiting for the
+     * run to end.
+     *
+     * @param array<string, mixed> $event
+     */
+    private function emit(array $event): void
+    {
         // The zero fraction is kept: a float that lost it would read as the int
         // it was compared against, turning a type failure into a tautology.
-        $json = json_encode($this->document(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION) ?: '{}';
+        $json = json_encode($event, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION) ?: '{}';
 
         $this->output->write($json . "\n", false, OutputInterface::OUTPUT_RAW);
     }
 
     /**
-     * The document as it stands: the header, every actionable entry, and the
-     * totals. Built from whatever has been collected, so a run cut short still
-     * reports what it managed to see.
+     * The closing event: the totals, in the units the entries were reported in.
+     * Built from whatever has been collected, so a run cut short still reports
+     * what it managed to see.
      *
      * @return array<string, mixed>
      */
-    private function document(): array
+    private function summary(): array
     {
         $failing = $this->counts['failing'] ?? 0;
         $errors = $this->counts['error'] ?? 0;
@@ -218,57 +270,48 @@ final class Agent extends AbstractFormatter
         $shortfall = $this->coverage !== null && !$this->coverage->met() ? 1 : 0;
         $stopped = $this->fatal !== null ? 1 : 0;
 
-        $result = [
-            'suite' => [
-                'v' => Schema::V,
-                'event' => Schema::EVENT_RUN_STARTED,
-                'suite' => $this->suite,
-                'examples' => $this->exampleCount,
-                'scenarios' => $this->scenarioCount,
-                'steps' => $this->stepCount,
-                'seed' => $this->seed,
-            ],
-            'examples' => $this->examples,
-            'result' => [
-                'v' => Schema::V,
-                'event' => Schema::EVENT_SUMMARY,
-                'examples' => $this->exampleCount,
-                'scenarios' => $this->scenarioCount,
-                'steps' => $this->stepCount,
-                // Counted in the units the entries are reported in: one per
-                // example, one per scenario. Steps are a size, not a verdict.
-                'passing' => $this->counts['passing'] ?? 0,
-                'failing' => $failing,
-                'errors' => $errors,
-                'pending' => $pending,
-                'skipped' => $this->counts['skipped'] ?? 0,
-                // The one number an agent checks: everything red or unfinished
-                // (failures + errors + pending), plus a missed coverage gate and
-                // anything that stopped the run. Zero means nothing to do.
-                'actionable' => $failing + $errors + $pending + $shortfall + $stopped,
-                'duration_ms' => (int) round(($this->results?->getDuration() ?? 0.0) * 1000),
-                'offers' => $this->results !== null ? $this->offers($this->results) : [],
-            ],
+        $summary = [
+            'v' => Schema::V,
+            'event' => Schema::EVENT_SUMMARY,
+            'examples' => $this->exampleCount,
+            'scenarios' => $this->scenarioCount,
+            'steps' => $this->stepCount,
+            // Counted in the units the entries are reported in: one per
+            // example, one per scenario. Steps are a size, not a verdict.
+            'passing' => $this->counts['passing'] ?? 0,
+            'failing' => $failing,
+            'errors' => $errors,
+            'pending' => $pending,
+            'skipped' => $this->counts['skipped'] ?? 0,
+            // The one number an agent checks: everything red or unfinished
+            // (failures + errors + pending), plus a missed coverage gate and
+            // anything that stopped the run. Zero means nothing to do.
+            'actionable' => $failing + $errors + $pending + $shortfall + $stopped,
+            'duration_ms' => (int) round(($this->results?->getDuration() ?? 0.0) * 1000),
         ];
 
         $rerun = $this->rerunEverything();
         if ($rerun !== null) {
-            $result['result']['rerun'] = $rerun;
+            $summary['rerun'] = $rerun;
         }
 
         if ($this->coverage !== null) {
-            $result['result']['coverage'] = [
+            $summary['coverage'] = [
                 'percent' => round($this->coverage->percent, 1),
                 'required' => $this->coverage->required,
                 'met' => $this->coverage->met(),
             ];
         }
 
-        if ($this->fatal !== null) {
-            $result['fatal'] = $this->fatal;
+        // Present only when there is something to take, as with everything else
+        // the summary carries conditionally: an empty list reads as a promise
+        // that was never made.
+        $offers = $this->results !== null ? $this->offers($this->results) : [];
+        if ($offers !== []) {
+            $summary['offers'] = $offers;
         }
 
-        return $result;
+        return $summary;
     }
 
     /**
@@ -278,16 +321,7 @@ final class Agent extends AbstractFormatter
      */
     private function rerunEverything(): ?string
     {
-        $targets = [];
-
-        foreach ($this->examples as $entry) {
-            $rerun = $entry['rerun'] ?? null;
-            if (is_string($rerun)) {
-                $targets[] = substr($rerun, strlen('run '));
-            }
-        }
-
-        $targets = array_values(array_unique($targets));
+        $targets = array_values(array_unique($this->rerunTargets));
 
         return $targets !== [] ? 'run ' . implode(' ', $targets) : null;
     }
@@ -347,9 +381,9 @@ final class Agent extends AbstractFormatter
     }
 
     /**
-     * Counts an example by state, and keeps it in the emitted list unless it
-     * passed: a green suite of thousands need not spend tokens on entries an
-     * agent will never act on; the summary still counts them.
+     * Counts an example by state, and reports it unless it passed: a green
+     * suite of thousands need not spend tokens on entries an agent will never
+     * act on; the summary still counts them.
      *
      * @param array<string, mixed> $entry
      */
@@ -360,8 +394,26 @@ final class Agent extends AbstractFormatter
         $this->exampleCount++;
 
         if ($state !== 'passing') {
-            $this->examples[] = $entry;
+            $this->report($entry);
         }
+    }
+
+    /**
+     * Sends an entry out the moment it is known, and remembers what it re-runs
+     * so the summary can still hand over one command for the lot.
+     *
+     * @param array<string, mixed> $entry
+     */
+    private function report(array $entry): void
+    {
+        $this->start();
+
+        $rerun = $entry['rerun'] ?? null;
+        if (is_string($rerun)) {
+            $this->rerunTargets[] = substr($rerun, strlen('run '));
+        }
+
+        $this->emit($entry);
     }
 
     /**
@@ -373,6 +425,7 @@ final class Agent extends AbstractFormatter
         $name = $origin->name($example->getTitle());
         $entry = [
             'v' => Schema::V,
+            'event' => Schema::EVENT_EXAMPLE,
             'id' => $this->identify($name),
             'example' => $name,
             'state' => $state,
@@ -544,6 +597,7 @@ final class Agent extends AbstractFormatter
 
         $entry = [
             'v' => Schema::V,
+            'event' => Schema::EVENT_EXAMPLE,
             'id' => $this->identify($origin->name),
             'example' => $origin->name,
             'state' => $state,
@@ -566,7 +620,7 @@ final class Agent extends AbstractFormatter
             $this->addRerun($entry, $location);
         }
 
-        $this->examples[] = $entry;
+        $this->report($entry);
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -462,9 +462,25 @@ final class Agent extends AbstractFormatter
             }
         }
 
+        $this->attachOutput($entry, $example->getOutput());
         $this->attachNotes($entry, $example);
 
         return $entry;
+    }
+
+    /**
+     * Attaches what the subject printed while the entry ran, when it printed
+     * anything. A process a step drove, a dump left in a spec: whatever reached
+     * standard output is a diagnosis about this entry, and it is reported here
+     * rather than mixed into the stream the document is written on.
+     *
+     * @param array<string, mixed> $entry
+     */
+    private function attachOutput(array &$entry, string $printed): void
+    {
+        if ($printed !== '') {
+            $entry['output'] = ValueExporter::exportOutput($printed);
+        }
     }
 
     /**
@@ -580,6 +596,7 @@ final class Agent extends AbstractFormatter
         $state = 'passing';
         $message = null;
         $expectation = [];
+        $printed = '';
 
         foreach ($scenario->getResults() as $step) {
             if (!$step instanceof StepResult) {
@@ -588,6 +605,10 @@ final class Agent extends AbstractFormatter
 
             $this->stepCount++;
             $stepState = $this->stepState($step);
+            // Every step's, passing ones included: a scenario that shells out
+            // usually does it in a step that worked, and reads the result in the
+            // one that broke.
+            $printed .= $step->getOutput();
 
             if ($stepState === 'passing') {
                 continue;
@@ -638,6 +659,7 @@ final class Agent extends AbstractFormatter
             $entry['message'] = $message;
         }
 
+        $this->attachOutput($entry, $printed);
         $entry['steps'] = $steps;
 
         // A scenario is addressed by the line its keyword sits on, which is what

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -433,17 +433,7 @@ final class Agent extends AbstractFormatter
 
         if ($state === 'failing') {
             $match = $this->failingMatch($example);
-            // phpspec names these from the matcher's point of view — getExpected()
-            // is the expect() subject (the value the code produced) and getActual()
-            // is the matcher's argument (the target). The agent contract uses the
-            // universal convention, so they are swapped here: actual = the subject,
-            // expected = the target.
-            $entry['expected'] = [
-                'matcher' => $match?->getMatcher(),
-                'value' => ValueExporter::export($match?->getActual()),
-                'negated' => $match?->isNegated() ?? false,
-            ];
-            $entry['actual'] = ValueExporter::export($match?->getExpected());
+            $entry += $this->expectation($match);
             $entry['message'] = $example->getMessage();
             $location = $this->location($match?->getFile(), $match?->getLine());
             $entry['spec'] = $location;
@@ -538,6 +528,31 @@ final class Agent extends AbstractFormatter
     }
 
     /**
+     * The expectation that did not hold, as the two values a reader compares.
+     * Whatever failed, an example or a story step, it is reported the same way,
+     * so nobody has to read a sentence back to find out what was wanted.
+     *
+     * phpspec names these from the matcher's point of view: getExpected() is the
+     * expect() subject (the value the code produced) and getActual() is the
+     * matcher's argument (the target). The agent contract uses the universal
+     * convention, so they are swapped here: actual = the subject, expected =
+     * the target.
+     *
+     * @return array{expected: array{matcher: string|null, value: mixed, negated: bool}, actual: mixed}
+     */
+    private function expectation(?MatchResult $match): array
+    {
+        return [
+            'expected' => [
+                'matcher' => $match?->getMatcher(),
+                'value' => ValueExporter::export($match?->getActual()),
+                'negated' => $match?->isNegated() ?? false,
+            ],
+            'actual' => ValueExporter::export($match?->getExpected()),
+        ];
+    }
+
+    /**
      * The first failing expectation of an example, or null when none failed.
      */
     private function failingMatch(ExampleResult $example): ?MatchResult
@@ -564,6 +579,7 @@ final class Agent extends AbstractFormatter
         $steps = [];
         $state = 'passing';
         $message = null;
+        $expectation = [];
 
         foreach ($scenario->getResults() as $step) {
             if (!$step instanceof StepResult) {
@@ -584,6 +600,19 @@ final class Agent extends AbstractFormatter
                 $message ??= $step->getError()->getMessage();
             }
 
+            // An expectation that did not hold puts its two values on the step,
+            // and on the scenario alongside the message it already hoists, so a
+            // reader acting on the entry never has to go a level deeper.
+            $match = $step->getMatch();
+            if ($match !== null) {
+                $reported += $this->expectation($match);
+                $at = $this->location($match->getFile(), $match->getLine());
+                if ($at !== null) {
+                    $reported['at'] = $at;
+                }
+                $expectation = $expectation !== [] ? $expectation : $this->expectation($match);
+            }
+
             $steps[] = $reported;
             $state = self::worst($state, $stepState);
         }
@@ -602,6 +631,8 @@ final class Agent extends AbstractFormatter
             'example' => $origin->name,
             'state' => $state,
         ];
+
+        $entry += $expectation;
 
         if ($message !== null) {
             $entry['message'] = $message;

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -435,9 +435,7 @@ final class Agent extends AbstractFormatter
             $match = $this->failingMatch($example);
             $entry += $this->expectation($match);
             $entry['message'] = $example->getMessage();
-            $location = $this->location($match?->getFile(), $match?->getLine());
-            $entry['spec'] = $location;
-            $this->addRerun($entry, $location);
+            $this->addLocation($entry, $this->location($match?->getFile(), $match?->getLine()));
             // No offer on a failure: the code exists and the behaviour is wrong,
             // there is nothing to generate — `state: failing` already says so.
         } elseif ($state === 'error') {
@@ -450,9 +448,7 @@ final class Agent extends AbstractFormatter
             // Mirrored, so one field answers "what went wrong" whatever the
             // state: the exception adds the class and the site, not the text.
             $entry['message'] = $error?->getMessage();
-            $location = $this->location($error?->getFile(), $error?->getLine());
-            $entry['spec'] = $location;
-            $this->addRerun($entry, $location);
+            $this->addLocation($entry, $this->location($error?->getFile(), $error?->getLine()));
             // A missing class/method/interface the error names becomes a concrete
             // offer to generate it, right on the example that hit it. Only present
             // when the error actually maps to something a generator can create.
@@ -554,17 +550,28 @@ final class Agent extends AbstractFormatter
      * convention, so they are swapped here: actual = the subject, expected =
      * the target.
      *
-     * @return array{expected: array{matcher: string|null, value: mixed, negated: bool}, actual: mixed}
+     * A failure that came back without its site came back without its detail:
+     * a parallel worker reports through JUnit, which carries the message and
+     * nothing else, and its stand-in expectation compares null with null. Only
+     * the site tells that apart from a real failure whose values are null,
+     * which is a comparison worth reporting: an anonymous matcher (any
+     * __call-based custom or predicate matcher) has no name to give either.
+     *
+     * @return array{expected?: array{matcher: string|null, value: mixed, negated: bool}, actual?: mixed}
      */
     private function expectation(?MatchResult $match): array
     {
+        if ($match === null || $this->location($match->getFile(), $match->getLine()) === null) {
+            return [];
+        }
+
         return [
             'expected' => [
-                'matcher' => $match?->getMatcher(),
-                'value' => ValueExporter::export($match?->getActual()),
-                'negated' => $match?->isNegated() ?? false,
+                'matcher' => $match->getMatcher(),
+                'value' => ValueExporter::export($match->getActual()),
+                'negated' => $match->isNegated(),
             ],
-            'actual' => ValueExporter::export($match?->getExpected()),
+            'actual' => ValueExporter::export($match->getExpected()),
         ];
     }
 
@@ -667,10 +674,8 @@ final class Agent extends AbstractFormatter
         // its own instead of dragging the whole story suite with it. Only a
         // failure is addressed, as with examples: a scenario waiting on undefined
         // steps is work to write, not work to re-run.
-        $location = $this->location($origin->path, $origin->line);
-        if ($state === 'failing' && $location !== null) {
-            $entry['spec'] = $location;
-            $this->addRerun($entry, $location);
+        if ($state === 'failing') {
+            $this->addLocation($entry, $this->location($origin->path, $origin->line));
         }
 
         $this->report($entry);
@@ -714,28 +719,34 @@ final class Agent extends AbstractFormatter
     }
 
     /**
-     * Attaches the exact line-targeted command that re-runs just this one
-     * example, so an agent can verify a single fix without a full-suite run.
-     * phpspec resolves a "spec.php:LINE" path to the example whose closure spans
-     * that line, and the expectation/error site always falls inside it — so the
-     * entry's own location is a valid target. Omitted when there is none.
+     * Attaches where the entry failed, and the exact line-targeted command that
+     * re-runs just that one, so an agent can verify a single fix without a
+     * full-suite run. phpspec resolves a "spec.php:LINE" path to the example
+     * whose closure spans that line, and the expectation/error site always
+     * falls inside it, so the entry's own location is a valid target. Both are
+     * absent when the location is not known: a key that says null is a question
+     * a reader has to ask twice.
      *
      * @param array<string, mixed> $entry
      */
-    private function addRerun(array &$entry, ?string $location): void
+    private function addLocation(array &$entry, ?string $location): void
     {
         if ($location !== null) {
+            $entry['spec'] = $location;
             $entry['rerun'] = 'run ' . $location;
         }
     }
 
     /**
      * Renders a file:line as a project-relative, forward-slashed location, or
-     * null when either part is missing.
+     * null when either part is missing. A blank file or a line of zero is
+     * missing too: a result that came back without its site (a parallel worker
+     * reports through JUnit, which carries none) must not be dressed up as
+     * ":0", which reads like a location and re-runs like nonsense.
      */
     private function location(?string $file, ?int $line): ?string
     {
-        if ($file === null || $line === null) {
+        if ($file === null || $line === null || $file === '' || $line <= 0) {
             return null;
         }
 

--- a/src/PhpSpec/Report/Formatter/Agent/Offers.php
+++ b/src/PhpSpec/Report/Formatter/Agent/Offers.php
@@ -14,6 +14,8 @@
 
 namespace PhpSpec\Report\Formatter\Agent;
 
+use PhpSpec\Offers\Offer;
+
 /**
  * @internal
  * Turns a run's code-generation candidates (the interactive runner's "shall I
@@ -26,7 +28,7 @@ final class Offers
 {
     /**
      * @param array<string, mixed> $candidates the GenerationCandidates::toArray() output
-     * @return list<array{action: string, target: string, value?: string}>
+     * @return list<array{id: string, action: string, target: string, value?: string}>
      */
     public static function fromCandidates(array $candidates): array
     {
@@ -40,7 +42,9 @@ final class Offers
             }
 
             $seen[$key] = true;
-            $offer = ['action' => $action, 'target' => $target];
+            // The id is derived, not invented, so the command that records the
+            // offer and the document that reports it agree without arranging it.
+            $offer = ['id' => Offer::generate($action, $target, [])->id, 'action' => $action, 'target' => $target];
             if ($value !== null) {
                 $offer['value'] = $value;
             }
@@ -83,25 +87,71 @@ final class Offers
      * Derives the single generation offer implied by an error message — a
      * missing class, mock interface, or method — or null when the error is not
      * something a generator can resolve. This lets each errored example carry
-     * its own offer, not just the run-wide summary.
+     * its own offer, not just the run-wide summary. Its id is the run-wide
+     * offer's id, because both are derived from the same action and target.
      *
-     * @return array{action: string, target: string}|null
+     * @return array{id: string, action: string, target: string}|null
      */
     public static function forError(string $message): ?array
     {
-        if (preg_match('/^Class "([^"]+)" not found$/', $message, $matches)) {
-            return ['action' => 'create_class', 'target' => $matches[1]];
+        $offer = match (true) {
+            preg_match('/^Class "([^"]+)" not found$/', $message, $matches) === 1
+                => ['action' => 'create_class', 'target' => $matches[1]],
+            preg_match('/Cannot create mock: class or interface \'([^\']+)\' does not exist/', $message, $matches) === 1
+                => ['action' => 'create_interface', 'target' => $matches[1]],
+            preg_match('/Call to undefined method ([^:]+)::([A-Za-z0-9_]+)\(\)/', $message, $matches) === 1
+                => ['action' => 'create_method', 'target' => $matches[1] . '::' . $matches[2]],
+            default => null,
+        };
+
+        if ($offer === null) {
+            return null;
         }
 
-        if (preg_match('/Cannot create mock: class or interface \'([^\']+)\' does not exist/', $message, $matches)) {
-            return ['action' => 'create_interface', 'target' => $matches[1]];
-        }
+        return ['id' => Offer::generate($offer['action'], $offer['target'], [])->id] + $offer;
+    }
 
-        if (preg_match('/Call to undefined method ([^:]+)::([A-Za-z0-9_]+)\(\)/', $message, $matches)) {
-            return ['action' => 'create_method', 'target' => $matches[1] . '::' . $matches[2]];
-        }
+    /**
+     * The candidates for one offer alone, so accepting it generates that and
+     * nothing else. The forward mapping above and this inverse are the same
+     * vocabulary, kept in one place so they cannot drift apart.
+     *
+     * @param array<string, mixed> $candidates the full GenerationCandidates::toArray() output
+     * @param string $action the offer's action
+     * @param string $target the offer's target
+     * @return array<string, mixed> a GenerationCandidates::toArray() shape holding only this offer
+     */
+    public static function candidateFor(array $candidates, string $action, string $target): array
+    {
+        $named = static fn(array $method): string => (string) ($method['className'] ?? '') . '::' . (string) ($method['methodName'] ?? '');
+        $matching = static fn(string $key, callable $keep): array => array_values(array_filter(
+            is_array($candidates[$key] ?? null) ? $candidates[$key] : [],
+            $keep,
+        ));
 
-        return null;
+        return match ($action) {
+            'create_class' => [
+                'missingSpecClasses' => $matching('missingSpecClasses', static fn(mixed $fqcn): bool => $fqcn === $target),
+                'missingStepClasses' => $matching('missingStepClasses', static fn(mixed $fqcn): bool => $fqcn === $target),
+            ],
+            'create_interface' => [
+                'missingMockTypes' => $matching('missingMockTypes', static fn(mixed $fqcn): bool => $fqcn === $target),
+            ],
+            'create_method' => [
+                'undefinedClassMethods' => $matching('undefinedClassMethods', static fn(mixed $m): bool => is_array($m) && $named($m) === $target),
+                'undefinedMockInterfaceMethods' => $matching('undefinedMockInterfaceMethods', static fn(mixed $m): bool => is_array($m) && $named($m) === $target),
+            ],
+            'fake_method' => [
+                'fakeableMethods' => $matching('fakeableMethods', static fn(mixed $m): bool => is_array($m) && $named($m) === $target),
+            ],
+            'create_steps' => [
+                'undefinedSteps' => array_intersect_key(
+                    is_array($candidates['undefinedSteps'] ?? null) ? $candidates['undefinedSteps'] : [],
+                    [$target => true],
+                ),
+            ],
+            default => [],
+        };
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent/Offers.php
+++ b/src/PhpSpec/Report/Formatter/Agent/Offers.php
@@ -112,49 +112,6 @@ final class Offers
     }
 
     /**
-     * The candidates for one offer alone, so accepting it generates that and
-     * nothing else. The forward mapping above and this inverse are the same
-     * vocabulary, kept in one place so they cannot drift apart.
-     *
-     * @param array<string, mixed> $candidates the full GenerationCandidates::toArray() output
-     * @param string $action the offer's action
-     * @param string $target the offer's target
-     * @return array<string, mixed> a GenerationCandidates::toArray() shape holding only this offer
-     */
-    public static function candidateFor(array $candidates, string $action, string $target): array
-    {
-        $named = static fn(array $method): string => (string) ($method['className'] ?? '') . '::' . (string) ($method['methodName'] ?? '');
-        $matching = static fn(string $key, callable $keep): array => array_values(array_filter(
-            is_array($candidates[$key] ?? null) ? $candidates[$key] : [],
-            $keep,
-        ));
-
-        return match ($action) {
-            'create_class' => [
-                'missingSpecClasses' => $matching('missingSpecClasses', static fn(mixed $fqcn): bool => $fqcn === $target),
-                'missingStepClasses' => $matching('missingStepClasses', static fn(mixed $fqcn): bool => $fqcn === $target),
-            ],
-            'create_interface' => [
-                'missingMockTypes' => $matching('missingMockTypes', static fn(mixed $fqcn): bool => $fqcn === $target),
-            ],
-            'create_method' => [
-                'undefinedClassMethods' => $matching('undefinedClassMethods', static fn(mixed $m): bool => is_array($m) && $named($m) === $target),
-                'undefinedMockInterfaceMethods' => $matching('undefinedMockInterfaceMethods', static fn(mixed $m): bool => is_array($m) && $named($m) === $target),
-            ],
-            'fake_method' => [
-                'fakeableMethods' => $matching('fakeableMethods', static fn(mixed $m): bool => is_array($m) && $named($m) === $target),
-            ],
-            'create_steps' => [
-                'undefinedSteps' => array_intersect_key(
-                    is_array($candidates['undefinedSteps'] ?? null) ? $candidates['undefinedSteps'] : [],
-                    [$target => true],
-                ),
-            ],
-            default => [],
-        };
-    }
-
-    /**
      * @param array<string, mixed> $candidates
      * @return list<string>
      */

--- a/src/PhpSpec/Report/Formatter/Agent/Schema.php
+++ b/src/PhpSpec/Report/Formatter/Agent/Schema.php
@@ -22,8 +22,11 @@ namespace PhpSpec\Report\Formatter\Agent;
  */
 final class Schema
 {
-    public const V = 1;
+    /** 2: the run answers in JSON Lines, one event per line, as it happens. */
+    public const V = 2;
 
     public const EVENT_RUN_STARTED = 'run_started';
+    public const EVENT_EXAMPLE = 'example';
+    public const EVENT_FATAL = 'fatal';
     public const EVENT_SUMMARY = 'summary';
 }

--- a/src/PhpSpec/Report/Formatter/Agent/ValueExporter.php
+++ b/src/PhpSpec/Report/Formatter/Agent/ValueExporter.php
@@ -29,6 +29,9 @@ final class ValueExporter
     private const ARRAY_MAX = 10;
     private const MAX_DEPTH = 5;
 
+    /** Printed output earns more room than a compared value: it is the diagnosis. */
+    private const OUTPUT_MAX = 4000;
+
     /**
      * Exports a value to a JSON-encodable representation.
      *
@@ -52,20 +55,31 @@ final class ValueExporter
     }
 
     /**
+     * Exports what a subject printed, under a cap of its own: a compared value
+     * is a value, but printed output is the diagnosis and is worth more room.
+     *
+     * @return string|array{truncated: true, length: int, value: string}
+     */
+    public static function exportOutput(string $value): string|array
+    {
+        return self::exportString($value, self::OUTPUT_MAX);
+    }
+
+    /**
      * Returns the string as-is, or a truncation marker when it exceeds the cap.
      *
      * @return string|array{truncated: true, length: int, value: string}
      */
-    private static function exportString(string $value): string|array
+    private static function exportString(string $value, int $max = self::STRING_MAX): string|array
     {
-        if (mb_strlen($value) <= self::STRING_MAX) {
+        if (mb_strlen($value) <= $max) {
             return $value;
         }
 
         return [
             'truncated' => true,
             'length' => mb_strlen($value),
-            'value' => mb_substr($value, 0, self::STRING_MAX),
+            'value' => mb_substr($value, 0, $max),
         ];
     }
 

--- a/src/PhpSpec/Report/Formatter/DetailSections.php
+++ b/src/PhpSpec/Report/Formatter/DetailSections.php
@@ -104,6 +104,7 @@ final class DetailSections
                         $output->write('     ' . ($frame['file'] ?? '?') . ':' . ($frame['line'] ?? '?') . PHP_EOL);
                     }
                 };
+                $this->attachPrinted('Errors', $example->getOutput());
             }
         } elseif ($example->isFailure()) {
             $failures = array_values(array_filter(
@@ -117,6 +118,7 @@ final class DetailSections
                         $this->matchFailure($output, $failure);
                     }
                 };
+                $this->attachPrinted('Failures', $example->getOutput());
             }
         } elseif ($example->isSkipped()) {
             $this->sections['Skipped'][] = static function (OutputInterface $output) use ($title): void {
@@ -170,12 +172,14 @@ final class DetailSections
                             $output->write('     ' . ($frame['file'] ?? '?') . ':' . ($frame['line'] ?? '?') . PHP_EOL);
                         }
                     };
+                    $this->attachPrinted('Errors', $step->getOutput());
                 } elseif ($step->isFailure() && $error !== null) {
                     $message = $error->getMessage();
                     $this->sections['Failures'][] = static function (OutputInterface $output) use ($title, $message): void {
                         $output->write(PHP_EOL . '  <fg=red>• ' . $title . '</>' . PHP_EOL);
                         $output->write(PHP_EOL . '  ' . $message . PHP_EOL);
                     };
+                    $this->attachPrinted('Failures', $step->getOutput());
                 }
 
                 foreach ($step->getWarnings() as $warning) {
@@ -261,6 +265,24 @@ final class DetailSections
             is_array($value) => var_export($value, true),
             is_object($value) => get_class($value) . '#' . spl_object_id($value),
             default => (string) $value,
+        };
+    }
+
+    /**
+     * Adds what the subject printed underneath the entry it belongs to, so the
+     * dump that explains a failure is read next to it instead of somewhere up
+     * the terminal. Nothing is added when nothing was printed.
+     */
+    private function attachPrinted(string $section, string $printed): void
+    {
+        if (trim($printed) === '') {
+            return;
+        }
+
+        $this->sections[$section][] = static function (OutputInterface $output) use ($printed): void {
+            $output->write(PHP_EOL . '  <fg=gray>printed:</>');
+            PrettyViews::printedOutput($output, $printed, 2);
+            $output->write(PHP_EOL);
         };
     }
 

--- a/src/PhpSpec/Report/Formatter/Pretty/PrettyViews.php
+++ b/src/PhpSpec/Report/Formatter/Pretty/PrettyViews.php
@@ -20,6 +20,7 @@ use PhpSpec\Result\FeatureResult;
 use PhpSpec\Result\ScenarioResult;
 use PhpSpec\Result\SpecificationResult;
 use PhpSpec\Result\StepResult;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -78,6 +79,11 @@ final class PrettyViews
                 $output->write(' <fg=gray>(' . number_format($example->getDuration() * 1000, 1) . 'ms)</>');
             }
         }
+        // A failing example shows what it printed with its failure, in the
+        // detail at the end, so it is not said twice.
+        if (!$example->isFailure() && !$example->isError()) {
+            self::printedOutput($output, $example->getOutput(), $indentation + 2);
+        }
         if ($example->hasWarnings()) {
             foreach ($example->getWarnings() as $warning) {
                 $output->write(PHP_EOL . str_repeat(' ', $indentation) . '  <fg=yellow>⚠️ ' . $warning['message'] . ' — at ' . basename($warning['file']) . ':' . $warning['line'] . '</>');
@@ -132,8 +138,28 @@ final class PrettyViews
         } elseif ($step->isSkipped()) {
             $output->write('    <fg=cyan>- ' . $step->getTitle() . '</>');
         }
+
+        if (!$step->isFailure() && !$step->isError()) {
+            self::printedOutput($output, $step->getOutput(), 6);
+        }
     }
 
+
+    /**
+     * What the subject printed, quoted rather than let loose: each line behind
+     * a bar, so a dump reads as the code talking and not as PhpSpec's own
+     * report. Console markup in the text is escaped, never interpreted.
+     */
+    public static function printedOutput(OutputInterface $output, string $printed, int $indentation): void
+    {
+        if (trim($printed) === '') {
+            return;
+        }
+
+        foreach (explode("\n", rtrim($printed, "\n")) as $line) {
+            $output->write(PHP_EOL . str_repeat(' ', $indentation) . '<fg=gray>▏ ' . OutputFormatter::escape($line) . '</>');
+        }
+    }
 
     /**
      * @param array<int, string> $surroundingCode

--- a/src/PhpSpec/Result/ExampleResult.php
+++ b/src/PhpSpec/Result/ExampleResult.php
@@ -39,6 +39,9 @@ final class ExampleResult implements Results
     /** @var array<array{severity: int, message: string, file: string, line: int}> Notice items (E_NOTICE, E_USER_NOTICE) collected during execution */
     private array $notices = [];
 
+    /** @var string What the subject printed while this example ran */
+    private string $output = '';
+
     /**
      * @param string $title the example description
      * @param array<MatchResult> $matchResults array of MatchResult instances from this example
@@ -251,6 +254,25 @@ final class ExampleResult implements Results
     public function hasNotices(): bool
     {
         return !empty($this->notices);
+    }
+
+    /**
+     * Stores what the subject printed while the example ran, which is a
+     * diagnostic about this example and not a stray line on the terminal.
+     *
+     * @param string $output everything the example's code printed
+     */
+    public function setOutput(string $output): void
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Returns what the subject printed while the example ran.
+     */
+    public function getOutput(): string
+    {
+        return $this->output;
     }
 
     /**

--- a/src/PhpSpec/Result/StepResult.php
+++ b/src/PhpSpec/Result/StepResult.php
@@ -36,6 +36,9 @@ final class StepResult implements Results
     /** @var list<array{severity: int, message: string, file: string, line: int}> */
     private array $warnings = [];
 
+    /** @var string What the step printed while it ran */
+    private string $output = '';
+
     /**
      * @param string $title the step description
      * @param string $state the outcome state: passed, failure, error, pending, undefined, or skipped
@@ -174,5 +177,24 @@ final class StepResult implements Results
     public function getWarnings(): array
     {
         return $this->warnings;
+    }
+
+    /**
+     * Stores what the step printed while it ran: when a step drives a process
+     * of its own, what that process said is the whole of the diagnosis.
+     *
+     * @param string $output everything the step printed
+     */
+    public function setOutput(string $output): void
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Returns what the step printed while it ran.
+     */
+    public function getOutput(): string
+    {
+        return $this->output;
     }
 }

--- a/src/PhpSpec/Result/StepResult.php
+++ b/src/PhpSpec/Result/StepResult.php
@@ -30,6 +30,9 @@ final class StepResult implements Results
     /** @var StepError|null Error that occurred during step execution */
     private ?StepError $error = null;
 
+    /** @var MatchResult|null The expectation that did not hold, when one failed */
+    private ?MatchResult $match = null;
+
     /** @var list<array{severity: int, message: string, file: string, line: int}> */
     private array $warnings = [];
 
@@ -122,6 +125,26 @@ final class StepResult implements Results
     public function getError(): ?StepError
     {
         return $this->error;
+    }
+
+    /**
+     * Keeps the expectation that did not hold, so what was wanted and what was
+     * had stay values a reader can compare, instead of a sentence to parse back.
+     *
+     * @param MatchResult $match the failing expectation
+     */
+    public function setMatch(MatchResult $match): void
+    {
+        $this->match = $match;
+    }
+
+    /**
+     * Returns the expectation that did not hold, or null when the step did not
+     * fail on one (it threw, or it passed).
+     */
+    public function getMatch(): ?MatchResult
+    {
+        return $this->match;
     }
 
     /**

--- a/src/PhpSpec/Specification/Example.php
+++ b/src/PhpSpec/Specification/Example.php
@@ -15,6 +15,7 @@
 namespace PhpSpec\Specification;
 
 use Closure;
+use PhpSpec\CapturedOutput;
 use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\EventDispatcher\Event\ExampleCompleted;
 use PhpSpec\EventDispatcher\Event\ExampleErrored;
@@ -163,20 +164,26 @@ class Example implements ExampleResultRegistry, Rebindable
             return true;
         }, E_WARNING | E_NOTICE | E_DEPRECATED | E_USER_WARNING | E_USER_NOTICE | E_USER_DEPRECATED);
 
+        // What the subject prints belongs to the example that provoked it, not
+        // to whatever the terminal happened to be showing at the time.
+        $printed = new CapturedOutput();
+
         $start = hrtime(true);
         try {
-            ($this->example)(...$this->resolveClosureArgs($this->example));
+            $printed->around(fn() => ($this->example)(...$this->resolveClosureArgs($this->example)));
         } catch (PendingException $e) {
             restore_error_handler();
             DispatcherRegistry::dispatcher()->removeSubscriber($subscriber);
             $this->exampleResult = new ExampleResult($this->title, [], false, true);
             $this->exampleResult->setWarnings($warnings);
+            $this->exampleResult->setOutput($printed->text());
             DispatcherRegistry::dispatcher()->dispatch(new ExampleCompleted($this->title, $this->exampleResult), ExampleCompleted::NAME);
             return $this->exampleResult;
         } catch (SkippedException $e) {
             restore_error_handler();
             DispatcherRegistry::dispatcher()->removeSubscriber($subscriber);
             $this->exampleResult = new ExampleResult($this->title, [], false, false, true);
+            $this->exampleResult->setOutput($printed->text());
             DispatcherRegistry::dispatcher()->dispatch(new ExampleCompleted($this->title, $this->exampleResult), ExampleCompleted::NAME);
             return $this->exampleResult;
         } catch (\Throwable $e) {
@@ -191,6 +198,7 @@ class Example implements ExampleResultRegistry, Rebindable
         restore_error_handler();
         DispatcherRegistry::dispatcher()->removeSubscriber($subscriber);
         $this->exampleResult->setDuration($elapsed);
+        $this->exampleResult->setOutput($printed->text());
         $unique = [];
         foreach ($warnings as $w) {
             $key = $w['message'] . ':' . $w['file'] . ':' . $w['line'];

--- a/src/PhpSpec/StoryBDD/Feature.php
+++ b/src/PhpSpec/StoryBDD/Feature.php
@@ -256,6 +256,9 @@ final readonly class Feature implements SpecBlock
                 $result = new StepResult($title, 'failure');
                 $ex = new \RuntimeException($message);
                 $result->setError(new StepError($message, $ex));
+                // The expectation itself travels with the result, so a reader is
+                // handed the two values instead of the sentence about them.
+                $result->setMatch($matchResult);
                 return $result;
             }
         }

--- a/src/PhpSpec/StoryBDD/Feature.php
+++ b/src/PhpSpec/StoryBDD/Feature.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec\StoryBDD;
 
+use PhpSpec\CapturedOutput;
 use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\Result\FeatureResult;
 use PhpSpec\Result\ScenarioResult;
@@ -224,10 +225,24 @@ final readonly class Feature implements SpecBlock
     }
 
     /**
+     * Runs the matched step, keeping what it printed on its result.
+     */
+    private function executeStep(StepNode $step, string $title, StepMatch $match, object $world, StepMatchCollector $collector): StepResult
+    {
+        // What the step printed belongs to the step: a scenario that drives a
+        // process of its own says everything it knows through that output.
+        $printed = new CapturedOutput();
+        $result = $this->outcomeOf($step, $title, $match, $world, $collector, $printed);
+        $result->setOutput($printed->text());
+
+        return $result;
+    }
+
+    /**
      * Runs the matched step body and settles its outcome: an expectation that
      * did not hold is a failure; a step whose code threw is an error.
      */
-    private function executeStep(StepNode $step, string $title, StepMatch $match, object $world, StepMatchCollector $collector): StepResult
+    private function outcomeOf(StepNode $step, string $title, StepMatch $match, object $world, StepMatchCollector $collector, CapturedOutput $printed): StepResult
     {
         try {
             $args = $match->args;
@@ -237,7 +252,7 @@ final readonly class Feature implements SpecBlock
             if ($step->table !== null) {
                 $args[] = $step->table;
             }
-            $match->callback->call($world, ...$args);
+            $printed->around(fn() => $match->callback->call($world, ...$args));
         } catch (PendingException $e) {
             return new StepResult($title, 'pending');
         } catch (SkippedException $e) {


### PR DESCRIPTION
- `--format=agent` answers in JSON Lines (protocol `v: 2`): `run_started`, an `example` line per entry as it happens, optional `fatal`, `summary` last.
- A failing story step reports `expected`/`actual`/`at`, on the step and hoisted onto the entry, instead of only the English of it.
- What a spec or step printed is captured and reported as the entry's `output`; a scenario carries what all its steps printed, passing ones included.
- Capturing it also keeps stdout parseable: an `echo` in a spec used to be written into the middle of the document.
- Human formatters keep the output, under the example (Pretty) or with the failure detail (Pretty and Dot).
- The summary omits `offers` when the run found nothing to generate.
- Fixed: a parallel run reported `rerun: "run :0"` and a comparison of null with null; a failure without its site now reports its message alone.
- Docs state what a parallel run's entries do and do not carry.