### PR TITLE
Give a failure the context that explains it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+ - A failing entry carries one `expectation` block naming both sides (`matcher`, `expected`, `actual`, `negated`), replacing the split `expected`/`actual` fields the unreleased v2 stream had
+ - A matcher that names its target only in prose now states it as a value, so `toBeTrue()` reports expecting `true` instead of `null`, and emptiness expects the empty form of what it was given
+
 ### Added
  - Every offer PhpSpec makes carries an id, and `phpspec accept <id>` applies exactly what was reported, refusing an offer whose file has since changed
  - A failing story step reports the values it expected and got, on the step and on the entry, instead of only the sentence about them

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
  - A failing entry carries one `expectation` block naming both sides (`matcher`, `expected`, `actual`, `negated`), replacing the split `expected`/`actual` fields the unreleased v2 stream had
  - A matcher that names its target only in prose now states it as a value, so `toBeTrue()` reports expecting `true` instead of `null`, and emptiness expects the empty form of what it was given
+ - A matcher with no target at all, such as a predicate, says so with `"N/A"` instead of reporting a null one, and the human formatters stop printing the empty pair
+ - Objects in a failure detail are named by what they are rather than by instance id, as the agent format already did
 
 ### Added
  - Every offer PhpSpec makes carries an id, and `phpspec accept <id>` applies exactly what was reported, refusing an offer whose file has since changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,24 +6,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
- - A failing entry carries one `expectation` block naming both sides (`matcher`, `expected`, `actual`, `negated`), replacing the split `expected`/`actual` fields the unreleased v2 stream had
- - A matcher that names its target only in prose now states it as a value, so `toBeTrue()` reports expecting `true` instead of `null`, and emptiness expects the empty form of what it was given
- - A matcher with no target at all, such as a predicate, says so with `"N/A"` instead of reporting a null one, and the human formatters stop printing the empty pair
- - Objects in a failure detail are named by what they are rather than by instance id, as the agent format already did
-
 ### Added
  - Every offer PhpSpec makes carries an id, and `phpspec accept <id>` applies exactly what was reported, refusing an offer whose file has since changed
  - A failing story step reports the values it expected and got, on the step and on the entry, instead of only the sentence about them
  - What a spec or step printed is captured and reported as the entry's output, in the agent stream and under the failure in the human formatters
+ - `toThrow()` takes no argument, asserting only that something was thrown
 
 ### Changed
  - `--format=agent` answers in JSON Lines (protocol v2): one event per line as it happens, so a failure arrives before the suite ends
+ - A failing entry carries one `expectation` block naming both sides (`matcher`, `expected`, `actual`, `negated`), replacing the split `expected`/`actual` fields the unreleased v2 stream had
+ - A matcher that names its target only in prose now states it as a value, so `toBeTrue()` reports expecting `true` instead of `null`, and emptiness expects the empty form of what it was given
+ - A matcher with no target at all, such as a predicate, says so with `"N/A"` instead of reporting a null one, and the human formatters stop printing the empty pair
+ - `toThrow` reports the exception that was actually thrown, or "No exception", against the one it was asked for, instead of reporting the callable it was handed
+ - An exception carrying no message reads as `RuntimeException` rather than `RuntimeException("")`
+ - Objects in a failure detail are named by what they are rather than by instance id, as the agent format already did
  - The agent summary omits offers when the run found nothing to generate, as it already did for rerun and coverage
  - generate no longer writes when there is nobody to ask: it offers the change under an id, and `run --accept-offers` stays as the bulk shortcut for a run's own offers
 
 ### Fixed
  - A parallel run no longer reports `run :0` as an entry's rerun, nor a comparison of nothing with nothing: a failure that came back without its site now reports its message alone
+ - An array holding an object no longer makes the failure detail emit a PHP warning of its own
  - describe and exemplify refuse a name PHP could not parse instead of writing a spec that breaks the suite, and describe says what it needs when given nothing
  - accept resolves paths through the configuration the run was given, so `-c` is honoured
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -105,7 +105,21 @@ Scenario Outline is its own entry, named by its values
 A matcher that names its target only in prose still states it as a value, so
 `toBeTrue()` reports `expected: true` rather than the null it has no argument
 for. Emptiness wants the empty form of what it was given: `""` against a string,
-`[]` against an array, `0` against a number.
+`[]` against an array, `0` against a number. A matcher with no target at all,
+such as a predicate, says `"N/A"` rather than reporting a null one.
+
+`toThrow` compares what was asked for against what happened, not against the
+callable you handed it:
+
+| Expectation | `expected` | `actual` |
+|---|---|---|
+| `toThrow()` and it threw | `"N/A"` | `"Exception"` |
+| `toThrow()` and it did not | `"N/A"` | `"No exception"` |
+| `toThrow(RuntimeException::class)` | `"RuntimeException"` | `"RuntimeException"` |
+| `toThrow(RuntimeException::class, 'boom')` | `"RuntimeException(\"boom\")"` | `"RuntimeException(\"boom\")"` |
+| `toThrow(RuntimeException::class)` and it did not | `"RuntimeException"` | `"No exception"` |
+
+`toThrow()` now takes no argument at all, meaning "throw something".
 
 A **story step** that failed an expectation reports the same block, on the step
 inside `steps` (with `at`, the `file:line` of the expectation in your step file)

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -29,7 +29,7 @@ reaches you while the rest is still running.
 It is `--parallel`-safe, with one caveat: workers report back through JUnit,
 which carries the outcome, the message and a scenario's line, and nothing else.
 Entries from a parallel run therefore arrive in completion order and without
-`expected`, `actual` or `output`; a failing spec example also arrives without
+`expectation` or `output`; a failing spec example also arrives without
 `spec` and `rerun`, which JUnit has no room for. Run without `--parallel` when
 you want the whole of the detail.
 
@@ -40,7 +40,7 @@ class — produces four lines:
 
 ```json
 {"v":2,"event":"run_started","suite":"default","seed":null}
-{"v":2,"event":"example","id":"6fd046add251","example":"App\\Basket > totals the prices of its products","state":"failing","expected":{"matcher":"toBe","value":4000,"negated":false},"actual":3500,"message":"Expected 3500 to be 4000","spec":"spec/App/Basket.spec.php:6","rerun":"run spec/App/Basket.spec.php:6"}
+{"v":2,"event":"example","id":"6fd046add251","example":"App\\Basket > totals the prices of its products","state":"failing","expectation":{"matcher":"toBe","expected":4000,"actual":3500,"negated":false},"message":"Expected 3500 to be 4000","spec":"spec/App/Basket.spec.php:6","rerun":"run spec/App/Basket.spec.php:6"}
 {"v":2,"event":"example","id":"66b1647a77b6","example":"App\\Basket > applies a coupon","state":"error","message":"Class \"App\\Coupon\" not found","exception":{"class":"Error","message":"Class \"App\\Coupon\" not found","at":"spec/App/Basket.spec.php:8"},"spec":"spec/App/Basket.spec.php:8","rerun":"run spec/App/Basket.spec.php:8","offer":{"action":"create_class","target":"App\\Coupon"}}
 {"v":2,"event":"summary","examples":3,"scenarios":0,"steps":0,"passing":1,"failing":1,"errors":1,"pending":0,"skipped":0,"actionable":2,"duration_ms":4,"offers":[{"action":"create_class","target":"App\\Coupon"},{"action":"fake_method","target":"App\\Basket::total","value":"4000"}]}
 ```
