### PR TITLE
Name a path relative to the project however the platform spells its root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - generate no longer writes when there is nobody to ask: it offers the change under an id, and `run --accept-offers` stays as the bulk shortcut for a run's own offers
 
 ### Fixed
+ - Paths are named relative to the project however the platform spells its root, so on Windows guard no longer calls covered code untested, the JSON coverage report no longer keys sources absolutely, and a rerun command stays relative
  - A parallel run no longer reports `run :0` as an entry's rerun, nor a comparison of nothing with nothing: a failure that came back without its site now reports its message alone
  - An array holding an object no longer makes the failure detail emit a PHP warning of its own
  - The response matchers reported the two sides the wrong way round, so `toHaveStatus(201)` against a 500 said it expected 500

--- a/spec/PhpSpec/Guard/Coverage.spec.php
+++ b/spec/PhpSpec/Guard/Coverage.spec.php
@@ -24,6 +24,28 @@ describe(Coverage::class, function () {
     // logic line untested. That is right for one file and wrong for all of
     // them: a collector that reported nothing is a broken collector, not a
     // codebase without a single example, and guard must be able to tell.
+    // Xdebug reports a file as the filesystem resolved it, while the base comes
+    // from wherever the run was started. On Windows those are two spellings of
+    // one directory, and a base that recognises only its own leaves every file
+    // unknown, which guard reads as logic no example reached.
+    it('matches a file whose path spells the project differently', function () {
+        $real = sys_get_temp_dir() . '/phpspec_cov_' . getmypid();
+        $alias = sys_get_temp_dir() . '/phpspec_cov_alias_' . getmypid();
+        @mkdir($real . '/src', 0777, true);
+        @symlink($real, $alias);
+
+        try {
+            $coverage = Coverage::fromHits([(string) realpath($real) . '/src/Basket.php' => [7 => 1]], $alias);
+
+            expect($coverage->knows('src/Basket.php'))->toBeTrue();
+            expect($coverage->covers('src/Basket.php', 7))->toBeTrue();
+        } finally {
+            @unlink($alias);
+            @rmdir($real . '/src');
+            @rmdir($real);
+        }
+    });
+
     it('says when it holds no evidence at all', function () {
         expect(Coverage::nothing()->isEmpty())->toBeTrue();
         expect(Coverage::fromHits([], '/app')->isEmpty())->toBeTrue();

--- a/spec/PhpSpec/Guard/Coverage.spec.php
+++ b/spec/PhpSpec/Guard/Coverage.spec.php
@@ -29,20 +29,19 @@ describe(Coverage::class, function () {
     // one directory, and a base that recognises only its own leaves every file
     // unknown, which guard reads as logic no example reached.
     it('matches a file whose path spells the project differently', function () {
-        $real = sys_get_temp_dir() . '/phpspec_cov_' . getmypid();
-        $alias = sys_get_temp_dir() . '/phpspec_cov_alias_' . getmypid();
-        @mkdir($real . '/src', 0777, true);
-        @symlink($real, $alias);
+        $directory = sys_get_temp_dir() . '/phpspec_cov_' . getmypid();
+        @mkdir($directory . '/src', 0777, true);
 
         try {
-            $coverage = Coverage::fromHits([(string) realpath($real) . '/src/Basket.php' => [7 => 1]], $alias);
+            $hits = [(string) realpath($directory) . '/src/Basket.php' => [7 => 1]];
+
+            $coverage = Coverage::fromHits($hits, $directory . '/src/..');
 
             expect($coverage->knows('src/Basket.php'))->toBeTrue();
             expect($coverage->covers('src/Basket.php', 7))->toBeTrue();
         } finally {
-            @unlink($alias);
-            @rmdir($real . '/src');
-            @rmdir($real);
+            @rmdir($directory . '/src');
+            @rmdir($directory);
         }
     });
 

--- a/spec/PhpSpec/ProjectRoot.spec.php
+++ b/spec/PhpSpec/ProjectRoot.spec.php
@@ -1,0 +1,62 @@
+<?php
+
+use PhpSpec\ProjectRoot;
+
+describe(ProjectRoot::class, function () {
+
+    it('strips itself from a path inside it', function () {
+        $root = ProjectRoot::at('/app');
+
+        expect($root->relative('/app/src/Basket.php'))->toBe('src/Basket.php');
+    });
+
+    it('leaves a path that is not inside it alone', function () {
+        $root = ProjectRoot::at('/app');
+
+        expect($root->relative('/elsewhere/src/Basket.php'))->toBe('/elsewhere/src/Basket.php');
+    });
+
+    it('reads a path the same however its separators are written', function () {
+        $root = ProjectRoot::at('C:\\project');
+
+        expect($root->relative('C:/project/src/Basket.php'))->toBe('src/Basket.php');
+        expect($root->relative('C:\\project\\src\\Basket.php'))->toBe('src/Basket.php');
+    });
+
+    it('knows whether a path is inside it', function () {
+        $root = ProjectRoot::at('/app/src');
+
+        expect($root->holds('/app/src/Basket.php'))->toBeTrue();
+        expect($root->holds('/app/spec/Basket.spec.php'))->toBeFalse();
+    });
+
+    // The reason this class exists. One call gives PHP the directory as it was
+    // typed and another gives it as the filesystem resolves it, and on Windows
+    // those are different spellings of one place ("RUNNER~1" against
+    // "runneradmin"). A root that only knows one of them matches nothing, and
+    // every path stays absolute: coverage of a file nobody can name, a guard
+    // that reads every changed line as untested.
+    it('answers to every spelling of itself the filesystem accepts', function () {
+        $real = sys_get_temp_dir() . '/phpspec_root_' . getmypid();
+        $alias = sys_get_temp_dir() . '/phpspec_alias_' . getmypid();
+        @mkdir($real . '/src', 0777, true);
+        @symlink($real, $alias);
+
+        try {
+            $root = ProjectRoot::at($alias);
+
+            // Named through the alias, and through what it resolves to.
+            expect($root->relative($alias . '/src/Basket.php'))->toBe('src/Basket.php');
+            expect($root->relative((string) realpath($real) . '/src/Basket.php'))->toBe('src/Basket.php');
+        } finally {
+            @unlink($alias);
+            @rmdir($real . '/src');
+            @rmdir($real);
+        }
+    });
+
+    it('takes the working directory as the root when asked for here', function () {
+        expect(ProjectRoot::here()->relative((string) getcwd() . '/src/Basket.php'))->toBe('src/Basket.php');
+    });
+
+});

--- a/spec/PhpSpec/ProjectRoot.spec.php
+++ b/spec/PhpSpec/ProjectRoot.spec.php
@@ -37,21 +37,21 @@ describe(ProjectRoot::class, function () {
     // every path stays absolute: coverage of a file nobody can name, a guard
     // that reads every changed line as untested.
     it('answers to every spelling of itself the filesystem accepts', function () {
-        $real = sys_get_temp_dir() . '/phpspec_root_' . getmypid();
-        $alias = sys_get_temp_dir() . '/phpspec_alias_' . getmypid();
-        @mkdir($real . '/src', 0777, true);
-        @symlink($real, $alias);
+        $directory = sys_get_temp_dir() . '/phpspec_root_' . getmypid();
+        @mkdir($directory . '/src', 0777, true);
 
         try {
-            $root = ProjectRoot::at($alias);
+            // One directory, named two ways: as it was handed over, and as the
+            // filesystem resolves it. Windows makes that difference for free,
+            // handing the same place back as "RUNNER~1" from one call and
+            // "runneradmin" from another.
+            $root = ProjectRoot::at($directory . '/src/..');
 
-            // Named through the alias, and through what it resolves to.
-            expect($root->relative($alias . '/src/Basket.php'))->toBe('src/Basket.php');
-            expect($root->relative((string) realpath($real) . '/src/Basket.php'))->toBe('src/Basket.php');
+            expect($root->relative($directory . '/src/../src/Basket.php'))->toBe('src/Basket.php');
+            expect($root->relative((string) realpath($directory) . '/src/Basket.php'))->toBe('src/Basket.php');
         } finally {
-            @unlink($alias);
-            @rmdir($real . '/src');
-            @rmdir($real);
+            @rmdir($directory . '/src');
+            @rmdir($directory);
         }
     });
 

--- a/src/PhpSpec/Ai/Agent/ProjectPath.php
+++ b/src/PhpSpec/Ai/Agent/ProjectPath.php
@@ -14,6 +14,8 @@
 
 namespace PhpSpec\Ai\Agent;
 
+use PhpSpec\ProjectRoot;
+
 /**
  * @internal
  * The one project-path normaliser for the AI surfaces. Separators are
@@ -30,13 +32,7 @@ final class ProjectPath
      */
     public static function relative(string $path): string
     {
-        $path = str_replace('\\', '/', $path);
-        $cwd = str_replace('\\', '/', getcwd() ?: '.') . '/';
-        if (str_starts_with($path, $cwd)) {
-            $path = substr($path, strlen($cwd));
-        }
-
-        return ltrim($path, '/');
+        return ltrim(ProjectRoot::here()->relative($path), '/');
     }
 
     /**

--- a/src/PhpSpec/Coverage/JsonReportBuilder.php
+++ b/src/PhpSpec/Coverage/JsonReportBuilder.php
@@ -15,6 +15,7 @@
 namespace PhpSpec\Coverage;
 
 use PhpSpec\Filesystem;
+use PhpSpec\ProjectRoot;
 use PhpSpec\Source\Members;
 
 /**
@@ -98,18 +99,16 @@ final class JsonReportBuilder
      */
     private function buildSources(array $lines, string $srcPath, string $projectRoot, array $aggregate = []): array
     {
-        $srcPrefix = rtrim(str_replace('\\', '/', $srcPath), '/') . '/';
-        $rootPrefix = rtrim(str_replace('\\', '/', $projectRoot), '/') . '/';
+        $sourceRoot = ProjectRoot::at($srcPath);
+        $root = ProjectRoot::at($projectRoot);
         $sources = [];
 
         foreach ($lines as $file => $fileLines) {
-            $normalized = str_replace('\\', '/', $file);
-
-            if (!str_starts_with($normalized, $srcPrefix) || str_contains($normalized, "eval()'d code")) {
+            if (!$sourceRoot->holds($file) || str_contains(str_replace('\\', '/', $file), "eval()'d code")) {
                 continue;
             }
 
-            $relative = str_starts_with($normalized, $rootPrefix) ? substr($normalized, strlen($rootPrefix)) : $normalized;
+            $relative = $root->relative($file);
             $source = $this->filesystem->read($file);
             $sources[$relative] = [
                 'checksum' => md5($source),

--- a/src/PhpSpec/Guard/Coverage.php
+++ b/src/PhpSpec/Guard/Coverage.php
@@ -14,6 +14,8 @@
 
 namespace PhpSpec\Guard;
 
+use PhpSpec\ProjectRoot;
+
 /**
  * @internal
  * What the run exercised, line by line.
@@ -41,13 +43,11 @@ final readonly class Coverage
      */
     public static function fromHits(array $raw, string $baseDir = '.'): self
     {
-        $prefix = rtrim(str_replace('\\', '/', $baseDir), '/') . '/';
+        $root = ProjectRoot::at($baseDir);
         $hits = [];
 
         foreach ($raw as $file => $lines) {
-            $file = str_replace('\\', '/', $file);
-            $relative = str_starts_with($file, $prefix) ? substr($file, strlen($prefix)) : $file;
-            $hits[$relative] = $lines;
+            $hits[$root->relative($file)] = $lines;
         }
 
         return new self($hits);

--- a/src/PhpSpec/ProjectRoot.php
+++ b/src/PhpSpec/ProjectRoot.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ * (c) Ciaran McNulty <ciaran@ciaranmcnulty.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec;
+
+/**
+ * @internal
+ * A directory, and every spelling of it a path might arrive in.
+ *
+ * PhpSpec names files relative to the project all over: coverage, the agent
+ * stream, guard's delta. Each of those compares a path PHP produced against a
+ * root PhpSpec asked for, and the two need not be spelled alike. Separators
+ * differ on Windows, case is not significant there, and the same directory
+ * answers to both a short name ("RUNNER~1") and a long one ("runneradmin"),
+ * depending on which call produced it.
+ *
+ * A root that recognises only one spelling strips nothing, and a path that
+ * stays absolute is not merely ugly: it is a file the coverage report cannot
+ * name, and a file guard cannot find in its own coverage, which it then reads
+ * as logic no example reached.
+ */
+final readonly class ProjectRoot
+{
+    /**
+     * @param list<string> $spellings every form of this directory, with forward
+     *                                slashes and a trailing one
+     */
+    private function __construct(private array $spellings) {}
+
+    public static function at(string $directory): self
+    {
+        $spellings = [];
+
+        foreach ([$directory, realpath($directory)] as $spelling) {
+            if (is_string($spelling) && $spelling !== '') {
+                $spellings[] = rtrim(str_replace('\\', '/', $spelling), '/') . '/';
+            }
+        }
+
+        return new self(array_values(array_unique($spellings)));
+    }
+
+    /**
+     * The directory the process is working in.
+     */
+    public static function here(): self
+    {
+        return self::at(getcwd() ?: '.');
+    }
+
+    /**
+     * A path as the project refers to it, or unchanged when it lies outside.
+     */
+    public function relative(string $path): string
+    {
+        $path = str_replace('\\', '/', $path);
+
+        foreach ($this->spellings as $spelling) {
+            if ($this->under($path, $spelling)) {
+                return substr($path, strlen($spelling));
+            }
+        }
+
+        return $path;
+    }
+
+    /**
+     * Whether this path lies inside the directory.
+     */
+    public function holds(string $path): bool
+    {
+        $path = str_replace('\\', '/', $path);
+
+        foreach ($this->spellings as $spelling) {
+            if ($this->under($path, $spelling)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function under(string $path, string $spelling): bool
+    {
+        if (str_starts_with($path, $spelling)) {
+            return true;
+        }
+
+        // Windows does not distinguish paths by case, and the two calls that
+        // produced these two strings did not have to agree about it.
+        return DIRECTORY_SEPARATOR === '\\' && stripos($path, $spelling) === 0;
+    }
+}

--- a/src/PhpSpec/Report/Formatter/Agent.php
+++ b/src/PhpSpec/Report/Formatter/Agent.php
@@ -16,6 +16,7 @@ namespace PhpSpec\Report\Formatter;
 
 use PhpSpec\Coverage\CoverageVerdict;
 use PhpSpec\Guard\Verdict as GuardVerdict;
+use PhpSpec\ProjectRoot;
 use PhpSpec\Report\AbstractFormatter;
 use PhpSpec\Report\Formatter\Agent\Fatal;
 use PhpSpec\Report\Formatter\Agent\Offers;
@@ -795,19 +796,6 @@ final class Agent extends AbstractFormatter
             return null;
         }
 
-        // Normalise both sides to forward slashes before comparing: on Windows
-        // getcwd() yields backslashes while a file path may already carry
-        // forward slashes, so a raw DIRECTORY_SEPARATOR prefix check would miss
-        // and leak the absolute path.
-        $file = str_replace('\\', '/', $file);
-        $cwd = getcwd();
-        if ($cwd !== false) {
-            $cwd = str_replace('\\', '/', $cwd);
-            if (str_starts_with($file, $cwd . '/')) {
-                $file = substr($file, strlen($cwd) + 1);
-            }
-        }
-
-        return $file . ':' . $line;
+        return ProjectRoot::here()->relative($file) . ':' . $line;
     }
 }


### PR DESCRIPTION
On Windows, guard reported a violation for a method an example had covered. The same directory reaches PhpSpec spelled two ways: `getcwd()` gives one, and a path PHP resolved gives another (short name against long, and case). Four places stripped a project root by comparing strings, each normalising separators only, so none of them matched and every path stayed absolute.

- Guard could not find a covered file in its own coverage, read the whole change as untested, and failed the run.
- The JSON coverage report keyed its sources absolutely instead of project-relative.
- An agent `rerun` command carried an absolute path.

One `ProjectRoot` now knows every spelling of the root, and guard, the coverage report, the agent stream and the AI path helper all ask it.
