### PR TITLE
Never write generated code into a source tree nobody agreed to

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - An array holding an object no longer makes the failure detail emit a PHP warning of its own
  - describe and exemplify refuse a name PHP could not parse instead of writing a spec that breaks the suite, and describe says what it needs when given nothing
  - accept resolves paths through the configuration the run was given, so `-c` is honoured
+ - A run nobody can answer no longer takes silence for a yes and writes generated code into the source tree: it names what was on offer and how to accept it
 
 ## [9.0.0-beta.18](https://github.com/phpspec/phpspec/compare/9.0.0-beta.17...9.0.0-beta.18)
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -160,12 +160,29 @@ public function add()
 
 The `--fake` flag works by extracting the expected values from matcher results (via `fakeExpression` metadata) and using them as return values. This creates a quick feedback loop: write spec, run with `--fake`, get passing tests immediately, then replace the faked implementation with real logic.
 
+## Nothing is written without an answer
+
+Everything above is **offered**, never assumed. PhpSpec asks `[Y/n]` and writes
+only what you say yes to, where pressing Enter takes the default and says yes.
+
+A run with nobody to answer writes nothing at all. That covers
+`--no-interaction`, a CI job, an editor or agent shelling out, and a terminal
+whose input has already ended: in each case the question is printed with what it
+would have created, followed by the way to accept it, and no file appears.
+
+```
+Class App\Basket not found. Do you want me to create it for you?
+  Nothing was written: there is nobody to answer. Run with --accept-offers to create classes.
+```
+
+Silence is not consent: a run that cannot be answered must never leave code in
+a source tree that nobody agreed to.
+
 ## Applying Offers Non-Interactively (`--accept-offers`)
 