@@ -87,21 +87,27 @@ Scenario Outline is its own entry, named by its values
 | `spec` | The `file:line` of the failing assertion or the error, project-relative. For a scenario it is the line its `Scenario:` keyword sits on. Absent when the site is not known. |
 | `rerun` | The exact arguments to re-run **just this one example or scenario**: prepend your PhpSpec binary. No full-suite re-run needed to verify one fix. Absent with `spec`. |
 | `output` | What the code printed while this entry ran, present only when it printed something. See [Printed output](#printed-output). |
-| `steps` | Scenarios only: the steps that did not pass, each `{ title, state, message?, expected?, actual?, at? }`, in the order they were declared. |
+| `steps` | Scenarios only: the steps that did not pass, each `{ title, state, message?, expectation?, at? }`, in the order they were declared. |
 
-**`failing`** entries also carry the expectation:
+**`failing`** entries also carry `expectation`, both sides in one block:
 
-- `expected` — what the matcher wanted: `matcher` is its name (`toBe`,
-  `toThrow`, …), `value` is the target value, and `negated` is `true` when the
-  expectation used `not()`.
-- `actual` — the value your code actually produced.
-- `message` — PhpSpec's rendered failure message.
+```json
+"expectation": {"matcher": "toBeTrue", "expected": true, "actual": false, "negated": false}
+```
 
-> **Note on `expected` vs `actual`.** These follow the universal convention:
-> `expected.value` is what should have happened, `actual` is what did. (PhpSpec's
-> internal naming is the reverse — the formatter un-inverts it for you.)
+- `matcher` — the matcher's name (`toBe`, `toThrow`, …), `null` for a custom or
+  predicate matcher, which reaches PhpSpec anonymously.
+- `expected` — what the matcher wanted, `actual` — what your code produced, in
+  the universal sense of those words. (PhpSpec's internal naming is the reverse;
+  the formatter un-inverts it for you.)
+- `negated` — `true` when the expectation used `not()`.
 
-A **story step** that failed an expectation reports the same pair, on the step
+A matcher that names its target only in prose still states it as a value, so
+`toBeTrue()` reports `expected: true` rather than the null it has no argument
+for. Emptiness wants the empty form of what it was given: `""` against a string,
+`[]` against an array, `0` against a number.
+
+A **story step** that failed an expectation reports the same block, on the step
 inside `steps` (with `at`, the `file:line` of the expectation in your step file)
 and hoisted onto the entry next to `message`, so acting on the entry never means
 going a level deeper. A step whose code *threw* has a `message` and no
@@ -118,7 +124,7 @@ warnings/deprecations/notices, the entry gains `warnings`, `deprecations` and/or
 `notices` arrays of `{ "message", "at" }` — present only when non-empty.
 Sometimes the deprecation is the actual clue behind a failure.
 
-Large or object values in `expected`/`actual` are exported compactly (long
+Large or object values in `expectation` are exported compactly (long
 strings and arrays are truncated with a `{ "truncated": true, "length": N }`
 marker) so one entry can never flood a context window. Objects are named by what
 they are, not by which instance they were: an enum as `App\Status::Active`,
@@ -300,8 +306,9 @@ its `event`:
   the counts describe only what ran before it.
 - `example` lines are what needs attention (passing examples are not reported).
   Each has a `state`:
-  - `failing` — the code ran but behaviour is wrong. Look at `expected.value`
-    (what the spec wants), `actual` (what the code produced), and `message`.
+  - `failing` — the code ran but behaviour is wrong. Look at
+    `expectation.expected` (what the spec wants), `expectation.actual` (what the
+    code produced), and `message`.
     Fix the implementation; do not change the spec to match the code unless the
     spec is genuinely wrong.
   - `error`: an exception was thrown. `message` says what, `exception` adds the

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -88,6 +88,30 @@ Feature: Agent output format
     Then the output should be valid JSON
     And the reported entry should have printed "the counter said 2"
 
+  Scenario: A boolean failure says what the matcher wanted, not only what it got
+    Given a spec file "spec/App/Watch.spec.php":
+      """
+      <?php
+      describe('App\Watch', function () {
+          it('arrives', function () { expect(false)->toBeTrue(); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the reported entry should expect "true" and have got "false"
+
+  Scenario: An emptiness failure wants the empty form of what it was given
+    Given a spec file "spec/App/Bag.spec.php":
+      """
+      <?php
+      describe('App\Bag', function () {
+          it('holds nothing', function () { expect([1, 2])->toBeEmpty(); });
+      });
+      """
+    When I run phpspec run with option "--format=agent"
+    Then the output should be valid JSON
+    And the reported entry should expect "[]" and have got "[1,2]"
+
   Scenario: A failing example carries a line-targeted rerun command
     Given a spec file "spec/App/Calc.spec.php":
       """

--- a/features/scenarios/cli/agent-format.feature
+++ b/features/scenarios/cli/agent-format.feature
@@ -112,6 +112,41 @@ Feature: Agent output format
     Then the output should be valid JSON
     And the reported entry should expect "[]" and have got "[1,2]"
 
+  Scenario: A scenario hands over the log it was watching, read before its teardown
+    Given a PSR-4 project with "spec", "src", and "features" directories
+    And a feature file "features/watching.feature":
+      """
+      Feature: Watching
+        Scenario: Watching a file
+          Given the watcher is running
+          Then it should have arrived
+      """
+    And a step file "features/steps/watching.steps.php":
+      """
+      <?php
+
+      use function PhpSpec\attach;
+
+      given('the watcher is running', function () {
+          $this->log = sys_get_temp_dir() . '/phpspec_watch_' . getmypid() . '.log';
+          file_put_contents($this->log, 'nothing yet');
+          attach('watch.log', fn() => @file_get_contents($this->log));
+      });
+
+      then('it should have arrived', function () {
+          // The watcher writes its diagnosis only now, after the attachment was made.
+          file_put_contents($this->log, 'CANNOT READ --watch');
+          expect(false)->toBeTrue();
+      });
+
+      afterScenario(function () {
+          @unlink($this->log);
+      });
+      """
+    When I run phpspec run with option "features/ --format=agent"
+    Then the output should be valid JSON
+    And the reported entry should have attached "watch.log" containing "CANNOT READ --watch"
+
   Scenario: A failing example carries a line-targeted rerun command
     Given a spec file "spec/App/Calc.spec.php":
       """

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -171,8 +171,17 @@ then('the failing step should report expected {int} and actual {int}', function 
     $failing = array_values(array_filter($entry['steps'] ?? [], fn(array $step) => $step['state'] === 'failing'));
 
     expect($failing)->not()->toBe([]);
-    expect($failing[0]['expected']['value'])->toBe($expected);
-    expect($failing[0]['actual'])->toBe($actual);
+    expect($failing[0]['expectation']['expected'])->toBe($expected);
+    expect($failing[0]['expectation']['actual'])->toBe($actual);
+});
+
+// Both sides of a failure, plainly named and compared as the JSON a reader
+// decodes, so "true" and "[]" mean what they say.
+then('the reported entry should expect {string} and have got {string}', function (string $expected, string $actual) use ($events, $entries) {
+    $expectation = $entries($events($this->output))[0]['expectation'] ?? [];
+
+    expect(json_encode($expectation['expected'] ?? null))->toBe($expected);
+    expect(json_encode($expectation['actual'] ?? null))->toBe($actual);
 });
 
 // What the subject printed is a diagnosis about the entry it printed under, and

--- a/features/steps/assertions.steps.php
+++ b/features/steps/assertions.steps.php
@@ -184,6 +184,14 @@ then('the reported entry should expect {string} and have got {string}', function
     expect(json_encode($expectation['actual'] ?? null))->toBe($actual);
 });
 
+// Context only the test could reach, handed over under a name and read while
+// the run still stood where it was attached.
+then('the reported entry should have attached {string} containing {string}', function (string $name, string $text) use ($events, $entries) {
+    $attached = $entries($events($this->output))[0]['attachments'][$name] ?? null;
+
+    expect(is_array($attached) ? ($attached['value'] ?? $attached['error'] ?? '') : (string) $attached)->toContain($text);
+});
+
 // What the subject printed is a diagnosis about the entry it printed under, and
 // it reaches the reader as data instead of landing in the middle of the report.
 then('the reported entry should have printed {string}', function (string $text) use ($events, $entries) {

--- a/spec/PhpSpec/Attachments.spec.php
+++ b/spec/PhpSpec/Attachments.spec.php
@@ -1,0 +1,63 @@
+<?php
+
+use PhpSpec\Attachments;
+use PhpSpec\EventDispatcher\Event\AttachmentCreated;
+
+describe(Attachments::class, function () {
+
+    it('has nothing to say until something is handed over', function () {
+        $attachments = new Attachments();
+
+        expect($attachments->isEmpty())->toBeTrue();
+        expect($attachments->read())->toBe([]);
+    });
+
+    it('keeps text under the name it was handed over with', function () {
+        $attachments = new Attachments();
+        $attachments->add('stdout', 'CANNOT READ --watch');
+
+        expect($attachments->read())->toBe(['stdout' => 'CANNOT READ --watch']);
+    });
+
+    it('reads a closure at the end, not when it was handed over', function () {
+        $log = 'nothing yet';
+        $attachments = new Attachments();
+        $attachments->add('log', function () use (&$log) {
+            return $log;
+        });
+
+        // The process the step started goes on writing after the attachment was made.
+        $log = 'CANNOT READ --watch';
+
+        expect($attachments->read())->toBe(['log' => 'CANNOT READ --watch']);
+    });
+
+    it('keeps the latest under a name, so a helper offering it every poll leaves one', function () {
+        $attachments = new Attachments();
+        $attachments->add('log', 'first look');
+        $attachments->add('log', 'second look');
+
+        expect($attachments->read())->toBe(['log' => 'second look']);
+    });
+
+    it('says a closure could not be read rather than showing an empty block', function () {
+        $attachments = new Attachments();
+        $attachments->add('log', fn() => false);
+
+        expect($attachments->read())->toBe(['log' => ['error' => 'Nothing could be read']]);
+    });
+
+    it('says what went wrong when reading throws', function () {
+        $attachments = new Attachments();
+        $attachments->add('log', function () {
+            throw new RuntimeException('the workspace is gone');
+        });
+
+        expect($attachments->read())->toBe(['log' => ['error' => 'the workspace is gone']]);
+    });
+
+    it('subscribes to the attachment event', function () {
+        expect((new Attachments())->getSubscribedEvents())->toBe([AttachmentCreated::NAME => 'onAttachmentCreated']);
+    });
+
+});

--- a/spec/PhpSpec/Browser/Client.spec.php
+++ b/spec/PhpSpec/Browser/Client.spec.php
@@ -27,6 +27,32 @@ describe(Client::class, function () {
         expect($response->headers)->toHaveKey('Content-Type');
     });
 
+    // An assertion about a response says "expected 200, got 500" and never why.
+    // The body is the why, so the client hands it over for the report to use if
+    // the example turns out to need it.
+    it('hands over the request and what the server answered', function () {
+        $attachments = new \PhpSpec\Attachments();
+        $original = \PhpSpec\EventDispatcher\DispatcherRegistry::dispatcher();
+
+        try {
+            $isolated = new \PhpSpec\EventDispatcher\Dispatcher();
+            $isolated->addSubscriber($attachments);
+            \PhpSpec\EventDispatcher\DispatcherRegistry::set($isolated);
+
+            (new Client('http://fake-host', fn(string $url, $context) => [
+                'body' => 'Fatal: the widget service is down',
+                'headers' => ['HTTP/1.1 500 Internal Server Error'],
+            ]))->request('GET', '/widgets');
+        } finally {
+            \PhpSpec\EventDispatcher\DispatcherRegistry::set($original);
+        }
+
+        expect($attachments->read())->toBe([
+            'http.request' => 'GET http://fake-host/widgets (500)',
+            'http.response' => 'Fatal: the widget service is down',
+        ]);
+    });
+
     it('sends JSON body on POST', function () {
         $capturedContext = null;
 

--- a/spec/PhpSpec/Report/Formatter/Agent.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Agent.spec.php
@@ -294,8 +294,7 @@ describe(Agent::class, function () {
 
         $example = $doc['examples'][0];
         expect($example['state'])->toBe('failing');
-        expect($example['expected'])->toBe(['matcher' => 'toBe', 'value' => 4000, 'negated' => false]);
-        expect($example['actual'])->toBe(3500);
+        expect($example['expectation'])->toBe(['matcher' => 'toBe', 'expected' => 4000, 'actual' => 3500, 'negated' => false]);
         expect($example['message'])->toBe('Expected 3500 to be 4000');
         expect($example['spec'])->toBe('spec/App/Basket.spec.php:12');
         expect($example['rerun'])->toBe('run spec/App/Basket.spec.php:12');
@@ -312,9 +311,7 @@ describe(Agent::class, function () {
             new SpecificationResult('App\\X', [new ExampleResult('greets', [$match])]),
         ]))['examples'][0];
 
-        expect($example['expected'])->toBe(['matcher' => null, 'value' => null, 'negated' => false]);
-        expect($example)->toHaveKey('actual');
-        expect($example['actual'])->toBeNull();
+        expect($example['expectation'])->toBe(['matcher' => null, 'expected' => null, 'actual' => null, 'negated' => false]);
     });
 
     it('reports only the message when a failure came back without its site', function () use ($render) {
@@ -327,8 +324,7 @@ describe(Agent::class, function () {
         ]))['examples'][0];
 
         expect($example['message'])->toBe('Expected 3500 to be 4000');
-        expect($example)->not()->toHaveKey('expected');
-        expect($example)->not()->toHaveKey('actual');
+        expect($example)->not()->toHaveKey('expectation');
         // And no location invented from the parts it does not have.
         expect($example)->not()->toHaveKey('spec');
         expect($example)->not()->toHaveKey('rerun');
@@ -340,7 +336,7 @@ describe(Agent::class, function () {
             new SpecificationResult('App\\X', [new ExampleResult('rejects equality', [$match])]),
         ]))['examples'][0];
 
-        expect($example['expected']['negated'])->toBe(true);
+        expect($example['expectation']['negated'])->toBe(true);
     });
 
     it('derives a stable id from the full example name so an agent can recompute it', function () use ($render) {
@@ -541,11 +537,10 @@ describe(Agent::class, function () {
         ]))['examples'][0];
 
         // Hoisted onto the entry, next to the message it already hoists.
-        expect($entry['expected'])->toBe(['matcher' => 'toBe', 'value' => 3, 'negated' => false]);
-        expect($entry['actual'])->toBe(2);
+        expect($entry['expectation'])->toBe(['matcher' => 'toBe', 'expected' => 3, 'actual' => 2, 'negated' => false]);
         // And on the step that made it, with the line the expectation lives on.
-        expect($entry['steps'][0]['expected']['value'])->toBe(3);
-        expect($entry['steps'][0]['actual'])->toBe(2);
+        expect($entry['steps'][0]['expectation']['expected'])->toBe(3);
+        expect($entry['steps'][0]['expectation']['actual'])->toBe(2);
         expect($entry['steps'][0]['at'])->toBe('features/steps/counting.steps.php:4');
     });
 
@@ -557,8 +552,8 @@ describe(Agent::class, function () {
             new FeatureResult('Counting', [new ScenarioResult('Counting up', [$step], 2)], 'features/counting.feature'),
         ]))['examples'][0];
 
-        expect($entry)->not()->toHaveKey('expected');
-        expect($entry['steps'][0])->not()->toHaveKey('actual');
+        expect($entry)->not()->toHaveKey('expectation');
+        expect($entry['steps'][0])->not()->toHaveKey('expectation');
     });
 
     it('names a scenario by feature and scenario, so two never share an id', function () use ($render) {

--- a/spec/PhpSpec/Report/Formatter/Pretty.spec.php
+++ b/spec/PhpSpec/Report/Formatter/Pretty.spec.php
@@ -1,6 +1,7 @@
 <?php
 
 use PhpSpec\Report\Formatter\Pretty;
+use PhpSpec\Report\Formatter\Pretty\PrettyViews;
 use PhpSpec\Result\SuiteResult;
 use PhpSpec\Result\SpecificationResult;
 use PhpSpec\Result\ExampleResult;
@@ -14,6 +15,26 @@ use PhpSpec\StoryBDD\StepError;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 describe(Pretty::class, function() {
+
+    // A response body or a watched log can run to megabytes, and a terminal
+    // scrolling for a minute has buried the failure it was meant to explain.
+    it("cuts a flood of printed text, saying how much more there was", function() {
+        $output = new BufferedOutput();
+        PrettyViews::printedOutput($output, str_repeat('x', 4500), 2);
+        $written = $output->fetch();
+
+        expect(substr_count($written, 'x'))->toBe(4000);
+        expect($written)->toContain('… 500 more characters');
+    });
+
+    it("shows short printed text whole, with no note", function() {
+        $output = new BufferedOutput();
+        PrettyViews::printedOutput($output, "one\ntwo", 2);
+        $written = $output->fetch();
+
+        expect($written)->toContain('▏ one');
+        expect($written)->not()->toContain('more characters');
+    });
 
     it("formats passing results", function() {
         $output = new BufferedOutput();

--- a/spec/PhpSpec/Specification/Expectation.spec.php
+++ b/spec/PhpSpec/Specification/Expectation.spec.php
@@ -278,6 +278,53 @@ describe(Expectation::class, function() {
             expect($captured[0]->getMatcher())->toBe("toContain");
             expect($captured[0]->getExpected())->toBe("the haystack");
             expect($captured[0]->getActual())->toBe("missing needle");
+            expect($captured[0]->isTargetImplied())->toBeFalse();
+        });
+
+        // A matcher that names its target only in prose still states it as a
+        // value, so a report never says a failure expected null when it
+        // expected true, and marks it implied so a view does not read it back.
+        $failureOf = function (Closure $expectation): \PhpSpec\Result\MatchResult {
+            $original = \PhpSpec\EventDispatcher\DispatcherRegistry::dispatcher();
+            $captured = [];
+            $listener = new class($captured) implements \PhpSpec\EventDispatcher\Listener {
+                public function __construct(private array &$captured) {}
+                public function listen(\PhpSpec\EventDispatcher\Event $event): void
+                {
+                    if ($event instanceof \PhpSpec\EventDispatcher\Event\MatchCreated) {
+                        $this->captured[] = ($event->getMatch())();
+                    }
+                }
+            };
+
+            try {
+                $isolated = new \PhpSpec\EventDispatcher\Dispatcher();
+                $isolated->addListener($listener);
+                \PhpSpec\EventDispatcher\DispatcherRegistry::set($isolated);
+
+                $expectation();
+            } finally {
+                \PhpSpec\EventDispatcher\DispatcherRegistry::set($original);
+            }
+
+            return $captured[0];
+        };
+
+        it("states the target a matcher only names in prose", function() use ($failureOf) {
+            $failure = $failureOf(fn() => (new Expectation(false, __FILE__, __LINE__))->toBeTrue());
+
+            expect($failure->getActual())->toBeTrue();
+            expect($failure->getExpected())->toBeFalse();
+            expect($failure->isTargetImplied())->toBeTrue();
+        });
+
+        it("wants the empty form of whatever it was given", function() use ($failureOf) {
+            $of = fn(mixed $subject) => $failureOf(fn() => (new Expectation($subject, __FILE__, __LINE__))->toBeEmpty())->getActual();
+
+            expect($of([1, 2]))->toBe([]);
+            expect($of("stuff"))->toBe("");
+            expect($of(3434))->toBe(0);
+            expect($of(new \stdClass()))->toBeNull();
         });
     });
 

--- a/spec/PhpSpec/Specification/Expectation.spec.php
+++ b/spec/PhpSpec/Specification/Expectation.spec.php
@@ -318,6 +318,14 @@ describe(Expectation::class, function() {
             expect($failure->isTargetImplied())->toBeTrue();
         });
 
+        it("says a predicate had no target rather than reporting a null one", function() use ($failureOf) {
+            $failure = $failureOf(fn() => (new Expectation(3, __FILE__, __LINE__))->toSatisfy(fn($n) => $n > 10));
+
+            expect($failure->getActual())->toBe('N/A');
+            expect($failure->getExpected())->toBe(3);
+            expect($failure->isTargetImplied())->toBeTrue();
+        });
+
         it("wants the empty form of whatever it was given", function() use ($failureOf) {
             $of = fn(mixed $subject) => $failureOf(fn() => (new Expectation($subject, __FILE__, __LINE__))->toBeEmpty())->getActual();
 

--- a/spec/PhpSpec/Specification/Expectation.spec.php
+++ b/spec/PhpSpec/Specification/Expectation.spec.php
@@ -318,6 +318,40 @@ describe(Expectation::class, function() {
             expect($failure->isTargetImplied())->toBeTrue();
         });
 
+        // A callable is not the interesting half of a throw expectation: what it
+        // threw is, and that is only known once it has run.
+        it("reports what a callable threw against what it was asked for", function() use ($failureOf) {
+            // As a report shows them: phpspec stores the subject as "expected"
+            // and the matcher's target as "actual", and an exception is named
+            // rather than dumped.
+            $shown = fn(mixed $value) => is_object($value) ? \PhpSpec\ObjectName::of($value) : $value;
+            $sides = function (Closure $expectation) use ($failureOf, $shown) {
+                $failure = $failureOf($expectation);
+
+                return [$shown($failure->getActual()), $shown($failure->getExpected())];
+            };
+
+            // Asked only to throw, and it did: nothing was named to compare with.
+            expect($sides(fn() => (new Expectation(fn() => throw new Exception(), __FILE__, __LINE__))->not()->toThrow()))
+                ->toBe(['N/A', 'Exception']);
+
+            // Asked only to throw, and it did not.
+            expect($sides(fn() => (new Expectation(fn() => null, __FILE__, __LINE__))->toThrow()))
+                ->toBe(['N/A', 'No exception']);
+
+            // Asked for a class, by name alone when it carries no message.
+            expect($sides(fn() => (new Expectation(fn() => throw new RuntimeException(), __FILE__, __LINE__))->not()->toThrow(RuntimeException::class)))
+                ->toBe(['RuntimeException', 'RuntimeException']);
+
+            // Asked for a class and a message, so both sides carry both.
+            expect($sides(fn() => (new Expectation(fn() => throw new RuntimeException('boom'), __FILE__, __LINE__))->not()->toThrow(RuntimeException::class, 'boom')))
+                ->toBe(['RuntimeException("boom")', 'RuntimeException("boom")']);
+
+            // Asked for a class and handed nothing at all.
+            expect($sides(fn() => (new Expectation(fn() => null, __FILE__, __LINE__))->toThrow(RuntimeException::class)))
+                ->toBe(['RuntimeException', 'No exception']);
+        });
+
         it("says a predicate had no target rather than reporting a null one", function() use ($failureOf) {
             $failure = $failureOf(fn() => (new Expectation(3, __FILE__, __LINE__))->toSatisfy(fn($n) => $n > 10));
 

--- a/src/PhpSpec/Attachments.php
+++ b/src/PhpSpec/Attachments.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec;
+
+use Closure;
+use PhpSpec\EventDispatcher\Event\AttachmentCreated;
+use PhpSpec\EventDispatcher\Subscriber;
+
+/**
+ * @internal
+ * What a spec or a scenario handed over about itself, kept until the moment it
+ * is worth reading. PhpSpec cannot see the log a subject wrote or the output of
+ * a process a step drove, so the test says so itself; and because the value is
+ * often still being written when it is offered, a closure is read at the end
+ * rather than when it was handed over.
+ *
+ * Nothing is read for a unit that passed: an attachment is a diagnosis, and a
+ * green run has nothing to diagnose.
+ */
+final class Attachments implements Subscriber
+{
+    /** @var array<string, string|Closure> what was handed over, by name; the latest under a name wins */
+    private array $offered = [];
+
+    /**
+     * Returns the event names this subscriber listens to.
+     *
+     * @return array<string, string> map of event name to handler method name
+     */
+    public function getSubscribedEvents(): array
+    {
+        return [
+            AttachmentCreated::NAME => 'onAttachmentCreated',
+        ];
+    }
+
+    /**
+     * Takes one attachment. A name handed over twice keeps the latest: a helper
+     * offering the same log on every poll must not pile up copies of it.
+     *
+     * @param string|Closure $value the text, or a closure read when the failure is reported
+     */
+    public function add(string $name, string|Closure $value): void
+    {
+        $this->offered[$name] = $value;
+    }
+
+    /**
+     * Takes one that arrived over the event bus, which is how a step or an
+     * example reaches the collector for the unit it is running in.
+     */
+    public function onAttachmentCreated(AttachmentCreated $event): void
+    {
+        $this->add($event->name, $event->value);
+    }
+
+    /**
+     * Reads everything handed over, now. Called while the run is still standing
+     * where the attachment was made, before any teardown removes what it points
+     * at, so a closure reading a file still finds the file.
+     *
+     * A closure that fails says so instead of leaving an empty block, which
+     * would read as "the subject printed nothing" rather than "PhpSpec could
+     * not look".
+     *
+     * @return array<string, string|array{error: string}>
+     */
+    public function read(): array
+    {
+        $read = [];
+
+        foreach ($this->offered as $name => $value) {
+            $read[$name] = $value instanceof Closure ? self::resolve($value) : $value;
+        }
+
+        return $read;
+    }
+
+    /**
+     * Whether anything was handed over at all.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->offered === [];
+    }
+
+    /**
+     * @return string|array{error: string}
+     */
+    private static function resolve(Closure $value): string|array
+    {
+        try {
+            $read = $value();
+        } catch (\Throwable $e) {
+            return ['error' => $e->getMessage()];
+        }
+
+        // What file_get_contents answers when it cannot read: reported as the
+        // failure to look that it is, never as an empty attachment.
+        if ($read === false || $read === null) {
+            return ['error' => 'Nothing could be read'];
+        }
+
+        return is_string($read) ? $read : (string) json_encode($read);
+    }
+}

--- a/src/PhpSpec/Browser/Client.php
+++ b/src/PhpSpec/Browser/Client.php
@@ -16,6 +16,8 @@ namespace PhpSpec\Browser;
 
 use Closure;
 
+use function PhpSpec\attach;
+
 /**
  * @internal
  * Lightweight HTTP client using file_get_contents + stream contexts (zero dependencies).
@@ -110,6 +112,16 @@ final class Client
             }
         }
 
-        return new Response($status, $body, $responseHeaders);
+        $response = new Response($status, $body, $responseHeaders);
+
+        // What the server said, handed over so a failed expectation about a
+        // response is read next to the body that explains it: an assertion on
+        // the status says "expected 200, got 500" and never why. Attached on
+        // every request and only ever read when something needs attention, so a
+        // green suite pays nothing and the last request is the one reported.
+        attach('http.request', strtoupper($method) . ' ' . $url . ' (' . $status . ')');
+        attach('http.response', $body);
+
+        return $response;
     }
 }

--- a/src/PhpSpec/EventDispatcher/Event/AttachmentCreated.php
+++ b/src/PhpSpec/EventDispatcher/Event/AttachmentCreated.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\EventDispatcher\Event;
+
+use Closure;
+use PhpSpec\EventDispatcher\Event;
+
+/**
+ * @internal
+ * Dispatched when a spec or a step hands over context only it can reach: the
+ * output of a process it drove, the log the subject wrote, the page a browser
+ * is showing. A closure is read later, when the failure is reported, so a value
+ * that is still being written is current when it matters.
+ */
+final readonly class AttachmentCreated implements Event
+{
+    public const NAME = 'attachment.created';
+
+    /**
+     * @param string $name what to file it under; the same name twice is the same attachment, latest wins
+     * @param string|Closure $value the text, or a closure read when the failure is reported
+     */
+    public function __construct(
+        public string $name,
+        public string|Closure $value,
+    ) {}
+
+    /** {@inheritdoc} */
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/PhpSpec/Mock/Expectation.php
+++ b/src/PhpSpec/Mock/Expectation.php
@@ -72,13 +72,13 @@ final class Expectation extends BaseExpectation
     /**
      * Configures the mock method to throw an exception when called.
      *
-     * @param mixed $exceptionClass the exception class to throw
-     * @param mixed $message the exception message
+     * @param string $exceptionClass the exception class to throw
+     * @param string|null $message the exception message
      * @return $this
      */
-    public function toThrow($exceptionClass, $message = ''): static
+    public function toThrow(string $exceptionClass = '', ?string $message = null): static
     {
-        $this->mockSubject->toThrow($exceptionClass, $message);
+        $this->mockSubject->toThrow($exceptionClass, $message ?? '');
         return $this;
     }
 

--- a/src/PhpSpec/ObjectName.php
+++ b/src/PhpSpec/ObjectName.php
@@ -46,14 +46,28 @@ final class ObjectName
         // wall of absolute paths that shift with every edit. Its message is the
         // part that identifies it.
         if ($value instanceof Throwable) {
-            return $value::class . '("' . self::clip($value->getMessage()) . '")';
+            return self::named($value::class, $value->getMessage());
         }
 
         if ($value instanceof Stringable) {
-            return $value::class . '("' . self::clip(self::describe($value)) . '")';
+            return self::named($value::class, self::describe($value));
         }
 
         return $value::class;
+    }
+
+    /**
+     * A class and the description that tells one of its instances from another,
+     * as one rule: the class alone when there is nothing to add, so an exception
+     * carrying no message reads as "RuntimeException" and not as
+     * "RuntimeException("")". Also serves the side of a comparison that has no
+     * object yet, only the class and message a matcher was asked for.
+     */
+    public static function named(string $class, ?string $description): string
+    {
+        $description = $description !== null ? self::clip($description) : '';
+
+        return $description === '' ? $class : $class . '("' . $description . '")';
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -459,9 +459,32 @@ final class Agent extends AbstractFormatter
         }
 
         $this->attachOutput($entry, $example->getOutput());
+        $this->attachHandedOver($entry, $example->getAttachments());
         $this->attachNotes($entry, $example);
 
         return $entry;
+    }
+
+    /**
+     * Attaches what the spec or scenario handed over about itself: the log it
+     * watched, the output of a process it drove, the page a browser was
+     * showing. PhpSpec cannot reach any of that on its own, so what is here was
+     * offered deliberately, and only for an entry worth diagnosing.
+     *
+     * @param array<string, mixed> $entry
+     * @param array<string, string|array{error: string}> $attachments
+     */
+    private function attachHandedOver(array &$entry, array $attachments): void
+    {
+        $reported = [];
+
+        foreach ($attachments as $name => $value) {
+            $reported[$name] = is_string($value) ? ValueExporter::exportOutput($value) : $value;
+        }
+
+        if ($reported !== []) {
+            $entry['attachments'] = $reported;
+        }
     }
 
     /**
@@ -667,6 +690,7 @@ final class Agent extends AbstractFormatter
         }
 
         $this->attachOutput($entry, $printed);
+        $this->attachHandedOver($entry, $scenario->getAttachments());
         $entry['steps'] = $steps;
 
         // A scenario is addressed by the line its keyword sits on, which is what

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -557,7 +557,7 @@ final class Agent extends AbstractFormatter
      * which is a comparison worth reporting: an anonymous matcher (any
      * __call-based custom or predicate matcher) has no name to give either.
      *
-     * @return array{expected?: array{matcher: string|null, value: mixed, negated: bool}, actual?: mixed}
+     * @return array{expectation?: array{matcher: string|null, expected: mixed, actual: mixed, negated: bool}}
      */
     private function expectation(?MatchResult $match): array
     {
@@ -566,12 +566,12 @@ final class Agent extends AbstractFormatter
         }
 
         return [
-            'expected' => [
+            'expectation' => [
                 'matcher' => $match->getMatcher(),
-                'value' => ValueExporter::export($match->getActual()),
+                'expected' => ValueExporter::export($match->getActual()),
+                'actual' => ValueExporter::export($match->getExpected()),
                 'negated' => $match->isNegated(),
             ],
-            'actual' => ValueExporter::export($match->getExpected()),
         ];
     }
 

--- a/src/PhpSpec/Report/Formatter/DetailSections.php
+++ b/src/PhpSpec/Report/Formatter/DetailSections.php
@@ -110,6 +110,7 @@ final class DetailSections
                     }
                 };
                 $this->attachPrinted('Errors', $example->getOutput());
+                $this->attachHandedOver('Errors', $example->getAttachments());
             }
         } elseif ($example->isFailure()) {
             $failures = array_values(array_filter(
@@ -124,6 +125,7 @@ final class DetailSections
                     }
                 };
                 $this->attachPrinted('Failures', $example->getOutput());
+                $this->attachHandedOver('Failures', $example->getAttachments());
             }
         } elseif ($example->isSkipped()) {
             $this->sections['Skipped'][] = static function (OutputInterface $output) use ($title): void {
@@ -192,6 +194,10 @@ final class DetailSections
                     $this->sections[$section][] = self::noteEntry($title, $warning);
                 }
             }
+
+            // Handed over by the scenario, not by any one of its steps: whichever
+            // step failed, the log the scenario was watching is the same log.
+            $this->attachHandedOver('Failures', $scenario->getAttachments());
         }
     }
 
@@ -302,6 +308,26 @@ final class DetailSections
         }
 
         return '[' . implode(', ', $parts) . ']';
+    }
+
+    /**
+     * Adds what the spec or scenario handed over about itself, under the name
+     * it was handed over with, so a watched log reads next to the failure it
+     * explains.
+     *
+     * @param array<string, string|array{error: string}> $attachments
+     */
+    private function attachHandedOver(string $section, array $attachments): void
+    {
+        foreach ($attachments as $name => $value) {
+            $text = is_string($value) ? $value : 'could not be read: ' . $value['error'];
+
+            $this->sections[$section][] = static function (OutputInterface $output) use ($name, $text): void {
+                $output->write(PHP_EOL . '  <fg=gray>' . $name . ':</>');
+                PrettyViews::printedOutput($output, $text, 2);
+                $output->write(PHP_EOL);
+            };
+        }
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/DetailSections.php
+++ b/src/PhpSpec/Report/Formatter/DetailSections.php
@@ -37,6 +37,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class DetailSections
 {
+    /** How many elements of an array a pair shows before saying how many are left. */
+    private const ARRAY_MAX = 10;
+
     /** @var array<string, list<callable(OutputInterface): void>> */
     private array $sections = [];
 
@@ -269,12 +272,36 @@ final class DetailSections
         return match (true) {
             is_bool($value) => $value ? 'true' : 'false',
             is_null($value) => 'null',
-            is_array($value) => var_export($value, true),
+            is_array($value) => self::listing($value),
             // Named by what it is, not by which instance it was: two runs of the
             // same failure read the same, and "Money#180" told nobody anything.
             is_object($value) => ObjectName::of($value),
             default => (string) $value,
         };
+    }
+
+    /**
+     * An array by the same rule as anything else in it, element by element. Not
+     * var_export: an array holding an object with a reference back to itself
+     * makes that emit a PHP warning, and a report about a failure must never
+     * become a failure of its own.
+     *
+     * @param array<array-key, mixed> $value
+     */
+    private static function listing(array $value): string
+    {
+        $shown = array_slice($value, 0, self::ARRAY_MAX, true);
+        $parts = [];
+
+        foreach ($shown as $key => $item) {
+            $parts[] = is_int($key) ? self::value($item) : $key . ' => ' . self::value($item);
+        }
+
+        if (count($value) > self::ARRAY_MAX) {
+            $parts[] = '… ' . (count($value) - self::ARRAY_MAX) . ' more';
+        }
+
+        return '[' . implode(', ', $parts) . ']';
     }
 
     /**

--- a/src/PhpSpec/Report/Formatter/DetailSections.php
+++ b/src/PhpSpec/Report/Formatter/DetailSections.php
@@ -205,7 +205,10 @@ final class DetailSections
         $target = $failure->getActual();
         $matcher = $failure->getMatcher();
 
-        if ($matcher !== null && $target !== null) {
+        // A target the matcher's own name already states ("to be true") is not
+        // read back as a label and a value, which says the same thing twice.
+        // The message says it once, and the pair beneath names both sides.
+        if ($matcher !== null && $target !== null && !$failure->isTargetImplied()) {
             $label = ($failure->isNegated() ? 'not ' : '') . self::phrase($matcher);
             $this->pair($output, 'expected', self::value($subject), $label, self::value($target));
         } else {

--- a/src/PhpSpec/Report/Formatter/DetailSections.php
+++ b/src/PhpSpec/Report/Formatter/DetailSections.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec\Report\Formatter;
 
+use PhpSpec\ObjectName;
 use PhpSpec\Report\Formatter\Pretty\PrettyViews;
 use PhpSpec\Result\ContextResult;
 use PhpSpec\Result\ExampleResult;
@@ -23,6 +24,7 @@ use PhpSpec\Result\ScenarioResult;
 use PhpSpec\Result\SpecificationResult;
 use PhpSpec\Result\StepResult;
 use PhpSpec\Result\SuiteResult;
+use PhpSpec\Specification\Expectation;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -214,7 +216,9 @@ final class DetailSections
         } else {
             $output->write(PHP_EOL . '  ' . $failure->getMessage() . PHP_EOL);
 
-            if ($subject !== null || $target !== null) {
+            // A matcher with no target has nothing to put opposite the subject,
+            // and "expected: N/A" is a line that tells the reader nothing.
+            if (($subject !== null || $target !== null) && $target !== Expectation::NO_TARGET) {
                 $this->pair($output, 'expected', self::value($target), 'got', self::value($subject));
             }
         }
@@ -266,7 +270,9 @@ final class DetailSections
             is_bool($value) => $value ? 'true' : 'false',
             is_null($value) => 'null',
             is_array($value) => var_export($value, true),
-            is_object($value) => get_class($value) . '#' . spl_object_id($value),
+            // Named by what it is, not by which instance it was: two runs of the
+            // same failure read the same, and "Money#180" told nobody anything.
+            is_object($value) => ObjectName::of($value),
             default => (string) $value,
         };
     }

--- a/src/PhpSpec/Report/Formatter/Pretty/PrettyViews.php
+++ b/src/PhpSpec/Report/Formatter/Pretty/PrettyViews.php
@@ -29,6 +29,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PrettyViews
 {
+    /**
+     * How much printed or attached text a failure shows before saying how much
+     * more there was. The same cap the agent document uses, so both formatters
+     * cut at the same place and a reader comparing them sees the same text.
+     */
+    private const PRINTED_MAX = 4000;
+
     public static function specification(OutputInterface $output, SpecificationResult $specification, bool $verbose = false): void
     {
         $output->write(PHP_EOL);
@@ -146,9 +153,12 @@ final class PrettyViews
 
 
     /**
-     * What the subject printed, quoted rather than let loose: each line behind
-     * a bar, so a dump reads as the code talking and not as PhpSpec's own
-     * report. Console markup in the text is escaped, never interpreted.
+     * What the subject printed or handed over, quoted rather than let loose:
+     * each line behind a bar, so a dump reads as the code talking and not as
+     * PhpSpec's own report. Console markup in the text is escaped, never
+     * interpreted, and a flood is cut with a note of how much there was: a
+     * response body or a watched log can run to megabytes, and a terminal that
+     * scrolls for a minute has buried the failure it was meant to explain.
      */
     public static function printedOutput(OutputInterface $output, string $printed, int $indentation): void
     {
@@ -156,8 +166,15 @@ final class PrettyViews
             return;
         }
 
-        foreach (explode("\n", rtrim($printed, "\n")) as $line) {
+        $length = mb_strlen($printed);
+        $shown = $length > self::PRINTED_MAX ? mb_substr($printed, 0, self::PRINTED_MAX) : $printed;
+
+        foreach (explode("\n", rtrim($shown, "\n")) as $line) {
             $output->write(PHP_EOL . str_repeat(' ', $indentation) . '<fg=gray>▏ ' . OutputFormatter::escape($line) . '</>');
+        }
+
+        if ($length > self::PRINTED_MAX) {
+            $output->write(PHP_EOL . str_repeat(' ', $indentation) . '<fg=gray>▏ … ' . ($length - self::PRINTED_MAX) . ' more characters</>');
         }
     }
 

--- a/src/PhpSpec/Result/Detail/Failed.php
+++ b/src/PhpSpec/Result/Detail/Failed.php
@@ -48,6 +48,9 @@ final class Failed extends Detail
     /** @var bool Whether the matcher was negated (expect(...)->not()->...) */
     private bool $negated = false;
 
+    /** @var bool Whether the target is implied by the matcher's own name ("to be true") */
+    private bool $impliedTarget = false;
+
     /**
      * Creates a Failed detail from a matcher comparison.
      *
@@ -61,7 +64,7 @@ final class Failed extends Detail
      * @param ?string $matcher the matcher method that produced the failure (e.g. "toBe")
      * @param bool $negated whether the matcher was negated
      */
-    public static function matcher(mixed $expected, mixed $actual, string $message, SurroundingCode $code, int $line, string $file, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false): Detail
+    public static function matcher(mixed $expected, mixed $actual, string $message, SurroundingCode $code, int $line, string $file, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false, bool $impliedTarget = false): Detail
     {
         $failed = new self($message);
         $failed->expected = $expected;
@@ -72,6 +75,7 @@ final class Failed extends Detail
         $failed->fakeExpression = $fakeExpression;
         $failed->matcher = $matcher;
         $failed->negated = $negated;
+        $failed->impliedTarget = $impliedTarget;
         return $failed;
     }
 
@@ -81,6 +85,16 @@ final class Failed extends Detail
     public function getMatcher(): ?string
     {
         return $this->matcher;
+    }
+
+    /**
+     * Returns whether the target was implied by the matcher name rather than
+     * given by the caller, so a view can avoid reading it back ("to be true:
+     * true") while a report still names both sides.
+     */
+    public function isTargetImplied(): bool
+    {
+        return $this->impliedTarget;
     }
 
     /**

--- a/src/PhpSpec/Result/ExampleResult.php
+++ b/src/PhpSpec/Result/ExampleResult.php
@@ -42,6 +42,9 @@ final class ExampleResult implements Results
     /** @var string What the subject printed while this example ran */
     private string $output = '';
 
+    /** @var array<string, string|array{error: string}> Context the example handed over about itself */
+    private array $attachments = [];
+
     /**
      * @param string $title the example description
      * @param array<MatchResult> $matchResults array of MatchResult instances from this example
@@ -273,6 +276,27 @@ final class ExampleResult implements Results
     public function getOutput(): string
     {
         return $this->output;
+    }
+
+    /**
+     * Stores context the example handed over about itself, read before its
+     * teardown ran.
+     *
+     * @param array<string, string|array{error: string}> $attachments
+     */
+    public function setAttachments(array $attachments): void
+    {
+        $this->attachments = $attachments;
+    }
+
+    /**
+     * Returns the context the example handed over about itself.
+     *
+     * @return array<string, string|array{error: string}>
+     */
+    public function getAttachments(): array
+    {
+        return $this->attachments;
     }
 
     /**

--- a/src/PhpSpec/Result/MatchResult.php
+++ b/src/PhpSpec/Result/MatchResult.php
@@ -71,6 +71,7 @@ final readonly class MatchResult implements Results
         ?string $fakeExpression = null,
         ?string $matcher = null,
         bool $negated = false,
+        bool $impliedTarget = false,
     ): MatchResult {
         return new self(
             Result::Failed,
@@ -84,6 +85,7 @@ final readonly class MatchResult implements Results
                 $fakeExpression,
                 $matcher,
                 $negated,
+                $impliedTarget,
             ),
         );
     }
@@ -169,6 +171,15 @@ final readonly class MatchResult implements Results
     public function getMatcher(): ?string
     {
         return $this->detail instanceof Detail\Failed ? $this->detail->getMatcher() : null;
+    }
+
+    /**
+     * Returns whether the target was implied by the matcher name ("to be true")
+     * rather than given by the caller; false for a passed result.
+     */
+    public function isTargetImplied(): bool
+    {
+        return $this->detail instanceof Detail\Failed && $this->detail->isTargetImplied();
     }
 
     /**

--- a/src/PhpSpec/Result/ScenarioResult.php
+++ b/src/PhpSpec/Result/ScenarioResult.php
@@ -27,12 +27,27 @@ final readonly class ScenarioResult implements Results
      * @param array<StepResult> $stepResults child StepResult instances
      * @param int $line the line its "Scenario:" keyword sits on, or the examples
      *                  table row for an outline expansion; 0 when unknown
+     * @param array<string, string|array{error: string}> $attachments context the
+     *        scenario handed over about itself, read before its teardown ran
      */
     public function __construct(
         private string $title,
         private array $stepResults,
         private int $line = 0,
+        private array $attachments = [],
     ) {}
+
+    /**
+     * Context the scenario handed over about itself: the log it watched, the
+     * output of a process it drove. Empty unless something was attached, and
+     * only ever read for a scenario that needed attention.
+     *
+     * @return array<string, string|array{error: string}>
+     */
+    public function getAttachments(): array
+    {
+        return $this->attachments;
+    }
 
     /**
      * The line that addresses this scenario in a "file.feature:LINE" run, or 0

--- a/src/PhpSpec/Specification/EventfulExpectation.php
+++ b/src/PhpSpec/Specification/EventfulExpectation.php
@@ -48,10 +48,12 @@ final readonly class EventfulExpectation
      * @param bool $impliedTarget whether the target is implied by the matcher's own name
      * @param \Closure|null $actual what to report as the actual instead of the subject,
      *                              resolved after the matcher has run
+     * @param array{mixed}|null $expects what to report as the expected, wrapped so that
+     *                                   stating null is told apart from stating nothing
      * @param mixed ...$values format values for the failure message
      * @return void
      */
-    public function createMatchEvent(\Closure $match, string $message, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false, bool $impliedTarget = false, ?\Closure $actual = null, ...$values): void
+    public function createMatchEvent(\Closure $match, string $message, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false, bool $impliedTarget = false, ?\Closure $actual = null, ?array $expects = null, ...$values): void
     {
         DispatcherRegistry::dispatcher()->dispatch(new ExpectationStarted(), ExpectationStarted::NAME);
         DispatcherRegistry::dispatcher()->dispatch(new MatchCreated(fn() => match (true) {
@@ -60,7 +62,7 @@ final readonly class EventfulExpectation
             // now, so a matcher that only learns its actual by running knows it.
             default => MatchResult::failed(
                 $actual !== null ? $actual() : $this->subject,
-                $values[1] ?? null,
+                $expects !== null ? $expects[0] : ($values[1] ?? null),
                 Expectation::formatMessage($message, ...$values),
                 $this->file,
                 $this->line,

--- a/src/PhpSpec/Specification/EventfulExpectation.php
+++ b/src/PhpSpec/Specification/EventfulExpectation.php
@@ -46,16 +46,20 @@ final readonly class EventfulExpectation
      * @param string|null $matcher the matcher method that produced the expectation (e.g. "toBe")
      * @param bool $negated whether the matcher was negated
      * @param bool $impliedTarget whether the target is implied by the matcher's own name
+     * @param \Closure|null $actual what to report as the actual instead of the subject,
+     *                              resolved after the matcher has run
      * @param mixed ...$values format values for the failure message
      * @return void
      */
-    public function createMatchEvent(\Closure $match, string $message, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false, bool $impliedTarget = false, ...$values): void
+    public function createMatchEvent(\Closure $match, string $message, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false, bool $impliedTarget = false, ?\Closure $actual = null, ...$values): void
     {
         DispatcherRegistry::dispatcher()->dispatch(new ExpectationStarted(), ExpectationStarted::NAME);
         DispatcherRegistry::dispatcher()->dispatch(new MatchCreated(fn() => match (true) {
             $match($this->subject) => MatchResult::passed(),
+            // Resolved here rather than at call time: the matcher has run by
+            // now, so a matcher that only learns its actual by running knows it.
             default => MatchResult::failed(
-                $this->subject,
+                $actual !== null ? $actual() : $this->subject,
                 $values[1] ?? null,
                 Expectation::formatMessage($message, ...$values),
                 $this->file,

--- a/src/PhpSpec/Specification/EventfulExpectation.php
+++ b/src/PhpSpec/Specification/EventfulExpectation.php
@@ -45,10 +45,11 @@ final readonly class EventfulExpectation
      * @param string|null $fakeExpression PHP expression for --fake code generation
      * @param string|null $matcher the matcher method that produced the expectation (e.g. "toBe")
      * @param bool $negated whether the matcher was negated
+     * @param bool $impliedTarget whether the target is implied by the matcher's own name
      * @param mixed ...$values format values for the failure message
      * @return void
      */
-    public function createMatchEvent(\Closure $match, string $message, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false, ...$values): void
+    public function createMatchEvent(\Closure $match, string $message, ?string $fakeExpression = null, ?string $matcher = null, bool $negated = false, bool $impliedTarget = false, ...$values): void
     {
         DispatcherRegistry::dispatcher()->dispatch(new ExpectationStarted(), ExpectationStarted::NAME);
         DispatcherRegistry::dispatcher()->dispatch(new MatchCreated(fn() => match (true) {
@@ -62,6 +63,7 @@ final readonly class EventfulExpectation
                 $fakeExpression,
                 $matcher,
                 $negated,
+                $impliedTarget,
             )
         }), MatchCreated::NAME);
     }

--- a/src/PhpSpec/Specification/Example.php
+++ b/src/PhpSpec/Specification/Example.php
@@ -15,6 +15,7 @@
 namespace PhpSpec\Specification;
 
 use Closure;
+use PhpSpec\Attachments;
 use PhpSpec\CapturedOutput;
 use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\EventDispatcher\Event\ExampleCompleted;
@@ -144,11 +145,17 @@ class Example implements ExampleResultRegistry, Rebindable
         $subscriber = new ExampleSubscriber($this);
         DispatcherRegistry::dispatcher()->addSubscriber($subscriber);
 
+        // Read while the example is still standing where it attached them, which
+        // is before its afterEach hooks tidy away what they point at.
+        $attachments = new Attachments();
+        DispatcherRegistry::dispatcher()->addSubscriber($attachments);
+
         DispatcherRegistry::dispatcher()->dispatch(new ExampleStarted($this->title), ExampleStarted::NAME);
 
         if ($this->pending) {
             DispatcherRegistry::dispatcher()->removeSubscriber($subscriber);
             $this->exampleResult = new ExampleResult($this->title, [], false, true);
+            $this->keepAttachments($attachments);
             DispatcherRegistry::dispatcher()->dispatch(new ExampleCompleted($this->title, $this->exampleResult), ExampleCompleted::NAME);
             return $this->exampleResult;
         }
@@ -177,6 +184,7 @@ class Example implements ExampleResultRegistry, Rebindable
             $this->exampleResult = new ExampleResult($this->title, [], false, true);
             $this->exampleResult->setWarnings($warnings);
             $this->exampleResult->setOutput($printed->text());
+            $this->keepAttachments($attachments);
             DispatcherRegistry::dispatcher()->dispatch(new ExampleCompleted($this->title, $this->exampleResult), ExampleCompleted::NAME);
             return $this->exampleResult;
         } catch (SkippedException $e) {
@@ -184,6 +192,7 @@ class Example implements ExampleResultRegistry, Rebindable
             DispatcherRegistry::dispatcher()->removeSubscriber($subscriber);
             $this->exampleResult = new ExampleResult($this->title, [], false, false, true);
             $this->exampleResult->setOutput($printed->text());
+            $this->keepAttachments($attachments);
             DispatcherRegistry::dispatcher()->dispatch(new ExampleCompleted($this->title, $this->exampleResult), ExampleCompleted::NAME);
             return $this->exampleResult;
         } catch (\Throwable $e) {
@@ -208,8 +217,32 @@ class Example implements ExampleResultRegistry, Rebindable
         $this->exampleResult->setWarnings(array_values(array_filter($all, fn($w) => in_array($w['severity'], [E_WARNING, E_USER_WARNING]))));
         $this->exampleResult->setDeprecations(array_values(array_filter($all, fn($w) => in_array($w['severity'], [E_DEPRECATED, E_USER_DEPRECATED]))));
         $this->exampleResult->setNotices(array_values(array_filter($all, fn($w) => in_array($w['severity'], [E_NOTICE, E_USER_NOTICE]))));
+        $this->keepAttachments($attachments);
         DispatcherRegistry::dispatcher()->dispatch(new ExampleCompleted($this->title, $this->exampleResult), ExampleCompleted::NAME);
         return $this->exampleResult;
+    }
+
+    /**
+     * Puts what the example handed over about itself onto its result, and stops
+     * listening for more. Read here, while the example still stands where it
+     * attached them, because its afterEach hooks are next and they are what
+     * tidies away the files and processes an attachment points at.
+     *
+     * Nothing is read for an example that passed: an attachment is a diagnosis,
+     * and there is nothing to diagnose.
+     */
+    private function keepAttachments(Attachments $attachments): void
+    {
+        DispatcherRegistry::dispatcher()->removeSubscriber($attachments);
+
+        if ($attachments->isEmpty()) {
+            return;
+        }
+
+        $result = $this->exampleResult;
+        if ($result->isFailure() || $result->isError() || $result->isPending() || $result->isSkipped()) {
+            $result->setAttachments($attachments->read());
+        }
     }
 
     /**

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -32,6 +32,9 @@ class Expectation
      */
     public const NO_TARGET = 'N/A';
 
+    /** What a callable that was meant to throw reports having done instead. */
+    public const NOTHING_THROWN = 'No exception';
+
     /** @var bool whether the next matcher should invert its result */
     protected bool $negated = false;
 
@@ -772,25 +775,42 @@ class Expectation
      * @param string|null $message expected exception message (exact match)
      * @return static
      */
-    public function toThrow(string $exceptionClass, ?string $message = null): static
+    public function toThrow(string $exceptionClass = '', ?string $message = null): static
     {
+        // What the callable did, filled in as it runs: the exception it threw,
+        // or the sentence for having thrown none. The reader is comparing what
+        // was asked for against what happened, not against the callable itself.
+        $outcome = self::NOTHING_THROWN;
+
         return $this->match(
-            function ($expected) use ($exceptionClass, $message) {
+            function ($expected) use ($exceptionClass, $message, &$outcome) {
                 try {
                     $expected();
+
                     return false;
                 } catch (\Throwable $e) {
-                    if (!($e instanceof $exceptionClass)) {
+                    $outcome = $e;
+                    if ($exceptionClass !== '' && !($e instanceof $exceptionClass)) {
                         return false;
                     }
                     if ($message !== null && $e->getMessage() !== $message) {
                         return false;
                     }
+
                     return true;
                 }
             },
-            'Expected callable to throw %s',
-            $exceptionClass,
+            $exceptionClass === '' ? 'Expected callable to throw' : 'Expected callable to throw %s',
+            $exceptionClass === '' ? '' : ObjectName::named($exceptionClass, $message),
+            // Whatever it was asked for, or nothing at all when it was asked
+            // only to throw.
+            $exceptionClass === '' ? self::NO_TARGET : ObjectName::named($exceptionClass, $message),
+            // By reference, and not an arrow function: this has to read the
+            // outcome as it stands once the callable has run, not as it stood
+            // when the expectation was written.
+            ['__implied' => $exceptionClass === '', '__actual' => function () use (&$outcome) {
+                return $outcome;
+            }],
         );
     }
 
@@ -820,12 +840,18 @@ class Expectation
         // the value anyway, so a report can name both sides, but says it is
         // implied so a view does not read back "to be true: true".
         $implied = false;
+        // What to report as the actual, for a matcher whose subject is not the
+        // interesting half: toThrow is handed a callable and the reader wants
+        // the exception it threw, which is only known once it has run, so the
+        // marker is a closure resolved after the matcher decides.
+        $actual = null;
         // Extract the markers if the last argument is the marker array
         $markers = !empty($message) && is_array(end($message)) ? end($message) : [];
-        if (array_key_exists('__fake', $markers) || array_key_exists('__implied', $markers)) {
+        if (array_key_exists('__fake', $markers) || array_key_exists('__implied', $markers) || array_key_exists('__actual', $markers)) {
             array_pop($message);
             $fakeExpression = $markers['__fake'] ?? null;
             $implied = (bool) ($markers['__implied'] ?? false);
+            $actual = $markers['__actual'] ?? null;
         }
 
         if ($this->negated) {
@@ -836,7 +862,7 @@ class Expectation
             }
             $fakeExpression = null; // negated matchers don't produce fakes
         }
-        $this->eventCreator?->createMatchEvent($match, $message[0], $fakeExpression, $matcher, $negated, $implied, ...array_slice($message, 1));
+        $this->eventCreator?->createMatchEvent($match, $message[0], $fakeExpression, $matcher, $negated, $implied, $actual, ...array_slice($message, 1));
         return $this;
     }
 

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -634,8 +634,7 @@ class Expectation
             fn($expected) => ($d = self::extractResponseData($expected)) !== null && $d['status'] === 200,
             'Expected response to be OK (200), got %s',
             $data['status'] ?? 'non-Response',
-            200,
-            ['__implied' => true],
+            ['__implied' => true, '__expected' => 200, '__actual' => fn() => $data['status'] ?? 'No response'],
         );
     }
 
@@ -652,8 +651,7 @@ class Expectation
             fn($expected) => ($d = self::extractResponseData($expected)) !== null && $d['status'] === 400,
             'Expected response to be Bad Request (400), got %s',
             $data['status'] ?? 'non-Response',
-            400,
-            ['__implied' => true],
+            ['__implied' => true, '__expected' => 400, '__actual' => fn() => $data['status'] ?? 'No response'],
         );
     }
 
@@ -672,6 +670,7 @@ class Expectation
             'Expected response status %s, got %s',
             $code,
             $data['status'] ?? 'non-Response',
+            ['__expected' => $code, '__actual' => fn() => $data['status'] ?? 'No response'],
         );
     }
 
@@ -765,6 +764,7 @@ class Expectation
             $url,
             $data['headers']['Location'] ?? 'no Location header',
             $data['status'] ?? 'non-Response',
+            ['__expected' => $url, '__actual' => fn() => $data['headers']['Location'] ?? 'No Location header'],
         );
     }
 
@@ -845,13 +845,20 @@ class Expectation
         // the exception it threw, which is only known once it has run, so the
         // marker is a closure resolved after the matcher decides.
         $actual = null;
+        // What to report as the expected, for a matcher whose message needs its
+        // values in an order the report does not share: "Expected status %s, got
+        // %s" wants the target first, and taking the report's target from the
+        // second value would report the status it got as the one it wanted.
+        $expects = null;
         // Extract the markers if the last argument is the marker array
         $markers = !empty($message) && is_array(end($message)) ? end($message) : [];
-        if (array_key_exists('__fake', $markers) || array_key_exists('__implied', $markers) || array_key_exists('__actual', $markers)) {
+        $known = ['__fake', '__implied', '__actual', '__expected'];
+        if (array_intersect($known, array_keys($markers)) !== []) {
             array_pop($message);
             $fakeExpression = $markers['__fake'] ?? null;
             $implied = (bool) ($markers['__implied'] ?? false);
             $actual = $markers['__actual'] ?? null;
+            $expects = array_key_exists('__expected', $markers) ? [$markers['__expected']] : null;
         }
 
         if ($this->negated) {
@@ -862,7 +869,7 @@ class Expectation
             }
             $fakeExpression = null; // negated matchers don't produce fakes
         }
-        $this->eventCreator?->createMatchEvent($match, $message[0], $fakeExpression, $matcher, $negated, $implied, $actual, ...array_slice($message, 1));
+        $this->eventCreator?->createMatchEvent($match, $message[0], $fakeExpression, $matcher, $negated, $implied, $actual, $expects, ...array_slice($message, 1));
         return $this;
     }
 

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -25,6 +25,13 @@ use PhpSpec\ObjectName;
  */
 class Expectation
 {
+    /**
+     * What a matcher states when it has no target at all: a predicate decides
+     * for itself and can only report the subject it decided about. Said out
+     * loud, because a silent null reads as "it expected null".
+     */
+    public const NO_TARGET = 'N/A';
+
     /** @var bool whether the next matcher should invert its result */
     protected bool $negated = false;
 
@@ -60,11 +67,13 @@ class Expectation
             if ($message instanceof Closure) {
                 $message = $message($this->subject, ...$arguments);
             }
+            // A custom matcher's first argument is its target; one that takes
+            // none decides for itself and has none to report.
             return $this->match(
                 fn($expected) => ($custom['matcher'])($expected, ...$arguments),
                 $message,
                 $this->subject,
-                ...$arguments,
+                ...($arguments !== [] ? $arguments : [self::NO_TARGET, ['__implied' => true]]),
             );
         }
 
@@ -85,6 +94,8 @@ class Expectation
                     fn($expected) => (bool) $expected->$method(...$arguments),
                     "Expected %s to {$prefix} {$humanized}",
                     $this->subject,
+                    self::NO_TARGET,
+                    ['__implied' => true],
                 );
             }
         }
@@ -602,6 +613,8 @@ class Expectation
             fn($expected) => $predicate($expected),
             'Expected %s to satisfy predicate',
             $this->subject,
+            self::NO_TARGET,
+            ['__implied' => true],
         );
     }
 

--- a/src/PhpSpec/Specification/Expectation.php
+++ b/src/PhpSpec/Specification/Expectation.php
@@ -210,7 +210,8 @@ class Expectation
             fn($expected) => $expected === true,
             'Expected %s to be true',
             $this->subject,
-            ['__fake' => 'true'],
+            true,
+            ['__fake' => 'true', '__implied' => true],
         );
     }
 
@@ -225,7 +226,8 @@ class Expectation
             fn($expected) => $expected === false,
             'Expected %s to be false',
             $this->subject,
-            ['__fake' => 'false'],
+            false,
+            ['__fake' => 'false', '__implied' => true],
         );
     }
 
@@ -240,7 +242,8 @@ class Expectation
             fn($expected) => $expected === null,
             'Expected %s to be null',
             $this->subject,
-            ['__fake' => 'null'],
+            null,
+            ['__fake' => 'null', '__implied' => true],
         );
     }
 
@@ -255,7 +258,8 @@ class Expectation
             fn($expected) => empty($expected),
             'Expected %s to be empty',
             $this->subject,
-            ['__fake' => '[]'],
+            self::emptyLike($this->subject),
+            ['__fake' => '[]', '__implied' => true],
         );
     }
 
@@ -405,7 +409,8 @@ class Expectation
             fn($expected) => is_callable($expected),
             'Expected %s to be callable',
             $this->subject,
-            ['__fake' => 'function () {}'],
+            'callable',
+            ['__fake' => 'function () {}', '__implied' => true],
         );
     }
 
@@ -492,7 +497,8 @@ class Expectation
             fn($expected) => (bool) $expected === true,
             'Expected %s to be truthy',
             $this->subject,
-            ['__fake' => 'true'],
+            'truthy',
+            ['__fake' => 'true', '__implied' => true],
         );
     }
 
@@ -507,7 +513,8 @@ class Expectation
             fn($expected) => (bool) $expected === false,
             'Expected %s to be falsy',
             $this->subject,
-            ['__fake' => 'false'],
+            'falsy',
+            ['__fake' => 'false', '__implied' => true],
         );
     }
 
@@ -611,6 +618,8 @@ class Expectation
             fn($expected) => ($d = self::extractResponseData($expected)) !== null && $d['status'] === 200,
             'Expected response to be OK (200), got %s',
             $data['status'] ?? 'non-Response',
+            200,
+            ['__implied' => true],
         );
     }
 
@@ -627,6 +636,8 @@ class Expectation
             fn($expected) => ($d = self::extractResponseData($expected)) !== null && $d['status'] === 400,
             'Expected response to be Bad Request (400), got %s',
             $data['status'] ?? 'non-Response',
+            400,
+            ['__implied' => true],
         );
     }
 
@@ -774,6 +785,12 @@ class Expectation
      * Evaluates a matcher against the subject, handling negation and dispatching
      * the match event through EventfulExpectation.
      *
+     * The first value is the subject and the second is what the matcher wanted,
+     * which is reported as the failure's `expected` whether or not the message
+     * has a placeholder for it. A matcher that names its target only in prose
+     * ("to be true") therefore still states it as a value, so a reader is never
+     * told a failure expected null when it expected true.
+     *
      * @param Closure $match callback receiving the subject, returning bool
      * @param mixed ...$message format string followed by values, optionally ending with a fake expression array
      */
@@ -786,10 +803,16 @@ class Expectation
         $negated = $this->negated;
 
         $fakeExpression = null;
-        // Extract fakeExpression if last argument is an array with '__fake' key
-        if (!empty($message) && is_array(end($message)) && array_key_exists('__fake', end($message))) {
-            $fakeArg = array_pop($message);
-            $fakeExpression = $fakeArg['__fake'];
+        // A matcher whose target is implied by its own name ("to be true") states
+        // the value anyway, so a report can name both sides, but says it is
+        // implied so a view does not read back "to be true: true".
+        $implied = false;
+        // Extract the markers if the last argument is the marker array
+        $markers = !empty($message) && is_array(end($message)) ? end($message) : [];
+        if (array_key_exists('__fake', $markers) || array_key_exists('__implied', $markers)) {
+            array_pop($message);
+            $fakeExpression = $markers['__fake'] ?? null;
+            $implied = (bool) ($markers['__implied'] ?? false);
         }
 
         if ($this->negated) {
@@ -800,7 +823,7 @@ class Expectation
             }
             $fakeExpression = null; // negated matchers don't produce fakes
         }
-        $this->eventCreator?->createMatchEvent($match, $message[0], $fakeExpression, $matcher, $negated, ...array_slice($message, 1));
+        $this->eventCreator?->createMatchEvent($match, $message[0], $fakeExpression, $matcher, $negated, $implied, ...array_slice($message, 1));
         return $this;
     }
 
@@ -904,6 +927,22 @@ class Expectation
      * @param string $string source string
      * @return string string with first occurrence replaced
      */
+    /**
+     * The empty form of whatever it was given: what an emptiness matcher wanted
+     * instead of what it got. Reporting "" against an array of three hundred
+     * items would be a small lie, so the answer keeps the subject's own type.
+     */
+    private static function emptyLike(mixed $subject): mixed
+    {
+        return match (true) {
+            is_array($subject) => [],
+            is_string($subject) => '',
+            is_int($subject) => 0,
+            is_float($subject) => 0.0,
+            default => null,
+        };
+    }
+
     private static function replaceOne(string $pattern, string $replace, string $string): string
     {
         $pos = strpos($string, $pattern);

--- a/src/PhpSpec/StoryBDD/Feature.php
+++ b/src/PhpSpec/StoryBDD/Feature.php
@@ -14,6 +14,7 @@
 
 namespace PhpSpec\StoryBDD;
 
+use PhpSpec\Attachments;
 use PhpSpec\CapturedOutput;
 use PhpSpec\EventDispatcher\DispatcherRegistry;
 use PhpSpec\Result\FeatureResult;
@@ -139,6 +140,12 @@ final readonly class Feature implements SpecBlock
         $collector = new StepMatchCollector();
         DispatcherRegistry::dispatcher()->addSubscriber($collector);
 
+        // What the scenario hands over about itself, for as long as it runs: a
+        // step attaches in one place and a later step's failure is what makes it
+        // worth reading.
+        $attachments = new Attachments();
+        DispatcherRegistry::dispatcher()->addSubscriber($attachments);
+
         $stepResults = [];
         $failed = false;
 
@@ -170,13 +177,39 @@ final readonly class Feature implements SpecBlock
             }
         }
 
+        // Read before the teardown, and only for a scenario that needs
+        // attention: an after-hook that stops the process and clears the
+        // workspace would otherwise leave an empty attachment, which reads as
+        // "it said nothing" rather than "PhpSpec looked too late".
+        $attached = [];
+        if (!$attachments->isEmpty() && self::needsAttention($stepResults)) {
+            $attached = $attachments->read();
+        }
+
         $this->hooks->runAfterScenario($world);
 
         DispatcherRegistry::dispatcher()->removeSubscriber($collector);
+        DispatcherRegistry::dispatcher()->removeSubscriber($attachments);
 
         // An outline expansion is addressed by its own examples-table row; every
         // other scenario by its keyword line.
-        return new ScenarioResult($scenario->title, $stepResults, $scenario->exampleLine ?? $scenario->line);
+        return new ScenarioResult($scenario->title, $stepResults, $scenario->exampleLine ?? $scenario->line, $attached);
+    }
+
+    /**
+     * Whether any step left the scenario something to answer for.
+     *
+     * @param array<StepResult> $stepResults
+     */
+    private static function needsAttention(array $stepResults): bool
+    {
+        foreach ($stepResults as $step) {
+            if (!$step->isPassed()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/PhpSpec/functions.php
+++ b/src/PhpSpec/functions.php
@@ -12,313 +12,351 @@
  * file that was distributed with this source code.
  */
 
-use PhpSpec\EventDispatcher\DispatcherRegistry;
-use PhpSpec\EventDispatcher\Event\ContextCreated;
-use PhpSpec\EventDispatcher\Event\ExampleCreated;
-use PhpSpec\Mock\MatchableDouble;
-use PhpSpec\Specification\Context;
-use PhpSpec\Specification\Example;
-use PhpSpec\Specification\Expectation;
-use PhpSpec\Specification\PendingException;
-use PhpSpec\Specification\SkippedException;
+namespace {
+    use PhpSpec\EventDispatcher\DispatcherRegistry;
+    use PhpSpec\EventDispatcher\Event\ContextCreated;
+    use PhpSpec\EventDispatcher\Event\ExampleCreated;
+    use PhpSpec\Mock\MatchableDouble;
+    use PhpSpec\Specification\Context;
+    use PhpSpec\Specification\Example;
+    use PhpSpec\Specification\Expectation;
+    use PhpSpec\Specification\PendingException;
+    use PhpSpec\Specification\SkippedException;
 
-/**
- * Registers a new example (test case) in the current context scope.
- *
- * @param string $title descriptive label for the example
- * @param Closure $example executable test body
- */
-function it(string $title, Closure $example): void
-{
-    $it = new Example($title, $example);
+    /**
+     * Registers a new example (test case) in the current context scope.
+     *
+     * @param string $title descriptive label for the example
+     * @param Closure $example executable test body
+     */
+    function it(string $title, Closure $example): void
+    {
+        $it = new Example($title, $example);
 
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    if ($scope) {
-        $scope->addSpecBlock($it);
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        if ($scope) {
+            $scope->addSpecBlock($it);
+        }
+
+        DispatcherRegistry::dispatcher()->dispatch(
+            new ExampleCreated($title, $it),
+            ExampleCreated::NAME,
+        );
     }
 
-    DispatcherRegistry::dispatcher()->dispatch(
-        new ExampleCreated($title, $it),
-        ExampleCreated::NAME,
-    );
-}
-
-/**
- * Alias for it(). Registers a new example in the current context scope.
- *
- * @param string $title descriptive label for the example
- * @param Closure $example executable test body
- */
-function its(string $title, Closure $example): void
-{
-    it($title, $example);
-}
-
-/**
- * Creates an Expectation for the given subject value.
- *
- * Detects mock doubles and returns a Mock\Expectation for stub/verify assertions.
- * Falls back to a standard Expectation for plain values.
- *
- * @param mixed $subject value or mock return to assert against
- * @return Expectation
- */
-function expect(mixed $subject): Expectation
-{
-    $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
-    $file = $trace['file'] ?? '';
-    $line = $trace['line'] ?? 0;
-
-    if ($subject instanceof MatchableDouble) {
-        \PhpSpec\Mock\Expectation::$lastDouble = null;
-        \PhpSpec\Mock\Expectation::$lastMockReturn = null;
-        \PhpSpec\Mock\Expectation::$lastCallForAllow = null;
-        return new \PhpSpec\Mock\Expectation($subject, $file, $line);
+    /**
+     * Alias for it(). Registers a new example in the current context scope.
+     *
+     * @param string $title descriptive label for the example
+     * @param Closure $example executable test body
+     */
+    function its(string $title, Closure $example): void
+    {
+        it($title, $example);
     }
 
-    if (\PhpSpec\Mock\Expectation::$lastDouble !== null) {
-        $lastDouble = \PhpSpec\Mock\Expectation::$lastDouble;
-        $lastReturn = \PhpSpec\Mock\Expectation::$lastMockReturn;
-        \PhpSpec\Mock\Expectation::$lastDouble = null;
-        \PhpSpec\Mock\Expectation::$lastMockReturn = null;
-        \PhpSpec\Mock\Expectation::$lastCallForAllow = null;
+    /**
+     * Creates an Expectation for the given subject value.
+     *
+     * Detects mock doubles and returns a Mock\Expectation for stub/verify assertions.
+     * Falls back to a standard Expectation for plain values.
+     *
+     * @param mixed $subject value or mock return to assert against
+     * @return Expectation
+     */
+    function expect(mixed $subject): Expectation
+    {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
+        $file = $trace['file'] ?? '';
+        $line = $trace['line'] ?? 0;
 
-        if ($subject === $lastReturn) {
-            return new \PhpSpec\Mock\Expectation($lastDouble, $file, $line);
+        if ($subject instanceof MatchableDouble) {
+            \PhpSpec\Mock\Expectation::$lastDouble = null;
+            \PhpSpec\Mock\Expectation::$lastMockReturn = null;
+            \PhpSpec\Mock\Expectation::$lastCallForAllow = null;
+            return new \PhpSpec\Mock\Expectation($subject, $file, $line);
+        }
+
+        if (\PhpSpec\Mock\Expectation::$lastDouble !== null) {
+            $lastDouble = \PhpSpec\Mock\Expectation::$lastDouble;
+            $lastReturn = \PhpSpec\Mock\Expectation::$lastMockReturn;
+            \PhpSpec\Mock\Expectation::$lastDouble = null;
+            \PhpSpec\Mock\Expectation::$lastMockReturn = null;
+            \PhpSpec\Mock\Expectation::$lastCallForAllow = null;
+
+            if ($subject === $lastReturn) {
+                return new \PhpSpec\Mock\Expectation($lastDouble, $file, $line);
+            }
+        }
+
+        return new Expectation($subject, $file, $line);
+    }
+
+    /**
+     * Declares a describe block (context) grouping related examples.
+     *
+     * @param string $context description or class name for the group
+     * @param Closure $examples closure containing nested it()/describe()/let() calls
+     */
+    function describe(string $context, Closure $examples): void
+    {
+        $describe = new Context($context, $examples);
+
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        if ($scope) {
+            $scope->addSpecBlock($describe);
+        }
+
+        DispatcherRegistry::dispatcher()->dispatch(new ContextCreated($context, $describe), ContextCreated::NAME);
+    }
+
+    /**
+     * Alias for describe(). Declares a context block grouping related examples.
+     *
+     * @param string $context description for the group
+     * @param Closure $examples closure containing nested spec DSL calls
+     */
+    function context(string $context, Closure $examples): void
+    {
+        describe($context, $examples);
+    }
+
+    /**
+     * Defines shared state on the current context's world (Subject).
+     *
+     * Accepts either a property name + setter closure, or a single closure whose
+     * type-hinted parameters are auto-resolved as mock doubles.
+     *
+     * @param string|Closure $propertyOrSetter property name or injection closure
+     * @param Closure|null $setter value factory when first arg is a property name
+     */
+    function let(string|Closure $propertyOrSetter, ?Closure $setter = null): void
+    {
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        if ($scope instanceof Context) {
+            if ($propertyOrSetter instanceof Closure) {
+                $scope->modifyWithInjection($propertyOrSetter);
+            } elseif ($setter !== null) {
+                $scope->modify($propertyOrSetter, $setter);
+            }
         }
     }
 
-    return new Expectation($subject, $file, $line);
-}
-
-/**
- * Declares a describe block (context) grouping related examples.
- *
- * @param string $context description or class name for the group
- * @param Closure $examples closure containing nested it()/describe()/let() calls
- */
-function describe(string $context, Closure $examples): void
-{
-    $describe = new Context($context, $examples);
-
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    if ($scope) {
-        $scope->addSpecBlock($describe);
-    }
-
-    DispatcherRegistry::dispatcher()->dispatch(new ContextCreated($context, $describe), ContextCreated::NAME);
-}
-
-/**
- * Alias for describe(). Declares a context block grouping related examples.
- *
- * @param string $context description for the group
- * @param Closure $examples closure containing nested spec DSL calls
- */
-function context(string $context, Closure $examples): void
-{
-    describe($context, $examples);
-}
-
-/**
- * Defines shared state on the current context's world (Subject).
- *
- * Accepts either a property name + setter closure, or a single closure whose
- * type-hinted parameters are auto-resolved as mock doubles.
- *
- * @param string|Closure $propertyOrSetter property name or injection closure
- * @param Closure|null $setter value factory when first arg is a property name
- */
-function let(string|Closure $propertyOrSetter, ?Closure $setter = null): void
-{
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    if ($scope instanceof Context) {
-        if ($propertyOrSetter instanceof Closure) {
-            $scope->modifyWithInjection($propertyOrSetter);
-        } elseif ($setter !== null) {
-            $scope->modify($propertyOrSetter, $setter);
+    /**
+     * Registers a hook to run once before all examples in the current context.
+     *
+     * @param Closure $hook setup callback
+     */
+    function beforeAll(Closure $hook): void
+    {
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        if ($scope instanceof Context) {
+            $scope->addBeforeAll($hook);
         }
     }
-}
 
-/**
- * Registers a hook to run once before all examples in the current context.
- *
- * @param Closure $hook setup callback
- */
-function beforeAll(Closure $hook): void
-{
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    if ($scope instanceof Context) {
-        $scope->addBeforeAll($hook);
+    /**
+     * Registers a hook to run once after all examples in the current context.
+     *
+     * @param Closure $hook teardown callback
+     */
+    function afterAll(Closure $hook): void
+    {
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        if ($scope instanceof Context) {
+            $scope->addAfterAll($hook);
+        }
+    }
+
+    /**
+     * Registers a hook to run before each example in the current context.
+     *
+     * @param Closure $hook per-example setup callback
+     */
+    function beforeEach(Closure $hook): void
+    {
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        if ($scope instanceof Context) {
+            $scope->addBeforeEach($hook);
+        }
+    }
+
+    /**
+     * Registers a hook to run after each example in the current context.
+     *
+     * @param Closure $hook per-example teardown callback
+     */
+    function afterEach(Closure $hook): void
+    {
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        if ($scope instanceof Context) {
+            $scope->addAfterEach($hook);
+        }
+    }
+
+    /**
+     * Registers a pending (skipped) example. The example body is not executed.
+     *
+     * @param string $title descriptive label for the example
+     * @param Closure $example test body (will not run)
+     */
+    function xit(string $title, Closure $example): void
+    {
+        $it = new Example($title, $example);
+        $it->setPending(true);
+
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        $scope?->addSpecBlock($it);
+
+        DispatcherRegistry::dispatcher()->dispatch(
+            new ExampleCreated($title, $it),
+            ExampleCreated::NAME,
+        );
+    }
+
+    /**
+     * Declares a pending describe block. All nested examples are skipped.
+     *
+     * @param string $context description for the group
+     * @param Closure $examples closure containing nested spec DSL calls
+     */
+    function xdescribe(string $context, Closure $examples): void
+    {
+        $describe = new Context($context, $examples);
+        $describe->setPending(true);
+
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        $scope?->addSpecBlock($describe);
+
+        DispatcherRegistry::dispatcher()->dispatch(new ContextCreated($context, $describe), ContextCreated::NAME);
+    }
+
+    /**
+     * Alias for xdescribe(). Declares a pending context block.
+     *
+     * @param string $context description for the group
+     * @param Closure $examples closure containing nested spec DSL calls
+     */
+    function xcontext(string $context, Closure $examples): void
+    {
+        xdescribe($context, $examples);
+    }
+
+    /**
+     * Marks the current example as pending by throwing a PendingException.
+     *
+     * @param string $message reason the example is pending
+     * @throws PendingException always
+     */
+    function pending(string $message = 'Not yet implemented'): never
+    {
+        throw new PendingException($message);
+    }
+
+    /**
+     * Marks the current example as skipped by throwing a SkippedException.
+     *
+     * @param string $message reason the example is skipped
+     * @throws SkippedException always
+     */
+    function skip(string $message = 'Skipped'): never
+    {
+        throw new SkippedException($message);
+    }
+
+    /**
+     * Registers a custom matcher available to all expect() assertions.
+     *
+     * @param string $name matcher name (e.g. 'toBePositive')
+     * @param Closure $matcher callback receiving (subject, ...args) returning bool
+     * @param string $message failure message template with %s placeholders
+     */
+    function addMatcher(string $name, Closure $matcher, string $message): void
+    {
+        Expectation::addMatcher($name, $matcher, $message);
+    }
+
+    /**
+     * Registers a focused example. Only focused examples run when any exist in a context.
+     *
+     * @param string $title descriptive label for the example
+     * @param Closure $example executable test body
+     */
+    function fit(string $title, Closure $example): void
+    {
+        $it = new Example($title, $example);
+        $it->setFocused(true);
+
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        $scope?->addSpecBlock($it);
+
+        DispatcherRegistry::dispatcher()->dispatch(
+            new ExampleCreated($title, $it),
+            ExampleCreated::NAME,
+        );
+    }
+
+    /**
+     * Declares a focused describe block. Non-focused siblings are skipped.
+     *
+     * @param string $context description for the group
+     * @param Closure $examples closure containing nested spec DSL calls
+     */
+    function fdescribe(string $context, Closure $examples): void
+    {
+        $describe = new Context($context, $examples);
+        $describe->setFocused(true);
+
+        $scope = DispatcherRegistry::dispatcher()->currentScope();
+        $scope?->addSpecBlock($describe);
+
+        DispatcherRegistry::dispatcher()->dispatch(new ContextCreated($context, $describe), ContextCreated::NAME);
+    }
+
+    /**
+     * Alias for fdescribe(). Declares a focused context block.
+     *
+     * @param string $context description for the group
+     * @param Closure $examples closure containing nested spec DSL calls
+     */
+    function fcontext(string $context, Closure $examples): void
+    {
+        fdescribe($context, $examples);
     }
 }
 
-/**
- * Registers a hook to run once after all examples in the current context.
- *
- * @param Closure $hook teardown callback
- */
-function afterAll(Closure $hook): void
-{
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    if ($scope instanceof Context) {
-        $scope->addAfterAll($hook);
+namespace PhpSpec {
+    use Closure;
+    use PhpSpec\EventDispatcher\DispatcherRegistry;
+    use PhpSpec\EventDispatcher\Event\AttachmentCreated;
+
+    /**
+     * Hands PhpSpec context it cannot reach on its own, to be reported with the
+     * failure if there is one: the output of a process a step drove, the log the
+     * subject is writing, the page a browser is showing.
+     *
+     * Namespaced deliberately, unlike describe() and given(): a spec framework
+     * should not take a name as common as "attach" in everyone's global
+     * namespace, and taking none of the world's leaves scenario state alone.
+     * Import it where you use it:
+     *
+     *     use function PhpSpec\attach;
+     *
+     *     attach('stdout', $process->getOutput());
+     *     attach('log', fn() => file_get_contents($logFile));
+     *
+     * A closure is read at the end of the example or scenario, so a log still
+     * being written is current when it is read, and nothing is read at all when
+     * the run is green. Reading happens before any teardown, so a hook that
+     * stops the process and clears the workspace cannot empty the attachment
+     * first. The same name twice keeps the latest, so a helper offering the same
+     * log on every poll leaves one attachment rather than a pile.
+     *
+     * @param string $name what to file it under, e.g. "stdout" or "watch.log"
+     * @param string|Closure $value the text, or a closure returning it
+     */
+    function attach(string $name, string|Closure $value): void
+    {
+        DispatcherRegistry::dispatcher()->dispatch(new AttachmentCreated($name, $value), AttachmentCreated::NAME);
     }
-}
-
-/**
- * Registers a hook to run before each example in the current context.
- *
- * @param Closure $hook per-example setup callback
- */
-function beforeEach(Closure $hook): void
-{
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    if ($scope instanceof Context) {
-        $scope->addBeforeEach($hook);
-    }
-}
-
-/**
- * Registers a hook to run after each example in the current context.
- *
- * @param Closure $hook per-example teardown callback
- */
-function afterEach(Closure $hook): void
-{
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    if ($scope instanceof Context) {
-        $scope->addAfterEach($hook);
-    }
-}
-
-/**
- * Registers a pending (skipped) example. The example body is not executed.
- *
- * @param string $title descriptive label for the example
- * @param Closure $example test body (will not run)
- */
-function xit(string $title, Closure $example): void
-{
-    $it = new Example($title, $example);
-    $it->setPending(true);
-
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    $scope?->addSpecBlock($it);
-
-    DispatcherRegistry::dispatcher()->dispatch(
-        new ExampleCreated($title, $it),
-        ExampleCreated::NAME,
-    );
-}
-
-/**
- * Declares a pending describe block. All nested examples are skipped.
- *
- * @param string $context description for the group
- * @param Closure $examples closure containing nested spec DSL calls
- */
-function xdescribe(string $context, Closure $examples): void
-{
-    $describe = new Context($context, $examples);
-    $describe->setPending(true);
-
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    $scope?->addSpecBlock($describe);
-
-    DispatcherRegistry::dispatcher()->dispatch(new ContextCreated($context, $describe), ContextCreated::NAME);
-}
-
-/**
- * Alias for xdescribe(). Declares a pending context block.
- *
- * @param string $context description for the group
- * @param Closure $examples closure containing nested spec DSL calls
- */
-function xcontext(string $context, Closure $examples): void
-{
-    xdescribe($context, $examples);
-}
-
-/**
- * Marks the current example as pending by throwing a PendingException.
- *
- * @param string $message reason the example is pending
- * @throws PendingException always
- */
-function pending(string $message = 'Not yet implemented'): never
-{
-    throw new PendingException($message);
-}
-
-/**
- * Marks the current example as skipped by throwing a SkippedException.
- *
- * @param string $message reason the example is skipped
- * @throws SkippedException always
- */
-function skip(string $message = 'Skipped'): never
-{
-    throw new SkippedException($message);
-}
-
-/**
- * Registers a custom matcher available to all expect() assertions.
- *
- * @param string $name matcher name (e.g. 'toBePositive')
- * @param Closure $matcher callback receiving (subject, ...args) returning bool
- * @param string $message failure message template with %s placeholders
- */
-function addMatcher(string $name, Closure $matcher, string $message): void
-{
-    Expectation::addMatcher($name, $matcher, $message);
-}
-
-/**
- * Registers a focused example. Only focused examples run when any exist in a context.
- *
- * @param string $title descriptive label for the example
- * @param Closure $example executable test body
- */
-function fit(string $title, Closure $example): void
-{
-    $it = new Example($title, $example);
-    $it->setFocused(true);
-
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    $scope?->addSpecBlock($it);
-
-    DispatcherRegistry::dispatcher()->dispatch(
-        new ExampleCreated($title, $it),
-        ExampleCreated::NAME,
-    );
-}
-
-/**
- * Declares a focused describe block. Non-focused siblings are skipped.
- *
- * @param string $context description for the group
- * @param Closure $examples closure containing nested spec DSL calls
- */
-function fdescribe(string $context, Closure $examples): void
-{
-    $describe = new Context($context, $examples);
-    $describe->setFocused(true);
-
-    $scope = DispatcherRegistry::dispatcher()->currentScope();
-    $scope?->addSpecBlock($describe);
-
-    DispatcherRegistry::dispatcher()->dispatch(new ContextCreated($context, $describe), ContextCreated::NAME);
-}
-
-/**
- * Alias for fdescribe(). Declares a focused context block.
- *
- * @param string $context description for the group
- * @param Closure $examples closure containing nested spec DSL calls
- */
-function fcontext(string $context, Closure $examples): void
-{
-    fdescribe($context, $examples);
 }


### PR DESCRIPTION
- A failing entry carries one `expectation` block: `matcher`, `expected`, `actual`, `negated`.
- Matchers state what they wanted: `toBeTrue()` expects `true`, emptiness expects the empty form of what it was given, a matcher with no target says `"N/A"`.
- `toThrow` compares the exception thrown against the one asked for, and takes no argument to mean "throw something".
- `PhpSpec\attach($name, $text|$closure)` hands over context PhpSpec cannot reach; a closure is read at the end, before teardown, and only when the run is not green.
- The browser client attaches the request and the response body, so an assertion about a status is read next to what the server actually said.
- Fixed: the response matchers reported the two sides the wrong way round; an array holding an object made the failure detail emit a PHP warning; printed and attached text had no cap in the terminal.