-Everything above is offered interactively -- PhpSpec asks `[y/n]` before it
-writes. `--accept-offers` applies **every** pending offer (missing classes,
-interfaces, methods, and feature steps) in one non-interactive pass, then exits
-`0`:
+`--accept-offers` is how you say yes in advance. It applies **every** pending
+offer (missing classes, interfaces, methods, and feature steps) in one
+non-interactive pass, then exits `0`:
 
 ```bash
 bin/phpspec run --accept-offers            # generate all missing code, no prompts

--- a/features/scenarios/cli/code-generation.feature
+++ b/features/scenarios/cli/code-generation.feature
@@ -29,6 +29,43 @@ Feature: Code generation
     When I run phpspec run and answer "y" to generation prompts
     Then the class "src/App/Calculator.php" should contain "function add"
 
+  Scenario: A run nobody can answer writes nothing into the source tree
+    Given a spec file "spec/App/Basket.spec.php":
+      """
+      <?php
+
+      use App\Basket;
+
+      describe('Basket', function () {
+          it('totals nothing to start with', function () {
+              expect((new Basket())->total())->toBe(0);
+          });
+      });
+      """
+    When I run phpspec run
+    Then no file "src/App/Basket.php" should be generated
+    And the output should contain "accept-offers"
+    And the exit code should be 1
+
+  # An empty answer at a terminal is somebody pressing Enter, which takes the
+  # default. Nothing to read at all is nobody there, and must not be read as one.
+  Scenario: A question nobody is there to answer writes nothing either
+    Given a spec file "spec/App/Basket.spec.php":
+      """
+      <?php
+
+      use App\Basket;
+
+      describe('Basket', function () {
+          it('totals nothing to start with', function () {
+              expect((new Basket())->total())->toBe(0);
+          });
+      });
+      """
+    When I run phpspec run with nobody to answer it
+    Then no file "src/App/Basket.php" should be generated
+    And the output should contain "Nothing was written"
+
   Scenario: Generate an interface from mock error
     Given a spec file "spec/App/Service.spec.php":
       """

--- a/features/scenarios/cli/code-generation.feature
+++ b/features/scenarios/cli/code-generation.feature
@@ -47,6 +47,24 @@ Feature: Code generation
     And the output should contain "accept-offers"
     And the exit code should be 1
 
+  Scenario: --no-interaction writes nothing into the source tree
+    Given a spec file "spec/App/Basket.spec.php":
+      """
+      <?php
+
+      use App\Basket;
+
+      describe('Basket', function () {
+          it('totals nothing to start with', function () {
+              expect((new Basket())->total())->toBe(0);
+          });
+      });
+      """
+    When I run phpspec run in a fresh process with option "--no-interaction"
+    Then no file "src/App/Basket.php" should be generated
+    And the output should contain "Nothing was written"
+    And the output should contain "src/App/Basket.php"
+
   # An empty answer at a terminal is somebody pressing Enter, which takes the
   # default. Nothing to read at all is nobody there, and must not be read as one.
   Scenario: A question nobody is there to answer writes nothing either

--- a/features/scenarios/cli/code-generation.feature
+++ b/features/scenarios/cli/code-generation.feature
@@ -63,7 +63,8 @@ Feature: Code generation
     When I run phpspec run in a fresh process with option "--no-interaction"
     Then no file "src/App/Basket.php" should be generated
     And the output should contain "Nothing was written"
-    And the output should contain "src/App/Basket.php"
+    # Named without its separators: Windows writes them the other way round.
+    And the output should contain "Basket.php"
 
   # An empty answer at a terminal is somebody pressing Enter, which takes the
   # default. Nothing to read at all is nobody there, and must not be read as one.

--- a/features/steps/runner.steps.php
+++ b/features/steps/runner.steps.php
@@ -98,6 +98,12 @@ when('I run phpspec run in a fresh process with option {string}', function (stri
     _phpspec_exec_subprocess($this, 'run ' . $options);
 });
 
+// A terminal PhpSpec can print a question to, with nothing behind it to answer:
+// the subprocess gets its input closed rather than fed.
+when('I run phpspec run with nobody to answer it', function () {
+    _phpspec_exec_subprocess($this, 'run');
+});
+
 when('I run phpspec run {string}', function (string $path) {
     _phpspec_exec($this, 'run ' . $path);
 });

--- a/spec/PhpSpec/Console/Command/Run/CodeGenerator.spec.php
+++ b/spec/PhpSpec/Console/Command/Run/CodeGenerator.spec.php
@@ -3,6 +3,7 @@
 use PhpSpec\Console\Command\Pair\Chooser;
 use PhpSpec\Console\Command\Pair\PairOutput;
 use PhpSpec\Console\Command\Run\CodeGenerator;
+use PhpSpec\Console\Command\Run\Generation;
 use PhpSpec\Result\ContextResult;
 use PhpSpec\Result\ExampleResult;
 use PhpSpec\Result\FeatureResult;
@@ -102,7 +103,7 @@ describe(CodeGenerator::class, function () {
             $specFile = $absDir . '/spec/CgTest/Widget.spec.php';
             file_put_contents($specFile, "<?php\nit('works', fn() => expect(\$this->widget->spin())->toBe(true));\n");
 
-            $generator = new CodeGenerator($relDir . '/src', $relDir . '/spec', false);
+            $generator = new CodeGenerator($relDir . '/src', $relDir . '/spec', Generation::Accepts);
 
             $original = eval("return new \\Error('Call to undefined method CgTest\\\\Widget::spin()');");
             $error = new \PhpSpec\Specification\ExampleError(
@@ -122,7 +123,6 @@ describe(CodeGenerator::class, function () {
             $generator->generate($this->output, $suite, false);
             $out = $this->output->fetch();
 
-            expect($out)->toContain('Do you want me to create');
             expect($out)->toContain('spin()');
             expect($out)->toContain('[MODIFIED]');
             expect($out)->toContain('public function spin');
@@ -146,7 +146,7 @@ describe(CodeGenerator::class, function () {
             $specFile = $absDir . '/spec/test.spec.php';
             file_put_contents($specFile, "<?php\nit('mocks', function(CgTest2\\Repo \$mock) {});\n");
 
-            $generator = new CodeGenerator($relDir . '/src', $relDir . '/spec', false);
+            $generator = new CodeGenerator($relDir . '/src', $relDir . '/spec', Generation::Accepts);
 
             $original = new \RuntimeException("Cannot create mock: class or interface 'CgTest2\\Repo' does not exist");
             $error = new \PhpSpec\Specification\ExampleError(
@@ -167,8 +167,10 @@ describe(CodeGenerator::class, function () {
             $out = $this->output->fetch();
 
             expect($out)->toContain('interface');
-            expect($out)->toContain('CgTest2\Repo');
             expect($out)->toContain('[NEW FILE]');
+            // Where it went, and under which namespace: taking the offer says
+            // what was written, since there was no question to say it first.
+            expect(file_get_contents($absDir . '/src/CgTest2/Repo.php'))->toContain('namespace CgTest2;');
 
             // Cleanup
             array_map('unlink', glob($absDir . '/src/CgTest2/*') ?: []);
@@ -198,7 +200,7 @@ describe(CodeGenerator::class, function () {
                 "<?php\n\nnamespace App\\Model;\n\nclass User\n{\n}\n",
             );
 
-            $generator = new CodeGenerator($relDir . '/src', $relDir . '/spec', false, psr4Prefix: 'App');
+            $generator = new CodeGenerator($relDir . '/src', $relDir . '/spec', Generation::Accepts, psr4Prefix: 'App');
 
             $original = new \RuntimeException('Class "App\Model\User" not found');
             $error = new \PhpSpec\Specification\ExampleError('Class "App\Model\User" not found', $original);

--- a/src/PhpSpec/Console/Command/Accept.php
+++ b/src/PhpSpec/Console/Command/Accept.php
@@ -18,6 +18,7 @@ use PhpSpec\Ai\Agent\Proposal;
 use PhpSpec\Ai\Agent\Writer;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Run\CodeGenerator;
+use PhpSpec\Console\Command\Run\Generation;
 use PhpSpec\Console\Command\Run\GenerationCandidates;
 use PhpSpec\Filesystem;
 use PhpSpec\Offers\Offer;
@@ -164,7 +165,9 @@ final class Accept extends Command
         $generator = new CodeGenerator(
             ltrim($this->config->getSrcPath(), './'),
             ltrim($this->config->getSpecPath(), './'),
-            false,
+            // Asked for by name on the command line: the person has already
+            // said yes, and there is nothing left to put to them.
+            Generation::Accepts,
             $this->config->getSpecSuffix(),
             $this->config->getPsr4Prefix(),
         );

--- a/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
+++ b/src/PhpSpec/Console/Command/Pair/CommandDispatcher.php
@@ -25,6 +25,7 @@ use PhpSpec\CodeGeneration\SpecGenerator;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Pair;
 use PhpSpec\Console\Command\Run\CodeGenerator;
+use PhpSpec\Console\Command\Run\Generation;
 use PhpSpec\Console\Command\Run\GenerationCandidates;
 use PhpSpec\Console\Command\Run\RecencyScanner;
 use PhpSpec\Console\Command\Run\SuiteSummary;
@@ -586,7 +587,7 @@ final class CommandDispatcher
         $codeGenerator = new CodeGenerator(
             ltrim($this->config->getSrcPath(), './'),
             ltrim($this->config->getSpecPath(), './'),
-            $this->interactive,
+            $this->interactive ? Generation::Asks : Generation::Accepts,
             $this->config->getSpecSuffix(),
             $this->config->getPsr4Prefix(),
             $this->chooser,

--- a/src/PhpSpec/Console/Command/Run.php
+++ b/src/PhpSpec/Console/Command/Run.php
@@ -18,6 +18,7 @@ use DOMException;
 use PhpSpec\Configuration;
 use PhpSpec\Console\Command\Run\CodeGenerator;
 use PhpSpec\Console\Command\Run\CoverageReporter;
+use PhpSpec\Console\Command\Run\Generation;
 use PhpSpec\Console\Command\Run\GenerationCandidates;
 use PhpSpec\Console\Command\Run\GenerationReport;
 use PhpSpec\Console\Command\Run\RunOutcome;
@@ -276,7 +277,7 @@ final class Run extends Command
             // Apply every pending generation offer without prompting, then exit.
             // The run's own output already went out; generation notes are discarded
             // so an upstream --format=agent document stays a single clean object.
-            $this->generateCode(new BufferedOutput(), $results, (bool) $input->getOption('fake'), false);
+            $this->generateCode(new BufferedOutput(), $results, (bool) $input->getOption('fake'), Generation::Accepts);
 
             return 0;
         }
@@ -287,11 +288,11 @@ final class Run extends Command
         $reportPath = GenerationReport::requestedPath();
         if ($reportPath !== null) {
             GenerationReport::write($reportPath, new RunOutcome(
-                $this->codeGenerator(false)->scan($results),
+                $this->codeGenerator(Generation::Declines)->scan($results),
                 SuiteSummary::fromSuiteResult($results),
             ));
         } elseif (!in_array($this->resolveFormat($input), ['junit', 'html', 'agent'], true)) {
-            $this->generateCode($prose, $results, (bool) $input->getOption('fake'), $input->isInteractive());
+            $this->generateCode($prose, $results, (bool) $input->getOption('fake'), $input->isInteractive() ? Generation::Asks : Generation::Declines);
         }
 
         if ($formatter instanceof Agent) {
@@ -758,16 +759,17 @@ final class Run extends Command
      * @param Output $output the console output for prompts and confirmation messages
      * @param SuiteResult $results the suite results to scan for generation candidates
      * @param bool $fake whether --fake mode is enabled
+     * @param Generation $generation how an offer is answered when nobody is asked
      */
-    private function generateCode(Output $output, SuiteResult $results, bool $fake, bool $interactive = true): void
+    private function generateCode(Output $output, SuiteResult $results, bool $fake, Generation $generation = Generation::Asks): void
     {
-        $this->codeGenerator($interactive)->generate($output, $results, $fake);
+        $this->codeGenerator($generation)->generate($output, $results, $fake);
     }
 
     /**
      * Builds a CodeGenerator configured from the project paths.
      *
-     * @param bool $interactive whether generation should prompt (false = auto-accept)
+     * @param Generation $generation how an offer is answered when nobody is asked
      * @return CodeGenerator
      */
     /**
@@ -801,15 +803,15 @@ final class Run extends Command
      */
     private function candidates(SuiteResult $results): GenerationCandidates
     {
-        return $this->candidates ??= $this->codeGenerator(false)->scan($results);
+        return $this->candidates ??= $this->codeGenerator(Generation::Declines)->scan($results);
     }
 
-    private function codeGenerator(bool $interactive): CodeGenerator
+    private function codeGenerator(Generation $generation): CodeGenerator
     {
         return new CodeGenerator(
             ltrim($this->config->getSrcPath(), './'),
             ltrim($this->config->getSpecPath(), './'),
-            $interactive,
+            $generation,
             $this->config->getSpecSuffix(),
             $this->config->getPsr4Prefix(),
         );

--- a/src/PhpSpec/Console/Command/Run/CodeGenerator.php
+++ b/src/PhpSpec/Console/Command/Run/CodeGenerator.php
@@ -171,9 +171,13 @@ final readonly class CodeGenerator
                 continue;
             }
 
+            // Named with the file it would write. That path is worked out from
+            // the source root and the namespace, so it is a guess, and nobody
+            // can correct a guess they are never shown.
             $this->confirmAndGenerate($output, sprintf(
-                '  <fg=yellow>Class <fg=white>%s</> not found. Do you want me to create it for you?</>',
+                '  <fg=yellow>Class <fg=white>%s</> not found. Do you want me to create it in <fg=white>%s</>?</>',
                 $fqcn,
+                $location->filePath(),
             ), 'create-class', 'create classes', fn() => $classGenerator->generate($fqcn), $location->filePath());
         }
     }
@@ -212,8 +216,9 @@ final readonly class CodeGenerator
                 }
 
                 $this->confirmAndGenerate($output, sprintf(
-                    '  <fg=yellow>Do you want me to create class <fg=white>%s</> for you?</>',
+                    '  <fg=yellow>Do you want me to create class <fg=white>%s</> in <fg=white>%s</>?</>',
                     $fqcn,
+                    $location->filePath(),
                 ), 'create-class', 'create classes', fn() => $classGenerator->generate($fqcn), $location->filePath());
             }
         }
@@ -246,8 +251,9 @@ final readonly class CodeGenerator
             }
 
             $this->confirmAndGenerate($output, sprintf(
-                '  <fg=yellow>Do you want me to create interface <fg=white>%s</> for you?</>',
+                '  <fg=yellow>Do you want me to create interface <fg=white>%s</> in <fg=white>%s</>?</>',
                 $fqcn,
+                $location->filePath(),
             ), 'create-interface', 'create interfaces', fn() => $interfaceGenerator->generate($fqcn), $location->filePath());
         }
     }

--- a/src/PhpSpec/Console/Command/Run/CodeGenerator.php
+++ b/src/PhpSpec/Console/Command/Run/CodeGenerator.php
@@ -44,7 +44,7 @@ final readonly class CodeGenerator
     /**
      * @param string $srcPath relative path to the source directory
      * @param string $specPath relative path to the spec directory
-     * @param bool $interactive whether to prompt for user input (false = auto-accept all)
+     * @param Generation $generation how an offer is answered when nobody is asked
      * @param string $specSuffix file suffix for spec files
      * @param string $psr4Prefix PSR-4 namespace prefix mapped to $srcPath
      * @param Chooser|null $chooser when given, questions are presented through this
@@ -53,7 +53,7 @@ final readonly class CodeGenerator
     public function __construct(
         private string $srcPath,
         private string $specPath,
-        private bool $interactive = true,
+        private Generation $generation = Generation::Asks,
         private string $specSuffix = '.spec.php',
         private string $psr4Prefix = '',
         private ?Chooser $chooser = null,
@@ -427,18 +427,52 @@ final readonly class CodeGenerator
             return $this->chooser->choose($question, $kind, $action);
         }
 
+        if ($this->generation === Generation::Accepts) {
+            return true;
+        }
+
+        $asking = $this->generation === Generation::Asks;
+
         $output->writeln('');
-        $output->writeln("$question [Y/n] ");
+        $output->writeln($asking ? "$question [Y/n] " : $question);
+
+        $answer = $asking ? $this->answer($output) : null;
+
+        // Nobody answered: --no-interaction, or a standard input with nothing
+        // on it. An unanswered question is not a yes, whatever the default
+        // would have been, because reading it as one puts files in a source
+        // tree that nobody agreed to. Said out loud, with the way to accept
+        // it, because a person reading a log still wants to know what was
+        // offered.
+        if ($answer === null) {
+            $output->writeln(sprintf(
+                '  <fg=yellow>Nothing was written: there is nobody to answer. Run with --accept-offers to %s.</>',
+                $action,
+            ));
+
+            return false;
+        }
+
+        return $answer === '' || strtolower($answer) === 'y';
+    }
+
+    /**
+     * What the person answered, or nothing when there was nobody there.
+     */
+    private function answer(Output $output): ?string
+    {
         if ($output instanceof ScrollRegionOutput) {
             $output->prepareForInput();
         }
+
         $answer = $this->ask('  > ');
-        if ($output instanceof ScrollRegionOutput) {
+
+        if ($output instanceof ScrollRegionOutput && $answer !== null) {
             $output->returnToContent();
             $output->echoInput($answer ?: 'Y');
         }
 
-        return $answer === '' || strtolower($answer) === 'y';
+        return $answer;
     }
 
     /**
@@ -472,15 +506,22 @@ final readonly class CodeGenerator
      * @param string $prompt the prompt string to display
      * @return string the user's input, or empty string if no input
      */
-    private function ask(string $prompt): string
+    /**
+     * One line of input, or null at end of input.
+     *
+     * The difference matters: an empty line is somebody pressing Enter, which
+     * takes the default, while nothing to read at all is nobody there.
+     */
+    private function ask(string $prompt): ?string
     {
-        if (!$this->interactive) {
-            return '';
-        }
         if (function_exists('readline') && stream_isatty(STDIN)) {
-            return (string) readline($prompt);
+            $answer = readline($prompt);
+
+            return $answer === false ? null : $answer;
         }
+
         $line = fgets(STDIN);
-        return $line === false ? '' : rtrim($line, "\r\n");
+
+        return $line === false ? null : rtrim($line, "\r\n");
     }
 }

--- a/src/PhpSpec/Console/Command/Run/Generation.php
+++ b/src/PhpSpec/Console/Command/Run/Generation.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\Console\Command\Run;
+
+/**
+ * @internal
+ * How an offer to write code is answered.
+ *
+ * Three answers, because "there is nobody to ask" was previously read as
+ * "yes": a run with no terminal to prompt would write classes into a source
+ * tree nobody had agreed to. An unanswered question is not consent.
+ */
+enum Generation
+{
+    /** Put every offer to the person running it. */
+    case Asks;
+
+    /** Take every offer, because the person already said so (accept, pair). */
+    case Accepts;
+
+    /** Write nothing, because there is nobody to ask. */
+    case Declines;
+}


### PR DESCRIPTION
`phpspec run --no-interaction` wrote generated classes into the source tree without asking. An unanswered prompt returned an empty string, and an empty string is Enter at `[Y/n]`, so "nobody was asked" and "somebody said yes" were the same value.

- Nothing is written when there is nobody to answer: `--no-interaction`, CI, an editor or agent shelling out, or a standard input that has already ended.
- The offer is still named, with `--accept-offers` as the way to take it.
- `yes | phpspec run`, `--accept-offers` and a terminal all behave as before.
- Every create offer now says which file it would write, so a guessed path can be refused before it happens.
